### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 145.1.20251009.134757 for desktop.

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3337,6 +3337,18 @@ FX_145_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_145_1_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx145 10-09 Trainhop",
+    slug="newtab-145-1009-trainhop",
+    description="Desktop users having the New Tab 145.1.20251009 train hop,"
+    "which includes users of Fx144",
+    targeting="newtabAddonVersion|versionCompare('145.1.20251009.134757') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",


### PR DESCRIPTION
Adds support for targeting the 145.1.20251009.134757 newtab trainhop on desktop.

- Reason

This commit will allow us to create experiments targeting users of the New Tab trainhop that was just released to Firefox 144 users on the release channel.

- Change

Fixes #13697