### PR TITLE
fix(nimbus): fix codemirror not initiliazing on branch values after hmx swap event

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
@@ -11,10 +11,6 @@ const setupCodemirroReadOnlyJSON = () => {
   const textareas = document.querySelectorAll(selector);
 
   textareas.forEach((textarea) => {
-    if (textarea._codemirrorInitialized) {
-      return;
-    }
-    textarea._codemirrorInitialized = true;
     const extensions = [
       basicSetup,
       json(),
@@ -40,4 +36,8 @@ const setupCodemirroReadOnlyJSON = () => {
 
 $(() => {
   setupCodemirroReadOnlyJSON();
+
+  document.body.addEventListener("htmx:afterSwap", function () {
+    setupCodemirroReadOnlyJSON();
+  });
 });


### PR DESCRIPTION
Because

- Codemirror was failing to load correctly after review controls were used

This commit

- Fixes that issue 

Fixes #13563