### PR TITLE
fix(nimbus): align columns on branch tables

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -19,10 +19,10 @@
   <table class="table table-striped">
     <tbody>
       <tr>
-        <th>Slug</th>
-        <td>{{ branch.slug|format_not_set }}</td>
-        <th>Ratio</th>
-        <td>{{ branch.ratio|format_not_set }}</td>
+        <th class="w-25">Slug</th>
+        <td class="w-25">{{ branch.slug|format_not_set }}</td>
+        <th class="w-25">Ratio</th>
+        <td class="w-25">{{ branch.ratio|format_not_set }}</td>
       </tr>
       <tr>
         <th>Description</th>


### PR DESCRIPTION
Because

- Branch tables were misaligned and bothersome to look at

This commit

- Aligns table columns 

Fixes #12907