### PR TITLE
feat(nimbus): Reset date filtering option on home page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/date_filter_dropdown.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/date_filter_dropdown.html
@@ -34,6 +34,26 @@
               overflow: auto">
     <strong class="dropdown-header">Filter by Date</strong>
     <div class="m-0 date-filter">
+      <div class="form-check" id="filter-choice-date_range-clear">
+        <input class="form-check-input"
+               type="radio"
+               name="date_range"
+               value=""
+               id="date_range-clear"
+               {% if not form.date_range.value %}checked{% endif %}
+               hx-get="{{ url }}"
+               hx-target="{{ hx_target }}"
+               hx-select="{{ hx_select }}"
+               hx-swap="outerHTML"
+               hx-trigger="change"
+               hx-include="input:checked, select"
+               hx-vals='{"date_range": ""}'
+               hx-push-url="true">
+        <label class="form-check-label" for="date_range-clear">
+          <strong>All Dates</strong>
+        </label>
+      </div>
+      <hr class="my-2">
       {% for choice_value, choice_label in choices %}
         {% if choice_value not in "custom" %}
           <div class="form-check" id="filter-choice-date_range-{{ choice_value }}">


### PR DESCRIPTION
Because

- Users once select the filtering on the date cannot unselect the option like last 7 days or like last year since we are using the radio button

This commit

- Adds the option all dates (selected by default) to reset the selected option 

Fixes #13651 