### PR TITLE
bug(nimbus): Require Firefox Labs fields in factory

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -3446,9 +3446,11 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
-            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
             firefox_min_version=version,
             is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
             is_rollout=True,
         )
 
@@ -3481,6 +3483,8 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_137,
             firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
             is_firefox_labs_opt_in=True,
             is_rollout=is_rollout,
         )
@@ -3573,13 +3577,14 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_137,
             is_rollout=True,
-            **{
-                "firefox_labs_title": None,
-                "firefox_labs_description": None,
-                "firefox_labs_group": None,
-                **experiment_fields,
-            },
         )
+
+        # We cannot pass experiment_fields to the factory due to it enforcing
+        # required fields when is_firefox_labs=True.
+        for field, value in experiment_fields.items():
+            setattr(experiment, field, value)
+
+        experiment.save()
 
         serializer = NimbusReviewSerializer(
             experiment,

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -491,20 +491,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
         lambda o: random.choice(list(NimbusExperiment.QAStatus)).value
     )
     is_firefox_labs_opt_in = factory.LazyAttribute(lambda o: False)
-    firefox_labs_title = factory.LazyAttribute(
-        lambda o: faker.catch_phrase() if o.is_firefox_labs_opt_in else None
-    )
-    firefox_labs_description = factory.LazyAttribute(
-        lambda o: faker.catch_phrase() if o.is_firefox_labs_opt_in else None
-    )
     firefox_labs_description_links = factory.LazyAttribute(lambda o: "null")
-    firefox_labs_group = factory.LazyAttribute(
-        lambda o: (
-            random.choice(NimbusExperiment.FirefoxLabsGroups.choices)[0]
-            if o.is_firefox_labs_opt_in
-            else None
-        )
-    )
     requires_restart = factory.LazyAttribute(
         lambda o: (random.choice([True, False]) if o.is_firefox_labs_opt_in else False)
     )
@@ -648,14 +635,25 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
         *args,
         **kwargs,
     ):
-        experiment = super().create(*args, **kwargs)
-
         if branches is not None:
             raise factory.FactoryError(
                 "A NimbusExperiment factory can not specify branches at creation time, "
                 "please modify the branches that are created or delete them and add "
                 "new ones."
             )
+
+        if kwargs.get("is_firefox_labs_opt_in", False):
+            for field in (
+                "firefox_labs_title",
+                "firefox_labs_description",
+                "firefox_labs_group",
+            ):
+                if kwargs.get(field) is None:
+                    raise factory.FactoryError(
+                        f"The field {field} is required when is_firefox_labs_opt_in=True"
+                    )
+
+        experiment = super().create(*args, **kwargs)
 
         if excluded_experiments is not None:
             experiment.excluded_experiments.add(*excluded_experiments)

--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -286,9 +286,9 @@ class NimbusExperimentFilter(django_filters.FilterSet):
     def filter_type(self, queryset, name, value):
         query = Q()
         if TypeChoices.EXPERIMENT in value:
-            query |= Q(is_rollout=False)
+            query |= Q(is_rollout=False, is_firefox_labs_opt_in=False)
         if TypeChoices.ROLLOUT in value:
-            query |= Q(is_rollout=True)
+            query |= Q(is_rollout=True, is_firefox_labs_opt_in=False)
         if TypeChoices.LABS in value:
             query |= Q(is_firefox_labs_opt_in=True)
         return queryset.filter(query)

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -111,18 +111,19 @@ class TestHomeFilters(AuthTestCase):
         labs = NimbusExperimentFactory.create(
             owner=self.user,
             is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
             is_rollout=False,
             name="Labs One",
         )
         rollout = NimbusExperimentFactory.create(
             owner=self.user,
-            is_firefox_labs_opt_in=False,
             is_rollout=True,
             name="Rollout One",
         )
         experiment = NimbusExperimentFactory.create(
             owner=self.user,
-            is_firefox_labs_opt_in=False,
             is_rollout=False,
             name="Experiment One",
         )

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -2497,6 +2497,9 @@ class TestNimbusBranchesForm(RequestFormTestCase):
             feature_configs=[feature_config],
             is_rollout=True,
             is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group=NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING,
         )
         experiment.branches.all().delete()
         experiment.changes.all().delete()

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -251,25 +251,62 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
     @parameterized.expand(
         (
-            (TypeChoices.ROLLOUT, True, False),
-            (TypeChoices.EXPERIMENT, False, False),
-            (TypeChoices.LABS, False, True),
+            (
+                TypeChoices.ROLLOUT,
+                {"slug": "experiment", "is_rollout": True},
+                [
+                    {"slug": "rollout", "is_rollout": False},
+                    {
+                        "slug": "labs",
+                        "is_rollout": True,
+                        "is_firefox_labs_opt_in": True,
+                        "firefox_labs_title": "title",
+                        "firefox_labs_description": "description",
+                        "firefox_labs_group": (
+                            NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING
+                        ),
+                    },
+                ],
+            ),
+            (
+                TypeChoices.EXPERIMENT,
+                {"slug": "experiment"},
+                [
+                    {"slug": "rollout", "is_rollout": True},
+                    {
+                        "slug": "labs",
+                        "is_firefox_labs_opt_in": True,
+                        "firefox_labs_title": "title",
+                        "firefox_labs_description": "description",
+                        "firefox_labs_group": (
+                            NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING
+                        ),
+                    },
+                ],
+            ),
+            (
+                TypeChoices.LABS,
+                {
+                    "slug": "labs",
+                    "is_firefox_labs_opt_in": True,
+                    "firefox_labs_title": "title",
+                    "firefox_labs_description": "description",
+                    "firefox_labs_group": (
+                        NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING
+                    ),
+                },
+                [{"slug": "experiment"}, {"slug": "rollout", "is_rollout": True}],
+            ),
         )
     )
