### PR TITLE
fix(nimbus): remove leading + trailing whitespace when copying preview url

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
@@ -31,7 +31,7 @@ const setupPreviewUrlCopyToast = () => {
   var copiedToast = document.getElementById("preview-toast");
   if (previewUrl && copiedToast) {
     previewUrl.addEventListener("click", function () {
-      navigator.clipboard.writeText(previewUrl.textContent);
+      navigator.clipboard.writeText(previewUrl.textContent.trim());
       var toast = bootstrap.Toast.getOrCreateInstance(copiedToast);
       toast.show();
     });


### PR DESCRIPTION
Because

- Extra whitespace padding the url adds no information and makes the copied text longer

This commit

- Removes leading + trailing whitespace after copying preview url

Fixes #13435 