### PR TITLE
fix(nimbus): fix misaligned screenshot fields on invalid input

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -193,7 +193,7 @@
                   {% for screenshot_form in branch_form.screenshot_formset %}
                     {% with forloop.counter0 as screenshot_index %}
                       {{ screenshot_form.id }}
-                      <div class="row mb-2">
+                      <div class="row mb-2 align-items-start">
                         <div class="col-4">
                           {{ screenshot_form.image|add_error_class:"is-invalid" }}
                           {% for error in screenshot_form.image.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}


### PR DESCRIPTION
Because

- When uploading an invalid screenshot to branches the error message would cause the screenshot and description fields to be misaligned

This commit

- Realigns those fields if an error message is shown

Fixes #13010