### PR TITLE
feat(nimbus): Improve filters type

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -474,14 +474,6 @@ class NimbusConstants:
         EXPERIMENT = "Experiment", "🔬 Experiment"
         LABS = "Labs", "🧪 Labs"
 
-        @property
-        def emoji(self):
-            return self.label.split(" ", 1)[0]
-
-        @property
-        def title(self):
-            return self.value
-
     class Version(models.TextChoices):
         @staticmethod
         def parse(version_str):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1511,17 +1511,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def home_type_choice(self):
-        mapping = {
-            "labs": NimbusConstants.HomeTypeChoices.LABS,
-            "rollout": NimbusConstants.HomeTypeChoices.ROLLOUT,
-            "experiment": NimbusConstants.HomeTypeChoices.EXPERIMENT,
-        }
+        match (self.is_firefox_labs_opt_in, self.is_rollout):
+            case (True, _):
+                return NimbusConstants.HomeTypeChoices.LABS
+            case (False, True):
+                return NimbusConstants.HomeTypeChoices.ROLLOUT
+            case (False, False):
+                return NimbusConstants.HomeTypeChoices.EXPERIMENT
 
-        if self.is_firefox_labs_opt_in:
-            return mapping["labs"]
-        if self.is_rollout:
-            return mapping["rollout"]
-        return mapping["experiment"]
 
     def get_home_type_display(self):
         return self.home_type_choice.label

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1511,18 +1511,20 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def home_type_choice(self):
-        return (
-            NimbusConstants.HomeTypeChoices.LABS
-            if self.is_firefox_labs_opt_in
-            else (
-                NimbusConstants.HomeTypeChoices.ROLLOUT
-                if self.is_rollout
-                else NimbusConstants.HomeTypeChoices.EXPERIMENT
-            )
-        )
+        mapping = {
+            "labs": NimbusConstants.HomeTypeChoices.LABS,
+            "rollout": NimbusConstants.HomeTypeChoices.ROLLOUT,
+            "experiment": NimbusConstants.HomeTypeChoices.EXPERIMENT,
+        }
+
+        if self.is_firefox_labs_opt_in:
+            return mapping["labs"]
+        if self.is_rollout:
+            return mapping["rollout"]
+        return mapping["experiment"]
 
     def get_home_type_display(self):
-        return self.home_type_choice.emoji
+        return self.home_type_choice.label
 
     @property
     def should_timeout(self):

--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -403,9 +403,9 @@ class NimbusExperimentsHomeFilter(django_filters.FilterSet):
     def filter_type(self, queryset, name, values):
         query = Q()
         for v in values:
-            t = NimbusConstants.HomeTypeChoices(v)
+            delivery_type = NimbusConstants.HomeTypeChoices(v)
 
-            match t:
+            match delivery_type:
                 case NimbusConstants.HomeTypeChoices.LABS:
                     query |= Q(is_firefox_labs_opt_in=True)
                 case NimbusConstants.HomeTypeChoices.ROLLOUT:

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -108,9 +108,7 @@
                         {% endif %}
                       </td>
                       <td>{{ experiment.get_application_display }}</td>
-                      <td>
-                        <span title="{{ experiment.home_type_choice.title }}">{{ experiment.get_home_type_display }}</span>
-                      </td>
+                      <td>{{ experiment.get_home_type_display }}</td>
                       <td>{{ experiment.get_channel_display }}</td>
                       <td>{{ experiment.population_percent|floatformat:2 }}%</td>
                       <td>

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -12,6 +12,7 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
+from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusExperiment,
     NimbusExperimentBranchThroughExcluded,
@@ -3271,9 +3272,15 @@ class TestNimbusExperimentsHomeView(AuthTestCase):
         rollout = NimbusExperimentFactory.create(owner=self.user, is_rollout=True)
         experiment = NimbusExperimentFactory.create(owner=self.user, is_rollout=False)
 
-        self.assertEqual(labs.get_home_type_display(), "🧪")
-        self.assertEqual(rollout.get_home_type_display(), "📈")
-        self.assertEqual(experiment.get_home_type_display(), "🔬")
+        self.assertEqual(
+            labs.get_home_type_display(), NimbusConstants.HomeTypeChoices.LABS
+        )
+        self.assertEqual(
+            rollout.get_home_type_display(), NimbusConstants.HomeTypeChoices.ROLLOUT
+        )
+        self.assertEqual(
+            experiment.get_home_type_display(), NimbusConstants.HomeTypeChoices.EXPERIMENT
+        )
 
 
 class TestSlugRedirectToSummary(AuthTestCase):


### PR DESCRIPTION
Because

- We are only showing the icon for the type in my delivery table, we should show the icon with the type name 

This commit

- Shows icon and type name in a column
- Improved variable name
- Uses match case to check the type

Fixes #13334 