### PR TITLE
chore(ci): Bump iOS version for iOS tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ orbs:
   gh: circleci/github-cli@2.2
   gcp-cli: circleci/gcp-cli@3.3.1
   android: circleci/android@2.5.0
-  macos: circleci/macos@2.5.2
+  macos: circleci/macos@2.5.4
 commands:
   check_file_paths:
     description: "Check file paths"
@@ -519,7 +519,8 @@ jobs:
 
   integration_nimbus_ios_enrollment:
     macos:
-      xcode: 16.2
+      xcode: << parameters.ios_version >>
+    resource_class: m4pro.medium
     parameters:
       file_path:
         type: string
@@ -560,6 +561,7 @@ jobs:
             git checkout "$BRANCH"
             sh ./bootstrap.sh
             cd firefox-ios
+            xcodebuild -downloadComponent MetalToolchain
             xcodebuild build-for-testing -scheme Fennec -target Client -destination 'platform=iOS Simulator,name=<< parameters.simulator_device >>,OS=<< parameters.ios_version >>' COMPILER_INDEX_STORE_ENABLE=NO CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO ARCHS="arm64"
       - run:
           name: Run Tests
@@ -928,6 +930,7 @@ workflows:
             branches:
               only:
                 - update_firefox_versions
+                - fix-13658
       - integration_nimbus_desktop_ui:
           name: Test Desktop Nimbus UI (Release Firefox)
           filters:
@@ -986,27 +989,17 @@ workflows:
               only:
                 - update_firefox_versions
       - integration_nimbus_ios_enrollment:
-          name: Test Firefox for iOS Beta
-          requires:
-            - Create Fenix and iOS recipes
-          file_path: experimenter/tests/firefox_fennec_beta_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
-          filters:
-            branches:
-              only:
-                - update_firefox_versions
-      - integration_nimbus_ios_enrollment:
           name: Test Firefox for iOS Release
           requires:
             - Create Fenix and iOS recipes
           file_path: experimenter/tests/firefox_fennec_release_build.env
-          ios_version: "18.2"
-          simulator_device: iPhone 16
+          ios_version: "26.0"
+          simulator_device: iPhone 17
           filters:
             branches:
               only:
                 - update_firefox_versions
+                - fix-13658
       - integration_nimbus_sdk_targeting:
           name: Test SDK Targeting (Release Firefox)
           filters:

--- a/experimenter/tests/firefox_fennec_beta_build.env
+++ b/experimenter/tests/firefox_fennec_beta_build.env
@@ -1,3 +1,0 @@
-FIREFOX_FENNEC_BETA_VERSION_ID="Firefox beta v141.0b9"
-BRANCH="60988e47a35b5d035e0fd99c5ed8b67868d1337c"
-# Firefox version is "143.0.3"

--- a/experimenter/tests/integration/nimbus/ios/xcodebuild.py
+++ b/experimenter/tests/integration/nimbus/ios/xcodebuild.py
@@ -11,7 +11,7 @@ LOGGER = logging.getLogger(__name__).addHandler(logging.NullHandler())
 
 class XCodeBuild:
     def __init__(self, log, **kwargs):
-        self.device = os.getenv("IOS_DEVICE", "iPhone 16")
+        self.device = os.getenv("SIMULATOR_DEVICE", "iPhone 16")
         self.ios_version = os.getenv("IOS_VERSION", "18.1")
         self.binary = "xcodebuild"
         self.destination = (

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -57,18 +57,6 @@ fetch_task_info() {
             mv firefox_fennec_release_build.env experimenter/tests
             return
             ;;
-        fennec_beta)
-            releases=$(curl "${CURLFLAGS[@]}" "${FENNEC_GITHUB_API}/releases" | jq '[.[] | select(.prerelease == true) | select(.name | test("^Firefox beta v[0-9]+\\.[0-9]+b[0-9]+$"; "i"))][0]')
-            version=$(echo "$releases" | jq -r '.name')
-            branch=$(echo "$releases" | jq -r '.target_commitish')
-
-            echo "FIREFOX_FENNEC_BETA_VERSION_ID ${version}"
-            echo "FIREFOX_FENNEC_BETA_VERSION_ID=\"${version}\"" > firefox_fennec_beta_build.env
-            echo "BRANCH=\"${branch}\"" >> firefox_fennec_beta_build.env
-            echo "# Firefox version is ${release_version}" >> firefox_fennec_beta_build.env
-            mv firefox_fennec_beta_build.env experimenter/tests
-            return
-            ;;
         *)
             echo "Unknown variant: ${variant}. Please specify a valid variant."
             return


### PR DESCRIPTION
Because

- Firefox for iOS now uses iOS 26

This commit

- Updates our circleci test jobs to use ios 26
- Removes iOS Beta jobs and tracking files.

Fixes #13658 