### PR TITLE
feat(nimbus): Show date tooltip on i icon

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/home_sortable_header.html
@@ -34,7 +34,7 @@
                data-bs-toggle="tooltip"
                data-bs-placement="top"
                data-bs-html="true"
-               title="<div class='text-start'><strong>Progress Bar Colors:</strong><br> <span class='text-success'>●</span> Active enrollment<br> <span class='text-info'>●</span> Observation phase<br> <span class='text-secondary'>●</span> Completed<br> <span class='text-danger'>●</span> Overdue</div>"></i>
+               title="<div class='text-start'><strong>Progress Bar Colors:</strong><br> <span class='text-success'>●</span> Enrolling<br> <span class='text-info'>●</span>Observing<br> <span class='text-secondary'>●</span> Complete<br> <span class='text-danger'>●</span> Overdue</div>"></i>
           {% endif %}
           {% if current_sort == field %}
             <i class="ps-1 fa-solid fa-chevron-up"></i>


### PR DESCRIPTION
Because

- We are showing the tooltip on the text `Date` which is leading to multiple appearance of the tooltips

This commit

- Move the tooltip content to only visible on hover of `i ` icon

Fixes #13650 