### PR TITLE
feat(nimbus): Show selected features

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/filter_dropdown.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/filter_dropdown.html
@@ -69,7 +69,7 @@
                    name="{{ filter_name }}"
                    id="{{ filter_name }}-{{ value|slugify }}"
                    value="{{ value }}"
-                   {% if selected_values and value in selected_values %}checked{% endif %}>
+                   {% if selected_values and value|to_str in selected_values %}checked{% endif %}>
             <label class="form-check-label" for="{{ filter_name }}-{{ value|slugify }}">{{ label }}</label>
           </div>
         {% endfor %}

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -201,6 +201,11 @@ def home_status_display_with_icon(experiment):
 
 
 @register.filter
+def to_str(value):
+    return str(value)
+
+
+@register.filter
 def experiment_date_progress(experiment):
     today = date.today()
 


### PR DESCRIPTION
Because

- Features selected are not visible when you visit the feature filter again on the home page

This commit

- Converts the id into strings to allow to show it selected

Fixes #13646 

