### PR TITLE
bug(project): Update settings.py to have defaults for github variables.

### DIFF
--- a/experimenter/experimenter/klaatu/tasks.py
+++ b/experimenter/experimenter/klaatu/tasks.py
@@ -1,10 +1,10 @@
-import os
 import time
 
 import jwt
 import markus
 import requests
 from celery.utils.log import get_task_logger
+from django.conf import settings
 from packaging import version
 
 from experimenter.celery import app
@@ -23,9 +23,9 @@ parse = NimbusConstants.Version.parse
 
 
 def _create_auth_token() -> str:
-    app_id = os.environ["GH_APP_ID"]
-    installation_id = os.environ["GH_INSTALLATION_ID"]
-    private_key = os.environ["GH_APP_PRIVATE_KEY"].replace("\\n", "\n")
+    app_id = settings.GH_APP_ID
+    installation_id = settings.GH_INSTALLATION_ID
+    private_key = settings.GH_APP_PRIVATE_KEY.replace("\\n", "\n")
 
     now = int(time.time())
     payload = {"iat": now, "exp": now + 540, "iss": app_id}

--- a/experimenter/experimenter/klaatu/tests/test_tasks.py
+++ b/experimenter/experimenter/klaatu/tests/test_tasks.py
@@ -1,7 +1,6 @@
-import os
 from unittest import mock
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from parameterized import parameterized
 
 from experimenter.experiments.constants import NimbusConstants
@@ -179,14 +178,10 @@ class TestNimbusKlaatuTasks(TestCase):
         self.assertEqual(self.experiment.klaatu_status, value)
 
     def test_klaatu_task_auth_token_generation(self):
-        with mock.patch.dict(
-            os.environ,
-            {
-                "GH_APP_ID": "1",
-                "GH_INSTALLATION_ID": "2",
-                "GH_APP_PRIVATE_KEY": "-----BEGIN KEY-----\\nabc\\n-----END KEY-----",
-            },
-            clear=False,
+        with override_settings(
+            GH_APP_ID=1,
+            GH_INSTALLATION_ID=2,
+            GH_APP_PRIVATE_KEY="-----BEGIN KEY-----\\nabc\\n-----END KEY-----",
         ):
             jwt_patcher = mock.patch(
                 "experimenter.klaatu.tasks.jwt.encode", return_value="jwt123"

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -44,9 +44,9 @@ APP_VERSION = config("APP_VERSION", default=None)
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = config("SECRET_KEY")
 
-GH_APP_ID = config("GH_APP_ID")
-GH_INSTALLATION_ID = config("GH_INSTALLATION_ID")
-GH_APP_PRIVATE_KEY = config("GH_APP_PRIVATE_KEY")
+GH_APP_ID = config("GH_APP_ID", default=None)
+GH_INSTALLATION_ID = config("GH_INSTALLATION_ID", default=None)
+GH_APP_PRIVATE_KEY = config("GH_APP_PRIVATE_KEY", default=None)
 
 DEV_USER_EMAIL = "dev@example.com"
 


### PR DESCRIPTION
Because

- I made a change recently to add specific github environment variables to the project scope for the Klaatu tasks. I did not add defaults to them in the settings.py and this is causing django to choke.

This commit

- Adds the defaults
- Uses the settings file within the task to access the variables

Fixes #13487 