### PR TITLE
bug(nimbus): trim whitespace from copied slugs

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -65,7 +65,7 @@ const setupSlugCopyToast = () => {
   var copiedToast = document.getElementById("slug-toast");
   if (slug && copiedToast) {
     slug.addEventListener("click", function () {
-      navigator.clipboard.writeText(slug.textContent);
+      navigator.clipboard.writeText(slug.textContent.trim());
       var toast = bootstrap.Toast.getOrCreateInstance(copiedToast);
       toast.show();
     });


### PR DESCRIPTION
Because

* When we copy the slug to the paste buffer we were including unnecessary wrapping whitespace

This commit

* Trims the whitespace off the slug before sending it to the pastebuffer

fixes #13190

