### PR TITLE
feat(nimbus): setup results page with required data

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1546,6 +1546,19 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return False
 
     @property
+    def has_exposures(self):
+        # True if there are any exposures in the results data
+        if self.results_data and "v3" in self.results_data:
+            results_data = self.results_data["v3"]
+            for window in ["overall", "weekly"]:
+                if results_data.get(window):
+                    exposure_data = results_data[window].get("exposures", {}).get("all")
+                    if exposure_data is not None:
+                        return True
+
+        return False
+
+    @property
     def show_results_url(self):
         # if there are results, show them! even if the dates are wrong
         # (the dates may have been overridden in metric-hub)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3259,6 +3259,22 @@ class TestNimbusExperiment(TestCase):
 
         self.assertTrue(experiment.has_displayable_results)
 
+    def test_has_exposures_results_true(self):
+        results_data = {"v3": {"overall": {"exposures": {"all": {}}}}}
+        experiment = NimbusExperimentFactory.create()
+        experiment.results_data = results_data
+        experiment.save()
+
+        self.assertTrue(experiment.has_exposures)
+
+    def test_has_exposures_results_false(self):
+        results_data = {"v3": {"overall": {"enrollments": {"all": {}}}}}
+        experiment = NimbusExperimentFactory.create()
+        experiment.results_data = results_data
+        experiment.save()
+
+        self.assertFalse(experiment.has_exposures)
+
     @parameterized.expand(
         [
             ({},),

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -2988,6 +2988,102 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(response.context["experiment"], experiment)
         self.assertTemplateUsed(response, "nimbus_experiments/results.html")
 
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "other_metrics": {"group": {"metricA": "Metric A"}},
+                        "metadata": {
+                            "metrics": {"metricA": {"friendlyName": "Friendly Metric A"}},
+                        },
+                        "overall": {
+                            "enrollments": {"all": {}},
+                            "exposures": {"all": {}},
+                        },
+                        "weekly": {
+                            "enrollments": {"all": {}},
+                            "exposures": {"all": {}},
+                        },
+                    }
+                },
+                "exposures",
+                {"metricA": "Friendly Metric A"},
+            ),
+            (
+                {
+                    "v3": {
+                        "other_metrics": {"group": {"metricA": "Metric A"}},
+                        "metadata": {
+                            "metrics": {"metricA": {"friendlyName": "Friendly Metric A"}},
+                        },
+                        "overall": {"enrollments": {"all": {}}},
+                    }
+                },
+                "enrollments",
+                {"metricA": "Friendly Metric A"},
+            ),
+        ]
+    )
+    def test_results_view_context_and_defaults(
+        self, results_data, selected_analysis_basis, default_metrics
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+        )
+
+        experiment.results_data = results_data
+        experiment.save()
+
+        response = self.client.get(
+            reverse("nimbus-ui-results", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.context["results_data"], experiment.results_data.get("v3")
+        )
+        self.assertEqual(response.context["default_metrics"], default_metrics)
+        self.assertEqual(
+            response.context["selected_reference_branch"],
+            experiment.reference_branch.name,
+        )
+        self.assertEqual(response.context["selected_segment"], "all")
+        self.assertEqual(
+            response.context["selected_analysis_basis"], selected_analysis_basis
+        )
+
+    def test_results_view_query_param_overrides(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+        )
+
+        experiment.results_data = {
+            "v3": {
+                "other_metrics": {},
+                "metadata": {"metrics": {}},
+                "overall": {"enrollments": {"all": {}}, "exposures": {"all": {}}},
+            }
+        }
+        experiment.save()
+
+        response = self.client.get(
+            reverse(
+                "nimbus-ui-results",
+                kwargs={"slug": experiment.slug},
+                query={
+                    "reference_branch": "treatment-a",
+                    "segment": "foo",
+                    "analysis_basis": "enrollments",
+                },
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["selected_reference_branch"], "treatment-a")
+        self.assertEqual(response.context["selected_segment"], "foo")
+        self.assertEqual(response.context["selected_analysis_basis"], "enrollments")
+
 
 class TestBranchScreenshotCreateView(AuthTestCase):
     def test_post_creates_screenshot(self):


### PR DESCRIPTION
Because

- Results page view context requires specific data to render contents 

This commit

- Passes the required context data through the view

Fixes #13682 