### PR TITLE
fix(ui): build outcome doc links correctly

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1080,21 +1080,21 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         expected_primary_links = [
             (
                 "outcome1",
-                "https://mozilla.github.io/metric-hub/outcomes/firefox-desktop/outcome1",
+                "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/outcome1",
             ),
             (
                 "outcome2",
-                "https://mozilla.github.io/metric-hub/outcomes/firefox-desktop/outcome2",
+                "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/outcome2",
             ),
         ]
         expected_secondary_links = [
             (
                 "outcome3",
-                "https://mozilla.github.io/metric-hub/outcomes/firefox-desktop/outcome3",
+                "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/outcome3",
             ),
             (
                 "outcome4",
-                "https://mozilla.github.io/metric-hub/outcomes/firefox-desktop/outcome4",
+                "https://mozilla.github.io/metric-hub/outcomes/firefox_desktop/outcome4",
             ),
         ]
         expected_segment_links = [

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -237,11 +237,17 @@ class NimbusExperimentsListTableView(NimbusExperimentsListView):
 def build_experiment_context(experiment):
     outcome_doc_base_url = "https://mozilla.github.io/metric-hub/outcomes/"
     primary_outcome_links = [
-        (outcome, f"{outcome_doc_base_url}{experiment.application}/{outcome}")
+        (
+            outcome,
+            f"{outcome_doc_base_url}{experiment.application.replace('-', '_')}/{outcome}",
+        )
         for outcome in experiment.primary_outcomes
     ]
     secondary_outcome_links = [
-        (outcome, f"{outcome_doc_base_url}{experiment.application}/{outcome}")
+        (
+            outcome,
+            f"{outcome_doc_base_url}{experiment.application.replace('-', '_')}/{outcome}",
+        )
         for outcome in experiment.secondary_outcomes
     ]
 


### PR DESCRIPTION
Because

- the outcome docs links erroneously use the hyphenated application name

This commit

- replaces hyphens in the app name with underscores so the links work

Fixes #13111