### PR TITLE
feature(nimbus): Add feature page callout and title.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -91,6 +91,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             <a href="https://experimenter.info/for-product">Learn</a> how to get started.
         """,
     }
+    # TODO: Add learn more URL for feature page (EXP-5876)
     FEATURE_PAGE_LINKS = {"feature_learn_more_url": ""}
 
     class ReviewRequestMessages(Enum):

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -91,6 +91,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             <a href="https://experimenter.info/for-product">Learn</a> how to get started.
         """,
     }
+    FEATURE_PAGE_LINKS = {"feature_learn_more_url": ""}
 
     class ReviewRequestMessages(Enum):
         END_EXPERIMENT = "end this experiment"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -3,21 +3,8 @@
 {% block content %}
   <div id="feature-page" class="bg-body-tertiary py-4">
     <div class="container">
-      <div class="card shadow-sm border-0 p-4 mb-4">
-        <div class="d-flex flex-column align-items-center text-center justify-content-center">
-          <div id="feature-page-banner" class="text-center">
-            <h3 id="feature-page-welcome-message" class="fw-semibold mb-1">
-              Welcome to your Feature Health Dashboard, {{ request.user }}!
-            </h3>
-            <p class="fw-semibold mb-2 text-muted fs-6">Track a feature's Nimbus history and QA status in this summary view!</p>
-            <a href="{{ links.feature_learn_more_url }}"
-               id="feature-page-learn-more-link"
-               class="btn btn-primary btn-sm"
-               target="_blank"
-               rel="noopener noreferrer">Learn More</a>
-          </div>
-        </div>
-      </div>
+      {% include "nimbus_experiments/heading_card.html" with page_name="feature" heading_text="Welcome to your Feature Health Dashboard," subheading_text="Track a feature's Nimbus history and QA status in this summary view!" link_url=links.feature_learn_more_url btn_text="Learn More" %}
+
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -2,6 +2,22 @@
 
 {% block content %}
   <div id="feature-page" class="bg-body-tertiary py-4">
-    <div class="container"></div>
+    <div class="container">
+      <div class="card shadow-sm border-0 p-4 mb-4">
+        <div class="d-flex flex-column align-items-center text-center justify-content-center">
+          <div id="feature-page-banner" class="text-center">
+            <h3 id="feature-page-welcome-message" class="fw-semibold mb-1">
+              Welcome to your Feature Health Dashboard, {{ request.user }}!
+            </h3>
+            <p class="fw-semibold mb-2 text-muted fs-6">Track a feature's Nimbus history and QA status in this summary view!</p>
+            <a href="{{ links.feature_learn_more_url }}"
+               id="feature-page-learn-more-link"
+               class="btn btn-primary btn-sm"
+               target="_blank"
+               rel="noopener noreferrer">Learn More</a>
+          </div>
+        </div>
+      </div>
+    </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/heading_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/heading_card.html
@@ -1,0 +1,14 @@
+<div id="{{ page_name }}-page-card"
+     class="card shadow-sm border-0 p-4 mb-4">
+  <div class="d-flex flex-column align-items-center text-center justify-content-center">
+    <div id="{{ page_name }}-page-banner" class="text-center">
+      <h3 id="{{ page_name }}-page-heading-message" class="fw-semibold mb-1">{{ heading_text }} {{ request.user }}!</h3>
+      <p class="fw-semibold mb-2 text-muted fs-6">{{ subheading_text }}</p>
+      <a href="{{ link_url }}"
+         id="{{ page_name }}-page-learn-more-link"
+         class="btn btn-primary btn-sm"
+         target="_blank"
+         rel="noopener noreferrer">{{ btn_text }}</a>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -635,6 +635,11 @@ class NimbusFeaturesView(FilterView):
     def get_queryset(self):
         return NimbusFeatureConfig.objects.filter().order_by("-name")
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["links"] = NimbusUIConstants.FEATURE_PAGE_LINKS
+        return context
+
 
 class NimbusExperimentsHomeView(FilterView):
     template_name = "nimbus_experiments/home.html"


### PR DESCRIPTION
Because

- The feature page needs a headingand a title (duhh)

This commit

- Adds the heading and title to the feature health page.

Fixes #13340 