### PR TITLE
feat(nimbus): Add advanced targeting for terms of use users

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2318,6 +2318,28 @@ IOS_TIPS_NOTIFICATIONS_ENABLED_USER = NimbusTargetingConfig(
     application_choice_names=(Application.IOS.name,),
 )
 
+IOS_ACCEPTED_TERMS_OF_USE_USER = NimbusTargetingConfig(
+    name="Users Who Accepted Terms of Use",
+    slug="ios_accepted_terms_of_use_user",
+    description="Users that have already accepted the Terms of Use",
+    targeting="has_accepted_terms_of_use == true",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
+IOS_NOT_ACCEPTED_TERMS_OF_USE_USER = NimbusTargetingConfig(
+    name="Users Who Have Not Accepted Terms of Use",
+    slug="ios_not_accepted_terms_of_use_user",
+    description="Users that have not accepted the Terms of Use",
+    targeting="has_accepted_terms_of_use == false",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.IOS.name,),
+)
+
 IOS_APPLE_INTELLIGENCE_AVAILABLE_USER = NimbusTargetingConfig(
     name="Apple Intelligence Available Users",
     slug="ios_apple_intelligence_available_user",

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -102,6 +102,7 @@ def test_check_mobile_targeting(
             "is_default_browser": True,
             "is_bottom_toolbar_user": True,
             "has_enabled_tips_notifications": True,
+            "has_accepted_terms_of_use": True,
             "is_apple_intelligence_available": True,
             "cannot_use_apple_intelligence": True,
             "install_referrer_response_utm_source": "test",


### PR DESCRIPTION
Because

- We want to be able to target iOS users that have accepted or not accepted the Terms of Use (ToU). See associated [PR](https://github.com/mozilla-mobile/firefox-ios/pull/28249)  for more details.

This commit adds  two advanced targeting options:

- iOS users who have accepted the ToU
- iOS users who have not yet accepted the ToU

Fixes https://github.com/mozilla/experimenter/issues/13480 
Fixes https://mozilla-hub.atlassian.net/browse/FXIOS-12398