### PR TITLE
bug(nimbus): feature value must be not null

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -464,7 +464,7 @@ class NimbusBranchFeatureValueForm(forms.ModelForm):
         value = self.cleaned_data.get("value")
 
         if not value or value.strip() == "":
-            return None
+            return "{}"
         return value
 
 


### PR DESCRIPTION
Becuase

* We had added a case to the branch feature value form that defaulted the value to None if it was not provided by the form
* The db field can not be null
* This could cause 500 if the user attempts to save with an empty value

This commit

* Changes the fallback value to an empty json object

fixes #13383
