### PR TITLE
bug(nimbus): Update the advanced targeting config for sponsored content opt outs to remove Adjust condition

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2433,18 +2433,18 @@ TOU_TARGETING_ANDROID_ACCEPTED = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
-TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SHORTCUTS_STORIES_OR_MKT = (
+TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SHORTCUTS_OR_STORIES_OPT_OUTS = (
     NimbusTargetingConfig(
         name=(
             "Users that have not accepted the Terms of Use "
-            "and have not opted out of any sponsored content or Adjust"
+            "and have not opted out of any sponsored content"
         ),
-        slug="users_not_accepted_tou_no_shortcuts_stories_mkt",
+        slug="users_not_accepted_tou_no_shortcuts_or_stories_opt_outs",
         description=(
             "Targeting users who have NOT accepted the Terms of Use "
-            "and have NOT opted out of any sponsored content or Adjust"
+            "and have NOT opted out of any sponsored content"
         ),
-        targeting="user_accepted_tou == false && no_shortcuts_stories_mkt == true",
+        targeting="user_accepted_tou == false && no_shortcuts_or_stories_opt_outs == true",
         desktop_telemetry="",
         sticky_required=False,
         is_first_run_required=False,


### PR DESCRIPTION
Because
- The original metric key `users_not_accepted_tou_no_shortcuts_stories_mkt` was updated to `no_shortcuts_or_stories_opt_outs`.

Reason
-  The marketing targeting has been removed completely.

This commit

- Updates the metric key used for the config.

Fixes #github_issue_number
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1984639