### PR TITLE
fix(nimbus): fix recipe dropdown not able to close after opening

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/experiment_detail.js
@@ -1,5 +1,3 @@
-import * as bootstrap from "bootstrap";
-
 const setupCollapseRecipe = () => {
   const collapseRecipe = document.getElementById("collapse-recipe");
   if (!collapseRecipe) return;
@@ -32,7 +30,7 @@ const setupPreviewUrlCopyToast = () => {
   if (previewUrl && copiedToast) {
     previewUrl.addEventListener("click", function () {
       navigator.clipboard.writeText(previewUrl.textContent.trim());
-      var toast = bootstrap.Toast.getOrCreateInstance(copiedToast);
+      var toast = window.bootstrap.Toast.getOrCreateInstance(copiedToast);
       toast.show();
     });
   }


### PR DESCRIPTION
Because

- Collapsible menus such as the JSON recipes could not be closed after they were open

This commit

- FIxes this issue

Fixes #13562 