### PR TITLE
Revert "fix(nimbus): Update the `TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SPONSORED_OPT_OUTS` configuration to be first run"

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2527,7 +2527,7 @@ TOU_TARGETING_ANDROID_NOT_ACCEPTED_AND_NO_SPONSORED_OPT_OUTS = NimbusTargetingCo
     targeting="user_accepted_tou == false && no_shortcuts_or_stories_opt_outs == true",
     desktop_telemetry="",
     sticky_required=False,
-    is_first_run_required=True,
+    is_first_run_required=False,
     application_choice_names=(Application.FENIX.name,),
 )
 


### PR DESCRIPTION
Reverts mozilla/experimenter#13681

Need to re-verify the reported issue without this change.