### PR TITLE
Trainhop advanced targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3300,6 +3300,16 @@ MAC_SIGNED_OUT_USER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_145_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx145 9-19 Trainhop",
+    slug="newtab-145-0919-trainhop",
+    description="Desktop users having the New Tab 145.0.20250919 train hop, which includes users of Fx143",
+    targeting="newtabAddonVersion|versionCompare('145.0.20250919.173227') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
 
 class TargetingConstants:
     TARGETING_CONFIGS = {

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3303,13 +3303,15 @@ MAC_SIGNED_OUT_USER = NimbusTargetingConfig(
 FX_145_TRAINHOP = NimbusTargetingConfig(
     name="New Tab Fx145 9-19 Trainhop",
     slug="newtab-145-0919-trainhop",
-    description="Desktop users having the New Tab 145.0.20250919 train hop, which includes users of Fx143",
+    description="Desktop users having the New Tab 145.0.20250919 train hop,"
+    "which includes users of Fx143",
     targeting="newtabAddonVersion|versionCompare('145.0.20250919.173227') >= 0",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )
+
 
 class TargetingConstants:
     TARGETING_CONFIGS = {


### PR DESCRIPTION
Add support for HNT NewTab train hop targeting

- Reason

This commit will allow us to create experiments targeting users of the New Tab trainhop that was just released to Firefox 143 users.

- Change

Fixes https://github.com/mozilla/experimenter/issues/13619