### PR TITLE
feat(nimbus): disable prevent_pref_conflicts field for rollouts

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -698,6 +698,9 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
         self.was_labs_opt_in = self.instance.is_firefox_labs_opt_in
 
+        if self.instance.is_rollout:
+            self.fields["prevent_pref_conflicts"].disabled = True
+
     @property
     def errors(self):
         errors = super().errors

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -71,6 +71,9 @@
               <label class="form-check-label" for="id_prevent_pref_conflicts">
                 Prevent enrollment if users have changed any prefs set by this experiment
               </label>
+              {% if form.prevent_pref_conflicts.field.disabled %}
+                <div class="form-text">This option is required for rollouts to prevent re-enrollment after pref changes.</div>
+              {% endif %}
             </div>
             {% for error in validation_errors.prevent_pref_conflicts %}
               <div class="form-text text-danger">{{ error }}</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -2697,6 +2697,7 @@ class TestNimbusBranchesForm(RequestFormTestCase):
         experiment = form.save()
         self.assertTrue(experiment.is_rollout)
         self.assertTrue(experiment.prevent_pref_conflicts)
+        self.assertTrue(form.fields["prevent_pref_conflicts"].disabled)
 
 
 class TestNimbusBranchCreateForm(RequestFormTestCase):


### PR DESCRIPTION
Becuase

* We force prevent_pref_conflicts for all rollouts now
* We should disable the field altogether to indicate to the user that it is mandatory

This commit

* Disables the prevent_pref_conflicts field for rollouts
* Adds a little helpful text description for why it's required

fixes #13523
