### PR TITLE
bug(nimbus): make multiselect description text visible

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -35,6 +35,10 @@
       color: var(--bs-primary-text-emphasis, #084298) !important;
       box-shadow: 0 1px 4px rgba(0, 0, 0, 0.04);
       outline: none;
+
+      .text-muted {
+        color: var(--bs-primary-text-emphasis, #084298) !important;
+      }
     }
   }
 


### PR DESCRIPTION
Becuase

* We overrode a bunch of the bootstrap select elements CSS
* We missed a rule to make the description text visible for a selected row

This commit

* Adds the missing rule to make the selected rows description text visible

fixes #13261
