### PR TITLE
bug(nimbus): remove jquery dependency from list page script

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/experiment_list.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/experiment_list.js
@@ -4,8 +4,10 @@ document.body.addEventListener("htmx:afterSwap", function () {
   const urlParams = new URLSearchParams(window.location.search);
   const sortValue = urlParams.get("sort");
   const statusValue = urlParams.get("status");
-  $('#filter-form input[name="status"]').each(
-    (i, e) => (e.value = statusValue),
-  );
-  $('#filter-form input[name="sort"]').each((i, e) => (e.value = sortValue));
+  document
+    .querySelectorAll('#filter-form input[name="status"]')
+    .forEach((e) => (e.value = statusValue));
+  document
+    .querySelectorAll('#filter-form input[name="sort"]')
+    .forEach((e) => (e.value = sortValue));
 });


### PR DESCRIPTION
Because

* When we added webpack to all the frontend assets we missed explicitly importing jquery on one script
* This is the script responsible for managing state between the status tabs and the filters on the sidebar
* We could simply import jquery to fix that script
* But it's also quite small and we can accomplish the same thing without using jquery at all

This commit

* Removes the jquery dependency from the list page script
* This should restore the status tab and sidebar filter synchronization behaviour

fixes #12965

