### PR TITLE
feat(nimbus): add links to edit metrics tooltips

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -81,6 +81,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "revenue_risk_link": "https://experimenter.info/vp-sign-off",
         "partner_related_risk_link": "https://experimenter.info/legal-sign-off",
     }
+    METRICS_PAGE_LINKS = {
+        "metrics_hub_url": "https://mozilla.github.io/metric-hub/metrics/firefox_desktop/",
+        "segment_metrics_hub_url": "https://mozilla.github.io/metric-hub/segments/firefox_desktop/",
+    }
     HOME_PAGE_TOOLTIPS = {
         "draft_or_preview": """This is anything that you own or are subscribed
             to follow - which are in Draft or Preview states. Go to the link to

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -30,10 +30,12 @@
           <div class="col">
             <label for="primary_outcomes" class="form-label">
               Primary Outcomes
-              <i class="fa-regular fa-circle-question"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 data-bs-title="Specific metrics you’d like to impact in your experiment, which will be part of the analysis."></i>
+              <a target="_blank" href="{{ links.metrics_hub_url }}">
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   data-bs-title="Specific metrics you’d like to impact in your experiment, which will be part of the analysis."></i>
+              </a>
               {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
             </label>
             <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
@@ -49,10 +51,12 @@
           <div class="col">
             <label for="secondary_outcomes" class="form-label">
               Secondary Outcomes
-              <i class="fa-regular fa-circle-question"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 data-bs-title="Specific metrics that you are interested in observing in your experiment but they don't affect the results of your experiment."></i>
+              <a target="_blank" href="{{ links.metrics_hub_url }}">
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   data-bs-title="Specific metrics that you are interested in observing in your experiment but they don't affect the results of your experiment."></i>
+              </a>
               {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
             </label>
             <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
@@ -69,10 +73,12 @@
           <div class="col">
             <label for="segments" class="form-label">
               Segments
-              <i class="fa-regular fa-circle-question"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 data-bs-title="Select user segments if you want to view your results sliced by specific sub-groups of users."></i>
+              <a target="_blank" href="{{ links.segment_metrics_hub_url }}">
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   data-bs-title="Select user segments if you want to view your results sliced by specific sub-groups of users."></i>
+              </a>
               {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
             </label>
             <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">{{ form.segments }}</div>

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -516,6 +516,11 @@ class MetricsUpdateView(
     def can_edit(self):
         return self.object.can_edit_metrics()
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["links"] = NimbusUIConstants.METRICS_PAGE_LINKS
+        return context
+
 
 class AudienceUpdateView(
     SaveAndContinueMixin,


### PR DESCRIPTION
Because

- Guiding links for metric sources were missing

This commit

- Adds those links

Fixes #13429