### PR TITLE
fix(nimbus): Update the `TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SPONSORED_OPT_OUTS` configuration to be first run

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2534,7 +2534,7 @@ TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SPONSORED_OPT_OUTS = NimbusTargetingCo
     targeting="user_accepted_tou == false && no_shortcuts_or_stories_opt_outs == true",
     desktop_telemetry="",
     sticky_required=False,
-    is_first_run_required=False,
+    is_first_run_required=True,
     application_choice_names=(Application.FENIX.name,),
 )
 


### PR DESCRIPTION
Because

- The ToU prompt is still being displayed after the user has completed onboarding. The theory here is that the config needs to be first-run to prevent the user from being enrolled erroneously after onboarding is completed.

This commit

- Updates `TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SPONSORED_OPT_OUTS` to be first-run.

Fixes [#1994130](https://bugzilla.mozilla.org/show_bug.cgi?id=1994130)