### PR TITLE
feat(nimbus): Add advanced targeting for TOU experiences in users who…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3208,8 +3208,7 @@ TOU_EXPERIENCE_0 = NimbusTargetingConfig(
     name="TOU Experience 0",
     slug="tou_experience_0",
     description=(
-        "User has not accepted TOU V4 or higher",
-        "and should see TOU experience 0",
+        "User has not accepted TOU V4 or higher and should see TOU experience 0"
     ),
     targeting=f"""
     (
@@ -3230,8 +3229,7 @@ TOU_EXPERIENCE_1 = NimbusTargetingConfig(
     name="TOU Experience 1",
     slug="tou_experience_1",
     description=(
-        "User has not accepted TOU V4 or higher",
-        "and should see TOU experience 1",
+        "User has not accepted TOU V4 or higher and should see TOU experience 1"
     ),
     targeting=f"""
     (
@@ -3252,8 +3250,7 @@ TOU_EXPERIENCE_2 = NimbusTargetingConfig(
     name="TOU Experience 2",
     slug="tou_experience_2",
     description=(
-        "User has not accepted TOU V4 or higher",
-        "and should see TOU experience 2",
+        "User has not accepted TOU V4 or higher and should see TOU experience 2"
     ),
     targeting=f"""
     (


### PR DESCRIPTION
… have not accepted TOU

Because

- We wish to show different TOU experiences to users based on a list of set criteria (see linked issue for more details)

This commit

- Adds three new targeting constants for the three TOU experiences
- Makes existing TOU related variables more robust across regions by checking to see if system prefs are enabled before checking the related non-system pref is truthy or falsey.
- Removes outdated variables/TOU version references that no longer apply now that we've migrated to new TOU preference names.

Fixes #13571
