### PR TITLE
feat(nimbus): Add targeting for iOS existing users who have not accepted ToU

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2367,7 +2367,7 @@ IOS_EXISTING_USERS_NOT_ACCEPTED_TERMS_OF_USE = NimbusTargetingConfig(
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,
-    application_choice_names=(Application.IOS.name,)
+    application_choice_names=(Application.IOS.name,),
 )
 
 IOS_APPLE_INTELLIGENCE_AVAILABLE_USER = NimbusTargetingConfig(


### PR DESCRIPTION

Because

- We want to be able to target existing iOS users (that have been using the app for 28+ days) who have not accepted Terms of Use (ToU)

This commit adds one advanced targeting options:

- iOS existing users who have not accepted ToU (it combines 2 options that are already implemented - existing iOS users and users who have not accepted ToU)

Fixes [#30043](https://github.com/mozilla-mobile/firefox-ios/issues/30043)
Fixes [FXIOS-13869](https://mozilla-hub.atlassian.net/browse/FXIOS-13869)