### PR TITLE
feat(nimbus): Add tooltip to deliveries table on feature health page.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -142,7 +142,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     delivery"""
 
     FEATURE_PAGE_LINKS = {
-        "feature_learn_more_url": "https://experimenter.info/for-product#track-your-feature-health"
+        "feature_learn_more_url": "https://experimenter.info/for-product#track-your-feature-health",
+        "deliveries_table_tooltip": """This shows all Nimbus experiments, rollouts, Labs
+        experiences, etc. associated with your selected feature.""",
     }
 
     class ReviewRequestMessages(Enum):

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -42,6 +42,10 @@
                style="width: 60px;
                       height: auto" />
           Deliveries
+          <i class="fa-regular fa-circle-question"
+             data-bs-toggle="tooltip"
+             data-bs-placement="top"
+             data-bs-title="{{ links.deliveries_table_tooltip }}"></i>
         </h5>
         <div>
           <div id="deliveries-table">


### PR DESCRIPTION
Because

- We need to add a tooltip for information about the deliveries table on the features health page

This commit

- Adds the tooltip

Fixes #13763