### PR TITLE
feat(nimbus): Filter by date

### DIFF
--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -1,3 +1,5 @@
+from datetime import date, datetime, timedelta
+
 import django_filters
 from django import forms
 from django.contrib.auth.models import User
@@ -93,6 +95,15 @@ class IconMultiSelectWidget(MultiSelectWidget):
         context = super().get_context(name, value, attrs)
         context["icon"] = self.icon
         return context
+
+
+class DateRangeChoices(models.TextChoices):
+    LAST_7_DAYS = "last_7_days", "Last 7 Days"
+    LAST_30_DAYS = "last_30_days", "Last 30 Days"
+    LAST_3_MONTHS = "last_3_months", "Last 3 Months"
+    LAST_6_MONTHS = "last_6_months", "Last 6 Months"
+    THIS_YEAR = "this_year", "This Year"
+    CUSTOM = "custom", "Custom Date Range"
 
 
 class NimbusExperimentFilter(django_filters.FilterSet):
@@ -424,10 +435,25 @@ class NimbusExperimentsHomeFilter(django_filters.FilterSet):
             attrs={"title": "All Features"},
         ),
     )
+    date_range = django_filters.ChoiceFilter(
+        choices=DateRangeChoices.choices,
+        method="filter_by_date_range",
+        required=False,
+    )
 
     class Meta:
         model = NimbusExperiment
