### PR TITLE
feat(nimbus): Filter by feature

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
@@ -7,7 +7,7 @@
       hx-target="{{ hx_target }}"
       hx-select="{{ hx_select }}"
       hx-swap="outerHTML"
-      hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked"  {# keep current filters when sorting #}
+      hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked, .feature-filter input[name='feature_configs']:checked"  {# keep current filters when sorting #}
       class="d-inline-block m-0">
       {# Preserve ALL existing filters except "sort" (we set it explicitly) #}
       {% for form_field in form %}
@@ -58,6 +58,11 @@
     {# ------------------------ FILTER FORM (Application) ------------------------ #}
     {% if field == "application" %}
       {% include "common/filter_dropdown.html" with filter_name="application" filter_label="Application" choices=form.fields.application.choices selected_values=form.application.value icon_filter="application_icon_info" url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}
+
+    {% endif %}
+    {# ------------------------ FILTER FORM (Features) ------------------------ #}
+    {% if field == "feature_configs__slug" %}
+      {% include "common/filter_dropdown.html" with filter_name="feature_configs" filter_label="Features" choices=form.fields.feature_configs.choices selected_values=form.feature_configs.value icon_filter=None url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}
 
     {% endif %}
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -75,7 +75,7 @@
                   hx-select="#my-deliveries-table-section"
                   hx-target="#my-deliveries-table-section"
                   hx-trigger="change"
-                  hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked"
+                  hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked, .feature-filter input[name='feature_configs']:checked"
                   class="d-inline-block">
               <div class="form-group mb-0">
                 {% render_field my_deliveries_filter.form.my_deliveries_status class="form-select form-select-sm w-auto" %}
@@ -200,7 +200,7 @@
                   {% if all_my_experiments_page.has_previous %}
                     <li class="page-item">
                       <a class="page-link"
-                         hx-get="?my_deliveries_page={{ all_my_experiments_page.previous_page_number }}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
+                         hx-get="?my_deliveries_page={{ all_my_experiments_page.previous_page_number }}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
                          hx-target="#my-deliveries-table-section"
                          hx-select="#my-deliveries-table-section"
                          hx-push-url="true">Previous</a>
@@ -214,7 +214,7 @@
                   {% if all_my_experiments_page.has_next %}
                     <li class="page-item">
                       <a class="page-link"
-                         hx-get="?my_deliveries_page={{ all_my_experiments_page.next_page_number }}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
+                         hx-get="?my_deliveries_page={{ all_my_experiments_page.next_page_number }}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
                          hx-target="#my-deliveries-table-section"
                          hx-select="#my-deliveries-table-section"
                          hx-push-url="true">Next</a>


### PR DESCRIPTION
Because

- We want to allow users to filter by feature on my deliveries section

This commit

- Shows by default all the features if you no experiment subscribed or owned and which is not archieved
- If you have deliveries, then only show filter for the feature which are linked to the deliveries instead of showing it all

Fixes #13424 