### PR TITLE
feat(nimbus): Add advanced targeting for Accounts Adoption for Browser Milestones

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3104,6 +3104,23 @@ SIGNED_OUT_EXISTING_USER_FXA_ENABLED_NO_ENTERPRISE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+SIGNED_OUT_USER_FXA_ENABLED_NO_ENTERPRISE = NimbusTargetingConfig(
+    name="Signed-out user, FxA enabled, no enterprise policies",
+    slug="signed_out_user_fxa_enabled_no_enterprise",
+    description=(
+        "Users with profiles older than 7 days, who are NOT signed into FxA, "
+        "with FxA enabled, and no enterprise policies"
+    ),
+    targeting=(
+        f"{PROFILEMORETHAN7DAYS} && {NO_ENTERPRISE.targeting} "
+        "&& !isFxASignedIn && isFxAEnabled"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 SIGNED_OUT_POST_FIRST_RUN_USER_FXA_ENABLED_NO_ENTERPRISE = NimbusTargetingConfig(
     name="Signed-out user, post first run, FxA enabled, no enterprise policies",
     slug="signed_out_user_post_first_run_fxa_enabled_no_enterprise",


### PR DESCRIPTION
To support the accounts adoption callout for browser milestones experiments (ie. [url visits](https://docs.google.com/document/d/1EdwBD4I-8ypvMKV_EDu6-tcOorS101fKr_gJ3nz4wrs/edit?tab=t.0), [bookmarks](https://docs.google.com/document/d/1LJ6oEIIwevIDcxCbXIfZ-QbVMVsf98QcI-8zrRy1k-o/edit?tab=t.0), and [tabs open](https://docs.google.com/document/d/1grjkuYu5HV4u7f9YTLi3TUTm8STQwuLNEubr3sqIovE/edit?tab=t.0)), this commit adds advanced targeting that covers:
- Profile age 7 days and older
- !isFxASignedIn
- isFxAEnabled
- Exclude enterprise users