### PR TITLE
feat(nimbus): display firefox labs fields on overview page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -63,6 +63,47 @@
       {% endif %}
     </tbody>
   </table>
+  {% if experiment.is_firefox_labs_opt_in %}
+    <h6>Firefox Labs</h6>
+    <table class="table table-striped">
+      <tbody>
+        <tr>
+          <th>Title</th>
+          <td class="w-75">{{ experiment.firefox_labs_title|default:"---" }}</td>
+        </tr>
+        <tr>
+          <th>Description</th>
+          <td class="w-75">{{ experiment.firefox_labs_description|default:"---" }}</td>
+        </tr>
+        <tr>
+          <th>Description Links</th>
+          <td class="w-75">
+            {% if experiment.firefox_labs_description_links %}
+              <code>{{ experiment.firefox_labs_description_links|format_not_set|format_json }}</code>
+            {% else %}
+              ---
+            {% endif %}
+          </td>
+        </tr>
+        <tr>
+          <th>Group</th>
+          <td class="w-75">{{ experiment.firefox_labs_group }}</td>
+        </tr>
+        <tr>
+          <th>Requires Restart?</th>
+          {% if experiment.requires_restart %}
+            <td class="w-75">
+              <i class="fa-regular fa-circle-check text-success"></i></i>
+            </td>
+          {% else %}
+            <td class="w-75">
+              <i class="fa-regular fa-circle-xmark text-danger"></i>
+            </td>
+          {% endif %}
+        </tr>
+      </tbody>
+    </table>
+  {% endif %}
 </div>
 <div class="modal fade"
      id="promoteToRolloutModal-{{ branch.slug }}"


### PR DESCRIPTION
Because

- Firefox labs fields were not being displayed on the overview page

This commit

- Adds a conditionally rendered table that appears only if a labs rollout is being created

Fixes #13312 