### PR TITLE
fix(nimbus): format feature config as list

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -99,7 +99,7 @@
               <th>Feature config</th>
               <td>
                 {% for feature in experiment.feature_configs.all %}
-                  {{ feature.name }} - {{ feature.description }}
+                  <p>{{ feature.name }} - {{ feature.description }}</p>
                 {% empty %}
                   <span class="text-danger">Not set</span>
                 {% endfor %}


### PR DESCRIPTION
Because

- Feature config was difficult to read 

This commit

- Formats the feature config as a list of easy to read elements

Fixes #13556 