### PR TITLE
bug(nimbus): repair autocomplete in feature value editor

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1,4 +1,3 @@
-import json
 from collections import defaultdict
 
 from django import forms
@@ -451,7 +450,7 @@ class NimbusBranchFeatureValueForm(forms.ModelForm):
         ):
             self.fields["value"].widget.attrs.update(
                 {
-                    "data-schema": json.dumps(schema.schema),
+                    "data-schema": schema.schema,
                 }
             )
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3592,7 +3592,18 @@ class TestBranchFeatureValueForm(RequestFormTestCase):
             for fv in experiment.reference_branch.feature_values.all()
         }
 
-        self.assertIn("data-schema", forms["with-schema"].fields["value"].widget.attrs)
+        self.assertEqual(
+            json.loads(forms["with-schema"].fields["value"].widget.attrs["data-schema"]),
+            {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "description": (
+                    "Fake schema that matches NimbusBranchFactory feature_value factory"
+                ),
+                "type": "object",
+                "patternProperties": {"^.*$": {"type": "string"}},
+                "additionalProperties": False,
+            },
+        )
         self.assertNotIn(
             "data-schema", forms["without-schema"].fields["value"].widget.attrs
         )


### PR DESCRIPTION
Becuase

* We recently added some logic to prevent initializing autocomplete for features without schemas in #13076
* We accidentally double-serialized the schema to JSON
* This caused the page to attempt to load the schema but receive a string instead

This commit

* Removes the unnecessary double JSON serialization
* Adds more explicit checks in the test to ensure the schema is single escaped

fixes #13382

