### PR TITLE
feat(nimbus): only target prefs set by branch values

### DIFF
--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1048,10 +1048,14 @@ class TestNimbusExperiment(TestCase):
         JEXLParser().parse(experiment.targeting)
 
     @mock_valid_features
-    def test_targeting_with_prevent_pref_conflicts_set_prefs(self):
+    def test_targeting_with_prevent_pref_conflicts_set_prefs_from_feature_values(self):
         Features.clear_cache()
         call_command("load_feature_configs")
 
+        feature = NimbusFeatureConfig.objects.get(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="setPrefFeature",
+        )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -1062,23 +1066,56 @@ class TestNimbusExperiment(TestCase):
             locales=[],
             countries=[],
             prevent_pref_conflicts=True,
-            feature_configs=[
-                NimbusFeatureConfig.objects.get(
-                    application=NimbusExperiment.Application.DESKTOP,
-                    slug="oldSetPrefFeature",
-                )
-            ],
+            feature_configs=[feature],
         )
+        for branch in experiment.branches.all():
+            branch.feature_values.all().delete()
+            branch.feature_values.create(
+                feature_config=feature,
+                value=json.dumps({"user": "something"}),
+            )
 
         self.assertEqual(
             experiment.targeting,
             (
                 '(browserSettings.update.channel in ["release"]) && '
                 "((experiment.slug in activeExperiments) || ("
-                "(!('nimbus.test.boolean'|preferenceIsUserSet)) && "
-                "(!('nimbus.test.int'|preferenceIsUserSet)) && "
-                "(!('nimbus.test.string'|preferenceIsUserSet))))"
+                "(!('nimbus.user'|preferenceIsUserSet))))"
             ),
+        )
+        JEXLParser().parse(experiment.targeting)
+
+    @mock_valid_features
+    def test_targeting_with_prevent_pref_conflicts_invalid_json(self):
+        Features.clear_cache()
+        call_command("load_feature_configs")
+
+        feature = NimbusFeatureConfig.objects.get(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="setPrefFeature",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            languages=[],
+            locales=[],
+            countries=[],
+            prevent_pref_conflicts=True,
+            feature_configs=[feature],
+        )
+        for branch in experiment.branches.all():
+            branch.feature_values.all().delete()
+            branch.feature_values.create(
+                feature_config=feature,
+                value="invalid json !@#$",
+            )
+
+        self.assertEqual(
+            experiment.targeting,
+            '(browserSettings.update.channel in ["release"])',
         )
         JEXLParser().parse(experiment.targeting)
 


### PR DESCRIPTION
Becuase

* Users can choose to target against prefs set by a feature
* Previously we included all prefs touched by a feature regardless of whether they were actually set in the branch values
* This caused some features that touch many prefs to have very long targeting strings even if they only set a small number of values in the branches
* This also caused some experiments with disjoint sets of prefs from the same feature to collide unintentionally

This commit

* Filters the prefs included in targeting to only those set in the branch values

fixes #12428

