### PR TITLE
feat(nimbus): Warn on experiment/rollout pref collisions

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -38,6 +38,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         If this rollout is launched, a client meeting the advanced
         targeting criteria will be enrolled in one and not the other and
         you will not be able to adjust the sizing for this rollout."""
+    PREF_TARGETING_WARNING = """WARNING: The following rollouts are LIVE
+    that set the same prefs and may reduce the eligible population for your experiment
+    which may result in reduced statistical power and precision or prevent enrollment
+    entirely. Please check that the configured population proportion has accounted for
+    this:"""
 
     AUDIENCE_OVERLAP_WARNING = "https://experimenter.info/faq/warnings/#audience-overlap"
     ROLLOUT_BUCKET_WARNING = (

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -50,7 +50,11 @@
              role="alert">
           <p class="mb-1">{{ warning.text }}</p>
           <ul class="mb-1">
-            {% for slug in warning.slugs %}<li>{{ slug }}</li>{% endfor %}
+            {% for slug in warning.slugs %}
+              <li>
+                <a target="_blank" href="{% url "nimbus-ui-detail" slug=slug %}">{{ slug }}</a>
+              </li>
+            {% endfor %}
           </ul>
           {% if warning.learn_more_link %}
             <a href="{{ warning.learn_more_link }}"


### PR DESCRIPTION
Becuase

* If a rollout sets some prefs, and then an experiment would also set those prefs but has prevent_pref_conflicts enabled, the experiment will not enroll

This commit

* Adds a warning to an experiment that attempts to set prefs that are also touched by a rollout and has prevent_pref_conflicts enabled
* Also turns the slug list into links so you can actually inspect the related experiments/rollouts in audience warnings

fixes #12429

