### PR TITLE
chore(nimbus): Reformat generated experimenter YAML files

### DIFF
--- a/experimenter/experimenter/features/manifests/experimenter/developer.fml.yaml
+++ b/experimenter/experimenter/features/manifests/experimenter/developer.fml.yaml
@@ -1,9 +1,8 @@
----
 version: 1.0.0
 about:
   description: Nimbus Feature Manifest for Experimenter Web testing
 channels:
-  - developer
+- developer
 features:
   example-feature:
     description: An example feature.

--- a/experimenter/experimenter/features/manifests/experimenter/experimenter.yaml
+++ b/experimenter/experimenter/features/manifests/experimenter/experimenter.yaml
@@ -1,8 +1,7 @@
----
 example-feature:
   description: An example feature.
   hasExposure: true
-  exposureDescription: ""
+  exposureDescription: ''
   variables:
     emoji:
       type: string

--- a/experimenter/experimenter/features/manifests/experimenter/production.fml.yaml
+++ b/experimenter/experimenter/features/manifests/experimenter/production.fml.yaml
@@ -1,9 +1,8 @@
----
 version: 1.0.0
 about:
   description: Nimbus Feature Manifest for Experimenter Web testing
 channels:
-  - production
+- production
 features:
   example-feature:
     description: An example feature.

--- a/experimenter/experimenter/features/manifests/experimenter/staging.fml.yaml
+++ b/experimenter/experimenter/features/manifests/experimenter/staging.fml.yaml
@@ -1,9 +1,8 @@
----
 version: 1.0.0
 about:
   description: Nimbus Feature Manifest for Experimenter Web testing
 channels:
-  - staging
+- staging
 features:
   example-feature:
     description: An example feature.


### PR DESCRIPTION
Because:

- nimbus-cli updated to serde_yaml 0.9; and
- serde_yaml 0.9 changed its default output format

this commit:

- reformats our generated Experimenter manifests to match the new output format.

Fixes #13451