### PR TITLE
chore(experimenter): require experimenter FML generated updates to be committed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,29 @@ jobs:
           destination: gs://ecosystem-test-eng-metrics/experimenter/coverage
           extension: json
 
+  check_local_feature_manifests:
+    machine:
+      image: ubuntu-2204:2024.11.1
+      docker_layer_caching: true
+    resource_class: xlarge
+    working_directory: ~/experimenter
+    steps:
+      - checkout
+      - check_file_paths:
+          paths: "experimenter/experimenter/features/manifests/|experimenter/manifesttool/"
+      - run:
+          name: Check local feature manifests
+          command: |
+            cp .env.sample .env
+            make feature_manifests FETCH_ARGS="--local-apps"
+            if ! git diff --quiet experimenter/experimenter/features/manifests/; then
+              echo 'Please commit generated updates to local feature manifests:'
+              echo
+              echo '    make feature_manifests FETCH_ARGS="--local-apps"'
+              echo
+              exit 1
+            fi
+
   check_schemas:
     machine:
       image: ubuntu-2204:2024.11.1
@@ -888,6 +911,12 @@ workflows:
           name: Check Cirrus x86_64
       - check_cirrus_aarch64:
           name: Check Cirrus aarch64
+      - check_local_feature_manifests:
+          name: Check Local Feature Manifests
+          filters:
+            branches:
+              ignore:
+                - main
       - check_schemas:
           name: Check Schemas
           filters:

--- a/experimenter/experimenter/features/manifests/apps.yaml
+++ b/experimenter/experimenter/features/manifests/apps.yaml
@@ -137,6 +137,5 @@ firefox_desktop:
 experimenter_cirrus:
   slug: "experimenter"
   repo:
-    type: "github"
-    name: "mozilla/experimenter"
-  fml_path: "experimenter/experimenter/features/manifests/experimenter/nimbus.fml.yaml"
+    type: "local"
+  fml_path: "experimenter/features/manifests/experimenter/nimbus.fml.yaml"

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -11,11 +11,12 @@ from manifesttool.version import Version
 class RepositoryType(str, Enum):
     HGMO = "hgmo"  # hg.mozilla.org
     GITHUB = "github"
+    LOCAL = "local"
 
 
 class Repository(BaseModel):
     type: RepositoryType
-    name: str
+    name: str | None = None
     default_branch: str = Field(default="main")
 
     @model_validator(mode="before")
@@ -25,6 +26,16 @@ class Repository(BaseModel):
 
         if ty == RepositoryType.HGMO and default_branch is None:
             raise ValueError("hg.mozilla.org-hosted repositories require default_branch")
+
+        return values
+
+    @model_validator(mode="before")
+    def validate_name(cls, values: dict[str, Any]):
+        ty = values.get("type")
+        name = values.get("name")
+
+        if ty != RepositoryType.LOCAL and name is None:
+            raise ValueError("non-local repositories require name")
 
         return values
 

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional, TextIO
 
 import yaml
-from mozilla_nimbus_schemas import DesktopFeatureManifest, SdkFeatureManifest
+from mozilla_nimbus_schemas import DesktopFeatureManifest
 
 from manifesttool import github_api, hgmo_api, nimbus_cli
 from manifesttool.appconfig import AppConfig, DiscoveryStrategyType, RepositoryType
@@ -17,13 +17,15 @@ from manifesttool.version import Version
 @dataclass
 class FetchResult:
     app_name: str
-    ref: Ref
+    ref: Optional[Ref]
     version: Optional[Version]
     exc: Optional[Exception] = None
     cached: bool = False
 
     def __str__(self):  # pragma: no cover
-        as_str = f"{self.app_name} at {self.ref} version {self.version}"
+        as_str = self.app_name
+        if self.ref is not None:
+            as_str += f" at {self.ref} version {self.version}"
 
         if self.exc:
             as_str += f"\n{format_exception(self.exc)}"
@@ -49,20 +51,29 @@ def fetch_fml_app(
     if version is not None and ref is None:
         raise ValueError("Cannot fetch specific version without a ref.")
 
-    result = FetchResult(app_name=app_name, ref=ref or Ref("main"), version=version)
+    is_local = app_config.repo.type == RepositoryType.LOCAL
+    if ref is not None and is_local:
+        raise ValueError("Cannot fetch specific ref for repository type local.")
+
+    if version is not None and is_local:
+        raise ValueError("Cannot fetch specific version for repository type local.")
+
+    result = FetchResult(app_name=app_name, ref=ref, version=version)
 
     try:
         # We could operate against "main" for all these calls, but the repository
         # state might change between subsequent calls. That would mean the generated
         # single file manifests could differ because they were based on different
         # commits.
-        if ref is None:
+        if ref is None and not is_local:
             ref = result.ref = github_api.resolve_branch(
                 app_config.repo.name, app_config.repo.default_branch
             )
 
         if version:
             print(f"fetch: {app_name} at {ref} version {version}")
+        elif is_local:
+            print(f"fetch: {app_name} from local")
         else:
             print(f"fetch: {app_name} at {ref}")
 
@@ -70,14 +81,18 @@ def fetch_fml_app(
             fml_path = app_config.fml_path
         elif isinstance(app_config.fml_path, list):
             for fml_path in app_config.fml_path:
-                if github_api.file_exists(app_config.repo.name, fml_path, ref.target):
+                if is_local:
+                    if Path(fml_path).exists():
+                        break
+                elif github_api.file_exists(app_config.repo.name, fml_path, ref.target):
                     break
             else:
+                suffix = "" if is_local else f" at {ref}"
                 raise Exception(
-                    f"Could not find a feature manifest for {app_name} at {ref}"
+                    f"Could not find a feature manifest for {app_name}{suffix}"
                 )
 
-        channels = nimbus_cli.get_channels(app_config, fml_path, ref.target)
+        channels = nimbus_cli.get_channels(app_config, fml_path, ref)
         print(f"fetch: {app_name}: channels are {', '.join(channels)}")
 
         if not channels:
@@ -94,7 +109,7 @@ def fetch_fml_app(
                 app_config,
                 fml_path,
                 channel,
-                ref.target,
+                ref,
                 version,
             )
 


### PR DESCRIPTION
Because

- Changes to experimenter's nimbus.fml.yaml should be included in PRs rather than deferred to the next automated manifest tool run.

This commit

- Changes manifest tool to use the local version of experimenter's nimbus.fml.yaml
- Adds a circleci job to check that generated fml for experimenter is up to date

Fixes #13171