### PR TITLE
bug(nimbus): run local fml ci check on change to files in experimeter/

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/features/manifests/|experimenter/manifesttool/"
+          paths: "experimenter/experimenter/features/manifests/|experimenter/manifesttool/|^experimenter/[^/]+$|application-services/"
       - run:
           name: Check local feature manifests
           command: |


### PR DESCRIPTION
Because

- Dependency updates and config files can change generated FML

This commit

- Adds `^experimenter/[^/]+$` to the check file paths for running check_local_feature_manifests

Fixes #13453 