### PR TITLE
use env to pass output parameters

### DIFF
--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -63,8 +63,9 @@ jobs:
       - name: Tag image(s) for GAR
         id: meta
         shell: bash
+        env:
+          IMAGE_TAG: ${{ steps.mozcloud-tag.outputs.image_tag }}
         run: |
-          IMAGE_TAG="${{ steps.mozcloud-tag.outputs.image_tag }}"
           # Re-tag the image built by make build_prod (experimenter:deploy)
           docker tag experimenter:deploy "${IMAGE_BASE}:latest"
           docker tag experimenter:deploy "${IMAGE_BASE}:${IMAGE_TAG}"


### PR DESCRIPTION
use env to pass input and output parameters to prevent attacks from malicious input and dangerous writes, as described in [our guidelines](https://wiki.mozilla.org/GitHub/Repository_Security/GitHub_Workflows_%26_Actions#Perform_input_validation_and_encoding_on_Github_parameters).

