### PR TITLE
chore(ci): Update our CI to use a Github App for opening PRs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,8 +94,29 @@ commands:
           command: |
             FILES=$(ls -1 << parameters.source >>/*.<< parameters.extension >> 2>/dev/null)
             gsutil cp -n $FILES << parameters.destination >>
-
-
+  setup-github-bot:
+    steps:
+      - run:
+          name: Install Dependencies
+          command: |
+            pip install PyJWT requests cryptography
+      - gh/install
+      - run:
+          name: Generate token and setup git user
+          command: |
+            export GH_TOKEN=$(python .circleci/scripts/create_jwt.py)
+            if [ -z "$GH_TOKEN" ]; then
+              echo "❌ Failed to generate GH_TOKEN ❌"
+              exit 1
+            fi
+            echo "export GH_TOKEN=\"${GH_TOKEN}\"" >> "$BASH_ENV"
+            git config --global user.email "experimenter-ci-bot@mozilla.com"
+            git config --global user.name "Experimenter CircleCI Bot"
+            git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/b4handjr/experimenter.git
+            gh auth setup-git
+            gh auth status
+            gh config set git_protocol https
+            gh config set prompt disabled
 jobs:
   check_experimenter_x86_64:
     machine:
@@ -731,18 +752,8 @@ jobs:
       image: ubuntu-2204:2024.11.1
       docker_layer_caching: true
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "32:8e:72:0b:9a:a1:1c:b8:7e:90:e1:53:a3:73:68:47" # for git pushes from circleci, since relies on ssh
       - checkout
-      - gh/setup:
-          token: GH_EXTERNAL_CONFIG_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
-      - run:
-          name: Setup Git
-          command: |
-            git config --local user.name "dataops-ci-bot"
-            git config --local user.email "dataops+ci-bot@mozilla.com"
-            gh config set git_protocol https
+      - setup-github-bot
       - run:
           name: Check for External Config Update
           command: |
@@ -775,18 +786,8 @@ jobs:
       image: ubuntu-2204:2024.11.1
       docker_layer_caching: true
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "32:8e:72:0b:9a:a1:1c:b8:7e:90:e1:53:a3:73:68:47" # for git pushes from circleci, since relies on ssh
       - checkout
-      - gh/setup:
-          token: GH_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
-      - run:
-          name: Setup Git
-          command: |
-            git config --local user.name "dataops-ci-bot"
-            git config --local user.email "dataops+ci-bot@mozilla.com"
-            gh config set git_protocol https
+      - setup-github-bot
       - run:
           name: Check for Application Services update
           command: |
@@ -806,6 +807,24 @@ jobs:
             else
               echo "No config changes, skipping"
             fi
+  test-github-bot:
+    machine:
+      image: ubuntu-2204:2024.11.1
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - setup-github-bot
+      - run:
+          name: Make a PR
+          command: |
+            git checkout main
+            git pull origin main
+            touch test_file.txt
+            git checkout -B test-github-app
+            git add .
+            git commit -m "TESTING GITHUB APP BOT"
+            git push origin test-github-app -f
+            gh pr create -t "TESTING GITHUB APP BOT" -b "" --base main --head test-github-app --repo b4handjr/experimenter
 
   update_firefox_versions:
     machine:
@@ -813,18 +832,8 @@ jobs:
       docker_layer_caching: true
     working_directory: ~/experimenter
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "32:8e:72:0b:9a:a1:1c:b8:7e:90:e1:53:a3:73:68:47" # for git pushes from circleci, since relies on ssh
       - checkout
-      - gh/setup:
-          token: GH_TOKEN # for gh commands from circleci, since relies on user token, since por que no los dos?
-      - run:
-          name: Setup Git
-          command: |
-            git config --local user.name "dataops-ci-bot"
-            git config --local user.email "dataops+ci-bot@mozilla.com"
-            gh config set git_protocol https
+      - setup-github-bot
       - run:
           name: Check for external Update
           command: |
@@ -881,6 +890,7 @@ workflows:
 
   build:
     jobs:
+      - test-github-bot
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ commands:
           command: |
             export GH_TOKEN=$(python .circleci/scripts/create_jwt.py)
             if [ -z "$GH_TOKEN" ]; then
-              echo "❌ Failed to generate GH_TOKEN ❌"
+              echo "Failed to generate GH_TOKEN"
               exit 1
             fi
             echo "export GH_TOKEN=\"${GH_TOKEN}\"" >> "$BASH_ENV"
@@ -807,24 +807,6 @@ jobs:
             else
               echo "No config changes, skipping"
             fi
-  test-github-bot:
-    machine:
-      image: ubuntu-2204:2024.11.1
-      docker_layer_caching: true
-    steps:
-      - checkout
-      - setup-github-bot
-      - run:
-          name: Make a PR
-          command: |
-            git checkout main
-            git pull origin main
-            touch test_file.txt
-            git checkout -B test-github-app
-            git add .
-            git commit -m "TESTING GITHUB APP BOT"
-            git push origin test-github-app -f
-            gh pr create -t "TESTING GITHUB APP BOT" -b "" --base main --head test-github-app --repo b4handjr/experimenter
 
   update_firefox_versions:
     machine:
@@ -890,7 +872,6 @@ workflows:
 
   build:
     jobs:
-      - test-github-bot
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:

--- a/.circleci/scripts/create_jwt.py
+++ b/.circleci/scripts/create_jwt.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+import sys
+import os
+import time
+
+import jwt
+import requests
+
+
+app_id = os.environ["GH_APP_ID"]
+installation_id = os.environ["GH_INSTALLATION_ID"]
+private_key = os.environ["GH_APP_PRIVATE_KEY"].replace("\\n", "\n")
+
+now = int(time.time())
+payload = {
+    "iat": now,
+    "exp": now + 540,
+    "iss": app_id
+}
+jwt_token = jwt.encode(payload, private_key, algorithm="RS256")
+
+# Get installation token
+headers = {
+    "Authorization": f"Bearer {jwt_token}",
+    "Accept": "application/vnd.github+json"
+}
+response = requests.post(
+    f"https://api.github.com/app/installations/{installation_id}/access_tokens",
+    headers=headers
+)
+token = response.json()["token"]
+print(token)


### PR DESCRIPTION
Because

- We need to switch to using a GitHub app to push from CircleCI for any automated GitHub interactions

This commit

- Adds the setup to use a GitHub App.

[Example PR on my fork](https://github.com/b4handjr/experimenter/pull/6)

Fixes #13206 