### PR TITLE
bug(nimbus): fix intermittent labs test failures

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -3442,6 +3442,7 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
+            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
             firefox_min_version=version,
             is_firefox_labs_opt_in=True,
             is_rollout=True,
@@ -3475,6 +3476,7 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_137,
+            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
             is_firefox_labs_opt_in=True,
             is_rollout=is_rollout,
         )


### PR DESCRIPTION
Because

* We recently added some new validation and tests for firefox labs
* Separately we added a new firefox group with a minimum firefox version
* We forgot to affix the group in the labs validation tests, so intermittently the new group would be selected and fail the test

This commit

* Affixes a valid group in the new labs validation tests

fixes #13331

