### PR TITLE
feat(nimbus): Update Learn More URL on feature health page.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -141,8 +141,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     LIVE_MONITOR_TOOLTIP = """Live Monitoring shows enrollment/unenrollment for this
     delivery"""
 
-    # TODO: Add learn more URL for feature page (EXP-5876)
-    FEATURE_PAGE_LINKS = {"feature_learn_more_url": ""}
+    FEATURE_PAGE_LINKS = {
+        "feature_learn_more_url": "https://experimenter.info/for-product#track-your-feature-health"
+    }
 
     class ReviewRequestMessages(Enum):
         END_EXPERIMENT = "end this experiment"


### PR DESCRIPTION
Because

- We want to link to a specific page on experimenter.info from the Feature health page

This commit

- Adds the URL that will eventually have a page and information.

Fixes #13756 