### PR TITLE
chore(nimbus): lint and format experimenter/manifesttool/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,8 @@ JS_TEST_LEGACY = yarn workspace @experimenter/core test
 JS_TEST_RESULTS = DEBUG_PRINT_LIMIT=999999 CI=yes yarn workspace @experimenter/results test:cov
 RESULTS_SCHEMA_CHECK = python manage.py graphql_schema --out experimenter/results/test_schema.graphql&&diff experimenter/results/test_schema.graphql experimenter/results/schema.graphql || (echo GraphQL Schema is out of sync please run make generate_types;exit 1)
 RESULTS_TYPES_GENERATE = python manage.py graphql_schema --out experimenter/results/schema.graphql&&yarn workspace @experimenter/results generate-types
-RUFF_CHECK = ruff check experimenter/ tests/
-RUFF_FIX = ruff check --fix experimenter/ tests/
+RUFF_CHECK = ruff check experimenter/ manifesttool/ tests/
+RUFF_FIX = ruff check --fix experimenter/ manifesttool/ tests/
 RUFF_FORMAT_CHECK = ruff format --check --diff . --exclude node_modules
 RUFF_FORMAT_FIX = ruff format . --exclude node_modules
 CHECK_DOCS = python manage.py generate_docs --check=true

--- a/experimenter/manifesttool/appconfig.py
+++ b/experimenter/manifesttool/appconfig.py
@@ -20,6 +20,7 @@ class Repository(BaseModel):
     default_branch: str = Field(default="main")
 
     @model_validator(mode="before")
+    @classmethod
     def validate_default_branch(cls, values: dict[str, Any]):
         ty = values.get("type")
         default_branch = values.get("default_branch")
@@ -30,6 +31,7 @@ class Repository(BaseModel):
         return values
 
     @model_validator(mode="before")
+    @classmethod
     def validate_name(cls, values: dict[str, Any]):
         _type = values.get("type")
         name = values.get("name")
@@ -162,6 +164,7 @@ class AppConfig(BaseModel):
     release_discovery: ReleaseDiscovery | None = None
 
     @model_validator(mode="before")
+    @classmethod
     def validate_one_manifest_path(cls, values):
         has_fml_path = values.get("fml_path") is not None
         has_legacy_path = values.get("experimenter_yaml_path") is not None

