### PR TITLE
feat(nimbus): add channels to v7/v8 api

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -4170,6 +4170,10 @@
             ],
             "type": "string"
           },
+          "channels": {
+            "type": "string",
+            "readOnly": true
+          },
           "userFacingName": {
             "type": "string",
             "readOnly": true

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -4182,6 +4182,10 @@
             ],
             "type": "string"
           },
+          "channels": {
+            "type": "string",
+            "readOnly": true
+          },
           "userFacingName": {
             "type": "string",
             "readOnly": true

--- a/experimenter/experimenter/experiments/api/v7/serializers.py
+++ b/experimenter/experimenter/experiments/api/v7/serializers.py
@@ -53,6 +53,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     appName = serializers.SerializerMethodField()
     appId = serializers.SerializerMethodField()
     branches = NimbusBranchSerializer(many=True)
+    channels = serializers.SerializerMethodField()
     userFacingName = serializers.ReadOnlyField(source="name")
     userFacingDescription = serializers.ReadOnlyField(source="public_description")
     isEnrollmentPaused = serializers.ReadOnlyField(source="is_paused")
@@ -88,6 +89,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "appName",
             "appId",
             "channel",
+            "channels",
             "userFacingName",
             "userFacingDescription",
             "isEnrollmentPaused",
@@ -119,6 +121,13 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
 
     def get_appId(self, obj):
         return obj.application_config.channel_app_id.get(obj.channel, "")
+
+    def get_channels(self, obj):
+        if obj.channels:
+            return obj.channels
+        elif obj.channel:
+            return [obj.channel]
+        return []
 
     def get_featureIds(self, obj):
         return sorted(

--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -92,6 +92,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     appName = serializers.SerializerMethodField()
     appId = serializers.SerializerMethodField()
     branches = serializers.SerializerMethodField()
+    channels = serializers.SerializerMethodField()
     userFacingName = serializers.ReadOnlyField(source="name")
     userFacingDescription = serializers.ReadOnlyField(source="public_description")
     isEnrollmentPaused = serializers.ReadOnlyField(source="is_paused")
@@ -131,6 +132,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "appName",
             "appId",
             "channel",
+            "channels",
             "userFacingName",
             "userFacingDescription",
             "isEnrollmentPaused",
@@ -177,6 +179,13 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             serializer_cls = NimbusBranchSerializerMobile
 
         return serializer_cls(obj.branches.all(), many=True).data
+
+    def get_channels(self, obj):
+        if obj.channels:
+            return obj.channels
+        elif obj.channel:
+            return [obj.channel]
+        return []
 
     def get_featureIds(self, obj):
         return sorted(

--- a/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v7/test_serializers.py
@@ -24,7 +24,7 @@ class TestNimbusExperimentSerializer(TestCase):
             {"en-us": {"corge": "grault"}},
         ]
     )
-    def test_serializer_outputs_expected_schema(self, localizations):
+    def test_serializer_outputs_expected_schema_desktop(self, localizations):
         locale_en_us = LocaleFactory.create(code="en-US")
         application = NimbusExperiment.Application.DESKTOP
         feature1 = NimbusFeatureConfigFactory.create(application=application)
@@ -35,8 +35,8 @@ class TestNimbusExperimentSerializer(TestCase):
             application=application,
             firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
             feature_configs=[feature1, feature2],
-            channel=NimbusExperiment.Channel.NIGHTLY,
-            channels=[],
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
             primary_outcomes=["foo", "bar", "baz"],
             secondary_outcomes=["quux", "xyzzy"],
             locales=[locale_en_us],
@@ -66,7 +66,8 @@ class TestNimbusExperimentSerializer(TestCase):
                 "application": "firefox-desktop",
                 "appName": "firefox_desktop",
                 "appId": "firefox-desktop",
-                "channel": "nightly",
+                "channel": "",
+                "channels": ["nightly"],
                 # DRF manually replaces the isoformat suffix so we have to do the same
                 "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
                 "enrollmentEndDate": (
@@ -84,7 +85,7 @@ class TestNimbusExperimentSerializer(TestCase):
                 "schemaVersion": settings.NIMBUS_SCHEMA_VERSION,
                 "slug": experiment.slug,
                 "targeting": (
-                    f'(browserSettings.update.channel == "nightly") '
+                    f'(browserSettings.update.channel in ["nightly"]) '
                     f"&& (version|versionCompare('{min_required_version}') >= 0) "
                     f"&& (locale in ['en-US'])"
                 ),
@@ -141,6 +142,125 @@ class TestNimbusExperimentSerializer(TestCase):
                 },
                 branches_data,
             )
