### PR TITLE
chore(cirrus): update readme to clearly differentiate v1 and v2 api outputs

### DIFF
--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -274,7 +274,7 @@ Example output:
 
 
 
-### V1 API Output
+### V2 API Output
 
 The output will be a JSON object with the following properties:
 


### PR DESCRIPTION

Because

- I was about to link the readme to fxa and I couldn't readily tell which outputs i was looking at

This commit

- Changes the output section headers to specify the api version of the output described, and separates them from the curl examples
- Fixes the incorrectly lower-case `Features` v2 api output key
- Fixes some v1 api language to not indicate there is a `features` key in the response

Fixes #github_issue_number