--- a/experimenter/manifesttool/cli.py
+++ b/experimenter/manifesttool/cli.py
@@ -96,7 +96,7 @@ def fetch(
         elif app_config.experimenter_yaml_path is not None:
             results.append(fetch_legacy_app(context.manifest_dir, app_name, app_config))
         else:  # pragma: no cover
-            assert False, "unreachable"
+            raise AssertionError("unreachable")
 
         if app_config.release_discovery:
             ref_cache_path = app_dir / ".ref-cache.yaml"

--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -240,7 +240,7 @@ def fetch_releases(
         else:  # pragma: no cover
             raise AssertionError("unreachable")
 
-    if app_config.fml_path:
+    if app_config.fml_path:  # noqa: SIM108
         fetch_app = fetch_fml_app
     else:
         fetch_app = fetch_legacy_app

--- a/experimenter/manifesttool/github_api.py
+++ b/experimenter/manifesttool/github_api.py
@@ -1,13 +1,13 @@
 import os
+from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Generator, TYPE_CHECKING, Optional, overload
+from typing import Any, Optional, overload
 
 import requests
 
 from manifesttool import download
 from manifesttool.http import http_client
 from manifesttool.repository import Ref
-
 
 GITHUB_API_URL = "https://api.github.com"
 GITHUB_API_HEADERS = {
@@ -37,7 +37,9 @@ def api_request(
 
 
 def paginated_api_request(path: str, per_page: int = 100) -> Generator[Any, None, None]:
-    """Make several reqeusts to a paginated API resource and yield each page of results."""
+    """Make several reqeusts to a paginated API resource and yield each page of
+    results.
+    """
     page = 1
 
     while True:

--- a/experimenter/manifesttool/releases.py
+++ b/experimenter/manifesttool/releases.py
@@ -92,7 +92,7 @@ def discover_branched_releases(
     elif app_config.repo.type == RepositoryType.HGMO:
         resolve_branch = hgmo_api.resolve_branch
     else:  # pragma: no cover
-        raise AssertionError()
+        raise AssertionError
 
     # If there are no branches listed, we will only scan the default branch.
     branches = strategy.branches

--- a/experimenter/manifesttool/repository.py
+++ b/experimenter/manifesttool/repository.py
@@ -2,8 +2,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
-from pydantic import BaseModel, Field, RootModel
 import yaml
+from pydantic import Field, RootModel
 
 
 @dataclass

--- a/experimenter/manifesttool/tests/test_cli.py
+++ b/experimenter/manifesttool/tests/test_cli.py
@@ -32,7 +32,7 @@ def make_app_configs(app_configs: list[AppConfig]) -> AppConfigs:
 
 
 @contextmanager
-def cli_runner(*, app_configs: AppConfig, manifest_path: Path = Path(".")):
+def cli_runner(*, app_configs: AppConfig, manifest_path: Path = Path()):
     """Create a CliRunner with an isolated filesystem.
 
     The given AppConfigs will be written to disk before yielding the runner.
@@ -41,7 +41,8 @@ def cli_runner(*, app_configs: AppConfig, manifest_path: Path = Path(".")):
     runner = CliRunner()
     with runner.isolated_filesystem():
         with manifest_path.joinpath("apps.yaml").open("w") as f:
-            # We can't use app_configs.dict() because it will not translate Enums to strings.
+            # We can't use app_configs.dict() because it will not translate
+            # Enums to strings.
             as_json = app_configs.json()
             as_dict = json.loads(as_json)
 
@@ -68,13 +69,19 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
         fetch_fml_app.assert_called_with(
-            Path("."),
+            Path(),
             "fml_app",
             FML_APP_CONFIG,
         )
 
         self.assertIn(
-            "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved) version None\n",
+            """\
+SUMMARY:
+
+SUCCESS:
+
+fml_app at main (resolved) version None
+""",
             result.stdout,
         )
 
@@ -96,7 +103,14 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 1, result.exception or result.stdout)
 
         self.assertIn(
-            "SUMMARY:\n\nFAILURES:\n\nfml_app at main version None\nException: Connection error\n",
+            """\
+SUMMARY:
+
+FAILURES:
+
+fml_app at main version None
+Exception: Connection error
+""",
             result.stdout,
         )
 
@@ -118,13 +132,19 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
         fetch_legacy_app.assert_called_with(
-            Path("."),
+            Path(),
             "legacy_app",
             LEGACY_APP_CONFIG,
         )
 
         self.assertIn(
-            "SUMMARY:\n\nSUCCESS:\n\nlegacy_app at tip (resolved) version None\n",
+            """\
+SUMMARY:
+
+SUCCESS:
+
+legacy_app at tip (resolved) version None
+""",
             result.stdout,
         )
 
@@ -146,7 +166,14 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 1, result.exception or result.stdout)
 
         self.assertIn(
-            "SUMMARY:\n\nFAILURES:\n\nlegacy_app at tip version None\nException: Connection error\n",
+            """\
+SUMMARY:
+
+FAILURES:
+
+legacy_app at tip version None
+Exception: Connection error
+""",
             result.stdout,
         )
 
@@ -203,7 +230,7 @@ class CliTests(TestCase):
         # object that the mock cached. Hence, we need to provide the filled out
         # cache to this assertion.
         fetch_releases.assert_called_once_with(
-            Path("."),
+            Path(),
             "fml_app",
             app_config,
             cache,
@@ -280,7 +307,7 @@ class CliTests(TestCase):
         self.assertEqual(result.exit_code, 0, result.exception or result.stdout)
 
         fetch_legacy_app.assert_not_called()
-        fetch_fml_app.assert_called_once_with(Path("."), "fml_app", FML_APP_CONFIG)
+        fetch_fml_app.assert_called_once_with(Path(), "fml_app", FML_APP_CONFIG)
 
         self.assertIn(
             "SUMMARY:\n\nSUCCESS:\n\nfml_app at main (resolved) version None\n\n",

--- a/experimenter/manifesttool/tests/test_exception_utils.py
+++ b/experimenter/manifesttool/tests/test_exception_utils.py
@@ -23,25 +23,29 @@ class ExceptionUtilsTests(TestCase):
         [
             (
                 CalledProcessError(1, ["/bin/bogus"]),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n",
+                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n",  # noqa: E501
             ),
             (
                 CalledProcessError(1, ["/bin/bogus"], output=b"stdout"),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
-                "\n"
-                "stdout:\n"
-                "-----\n"
-                "stdout\n"
-                "-----\n",
+                """\
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.
+
+stdout:
+-----
+stdout
+-----
+""",
             ),
             (
                 CalledProcessError(1, ["/bin/bogus"], stderr=b"stderr"),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
-                "\n"
-                "stderr:\n"
-                "-----\n"
-                "stderr\n"
-                "-----\n",
+                """\
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.
+
+stderr:
+-----
+stderr
+-----
+""",
             ),
             (
                 CalledProcessError(
@@ -50,47 +54,53 @@ class ExceptionUtilsTests(TestCase):
                     output=b"multi-line\nstdout\n",
                     stderr=b"multi-line\nstderr\n",
                 ),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
-                "\n"
-                "stdout:\n"
-                "-----\n"
-                "multi-line\n"
-                "stdout\n"
-                "-----\n"
-                "\n"
-                "stderr:\n"
-                "-----\n"
-                "multi-line\n"
-                "stderr\n"
-                "-----\n",
+                """\
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.
+
+stdout:
+-----
+multi-line
+stdout
+-----
+
+stderr:
+-----
+multi-line
+stderr
+-----
+""",
             ),
             (
                 CalledProcessError(1, ["/bin/bogus"], output=b"\xff", stderr=b"stderr"),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.\n"
-                "\n"
-                "stdout:\n"
-                "-----\n"
-                "b'\\xff'\n"
-                "-----\n"
-                "\n"
-                "stderr:\n"
-                "-----\n"
-                "stderr\n"
-                "-----\n",
+                """\
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 1.
+
+stdout:
+-----
+b'\\xff'
+-----
+
+stderr:
+-----
+stderr
+-----
+""",
             ),
             (
                 CalledProcessError(2, ["/bin/bogus"], output=b"stdout", stderr=b"\xff"),
-                "subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 2.\n"
-                "\n"
-                "stdout:\n"
-                "-----\n"
-                "stdout\n"
-                "-----\n"
-                "\n"
-                "stderr:\n"
-                "-----\n"
-                "b'\\xff'\n"
-                "-----\n",
+                """\
+subprocess.CalledProcessError: Command '['/bin/bogus']' returned non-zero exit status 2.
+
+stdout:
+-----
+stdout
+-----
+
+stderr:
+-----
+b'\\xff'
+-----
+""",
             ),
         ],
     )
@@ -112,8 +122,8 @@ class ExceptionUtilsTests(TestCase):
         # Replace the line number in the test so that we don't have to update
         # this test if line numbers change.
         formatted = re.sub(
-            r"""File "/experimenter/manifesttool/tests/test_exception_utils.py", line \d+, in test_format_exception_tb""",
-            """File "/experimenter/manifesttool/tests/test_exception_utils.py", line 0000, in test_format_exception_tb""",
+            r"""File "/experimenter/manifesttool/tests/test_exception_utils.py", line \d+, in test_format_exception_tb""",  # noqa: E501
+            """File "/experimenter/manifesttool/tests/test_exception_utils.py", line 0000, in test_format_exception_tb""",  # noqa: E501
             format_exception(exc),
         )
 
@@ -136,6 +146,6 @@ this
 is
 stderr
 -----
-"""
+"""  # noqa: E501
 
         self.assertEqual(formatted, expected)

--- a/experimenter/manifesttool/tests/test_github_api.py
+++ b/experimenter/manifesttool/tests/test_github_api.py
@@ -76,7 +76,7 @@ class GitHubApiTests(TestCase):
             status=403,
             body="do not try to json parse this",
         )
-        with self.assertRaisesRegex(Exception, "GitHub API rate limit exceeded") as e:
+        with self.assertRaisesRegex(Exception, "GitHub API rate limit exceeded"):
             github_api.resolve_branch("owner/repo", "main")
 
     @responses.activate

--- a/experimenter/manifesttool/tests/test_repository.py
+++ b/experimenter/manifesttool/tests/test_repository.py
@@ -1,6 +1,6 @@
 from pathlib import Path
-from unittest import TestCase
 from tempfile import TemporaryDirectory
+from unittest import TestCase
 
 import yaml
 

--- a/experimenter/manifesttool/tests/test_version.py
+++ b/experimenter/manifesttool/tests/test_version.py
@@ -3,8 +3,8 @@ from unittest import TestCase
 
 import responses
 from parameterized import parameterized
-from responses import matchers
 from pydantic import BaseModel, ValidationError
+from responses import matchers
 
 from manifesttool.appconfig import (
     AppConfig,
@@ -356,7 +356,7 @@ class VersionTests(TestCase):
             model = VersionModel.parse_obj(obj)
             self.assertEqual(model.version, expected)
         else:
-            with self.assertRaisesRegex(ValidationError, f"Invalid version {repr(s)}"):
+            with self.assertRaisesRegex(ValidationError, f"Invalid version {s!r}"):
                 VersionModel.parse_obj(obj)
 
     @parameterized.expand(

--- a/experimenter/manifesttool/version.py
+++ b/experimenter/manifesttool/version.py
@@ -2,17 +2,18 @@ from __future__ import annotations
 
 import plistlib
 import re
+from collections.abc import Iterable
 from dataclasses import dataclass
-from pydantic import ValidationInfo
-from typing import Any, Iterable, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
+from pydantic import ValidationInfo
 from requests import HTTPError
 
 from manifesttool import github_api, hgmo_api
 from manifesttool.repository import Ref
 
 if TYPE_CHECKING:  # pragma: no cover
-    from manifesttool.appconfig import AppConfig, Repository, VersionFile
+    from manifesttool.appconfig import AppConfig, VersionFile
 
 
 @dataclass
@@ -29,7 +30,7 @@ class Version:
     patch: int = 0
 
     @classmethod
-    def from_match(cls, groups: dict[str, str]) -> "Version":
+    def from_match(cls, groups: dict[str, str]) -> Version:
         """Parse a Version out of regular expression match groups.
 
         Args:
@@ -52,7 +53,7 @@ class Version:
     VERSION_RE = re.compile(r"^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<patch>\d+))?)?")
 
     @classmethod
-    def parse(cls, s: str) -> Optional["Version"]:
+    def parse(cls, s: str) -> Optional[Version]:
         """Parse a version out of a given string.
 
         Any missing component will be assumed zero.
@@ -71,16 +72,16 @@ class Version:
     def __hash__(self) -> int:
         return hash(self.as_tuple())
 
-    def __lt__(self, other: "Version") -> bool:
+    def __lt__(self, other: Version) -> bool:
         return self.as_tuple() < other.as_tuple()
 
-    def __le__(self, other: "Version") -> bool:
+    def __le__(self, other: Version) -> bool:
         return self.as_tuple() <= other.as_tuple()
 
-    def __gt__(self, other: "Version") -> bool:
+    def __gt__(self, other: Version) -> bool:
         return self.as_tuple() > other.as_tuple()
 
-    def __ge__(self, other: "Version") -> bool:
+    def __ge__(self, other: Version) -> bool:
         return self.as_tuple() >= other.as_tuple()
 
     def __str__(self):  # pragma: no cover
@@ -102,7 +103,7 @@ class Version:
         if version := cls.parse(value):
             return version
 
-        raise ValueError(f"Invalid version {repr(value)}")
+        raise ValueError(f"Invalid version {value!r}")
 
 
 def find_versioned_refs(
@@ -234,7 +235,8 @@ def resolve_ref_versions(
                 break
         else:
             raise Exception(
-                f"Could not find version file for app {app_config.slug} at ref {ref.name} ({ref.target})"
+                f"Could not find version file for app {app_config.slug} at ref "
+                f"{ref.name} ({ref.target})"
             )
 
     return versions


### PR DESCRIPTION
Because:

- our existing ruff format and lint tasks were not linting and formatting the manifesttool/ directory

this commit:

- updates those tasks; and
- reformats manifesttool and addresses all lints.

Fixes #13343