### PR TITLE
feat(nimbus): warn on multichannel experiments

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1716,6 +1716,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             if pref_collision_warning := self.pref_targeting_rollout_collision_warning:
                 warnings.append(pref_collision_warning)
 
+            if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
+                warnings.append(
+                    {
+                        "text": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
+                        "slugs": [],
+                        "variant": "warning",
+                        "learn_more_link": "",
+                    }
+                )
+
         return warnings
 
     def get_invalid_fields_errors(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2419,6 +2419,8 @@ class TestNimbusExperiment(TestCase):
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -2436,6 +2438,8 @@ class TestNimbusExperiment(TestCase):
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -2460,6 +2464,8 @@ class TestNimbusExperiment(TestCase):
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.PREVIEW,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            application=NimbusExperiment.Application.DESKTOP,
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -2490,6 +2496,8 @@ class TestNimbusExperiment(TestCase):
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -2595,6 +2603,21 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(len(warnings), 1)
         self.assertEqual(warnings[0]["text"], NimbusUIConstants.PREF_TARGETING_WARNING)
         self.assertEqual(warnings[0]["slugs"], [rollout.slug])
+
+    def test_multichannel_experiments_warning(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.RELEASE],
+            is_rollout=False,
+        )
+
+        warnings = experiment.audience_overlap_warnings
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(
+            warnings[0]["text"], NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING
+        )
+        self.assertEqual(warnings[0]["slugs"], [])
 
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -43,6 +43,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     which may result in reduced statistical power and precision or prevent enrollment
     entirely. Please check that the configured population proportion has accounted for
     this:"""
+    EXPERIMENT_MULTICHANNEL_WARNING = """WARNING: This experiment is targeting multiple
+    channels.  Each channel has significantly different population sizes and user
+    behaviour.  Running an experiment on multiple channels can create misleading or
+    inaccurate results.  It is recommended to run experiments only on a single channel."""
 
     AUDIENCE_OVERLAP_WARNING = "https://experimenter.info/faq/warnings/#audience-overlap"
     ROLLOUT_BUCKET_WARNING = (


### PR DESCRIPTION
Becuase

* Now that desktop experiments/rollouts can target multiple channels
* It's possible to create a desktop experiment that targets multiple channels
* In general experiments should not target multiple channels because their populations are significantly different
* There may be some cases where an experiment should target multiple channels so we should only warn on it

This commit

* Adds a warning for desktop multichannel experiments

fixes #13533
