### PR TITLE
feat(nimbus): Use buttons for pagination on home page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -217,33 +217,51 @@
           </div>
           {% if all_my_experiments_page.has_other_pages %}
             {% with current_sort=request.GET.sort %}
-              <nav class="mt-3">
-                <ul class="pagination pagination-sm justify-content-center">
-                  {% if all_my_experiments_page.has_previous %}
+              <div class="row mt-3">
+                <div class="col text-center">
+                  <ul class="pagination justify-content-center">
+                    {% if all_my_experiments_page.has_previous %}
+                      <li class="page-item">
+                        <button class="page-link"
+                                type="button"
+                                hx-get="?my_deliveries_page={{ all_my_experiments_page.previous_page_number }}{% if request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
+                                hx-target="#my-deliveries-table-section"
+                                hx-select="#my-deliveries-table-section"
+                                hx-push-url="true">
+                          <i class="fa-solid fa-angle-left"></i>
+                        </button>
+                      </li>
+                    {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link">
+                          <i class="fa-solid fa-angle-left"></i>
+                        </span>
+                      </li>
+                    {% endif %}
                     <li class="page-item">
-                      <a class="page-link"
-                         hx-get="?my_deliveries_page={{ all_my_experiments_page.previous_page_number }}{% if request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
-                         hx-target="#my-deliveries-table-section"
-                         hx-select="#my-deliveries-table-section"
-                         hx-push-url="true">Previous</a>
+                      <div class="page-link">{{ all_my_experiments_page.number }} of {{ all_my_experiments_page.paginator.num_pages }}</div>
                     </li>
-                  {% endif %}
-                  <li class="page-item disabled">
-                    <span class="page-link">
-                      Page {{ all_my_experiments_page.number }} of {{ all_my_experiments_page.paginator.num_pages }}
-                    </span>
-                  </li>
-                  {% if all_my_experiments_page.has_next %}
-                    <li class="page-item">
-                      <a class="page-link"
-                         hx-get="?my_deliveries_page={{ all_my_experiments_page.next_page_number }}{% if request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
-                         hx-target="#my-deliveries-table-section"
-                         hx-select="#my-deliveries-table-section"
-                         hx-push-url="true">Next</a>
-                    </li>
-                  {% endif %}
-                </ul>
-              </nav>
+                    {% if all_my_experiments_page.has_next %}
+                      <li class="page-item">
+                        <button class="page-link"
+                                type="button"
+                                hx-get="?my_deliveries_page={{ all_my_experiments_page.next_page_number }}{% if request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% for v in my_deliveries_filter.form.type.value %}&type={{ v }}{% endfor %}{% if my_deliveries_filter.form.qa_status.value %}{% for q in my_deliveries_filter.form.qa_status.value %}&qa_status={{ q }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.channel.value %}{% for c in my_deliveries_filter.form.channel.value %}&channel={{ c }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.application.value %}{% for a in my_deliveries_filter.form.application.value %}&application={{ a }}{% endfor %}{% endif %}{% if my_deliveries_filter.form.feature_configs.value %}{% for f in my_deliveries_filter.form.feature_configs.value %}&feature_configs={{ f }}{% endfor %}{% endif %}{% if current_sort %}&sort={{ current_sort }}{% endif %}"
+                                hx-target="#my-deliveries-table-section"
+                                hx-select="#my-deliveries-table-section"
+                                hx-push-url="true">
+                          <i class="fa-solid fa-angle-right"></i>
+                        </button>
+                      </li>
+                    {% else %}
+                      <li class="page-item disabled">
+                        <span class="page-link">
+                          <i class="fa-solid fa-angle-right"></i>
+                        </span>
+                      </li>
+                    {% endif %}
+                  </ul>
+                </div>
+              </div>
             {% endwith %}
           {% endif %}
         </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -41,31 +41,51 @@
       {% endfor %}
     </ul>
     {% if page_obj.has_other_pages %}
-      <nav class="mt-2">
-        <ul class="pagination pagination-sm justify-content-center">
-          {% if page_obj.has_previous %}
+      <div class="row mt-2">
+        <div class="col text-center">
+          <ul class="pagination justify-content-center">
+            {% if page_obj.has_previous %}
+              <li class="page-item">
+                <button class="page-link"
+                        type="button"
+                        hx-get="?{{ pagination_param }}={{ page_obj.previous_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
+                        hx-target="#draft-preview-ready-for-attention"
+                        hx-select="#draft-preview-ready-for-attention"
+                        hx-push-url="true">
+                  <i class="fa-solid fa-angle-left"></i>
+                </button>
+              </li>
+            {% else %}
+              <li class="page-item disabled">
+                <span class="page-link">
+                  <i class="fa-solid fa-angle-left"></i>
+                </span>
+              </li>
+            {% endif %}
             <li class="page-item">
-              <a class="page-link"
-                 hx-get="?{{ pagination_param }}={{ page_obj.previous_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
-                 hx-target="#draft-preview-ready-for-attention"
-                 hx-select="#draft-preview-ready-for-attention"
-                 hx-push-url="true">Previous</a>
+              <div class="page-link">{{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</div>
             </li>
-          {% endif %}
-          <li class="page-item disabled">
-            <span class="page-link">Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}</span>
-          </li>
-          {% if page_obj.has_next %}
-            <li class="page-item">
-              <a class="page-link"
-                 hx-get="?{{ pagination_param }}={{ page_obj.next_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
-                 hx-target="#draft-preview-ready-for-attention"
-                 hx-select="#draft-preview-ready-for-attention"
-                 hx-push-url="true">Next</a>
-            </li>
-          {% endif %}
-        </ul>
-      </nav>
+            {% if page_obj.has_next %}
+              <li class="page-item">
+                <button class="page-link"
+                        type="button"
+                        hx-get="?{{ pagination_param }}={{ page_obj.next_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
+                        hx-target="#draft-preview-ready-for-attention"
+                        hx-select="#draft-preview-ready-for-attention"
+                        hx-push-url="true">
+                  <i class="fa-solid fa-angle-right"></i>
+                </button>
+              </li>
+            {% else %}
+              <li class="page-item disabled">
+                <span class="page-link">
+                  <i class="fa-solid fa-angle-right"></i>
+                </span>
+              </li>
+            {% endif %}
+          </ul>
+        </div>
+      </div>
     {% endif %}
   {% else %}
     <div class="text-center text-muted py-3">


### PR DESCRIPTION
Because

- We are using links `a` anchor tag for next and previous pagination and hence leading to `I` cursor on hover
- Also pagination links flashes on click

This commit

- Switching to button so that we can see proper hand on hover
- Using button solves the flashing issue too

Fixes #13641 #13660 