-    def test_filter_type(self, type_choice, is_rollout, is_labs):
+    def test_filter_type(self, type_choice, experiment_kwargs, other_experiments):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            is_rollout=is_rollout,
-            is_firefox_labs_opt_in=is_labs,
+            **experiment_kwargs,
         )
-        [
-            NimbusExperimentFactory.create(
-                status=NimbusExperiment.Status.LIVE,
-                is_rollout=(not is_rollout),
-                is_firefox_labs_opt_in=(not is_labs),
-            )
-            for _i in range(3)
-        ]
+
+        for kwargs in other_experiments:
+            NimbusExperimentFactory.create(status=NimbusExperiment.Status.LIVE, **kwargs)
 
         response = self.client.get(
             reverse("nimbus-list"),
@@ -3265,22 +3302,34 @@ class TestNimbusExperimentsHomeView(AuthTestCase):
         ]
         self.assertEqual(page1_names, sorted(names)[:6])
 
-    def test_home_type_display_returns_only_emoji(self):
-        labs = NimbusExperimentFactory.create(
-            owner=self.user, is_firefox_labs_opt_in=True
-        )
-        rollout = NimbusExperimentFactory.create(owner=self.user, is_rollout=True)
-        experiment = NimbusExperimentFactory.create(owner=self.user, is_rollout=False)
-
-        self.assertEqual(
-            labs.home_type_choice, NimbusConstants.HomeTypeChoices.LABS.label
-        )
-        self.assertEqual(
-            rollout.home_type_choice, NimbusConstants.HomeTypeChoices.ROLLOUT.label
-        )
-        self.assertEqual(
-            experiment.home_type_choice, NimbusConstants.HomeTypeChoices.EXPERIMENT.label
-        )
+    @parameterized.expand(
+        [
+            (
+                {
+                    "is_firefox_labs_opt_in": True,
+                    "firefox_labs_title": "title",
+                    "firefox_labs_description": "description",
+                    "firefox_labs_group": (
+                        NimbusExperiment.FirefoxLabsGroups.CUSTOMIZE_BROWSING
+                    ),
+                },
+                NimbusConstants.HomeTypeChoices.LABS.label,
+            ),
+            (
+                {"is_rollout": True},
+                NimbusConstants.HomeTypeChoices.ROLLOUT.label,
+            ),
+            (
+                {},
+                NimbusConstants.HomeTypeChoices.EXPERIMENT.label,
+            ),
+        ]
+    )
+    def test_home_type_display_returns_only_emoji(
+        self, experiment_kwargs, expected_label
+    ):
+        experiment = NimbusExperimentFactory.create(owner=self.user, **experiment_kwargs)
+        self.assertEqual(experiment.home_type_choice, expected_label)
 
 
 class TestSlugRedirectToSummary(AuthTestCase):


### PR DESCRIPTION
Because:

- we now have different Firefox Labs groups based on version;
- these fields are conditionally required only for Firefox Labs fields;
- we don't want to tie the NimbusExperiment factory too tightly to the
  NimbusReviewSerializer logic; and
- the validity of some fields depends on the version of the experiment

this commit:

- makes the `firefox_labs_title`, `firefox_labs_description`, and
  `firefox_labs_group` required fields when `is_firefox_labs=True` is
  passed to `NimbusExperimentFactory.create()` et al.

Fixes https://github.com/mozilla/experimenter/issues/13318