### PR TITLE
feat(nimbus): Break long names on home page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -108,7 +108,7 @@
                     <tr>
                       <td>
                         <a href="{% url 'nimbus-ui-detail' slug=experiment.slug %}"
-                           class="text-decoration-none fw-medium">{{ experiment.name }}</a>
+                           class="text-decoration-none fw-medium text-break">{{ experiment.name }}</a>
                       </td>
                       <td>
                         {% with status_info=experiment|home_status_display_with_icon %}


### PR DESCRIPTION
Because

- If you have a long uninterupted string as the name (~70 characters) of the delivery, then in my deliveries section, it is expanding the table to scroll horizontally

This commit

- Breaks the long text so that table does not expand 

Fixes #13735 