### PR TITLE
chore(ci): Fix test results upload directory for metrics dashboard.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,11 +156,11 @@ jobs:
       - store_test_results:
           path: workspace/test-results/junit.xml
       - upload-to-gcs:
-          source: workspace/test-results
+          source: dashboard/test-results
           destination: gs://ecosystem-test-eng-metrics/experimenter/junit
           extension: xml
       - upload-to-gcs:
-          source: workspace/test-results
+          source: dashboard/test-results
           destination: gs://ecosystem-test-eng-metrics/experimenter/coverage
           extension: json
 


### PR DESCRIPTION
Because

- The directory for uploading test and coverage reports was wrong

This commit

- Changes it to the correct directory.

Fixes #13422 