### PR TITLE
feat(nimbus): sort by merged channel and channels in list views

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -18,7 +18,7 @@ from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
 from django.db import models
-from django.db.models import Count, F, Q, QuerySet
+from django.db.models import Case, Count, F, Q, QuerySet, When
 from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
@@ -131,6 +131,15 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
         return self.for_collection(
             self.filter(NimbusExperiment.Filters.IS_ENDING, application__in=applications),
             collection,
+        )
+
+    def with_merged_channel(self):
+        return self.get_queryset().annotate(
+            merged_channel=Case(
+                When(Q(channel__isnull=False) & ~Q(channel=""), then=F("channel")),
+                default=F("channels__0"),
+                output_field=models.CharField(),
+            )
         )
 
 

--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -59,8 +59,8 @@ class SortChoices(models.TextChoices):
     QA_DOWN = "-qa_status"
     APPLICATION_UP = "application"
     APPLICATION_DOWN = "-application"
-    CHANNEL_UP = "channel"
-    CHANNEL_DOWN = "-channel"
+    CHANNEL_UP = "merged_channel"
+    CHANNEL_DOWN = "-merged_channel"
     SIZE_UP = "population_percent"
     SIZE_DOWN = "-population_percent"
     FEATURES_UP = "feature_configs__slug"
@@ -263,7 +263,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ]
 
     def filter_sort(self, queryset, name, value):
-        return queryset.order_by(value)
+        return queryset.order_by(value, "slug")
 
     def filter_status(self, queryset, name, value):
         return queryset.filter(STATUS_FILTERS[value](self.request))
@@ -328,8 +328,8 @@ class HomeSortChoices(models.TextChoices):
     APPLICATION_DOWN = "-application", "Application"
     TYPE_UP = "is_rollout", "Type"
     TYPE_DOWN = "-is_rollout", "Type"
-    CHANNEL_UP = "channel", "Channel"
-    CHANNEL_DOWN = "-channel", "Channel"
+    CHANNEL_UP = "merged_channel", "Channel"
+    CHANNEL_DOWN = "-merged_channel", "Channel"
     SIZE_UP = "population_percent", "Size"
     SIZE_DOWN = "-population_percent", "Size"
     DATES_UP = "_start_date", "Dates"
@@ -406,7 +406,7 @@ class NimbusExperimentsHomeFilter(django_filters.FilterSet):
                 return queryset  # Default = All Deliveries
 
     def filter_sort(self, queryset, name, value):
-        return queryset.order_by(value)
+        return queryset.order_by(value, "slug")
 
     def filter_type(self, queryset, name, values):
         query = Q()

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -226,6 +226,7 @@ class TestHomeFilters(AuthTestCase):
             application=NimbusExperiment.Application.FENIX,
             is_rollout=False,
             channel=NimbusExperiment.Channel.BETA,
+            channels=[],
             population_percent=5,
             firefox_min_version=120,
         )
@@ -234,7 +235,8 @@ class TestHomeFilters(AuthTestCase):
             name="Z High",
             application=NimbusExperiment.Application.DESKTOP,
             is_rollout=True,
-            channel=NimbusExperiment.Channel.RELEASE,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             population_percent=50,
             firefox_min_version=130,
         )

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -802,12 +802,32 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
     def test_sort_by_channel(self):
         experiment1 = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="desktop-beta",
             status=NimbusExperiment.Status.LIVE,
-            channel=NimbusExperiment.Channel.BETA,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.BETA],
         )
         experiment2 = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="desktop-release",
+            status=NimbusExperiment.Status.LIVE,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
+        )
+        experiment3 = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.FENIX,
+            slug="fenix-beta",
+            status=NimbusExperiment.Status.LIVE,
+            channel=NimbusExperiment.Channel.BETA,
+            channels=[],
+        )
+        experiment4 = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.FENIX,
+            slug="fenix-release",
             status=NimbusExperiment.Status.LIVE,
             channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
         )
 
         response = self.client.get(
@@ -819,7 +839,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
-            [experiment1.slug, experiment2.slug],
+            [experiment1.slug, experiment3.slug, experiment2.slug, experiment4.slug],
         )
 
         response = self.client.get(
@@ -831,7 +851,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
-            [experiment2.slug, experiment1.slug],
+            [experiment2.slug, experiment4.slug, experiment1.slug, experiment3.slug],
         )
 
     def test_sort_by_size(self):

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -176,7 +176,7 @@ class NimbusChangeLogsView(
 
 class NimbusExperimentsListView(NimbusExperimentViewMixin, FilterView):
     queryset = (
-        NimbusExperiment.objects.all()
+        NimbusExperiment.objects.with_merged_channel()
         .order_by("-_updated_date_time")
         .prefetch_related("feature_configs")
     )
@@ -648,7 +648,8 @@ class NimbusExperimentsHomeView(FilterView):
 
     def get_queryset(self):
         return (
-            NimbusExperiment.objects.filter(is_archived=False)
+            NimbusExperiment.objects.with_merged_channel()
+            .filter(is_archived=False)
             .filter(Q(owner=self.request.user) | Q(subscribers=self.request.user))
             .distinct()
             .order_by("-_updated_date_time")


### PR DESCRIPTION
Becuase

* We now have two fields for storing the channel(s) of an experiment
* To be able to sort by channel we need to combine those into a single field that can be sorted on

This commit

* Adds a query annotation called merged_channel that combines channel and channels
* Updates the landing and new home page sort fields to sort on that field
* Updates tests

fixes #13357

