### PR TITLE
bug(nimbus): Fix Windows 10 Firefox VPN advanced targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3081,15 +3081,16 @@ WIN10_FIREFOX_VPN_ELIGIBLE = NimbusTargetingConfig(
     slug="win10_firefox_vpn",
     description=(
         "Windows 10 users who are signed out, at least 7 days old, "
-        "no enterprise, default newtab, no adblock"
+        "no enterprise, are not using a proxy, and "
+        "do not have the VPN extension installed"
     ),
     targeting=(
-        "os.isWindows && os.windowsVersion == 10 && "
+        "os.isWindows && os.windowsVersion >= 10.0 && os.windowsBuildNumber < 22000 &&"
         "isFxAEnabled && !isFxASignedIn && "
         f"{NO_ENTERPRISE.targeting} && "
         f"{PROFILEMORETHAN7DAYS} && "
-        "'network.proxy.type'|preferenceValue != 2 && "
-        '!("e6eb0d1e856335fc" in attachedFxAOAuthClients|mapToProperty("id"))'
+        "'network.proxy.type'|preferenceValue != 1 && "
+        "addonsInfo.addons['vpn@mozilla.com'] == null"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
Because
- Current targeting is not limited to Windows 10.
- Targeting needs to exclude users of the VPN extension.
- The wrong proxy type was excluded.

This commit
- Fixes the Window 10 targeting by checking that the `windowsBuildNumber ` is less than `22000` .
- Removes the `attachedFxAOAuthClients` targeting.
- Adds targeting to check if the `vpn@mozilla.com` addon is installed.
- Updates the `network.proxy.type` check to target when type is not `1` instead.
- Updates the description to match.

Fixes [Bug 1986030](https://bugzilla.mozilla.org/show_bug.cgi?id=1986030)