### PR TITLE
chore(project): Add missing data for Mobile klaatu workflows.

### DIFF
--- a/experimenter/experimenter/klaatu/client.py
+++ b/experimenter/experimenter/klaatu/client.py
@@ -84,7 +84,8 @@ class KlaatuClient:
                 "slug": experiment_slug,
                 "branch": json.dumps(branch_slugs),
                 "firefox-version": json.dumps(targets),
-                "server": server,
+                "experiment-server": server,
+                "feature-name": "smoke",
             },
         }
 


### PR DESCRIPTION
Because

- We were missing some data needed to trigger the mobile workflows effectively

This commit

- Adds the missing data to the API call.

Fixes #13607