### PR TITLE
fix(nimbus): fix detailed analysis link

### DIFF
--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -150,7 +150,7 @@ class NimbusExperimentViewMixin:
 
         context["analysis_link"] = urljoin(
             NimbusUIConstants.SIDEBAR_COMMON_LINKS["Detailed Analysis"]["url"],
-            slug_underscore,
+            slug_underscore + ".html",
         )
         context["create_form"] = NimbusExperimentCreateForm()
 


### PR DESCRIPTION
Because

- Detailed analysis link in sidebar was not going to the correct url

This commit

- Fixes the url

Fixes #13768 