### PR TITLE
chore(nimbus): make htmx loading overlay transparent

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -76,7 +76,7 @@ const setupHTMXLoadingOverlay = () => {
   document.addEventListener("htmx:beforeRequest", function () {
     const loadingOverlay = document.querySelector("#htmx-loading-overlay");
     if (loadingOverlay) {
-      loadingOverlay.style.opacity = "1";
+      loadingOverlay.style.opacity = "0.75";
       loadingOverlay.style.pointerEvents = "auto";
     }
   });


### PR DESCRIPTION
Becuase

* We recently added an overlay when HTMX is making a request
* It was supposed to be semi transparent but it was accidentally fully opaque

This commit

* Changes the overlay opacity to be semi transparent

fixes #13544
