### PR TITLE
feat(nimbus) Make SPONSORED_SEARCH_SUGGESTIONS_DISABLED region agnostic

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -81,7 +81,8 @@ RECOMMENDED_OR_SPONSORED_STORIES_DISABLED = """
 )
 """
 SPONSORED_SEARCH_SUGGESTIONS_DISABLED = (
-    "'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceIsUserSet && !'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceValue"
+    "'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceIsUserSet "
+    "&& !'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceValue"
 )
 ADS_DISABLED = f"""
 (


### PR DESCRIPTION
Because

- QA found that the browser.urlbar.suggest.quicksuggest.sponsored pref is only enabled by default for GB and US and we want to only consider this pref disabled if a user explicitly turned it off.

This commit

- Checks to see if that pref is user set before checking its value.
