### PR TITLE
feat(nimbus): add icons to experiment timeline

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -6,9 +6,9 @@
 {% endblock %}
 
 {% block main_content_header %}
-  <div class="row mb-2">
+  <div class="d-flex mb-2 justify-content-between flex-column flex-xxl-row column-gap-3">
     <!-- Experiment Details -->
-    <div class="col-md-12 col-xl-5">
+    <div>
       <h4 class="mb-0">{{ experiment.name }}</h4>
       {% if experiment.is_archived %}
         <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
@@ -40,7 +40,7 @@
       {% endif %}
     </div>
     <!-- Experiment Timeline -->
-    <div class="col-md-12 col-xl-7" id="experiment-timeline">
+    <div id="experiment-timeline">
       {% include "nimbus_experiments/timeline.html" %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/timeline.html
@@ -1,7 +1,10 @@
 <ul class="list-group list-group-horizontal justify-content-between mb-3">
   {% for status in experiment.timeline %}
     <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-start {% if status.is_active %}bg-primary text-white{% endif %} {% if status.step > experiment.experiment_active_status %}bg-body-secondary{% endif %}">
-      <strong>{{ status.label }}</strong>
+      <div class="d-flex justify-content-center align-items-center">
+        <i class="me-2 {% if status.step < experiment.experiment_active_status %}fa-solid fa-circle-check text-success{% elif status.step > experiment.experiment_active_status %}fa-solid fa-clock text-warning{% else %}fa-solid fa-rotate{% endif %}"></i>
+        <strong>{{ status.label }}</strong>
+      </div>
       <small>{{ status.date|default:'<i class="fa-solid fa-minus"></i>' }}</small>
       {% if status.days is not None %}
         <div class="d-flex justify-content-center align-items-center">


### PR DESCRIPTION
Because

- There was some confusion on current state of experiment timeline

This commit

- Makes it crystal clear which step of the experiment creating/monitoring process the user is on by adding an icon to indicate the completed, current, and future states

Fixes #13513