### PR TITLE
chore(nimbus): align timeline content

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/timeline.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/timeline.html
@@ -1,8 +1,8 @@
 <ul class="list-group list-group-horizontal justify-content-between mb-3">
   {% for status in experiment.timeline %}
-    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-center {% if status.is_active %}bg-primary text-white{% endif %} {% if status.step > experiment.experiment_active_status %}bg-body-secondary{% endif %}">
+    <li class="list-group-item flex-fill text-center d-flex flex-column justify-content-start {% if status.is_active %}bg-primary text-white{% endif %} {% if status.step > experiment.experiment_active_status %}bg-body-secondary{% endif %}">
       <strong>{{ status.label }}</strong>
-      <small>{{ status.date|default:'---' }}</small>
+      <small>{{ status.date|default:'<i class="fa-solid fa-minus"></i>' }}</small>
       {% if status.days is not None %}
         <div class="d-flex justify-content-center align-items-center">
           <small class="mr-2">{{ status.days }} day{{ status.days|pluralize }}</small>
@@ -10,6 +10,10 @@
              data-bs-toggle="tooltip"
              data-bs-placement="bottom"
              title="{{ status.tooltip }}"></i>
+        </div>
+      {% else %}
+        <div class="d-flex justify-content-center align-items-center">
+          <small class="mr-2"><i class="fa-solid fa-minus"></i></small>
         </div>
       {% endif %}
     </li>


### PR DESCRIPTION
Because

* We had vertically centered the timeline content
* When days/dates are missing this caused the content to be misaligned

This commit

* Aligns everything to top
* Adds a placeholder for missing days/dates

fixes #13546