+
+    def test_serializer_outputs_expected_schema_mobile(self):
+        locale_en_us = LocaleFactory.create(code="en-US")
+        application = NimbusExperiment.Application.FENIX
+        feature1 = NimbusFeatureConfigFactory.create(application=application)
+        feature2 = NimbusFeatureConfigFactory.create(application=application)
+        documentation_link = NimbusDocumentationLinkFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
+            feature_configs=[feature1, feature2],
+            channel=NimbusExperiment.Channel.NIGHTLY,
+            channels=[],
+            primary_outcomes=["foo", "bar", "baz"],
+            secondary_outcomes=["quux", "xyzzy"],
+            locales=[locale_en_us],
+            _enrollment_end_date=datetime.date(2022, 1, 5),
+            documentation_links=[documentation_link],
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        experiment_data = serializer.data.copy()
+        bucket_data = dict(experiment_data.pop("bucketConfig"))
+        branches_data = [dict(b) for b in experiment_data.pop("branches")]
+        feature_ids_data = experiment_data.pop("featureIds")
+
+        self.assertIsNotNone(experiment.start_date)
+        self.assertIsNotNone(experiment.actual_enrollment_end_date)
+        self.assertIsNotNone(experiment.end_date)
+
+        expected_experiment_data = {
+            "arguments": {},
+            "application": "org.mozilla.fenix",
+            "appName": "fenix",
+            "appId": "org.mozilla.fenix",
+            "channel": "nightly",
+            "channels": ["nightly"],
+            # DRF manually replaces the isoformat suffix so we have to do the same
+            "startDate": experiment.start_date.isoformat().replace("+00:00", "Z"),
+            "enrollmentEndDate": (
+                experiment.actual_enrollment_end_date.isoformat().replace("+00:00", "Z")
+            ),
+            "endDate": experiment.end_date.isoformat().replace("+00:00", "Z"),
+            "id": experiment.slug,
+            "isEnrollmentPaused": True,
+            "isRollout": False,
+            "proposedDuration": experiment.proposed_duration,
+            "proposedEnrollment": experiment.proposed_enrollment,
+            "referenceBranch": experiment.reference_branch.slug,
+            "schemaVersion": settings.NIMBUS_SCHEMA_VERSION,
+            "slug": experiment.slug,
+            "targeting": "(locale in ['en-US'])",
+            "userFacingDescription": experiment.public_description,
+            "userFacingName": experiment.name,
+            "probeSets": [],
+            "outcomes": [
+                {"priority": "primary", "slug": "foo"},
+                {"priority": "primary", "slug": "bar"},
+                {"priority": "primary", "slug": "baz"},
+                {"priority": "secondary", "slug": "quux"},
+                {"priority": "secondary", "slug": "xyzzy"},
+            ],
+            "featureValidationOptOut": experiment.is_client_schema_disabled,
+            "locales": ["en-US"],
+            "localizations": None,
+            "publishedDate": experiment.published_date,
+            "documentationLinks": [
+                {"title": documentation_link.title, "link": documentation_link.link}
+            ],
+        }
+
+        self.assertDictEqual(
+            experiment_data,
+            expected_experiment_data,
+        )
+
+        self.assertEqual(set(feature_ids_data), {feature1.slug, feature2.slug})
+
+        self.assertEqual(
+            bucket_data,
+            {
+                "randomizationUnit": (
+                    experiment.bucket_range.isolation_group.randomization_unit
+                ),
+                "namespace": experiment.bucket_range.isolation_group.namespace,
+                "start": experiment.bucket_range.start,
+                "count": experiment.bucket_range.count,
+                "total": experiment.bucket_range.isolation_group.total,
+            },
+        )
+
+        self.assertEqual(len(branches_data), 2)
+        for branch in experiment.branches.all():
+            self.assertIn(
+                {
+                    "slug": branch.slug,
+                    "ratio": branch.ratio,
+                    "description": branch.description,
+                    "features": [
+                        {
+                            "featureId": fv.feature_config.slug,
+                            "value": json.loads(fv.value),
+                        }
+                        for fv in branch.feature_values.all()
+                    ],
+                    "screenshots": [s.image.url for s in branch.screenshots.all()],
+                },
+                branches_data,
+            )
+
+    def test_serializer_no_channel(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
+        )
+
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(serializer.data["channels"], [])
 
     def test_serializer_invalid_localizations_field(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Becuase

* We now have a channels field for desktop experiments
* We include the channel in the v7/v8 apis
* We can include channels in v7/v8 apis as a new field
* We should leave the existing channel field alone to not break existing callers
* We should leave v6 alone altogether becuase clients don't depend on the channel field

This commit

* Adds a channels field to v7/v8 apis that includes both the channel and channels fields values
* Updates tests to cover both desktop and non-desktop cases

fixes #13367
