### PR TITLE
feat(nimbus): Add padding on welcome banner

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -7,7 +7,7 @@
 {% block content %}
   <div id="home-page" class="bg-body-tertiary">
     <div class="container">
-      <div class="card shadow-sm border-0 p-4 mb-4">
+      <div class="card shadow-sm border-0 p-4 mb-4 mt-4">
         <div class="d-flex flex-column align-items-center text-center">
           <div class="d-flex align-items-start justify-content-center">
             <img src="{% static 'assets/welcome.svg' %}"


### PR DESCRIPTION
Because

- Home page welcome message banner have no spacing with the header

This commit

- Adds the padding on the top of the welcome message

Fixes #13743 
