### PR TITLE
feat(nimbus): ToU advance targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3163,7 +3163,9 @@ TOU_NOT_ACCEPTED_V4PLUS_MAC_OR_WIN = NimbusTargetingConfig(
 TOU_ACCEPTED_V4_MAC_OR_WIN_AND_SPONSORED_TOPSITES_ENABLED = NimbusTargetingConfig(
     name="Mac or Windows users accepted TOU version 4 and Sponsored TopSites enabled",
     slug="tou_accepted_mac_win_newtab_sponsored_topsites_enabled",
-    description="TOU version 4 or higher accepted, Mac or Win, and Sponsored TopSites enabled",
+    description=(
+        "TOU version 4 or higher accepted, Mac or Win, and Sponsored TopSites enabled"
+    ),
     targeting=f"""
     (
         (


### PR DESCRIPTION
Because

- Targeting currently exists for [TOU_ACCEPTED_V4PLUS_MAC_OR_WIN](https://github.com/mozilla/experimenter/blob/a392a251c659606938a2510140448b9933118d41/experimenter/experimenter/targeting/constants.py#L3145) and [NEWTAB_SPONSORED_TOPSITES_ENABLED](https://github.com/mozilla/experimenter/blob/a392a251c659606938a2510140448b9933118d41/experimenter/experimenter/targeting/constants.py#L1810). This new targeting will combine both of these targets.

This commit

- Adds the new targeting

Fixes #13668