### PR TITLE
feat(nimbus): change json fields readonly codemirror components

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
@@ -1,0 +1,43 @@
+import { basicSetup } from "codemirror";
+import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
+import { json, jsonParseLinter } from "@codemirror/lang-json";
+import { linter } from "@codemirror/lint";
+
+import $ from "jquery";
+
+const setupCodemirroReadOnlyJSON = () => {
+  const selector = ".readonly-json";
+  const textareas = document.querySelectorAll(selector);
+
+  textareas.forEach((textarea) => {
+    if (textarea._codemirrorInitialized) {
+      return;
+    }
+    textarea._codemirrorInitialized = true;
+    const extensions = [
+      basicSetup,
+      json(),
+      linter(jsonParseLinter()),
+      EditorState.readOnly.of(true),
+      EditorView.editable.of(false),
+    ];
+
+    const view = new EditorView({
+      doc: textarea.value,
+      extensions,
+      parent: textarea.parentNode,
+    });
+
+    view.dom.style.border = "1px solid #ccc";
+
+    textarea.parentNode.insertBefore(view.dom, textarea);
+    textarea.style.display = "none";
+
+    return view;
+  });
+};
+
+$(() => {
+  setupCodemirroReadOnlyJSON();
+});

--- a/experimenter/experimenter/nimbus_ui/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui/static/webpack.config.js
@@ -9,6 +9,7 @@ module.exports = {
     edit_audience: "./js/edit_audience.js",
     edit_branches: "./js/edit_branches.js",
     experiment_detail: "./js/experiment_detail.js",
+    branch_detail: "./js/branch_detail.js",
   },
   output: {
     filename: "[name].bundle.js",

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -321,11 +321,7 @@
               <th id="recipe-json">Recipe JSON</th>
               <td colspan="3" id="preview-recipe-json">
                 <div class="collapse" id="collapse-recipe">
-                  <code>
-                    <pre class="text-monospace" style="white-space: pre-wrap; word-wrap: break-word;">
-                        {{ experiment.recipe_json|linebreaks|linebreaksbr }}
-                      </pre>
-                  </code>
+                  <textarea class="readonly-json">{{ experiment.recipe_json }}</textarea>
                 </div>
                 <button class="btn btn-outline-primary btn-sm"
                         type="button"
@@ -378,4 +374,5 @@
   <script src="{% static 'nimbus_ui/setup_selectpicker.bundle.js' %}"></script>
   <script src="{% static 'nimbus_ui/review_controls.bundle.js' %}"></script>
   <script src="{% static 'nimbus_ui/experiment_detail.bundle.js' %}"></script>
+  <script src="{% static 'nimbus_ui/branch_detail.bundle.js' %}"></script>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -33,7 +33,7 @@
           <tr>
             <th>{{ feature_value.feature_config.name|format_not_set }} Value</th>
             <td colspan="3">
-              <code>{{ feature_value.value|format_not_set|format_json }}</code>
+              <textarea class="readonly-json">{{ feature_value.value }}</textarea>
             </td>
           </tr>
         {% endfor %}


### PR DESCRIPTION
Because

- Long JSON elements were difficult to parse through on overview page
- Lacked any syntax highlighting or folding capabilities

This commit

- Applies codemirror to existing json elements in overview page

Fixes #13073 