### PR TITLE
feature(nimbus): Add form for selecting a feature on the feature page.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1459,7 +1459,7 @@ class FeaturesForm(forms.ModelForm):
                 "class": "form-select",
             },
         ),
-        initial="firefox-desktop",
+        initial=NimbusExperiment.Application.DESKTOP.value,
     )
     feature_configs = forms.ChoiceField(
         label="",

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1461,12 +1461,15 @@ class FeaturesForm(forms.ModelForm):
         ),
         initial="firefox-desktop",
     )
-    feature_configs = FeatureConfigModelChoiceField(
-        required=False,
-        queryset=NimbusFeatureConfig.objects.all(),
-        widget=FeatureConfigMultiSelectWidget(attrs={}),
+    feature_configs = forms.ChoiceField(
+        label="",
+        choices=[],
+        widget=forms.widgets.Select(
+            attrs={
+                "class": "form-select",
+            },
+        ),
     )
-
     update_on_change_fields = ("application", "feature_configs")
 
     class Meta:
@@ -1479,10 +1482,10 @@ class FeaturesForm(forms.ModelForm):
         selected_app = self.data.get("application") or self.get_initial_for_field(
             self.fields["application"], "application"
         )
-
-        self.fields["feature_configs"].queryset = NimbusFeatureConfig.objects.filter(
-            application=selected_app
-        ).order_by("slug")
+        features = NimbusFeatureConfig.objects.filter(application=selected_app).order_by(
+            "slug"
+        )
+        self.fields["feature_configs"].choices = list(features.values_list("pk", "slug"))
 
         base_url = reverse("nimbus-ui-features")
         htmx_attrs = {

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -1,10 +1,40 @@
 {% extends "experimenter_base.html" %}
 
+{% load static %}
+{% load nimbus_extras %}
+{% load widget_tweaks %}
+
 {% block content %}
   <div id="feature-page" class="bg-body-tertiary py-4">
     <div class="container">
       {% include "nimbus_experiments/heading_card.html" with page_name="feature" heading_text="Welcome to your Feature Health Dashboard," subheading_text="Track a feature's Nimbus history and QA status in this summary view!" link_url=links.feature_learn_more_url btn_text="Learn More" %}
 
+      <form id="features-form"
+            method="get"
+            hx-get="{% url 'nimbus-ui-features' %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+            hx-select="#features-form"
+            hx-target="#features-form"
+            hx-swap="outerHTML">
+        {% csrf_token %}
+        <div class="card mb-3">
+          <div class="card-body">
+            <div class="row mb-4">
+              <div class="col-6">
+                <label for="id_application" class="form-label">Application</label>
+                {{ form.application|add_class:"form-control"|add_error_class:"is-invalid" }}
+                {% for error in form.application.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              </div>
+              <div class="col-6">
+                <label for="id_feature_config" class="form-label">Feature Config</label>
+                {{ form.feature_configs|add_class:"form-control" }}
+                {% for error in form.feature_configs.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              </div>
+            </div>
+            <div>{{ application }}</div>
+            <div>{{ feature_configs }}</div>
+          </div>
+        </div>
+      </form>
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3649,14 +3649,16 @@ class TestFeaturesViewForm(RequestFormTestCase):
 
     def test_features_view_feature_config_field_updates_correctly(self):
         NimbusExperimentFactory.create(owner=self.user)
+        name = "No Feature Firefox Desktop - None"
+        pk = 1
         form = FeaturesForm()
         feature_configs = form.fields["feature_configs"]
-        self.assertTrue(
-            feature_configs.queryset.filter(slug="no-feature-firefox-desktop").exists()
-        )
+        self.assertIn((pk, name), feature_configs.choices)
 
     def test_features_view_configs_update_correctly(self):
         NimbusExperimentFactory.create(owner=self.user)
+        name = "No Feature iOS - None"
+        pk = 3
         form = FeaturesForm(data={"application": "firefox-desktop"})
         feature_configs = form.fields["feature_configs"]
-        self.assertFalse(feature_configs.queryset.filter(slug="No Feature iOS").exists())
+        self.assertNotIn((pk, name), feature_configs.choices)

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -20,7 +20,6 @@ from experimenter.experiments.models import (
     NimbusExperiment,
     NimbusExperimentBranchThroughExcluded,
     NimbusExperimentBranchThroughRequired,
-    NimbusFeatureConfig,
 )
 from experimenter.experiments.tests.factories import (
     NimbusBranchFactory,
@@ -3650,38 +3649,32 @@ class TestFeaturesViewForm(RequestFormTestCase):
 
     def test_features_view_feature_config_field_updates_correctly(self):
         NimbusExperimentFactory.create(owner=self.user)
-        feature_config = NimbusFeatureConfigFactory.create(
+        feature_config_desktop = NimbusFeatureConfigFactory.create(
             slug="feature-desktop",
             name="Feature Desktop",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        feature_id = NimbusFeatureConfig.objects.values_list("pk", flat=True).get(
-            slug=feature_config.slug
-        )
-
-        form = FeaturesForm()
-        feature_configs = form.fields["feature_configs"]
-        self.assertIn(
-            (feature_id, f"{feature_config.name} - {feature_config.description}"),
-            feature_configs.choices,
-        )
-
-    def test_features_view_configs_update_correctly(self):
-        NimbusExperimentFactory.create(owner=self.user)
-        feature_config = NimbusFeatureConfigFactory.create(
+        feature_config_ios = NimbusFeatureConfigFactory.create(
             slug="feature-ios",
             name="Feature iOS",
             application=NimbusExperiment.Application.IOS,
-        )
-        feature_id = NimbusFeatureConfig.objects.values_list("pk", flat=True).get(
-            slug=feature_config.slug
         )
 
         form = FeaturesForm(
             data={"application": NimbusExperiment.Application.DESKTOP.value}
         )
         feature_configs = form.fields["feature_configs"]
+        self.assertIn(
+            (
+                feature_config_desktop.id,
+                f"{feature_config_desktop.name} - {feature_config_desktop.description}",
+            ),
+            feature_configs.choices,
+        )
         self.assertNotIn(
-            (feature_id, f"{feature_config.name} - {feature_config.description}"),
+            (
+                feature_config_ios.id,
+                f"{feature_config_desktop.name} - {feature_config_desktop.description}",
+            ),
             feature_configs.choices,
         )

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3639,7 +3639,7 @@ class TestBranchFeatureValueForm(RequestFormTestCase):
 
 
 class TestFeaturesViewForm(RequestFormTestCase):
-    def test_features_view_default_fields(self):
+    def test_features_view_default_fields_are_firefox_desktop(self):
         NimbusExperimentFactory.create(owner=self.user)
         form = FeaturesForm()
         application = form.fields["application"]

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -47,6 +47,7 @@ from experimenter.nimbus_ui.forms import (
     DocumentationLinkDeleteForm,
     DraftToPreviewForm,
     DraftToReviewForm,
+    FeaturesForm,
     LiveToCompleteForm,
     LiveToEndEnrollmentForm,
     LiveToUpdateRolloutForm,
@@ -3635,3 +3636,27 @@ class TestBranchFeatureValueForm(RequestFormTestCase):
         self.assertNotIn(
             "data-schema", forms["without-schema"].fields["value"].widget.attrs
         )
+
+
+class TestFeaturesViewForm(RequestFormTestCase):
+    def test_features_view_default_fields(self):
+        NimbusExperimentFactory.create(owner=self.user)
+        form = FeaturesForm()
+        application = form.fields["application"]
+        feature_configs = form.fields["feature_configs"]
+        self.assertEqual(application.initial, "firefox-desktop")
+        self.assertIsNone(feature_configs.initial)
+
+    def test_features_view_feature_config_field_updates_correctly(self):
+        NimbusExperimentFactory.create(owner=self.user)
+        form = FeaturesForm()
+        feature_configs = form.fields["feature_configs"]
+        self.assertTrue(
+            feature_configs.queryset.filter(slug="no-feature-firefox-desktop").exists()
+        )
+
+    def test_features_view_configs_update_correctly(self):
+        NimbusExperimentFactory.create(owner=self.user)
+        form = FeaturesForm(data={"application": "firefox-desktop"})
+        feature_configs = form.fields["feature_configs"]
+        self.assertFalse(feature_configs.queryset.filter(slug="No Feature iOS").exists())

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3370,11 +3370,30 @@ class TestNimbusFeaturesView(AuthTestCase):
         self.assertTrue(form.fields["feature_configs"])
         self.assertEqual(form.fields["feature_configs"].initial, None)
 
-    def test_features_view_dropdown_loads_correct_fields_on_request(self):
+    @parameterized.expand(
+        [
+            ("firefox-desktop", 1),
+            ("fenix", 2),
+            ("ios", "3"),
+            ("focus-android", 4),
+            ("klar-android", 5),
+            ("focus-ios", 6),
+            ("klar-ios", 7),
+            ("monitor-web", 286),
+            ("vpn-web", 292),
+            ("demo-app", 293),
+            ("experimenter", 294),
+        ]
+    )
+    def test_features_view_dropdown_loads_correct_fields_on_request(
+        self, application, feature_config
+    ):
         NimbusExperimentFactory.create(owner=self.user)
         url = reverse("nimbus-ui-features")
-        response = self.client.get(f"{url}/?application=ios&feature_configs=3")
+        response = self.client.get(
+            f"{url}/?application={application}&feature_configs={feature_config}"
+        )
         form = response.context["form"]
         self.assertTrue(form.fields["application"])
-        self.assertEqual(form["application"].value(), "ios")
-        self.assertEqual(form["feature_configs"].value()[0], "3")
+        self.assertEqual(form["application"].value(), application)
+        self.assertEqual(form["feature_configs"].value(), str(feature_config))

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -33,10 +33,7 @@ from experimenter.nimbus_ui.filtersets import (
     SortChoices,
     TypeChoices,
 )
-from experimenter.nimbus_ui.forms import (
-    QAStatusForm,
-    TakeawaysForm,
-)
+from experimenter.nimbus_ui.forms import QAStatusForm, TakeawaysForm
 from experimenter.nimbus_ui.views import StatusChoices
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.outcomes import Outcomes
@@ -3363,3 +3360,21 @@ class TestNimbusFeaturesView(AuthTestCase):
         response = self.client.get(reverse("nimbus-ui-features"))
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "nimbus_experiments/features.html")
+
+    def test_features_view_dropdown_loads_correct_default(self):
+        NimbusExperimentFactory.create(owner=self.user)
+        response = self.client.get(reverse("nimbus-ui-features"))
+        form = response.context["form"]
+        self.assertTrue(form.fields["application"])
+        self.assertEqual(form.fields["application"].initial, "firefox-desktop")
+        self.assertTrue(form.fields["feature_configs"])
+        self.assertEqual(form.fields["feature_configs"].initial, None)
+
+    def test_features_view_dropdown_loads_correct_fields_on_request(self):
+        NimbusExperimentFactory.create(owner=self.user)
+        url = reverse("nimbus-ui-features")
+        response = self.client.get(f"{url}/?application=ios&feature_configs=3")
+        form = response.context["form"]
+        self.assertTrue(form.fields["application"])
+        self.assertEqual(form["application"].value(), "ios")
+        self.assertEqual(form["feature_configs"].value()[0], "3")

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3415,25 +3415,19 @@ class TestNimbusFeaturesView(AuthTestCase):
             NimbusExperiment.Application.DESKTOP,
             NimbusExperiment.Application.IOS,
         ]
-        feature_config_desktop = NimbusFeatureConfigFactory.create(
-            slug="feature-desktop-multi",
-            name="Feature Desktop Multi",
+        feature_config_multi = NimbusFeatureConfigFactory.create(
+            slug="feature-multi",
+            name="Multi Feature",
             application=applications,
         )
 
-        feature_id_desktop = NimbusFeatureConfig.objects.values_list("pk", flat=True).get(
-            slug=feature_config_desktop.slug
-        )
-        feature_id_ios = NimbusFeatureConfig.objects.values_list("pk", flat=True).get(
-            slug=feature_config_desktop.slug
-        )
         url = reverse("nimbus-ui-features")
         response = self.client.get(
-            f"{url}?application={applications[0].value}&feature_configs={feature_id_desktop}"
+            f"{url}?application={applications[1].value}&feature_configs={feature_config_multi.id}"
         )
 
         self.assertEqual(response.status_code, 200)
         form = response.context["form"]
         self.assertTrue(form.fields["application"])
-        self.assertEqual(form["application"].value(), applications[0].value)
-        self.assertEqual(form["feature_configs"].value(), str(feature_id_ios))
+        self.assertEqual(form["application"].value(), applications[1].value)
+        self.assertEqual(form["feature_configs"].value(), str(feature_config_multi.id))

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -3,12 +3,12 @@ from django.core.paginator import Paginator
 from django.db.models import Q
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
-from django.views.generic import CreateView, DetailView
+from django.views.generic import CreateView, DetailView, TemplateView
 from django.views.generic.edit import UpdateView
 from django_filters.views import FilterView
 
 from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
-from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
+from experimenter.experiments.models import NimbusExperiment
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.nimbus_ui.filtersets import (
     STATUS_FILTERS,
@@ -32,6 +32,7 @@ from experimenter.nimbus_ui.forms import (
     DocumentationLinkDeleteForm,
     DraftToPreviewForm,
     DraftToReviewForm,
+    FeaturesForm,
     LiveToCompleteForm,
     LiveToEndEnrollmentForm,
     LiveToUpdateRolloutForm,
@@ -634,17 +635,22 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
     template_name = "nimbus_experiments/results.html"
 
 
-class NimbusFeaturesView(FilterView):
+class NimbusFeaturesView(TemplateView):
     template_name = "nimbus_experiments/features.html"
+    form_class = FeaturesForm
     filterset_class = NimbusExperimentFilter
     context_object_name = "features"
 
-    def get_queryset(self):
-        return NimbusFeatureConfig.objects.filter().order_by("-name")
+    def get_form(self):
+        return FeaturesForm(self.request.GET or None)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        form = self.get_form()
+        context["form"] = form
         context["links"] = NimbusUIConstants.FEATURE_PAGE_LINKS
+        context["application"] = self.request.GET.get("application")
+        context["feature_configs"] = self.request.GET.get("feature_configs")
         return context
 
 


### PR DESCRIPTION
Because

- We need to add a way to select an application and a corresponding feature for the feature page so that we can show information about that feature.

This commit

- Adds 2 dropdowns, 1 for the application and 1 for the feature config based on that application for the user to select from.

Fixes #13363 