### PR TITLE
chore(nimbus): Install libatomic1 dependency

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -62,6 +62,11 @@ ARG USERNAME=cirrus
 ARG USER_UID=10001
 ARG USER_GID=$USER_UID
 
+# Install libatomic1 for Node.js dependencies
+RUN apt-get update && \
+    apt-get -y install libatomic1 && \
+    rm -rf /var/lib/apt/lists/*
+
 RUN groupadd --gid $USER_GID $USERNAME \
     && useradd --uid $USER_UID --gid $USER_GID -m $USERNAME
 


### PR DESCRIPTION
Because

- Since we are using a slim version of Python which is missing the libatomic1 library which leads to make cirrus_check is failing

This commit

- Install the dependency- `libatomic1`

Fixes #13709 