### PR TITLE
fix(nimbus): fix json fields being duplicated on unrelated htmx updates

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/branch_detail.js
@@ -11,6 +11,8 @@ const setupCodemirroReadOnlyJSON = () => {
   const textareas = document.querySelectorAll(selector);
 
   textareas.forEach((textarea) => {
+    if (textarea.dataset.is_rendered) return;
+    textarea.dataset.is_rendered = true;
     const extensions = [
       basicSetup,
       json(),


### PR DESCRIPTION
Because

- Branch value json fields were being duplicated when "Edit" button in qa section was pressed

This commit

- Adds a flag to text area components that checks if it has been rendered to prevent duplicates

Fixes #13595 