### PR TITLE
chore(ci): Upload built android apk files as artifacts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -867,6 +867,12 @@ jobs:
           paths:
             - tests/integration/nimbus/android/app-fenix-debug-androidTest.apk
             - tests/integration/nimbus/android/app-fenix-x86_64-debug.apk
+      - store_artifacts:
+          path: ~/experimenter/experimenter/tests/integration/nimbus/android/app-fenix-debug-androidTest.apk
+          destination: app-fenix-debug-androidTest.apk
+      - store_artifacts:
+          path: ~/experimenter/experimenter/tests/integration/nimbus/android/app-fenix-x86_64-debug.apk
+          destination: app-fenix-x86_64-debug.apk
 
 workflows:
   update_configs:


### PR DESCRIPTION
Because

- Klaatu needs android test files due to limitations around GitHub Actions and building the Android files on demand.

This commit

- Uploads the android apk files we build for testing so that we can fetch them via the circleci API.

Fixes #13656
