### PR TITLE
feat(nimbus): Add advanced targeting for Windows 10 Firefox VPN eligibility

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3065,6 +3065,27 @@ TOU_NOT_ACCEPTED_EXISTING_USER_ADS_ENABLED_MAC_OR_WIN = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WIN10_FIREFOX_VPN_ELIGIBLE = NimbusTargetingConfig(
+    name="Windows 10 users eligible for Firefox VPN",
+    slug="win10_firefox_vpn",
+    description=(
+        "Windows 10 users who are signed out, at least 7 days old, "
+        "no enterprise, default newtab, no adblock"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion == 10 && "
+        "isFxAEnabled && !isFxASignedIn && "
+        f"{NO_ENTERPRISE.targeting} && "
+        f"{PROFILEMORETHAN7DAYS} && "
+        "'network.proxy.type'|preferenceValue != 2 && "
+        '!("e6eb0d1e856335fc" in attachedFxAOAuthClients|mapToProperty("id"))'
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_VERSION = "version|versionCompare('{version}') >= 0"


### PR DESCRIPTION
Because

- We want to be able to target users that are on Window 10 and are not using a manual proxy or the Mozilla VPN.

This commit

- Adds the advanced targeting for users who are on Windows 10, are not signed in, not in enterprise, have at least a 7 day old profile, do not have a manual proxy set and have not used the Mozilla VPN.