### PR TITLE
feat(nimbus): Remove targeting for Fakespot

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2477,17 +2477,6 @@ ANDROID_LATER_APP_LAUNCH_USERS_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.FENIX.name,),
 )
 
-IOS_REVIEW_CHECKER_ENABLED_USERS_ONLY = NimbusTargetingConfig(
-    name="Review checker enabled users only",
-    slug="ios_review_checker_enabled_users_only",
-    description="Targeting users who have opted in review checker",
-    targeting="is_review_checker_enabled",
-    desktop_telemetry="",
-    sticky_required=False,
-    is_first_run_required=False,
-    application_choice_names=(Application.IOS.name,),
-)
-
 ANDROID_DMA_USERS_ONLY = NimbusTargetingConfig(
     name="DMA users only",
     slug="android_dma_users_only",


### PR DESCRIPTION
Because

- We want to clean up unused code and targeting

This commit

- removed the advanded targeting for Fakespot in iOS as the targetting on the iOS side was already removed

Fixes [#Firefox iOS #25966](https://github.com/mozilla-mobile/firefox-ios/issues/25966)