### PR TITLE
bug(experimenter): fix experimenter app id to use . not -

### DIFF
--- a/experimenter/experimenter/glean/middleware.py
+++ b/experimenter/experimenter/glean/middleware.py
@@ -14,7 +14,7 @@ class GleanMiddleware:
         )
         self.pings = glean.load_pings(settings.BASE_DIR / "telemetry" / "pings.yaml")
         glean.Glean.initialize(
-            application_id="experimenter-backend",
+            application_id="experimenter.backend",
             application_version=settings.APP_VERSION,
             data_dir=settings.GLEAN_DATA_DIR,
             upload_enabled=settings.GLEAN_UPLOAD_ENABLED,


### PR DESCRIPTION
Because

- app id should be . separated not - separated

This commit

- Changes glean app id from experimenter-backend to experimenter.backend

Fixes #13754