### PR TITLE
feat(nimbus): Filter by deliveries status

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -244,11 +244,40 @@ def _get_application_icon_map():
     }
 
 
+def _get_status_icon_map():
+    from experimenter.experiments.constants import NimbusConstants
+
+    return {
+        NimbusConstants.Status.DRAFT: {
+            "icon": "fa-regular fa-file-lines",
+            "color": "text-muted",
+        },
+        NimbusConstants.Status.PREVIEW: {
+            "icon": "fa-regular fa-eye",
+            "color": "text-info",
+        },
+        NimbusConstants.Status.LIVE: {
+            "icon": "fa-solid fa-play",
+            "color": "text-success",
+        },
+        NimbusConstants.Status.COMPLETE: {
+            "icon": "fa-solid fa-flag-checkered",
+            "color": "text-primary",
+        },
+        NimbusConstants.PublishStatus.REVIEW: {
+            "icon": "fa-regular fa-hourglass-half",
+            "color": "text-warning",
+        },
+    }
+
+
 QA_STATUS_ICON_MAP = _get_qa_status_icon_map()
 CHANNEL_ICON_MAP = _get_channel_icon_map()
 APPLICATION_ICON_MAP = _get_application_icon_map()
+STATUS_ICON_MAP = _get_status_icon_map()
 
 # Icon filter type constants for template tags
 QA_ICON_FILTER_TYPE = "qa_icon_info"
 CHANNEL_ICON_FILTER_TYPE = "channel_icon_info"
 APPLICATION_ICON_FILTER_TYPE = "application_icon_info"
+STATUS_ICON_FILTER_TYPE = "status_icon_info"

--- a/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
@@ -7,7 +7,7 @@
       hx-target="{{ hx_target }}"
       hx-select="{{ hx_select }}"
       hx-swap="outerHTML"
-      hx-include=".type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked"  {# keep current filters when sorting #}
+      hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked"  {# keep current filters when sorting #}
       class="d-inline-block m-0">
       {# Preserve ALL existing filters except "sort" (we set it explicitly) #}
       {% for form_field in form %}
@@ -35,6 +35,11 @@
         </span>
       </button>
     </form>
+    {# ------------------------ FILTER FORM (Status) ------------------------ #}
+    {% if field == "status" %}
+      {% include "common/filter_dropdown.html" with filter_name="status" filter_label="Status" choices=form.fields.status.choices selected_values=form.status.value icon_filter="status_icon_info" url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}
+
+    {% endif %}
     {# ------------------------ FILTER FORM (Type) ------------------------ #}
     {% if field == "is_rollout" %}
       {% include "common/filter_dropdown.html" with filter_name="type" filter_label="Type" choices=form.fields.type.choices selected_values=form.type.value icon_filter=None url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -75,7 +75,7 @@
                   hx-select="#my-deliveries-table-section"
                   hx-target="#my-deliveries-table-section"
                   hx-trigger="change"
-                  hx-include=".type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked"
+                  hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked"
                   class="d-inline-block">
               <div class="form-group mb-0">
                 {% render_field my_deliveries_filter.form.my_deliveries_status class="form-select form-select-sm w-auto" %}
@@ -107,7 +107,16 @@
                         <a href="{% url 'nimbus-ui-detail' slug=experiment.slug %}"
                            class="text-decoration-none fw-medium">{{ experiment.name }}</a>
                       </td>
-                      <td>{{ experiment.status|capfirst }}</td>
+                      <td>
+                        {% with status_info=experiment|home_status_display_with_icon %}
+                          {% if status_info.icon_info.icon %}
+                            <span class="me-1 {{ status_info.icon_info.color }}">
+                              <i class="{{ status_info.icon_info.icon }}"></i>
+                            </span>
+                          {% endif %}
+                          {{ status_info.status }}
+                        {% endwith %}
+                      </td>
                       <td>
                         {% with icon_info=experiment.qa_status_icon_info %}
                           {% if icon_info.icon %}<span class="{{ icon_info.color }}"><i class="{{ icon_info.icon }}"></i></span>{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load nimbus_extras %}
 
 <div class="card shadow-sm border-0 px-3 pt-3 h-100 rounded-3 bg-primary-subtle"
      style="min-height: 450px">
@@ -23,7 +24,14 @@
                style="font-size: 1.05rem">{{ experiment.name }}</a>
           </div>
           <div class="text-muted small">
-            {{ experiment.status|capfirst }}
+            {% with status_info=experiment|home_status_display_with_icon %}
+              {% if status_info.icon_info.icon %}
+                <span class="me-1 {{ status_info.icon_info.color }}">
+                  <i class="{{ status_info.icon_info.icon }}"></i>
+                </span>
+              {% endif %}
+              {{ status_info.status }}
+            {% endwith %}
             {% if experiment.application %}• {{ experiment.application }}{% endif %}
             {% with channel=experiment.get_channel_display %}
               {% if channel %}• {{ channel }}{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -11,6 +11,8 @@ from experimenter.nimbus_ui.constants import (
     CHANNEL_ICON_MAP,
     QA_ICON_FILTER_TYPE,
     QA_STATUS_ICON_MAP,
+    STATUS_ICON_FILTER_TYPE,
+    STATUS_ICON_MAP,
 )
 
 register = template.Library()
@@ -121,6 +123,11 @@ def channel_icon_info(value):
     return NimbusConstants.Channel.get_icon_info(value)
 
 
+@register.filter
+def status_icon_info(value):
+    return STATUS_ICON_MAP.get(value, {"icon": "", "color": ""})
+
+
 @register.simple_tag
 def render_channel_icons(experiment):
     channels_data = []
@@ -168,7 +175,25 @@ def choices_with_icons(choices, icon_filter_type):
             icon_info = APPLICATION_ICON_MAP.get(
                 value, APPLICATION_ICON_MAP[NimbusConstants.Application.DESKTOP]
             )
+        elif icon_filter_type == STATUS_ICON_FILTER_TYPE:
+            icon_info = STATUS_ICON_MAP.get(value, {"icon": "", "color": ""})
 
         enriched_choices.append({"value": value, "label": label, "icon_info": icon_info})
 
     return enriched_choices
+
+
+@register.filter
+def home_status_display(experiment):
+    if not experiment.is_archived and experiment.is_review_timeline:
+        return NimbusConstants.PublishStatus.REVIEW
+
+    return experiment.status
+
+
+@register.filter
+def home_status_display_with_icon(experiment):
+    status = home_status_display(experiment)
+    icon_info = STATUS_ICON_MAP.get(status, {"icon": "", "color": ""})
+
+    return {"status": status, "icon_info": icon_info}


### PR DESCRIPTION
Because

- We want to allow users to filter the Deliveries by status of it

This commit

- Adds the filter which allows to filter deliveries by status

Fixes #13413 