-        fields = ["my_deliveries_status", "sort", "status"]
+        fields = [
+            "my_deliveries_status",
+            "sort",
+            "status",
+            "type",
+            "qa_status",
+            "channel",
+            "application",
+            "feature_configs",
+            "date_range",
+        ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -522,3 +548,51 @@ class NimbusExperimentsHomeFilter(django_filters.FilterSet):
         if not values:
             return queryset
         return queryset.filter(feature_configs__in=values).distinct()
+
+    def filter_by_date_range(self, queryset, name, value):
+        today = date.today()
+
+        if value == DateRangeChoices.LAST_7_DAYS:
+            start_date = today - timedelta(days=7)
+            return queryset.filter(_start_date__gte=start_date)
+        elif value == DateRangeChoices.LAST_30_DAYS:
+            start_date = today - timedelta(days=30)
+            return queryset.filter(_start_date__gte=start_date)
+        elif value == DateRangeChoices.LAST_3_MONTHS:
+            start_date = today - timedelta(days=90)
+            return queryset.filter(_start_date__gte=start_date)
+        elif value == DateRangeChoices.LAST_6_MONTHS:
+            start_date = today - timedelta(days=180)
+            return queryset.filter(_start_date__gte=start_date)
+        elif value == DateRangeChoices.THIS_YEAR:
+            start_date = date(today.year, 1, 1)
+            return queryset.filter(_start_date__gte=start_date)
+        elif value == DateRangeChoices.CUSTOM:
+            # Handle custom date range - can be start only, end only, or both
+            query = Q()
+            start_date_value = self.data.get("start_date")
+            end_date_value = self.data.get("end_date")
+
+            # Apply start date filter if provided
+            if start_date_value:
+                try:
+                    parsed_start_date = datetime.strptime(
+                        start_date_value, "%Y-%m-%d"
+                    ).date()
+                    query &= Q(_start_date__gte=parsed_start_date)
+                except (ValueError, TypeError, AttributeError):
+                    pass
+
+            # Apply end date filter if provided
+            if end_date_value:
+                try:
+                    parsed_end_date = datetime.strptime(end_date_value, "%Y-%m-%d").date()
+                    query &= Q(_computed_end_date__lte=parsed_end_date)
+                except (ValueError, TypeError, AttributeError):
+                    pass
+
+            # Only apply filter if we have at least one valid date
+            if start_date_value or end_date_value:
+                return queryset.filter(query)
+
+        return queryset

--- a/experimenter/experimenter/nimbus_ui/templates/common/date_filter_dropdown.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/date_filter_dropdown.html
@@ -1,0 +1,114 @@
+{% load nimbus_extras %}
+
+<div class="dropdown dropup date-filter ms-1 position-static">
+  <button class="btn btn-sm p-0 border-0 bg-transparent position-relative"
+          type="button"
+          data-bs-toggle="dropdown"
+          aria-expanded="false"
+          id="dateFilterDropdown{{ dropdown_id }}"
+          title="Filter by Date">
+    <i class="fa-solid fa-filter text-body"></i>
+    {% if form.date_range.value and form.date_range.value != "" %}
+      <span class="badge bg-primary"
+            style="position: absolute;
+                   top: -5px;
+                   right: -5px;
+                   font-size: 0.6em">1</span>
+    {% elif selected_values and selected_values != "" and selected_values != None %}
+      <span class="badge bg-primary"
+            style="position: absolute;
+                   top: -5px;
+                   right: -5px;
+                   font-size: 0.6em">1</span>
+    {% elif request.GET.start_date or request.GET.end_date %}
+      <span class="badge bg-primary"
+            style="position: absolute;
+                   top: -5px;
+                   right: -5px;
+                   font-size: 0.6em">1</span>
+    {% endif %}
+  </button>
+  <div class="dropdown-menu p-2 shadow-sm border rounded-2"
+       style="min-width: 280px;
+              max-height: 50vh;
+              overflow: auto">
+    <strong class="dropdown-header">Filter by Date</strong>
+    <div class="m-0 date-filter">
+      {% for choice_value, choice_label in choices %}
+        {% if choice_value not in "custom" %}
+          <div class="form-check" id="filter-choice-date_range-{{ choice_value }}">
+            <input class="form-check-input"
+                   type="radio"
+                   name="date_range"
+                   value="{{ choice_value }}"
+                   id="date_range-{{ choice_value }}"
+                   {% if choice_value == form.date_range.value %}checked{% endif %}
+                   hx-get="{{ url }}"
+                   hx-target="{{ hx_target }}"
+                   hx-select="{{ hx_select }}"
+                   hx-swap="outerHTML"
+                   hx-trigger="change"
+                   hx-include="input:checked, select"
+                   hx-vals='{"date_range": "{{ choice_value }}"}'>
+            <label class="form-check-label" for="date_range-{{ choice_value }}">{{ choice_label }}</label>
+          </div>
+        {% endif %}
+      {% endfor %}
+      <hr class="my-2">
+      <div class="form-check">
+        <input class="form-check-input"
+               type="radio"
+               name="date_range"
+               value="custom"
+               id="date_range-custom"
+               {% if form.date_range.value == "custom" or request.GET.start_date or request.GET.end_date %}checked{% endif %}
+               hx-get="{{ url }}"
+               hx-target="{{ hx_target }}"
+               hx-select="{{ hx_select }}"
+               hx-swap="outerHTML"
+               hx-trigger="change"
+               hx-include="input:checked, select, input[name='start_date'], input[name='end_date']"
+               hx-vals='{"date_range": "custom"}'>
+        <label class="form-check-label w-100" for="date_range-custom">
+          <div class="d-flex flex-column">
+            <span class="mb-2">Custom Date Range:</span>
+            <div class="d-flex align-items-center mb-2">
+              <label class="me-2" style="min-width: 80px;">Start Date:</label>
+              <input type="date"
+                     name="start_date"
+                     class="form-control form-control-sm"
+                     style="width: 150px"
+                     value="{{ request.GET.start_date|default:'' }}"
+                     min="2000-01-01"
+                     onclick="document.getElementById('date_range-custom').checked = true;"
+                     hx-get="{{ url }}"
+                     hx-target="{{ hx_target }}"
+                     hx-select="{{ hx_select }}"
+                     hx-swap="outerHTML"
+                     hx-trigger="change delay:500ms"
+                     hx-include="input:checked, select, input[name='start_date'], input[name='end_date']"
+                     hx-vals='{"date_range": "custom"}'>
+            </div>
+            <div class="d-flex align-items-center">
+              <label class="me-2" style="min-width: 80px;">End Date:</label>
+              <input type="date"
+                     name="end_date"
+                     class="form-control form-control-sm"
+                     style="width: 150px"
+                     value="{{ request.GET.end_date|default:'' }}"
+                     min="2000-01-01"
+                     onclick="document.getElementById('date_range-custom').checked = true;"
+                     hx-get="{{ url }}"
+                     hx-target="{{ hx_target }}"
+                     hx-select="{{ hx_select }}"
+                     hx-swap="outerHTML"
+                     hx-trigger="change delay:500ms"
+                     hx-include="input:checked, select, input[name='start_date'], input[name='end_date']"
+                     hx-vals='{"date_range": "custom"}'>
+            </div>
+          </div>
+        </label>
+      </div>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
@@ -7,7 +7,7 @@
       hx-target="{{ hx_target }}"
       hx-select="{{ hx_select }}"
       hx-swap="outerHTML"
-      hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked, .feature-filter input[name='feature_configs']:checked"  {# keep current filters when sorting #}
+      hx-include=".status-filter input[name='status']:checked, .type-filter input[name='type']:checked, .qa-filter input[name='qa_status']:checked, .channel-filter input[name='channel']:checked, .application-filter input[name='application']:checked, .feature-filter input[name='feature_configs']:checked, .date-filter input[name='date_range']:checked"  {# keep current filters when sorting #}
       class="d-inline-block m-0">
       {# Preserve ALL existing filters except "sort" (we set it explicitly) #}
       {% for form_field in form %}
@@ -63,6 +63,11 @@
   {# ------------------------ FILTER FORM (Application) ------------------------ #}
   {% if field == "application" %}
     {% include "common/filter_dropdown.html" with filter_name="application" filter_label="Application" choices=form.fields.application.choices selected_values=form.application.value icon_filter="application_icon_info" url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}
+
+  {% endif %}
+  {# ------------------------ FILTER FORM (Date Range) ------------------------ #}
+  {% if field == "_start_date" %}
+    {% include "common/date_filter_dropdown.html" with choices=form.fields.date_range.choices selected_values=form.date_range.value url=url hx_target=hx_target hx_select=hx_select current_sort=current_sort form=form dropdown_id=forloop.counter0 %}
 
   {% endif %}
   {# ------------------------ FILTER FORM (Features) ------------------------ #}


### PR DESCRIPTION
Because

- We want to allow users to filter by the dates in my deliveries section on the new home page

This commit

- Add filters on the dates to filter by options like last 7 days, last month etc and also able to enter the range either start date or end date or both the dates

Fixes #13476 