### PR TITLE
feat(nimbus): force prevent pref conflicts for rollouts

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -720,6 +720,9 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             cleaned_data["firefox_labs_group"] = ""
             cleaned_data["requires_restart"] = False
 
+        if cleaned_data["is_rollout"]:
+            cleaned_data["prevent_pref_conflicts"] = True
+
         return cleaned_data
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
Becuase

* Now that we only target against the prefs that are being set by an experiment/rollout
* We want to prevent the case that a user changes a pref, is unenrolled from a rollout, then is immediately re-enrolled and their pref is overwritten

This commit
* Forces prevent_pref_conflicts for rollouts

fixes #9615

