### PR TITLE
feat(nimbus): Add ability to set server types for klaatu tests.

### DIFF
--- a/experimenter/experimenter/klaatu/client.py
+++ b/experimenter/experimenter/klaatu/client.py
@@ -73,6 +73,7 @@ class KlaatuClient:
         experiment_slug: str,
         branch_slugs: list[str],
         targets: list[Union[KlaatuTargets, str]],
+        server: str = "prod",
     ) -> None:
         path = KlaatuEndpoints.DISPATCH.format(workflow=self.workflow_name)
         url = urljoin(self.base_url, path)
@@ -83,6 +84,7 @@ class KlaatuClient:
                 "slug": experiment_slug,
                 "branch": json.dumps(branch_slugs),
                 "firefox-version": json.dumps(targets),
+                "server": server,
             },
         }
 

--- a/experimenter/experimenter/klaatu/tasks.py
+++ b/experimenter/experimenter/klaatu/tasks.py
@@ -125,11 +125,15 @@ def klaatu_start_job(experiment: NimbusExperiment, application: str) -> None:
     clients = create_klaatu_clients(application, _create_auth_token())
     firefox_targets = get_firefox_targets(experiment)
     branches = get_branches(experiment)
+    server = "prod"
+    if settings.IS_STAGING:
+        server = "stage"
     for client in clients:
         client.run_test(
             experiment_slug=experiment.slug,
             branch_slugs=branches,
             targets=firefox_targets,
+            server=server,
         )
 
 

--- a/experimenter/experimenter/klaatu/tests/test_client.py
+++ b/experimenter/experimenter/klaatu/tests/test_client.py
@@ -25,6 +25,7 @@ class TestKlaatuClient(unittest.TestCase):
             experiment_slug="training-only-for-dev-tools",
             branch_slugs=["control"],
             targets=[KlaatuTargets.LATEST_BETA, "137.0"],
+            server="stage",
         )
 
     @mock.patch("experimenter.klaatu.client.requests.post")

--- a/experimenter/experimenter/klaatu/tests/test_tasks.py
+++ b/experimenter/experimenter/klaatu/tests/test_tasks.py
@@ -198,3 +198,15 @@ class TestNimbusKlaatuTasks(TestCase):
 
             token = tasks._create_auth_token()
         self.assertEqual(token, "gh_123abc456xyz")
+
+    @mock.patch("experimenter.klaatu.client.requests.post")
+    @mock.patch.object(tasks, "_create_auth_token", return_value="gh_123abc456xyz")
+    def test_klaatu_task_stage_job_starts_correctly(self, mock_client, mock_post):
+        with override_settings(
+            IS_STAGING=True,
+        ):
+            application = NimbusExperiment.Application.DESKTOP
+            mock_post.return_value.status_code = 204
+            self.create_experiment(application)
+
+            tasks.klaatu_start_job(self.experiment, application)


### PR DESCRIPTION
Because

- We want to test klaatu on stage so we need to add the option to set the server type when requesting a test run via Klaatu

This commit

- Adds the ability to specify the server type when starting a klaatu job.

Fixes #13530 