### PR TITLE
feat(nimbus): Add QA Runs table to feature health page.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1532,7 +1532,7 @@ class FeaturesForm(forms.ModelForm):
             "hx-select": "#features-form",
             "hx-target": "#features-form",
             "hx-swap": "outerHTML",
-            "hx-select-oob": "#deliveries-table",
+            "hx-select-oob": "#deliveries-table, #qa-info-table",
         }
         self.fields["application"].widget.attrs.update(htmx_attrs)
         self.fields["feature_configs"].widget.attrs.update(htmx_attrs)

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -83,7 +83,72 @@
             </table>
           </div>
         </div>
+        <hr>
+        <h5 class="fw-semibold">
+          <img src="{% static 'assets/my-deliveries.svg' %}"
+               alt="Hugging Foxes"
+               style="width: 60px;
+                      height: auto" />
+          QA Runs
+        </h5>
+        <div>
+          <div>
+            <table id="qa-info-table"
+                   class="table table-hover table-borderless align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>QA Run</th>
+                  <th>Date</th>
+                  <th>Test Type</th>
+                  <th>QA Status</th>
+                  <th>Test Plan/Experimenter Recipe</th>
+                  <th>TestRail Results</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for experiment in experiments %}
+                  <tr scope="row">
+                    <td id="qa-run">{{ experiment.qa_run|default:forloop.counter }}</td>
+                    <td id="qa-run-date">
+                      <a target="_blank" href="" class="text-decoration-none fw-medium">{{ experiment.qa_run_date|format_not_set }}</a>
+                    </td>
+                    <td id="qa-run-type">
+                      <a target="_blank" href="" class="text-decoration-none fw-medium">{{ experiment.qa_run_type|format_not_set }}</a>
+                    </td>
+                    <td id="qa-run-status">
+                      <div>
+                        {{ experiment.get_qa_status_display }}
+                        {% if experiment.qa_status == experiment.QAStatus.NOT_SET %}
+                          <i class="fa-regular fa-circle-question"></i>
+                        {% elif experiment.qa_status == experiment.QAStatus.GREEN or experiment.qa_status == experiment.QAStatus.SELF_GREEN %}
+                          <span class="text-success">
+                            <i class="fa-regular fa-circle-check"></i>
+                          </span>
+                        {% elif experiment.qa_status == experiment.QAStatus.YELLOW or experiment.qa_status == experiment.QAStatus.SELF_YELLOW %}
+                          <span class="text-warning"><i class="fa-regular fa-circle-pause"></i></span>
+                        {% elif experiment.qa_status == experiment.QAStatus.RED or experiment.qa_status == experiment.QAStatus.SELF_RED %}
+                          <span class="text-danger"><i class="fa-regular fa-circle-xmark"></i></span>
+                        {% endif %}
+                      </div>
+                    </td>
+                    <td id="qa-test-plan">
+                      <a target="_blank" href="" class="text-decoration-none fw-medium">{{ experiment.qa_run_test_plan|format_not_set }}</a>
+                    </td>
+                    <td id="qa-testrail-link">
+                      <a target="_blank" href="" class="text-decoration-none fw-medium">{{ experiment.qa_run_testrail_link|format_not_set }}</a>
+                    </td>
+                  {% empty %}
+                    <tr>
+                      <td colspan="12" class="fw-semibold text-center p-4">
+                        <h4>No QA Runs</h4>
+                      </td>
+                    </tr>
+                  {% endfor %}
+                </tbody>
+              </table
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  </div>
-{% endblock %}
+  {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3459,4 +3459,5 @@ class TestNimbusFeaturesView(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "#deliveries-table")
+        self.assertContains(response, "#qa-info-table")
         self.assertContains(response, experiment)


### PR DESCRIPTION
Because

- We want to display all the QA runs that experiments have on them based on the feature a user selects on the feature health page

This commit

- Adds the rough layout for that page. We don't currently have a lot of the information we need for this table but we plan to add a form to collect this.

Fixes #13611