### PR TITLE
 Bug 1995645 - Create advanced targeting for 144 Visual Search Messaging  Experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1965,6 +1965,17 @@ HAS_GOOGLE_AS_CURRENT_DEFAULT_SEARCH_ENGINE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+HAS_GOOGLE_AS_CURRENT_DEFAULT_SEARCH_ENGINE_NO_STICKY = NimbusTargetingConfig(
+    name="Has Google as current default search engine no sticky",
+    slug="has_google_as_current_default_search_engine_no_sticky",
+    description="Users with Google as current default engine no sticky enrollment",
+    targeting=("'google' in searchEngines.current"),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEW_ANDROID_13_USERS = NimbusTargetingConfig(
     name="New Android 13 Users",
     slug="new_android_13_users",


### PR DESCRIPTION
Because

* We need users to be unenrolled in the experiment and not see the
  messaging for visual search if their default engine is not google. The
  visual search feature will not work if their default engine is
  anything other than the Google. Therefore, we should not show
  the messaging for those users.

This commit

* Creates a new advanced target for google as default engine on desktop and
  sticky_required is false.

Fixes SNG-3014, Bug 1995645