### PR TITLE
chore(tests): Add publish/unpublish to preview test.

### DIFF
--- a/experimenter/experimenter/kinto/client.py
+++ b/experimenter/experimenter/kinto/client.py
@@ -16,6 +16,9 @@ class KintoClient:
         )
         self.review = review
         self.collection_data = None
+        self.read_bucket = (
+            settings.KINTO_BUCKET_WORKSPACE if not review else settings.KINTO_BUCKET_MAIN
+        )
 
     def _fetch_collection_data(self):
         self.collection_data = (
@@ -94,6 +97,6 @@ class KintoClient:
         return {
             r["id"]: r
             for r in self.kinto_http_client.get_records(
-                bucket=settings.KINTO_BUCKET_MAIN, collection=self.collection
+                bucket=self.read_bucket, collection=self.collection
             )
         }

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -161,6 +161,7 @@
         {% endif %}
         {% if experiment.can_preview_to_draft %}
           <button type="button"
+                  id="back-to-draft-button"
                   class="btn btn-secondary"
                   hx-post="{% url 'nimbus-ui-preview-to-draft' slug=experiment.slug %}"
                   hx-select="#content"

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -147,10 +147,11 @@ def _verify_url(request, base_url):
 
 @pytest.fixture
 def kinto_client(default_data):
-    kinto_url = os.getenv("INTEGRATION_TEST_KINTO_URL", "http://kinto:8888/v1")
-    return KintoClient(
-        APPLICATION_KINTO_COLLECTION[default_data.application], server_url=kinto_url
-    )
+    def _kinto_client(collection=APPLICATION_KINTO_COLLECTION[default_data.application]):
+        kinto_url = os.getenv("INTEGRATION_TEST_KINTO_URL", "http://kinto:8888/v1")
+        return KintoClient(collection=collection, server_url=kinto_url)
+
+    return _kinto_client
 
 
 @pytest.fixture

--- a/experimenter/tests/integration/nimbus/kinto/client.py
+++ b/experimenter/tests/integration/nimbus/kinto/client.py
@@ -8,6 +8,7 @@ KINTO_PASS = "review"
 KINTO_COLLECTION_DESKTOP = "nimbus-desktop-experiments"
 KINTO_COLLECTION_MOBILE = "nimbus-mobile-experiments"
 KINTO_COLLECTION_WEB = "nimbus-web-experiments"
+KINTO_COLLECTION_PREVIEW = "nimbus-preview"
 KINTO_BUCKET_WORKSPACE = "main-workspace"
 KINTO_REVIEW_STATUS = "to-review"
 KINTO_REJECTED_STATUS = "work-in-progress"
@@ -64,3 +65,8 @@ class KintoClient:
                 return
             time.sleep(2)
         raise Exception("Unable to reject kinto review")
+
+    def get_record_data(self):
+        return self.kinto_http_client.get_records(
+            collection=self.collection, bucket=KINTO_BUCKET_WORKSPACE
+        )

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -17,6 +17,7 @@ class SummaryPage(ExperimenterBase):
 
     _page_wait_locator = (By.CSS_SELECTOR, "#PageSummary")
     _promote_rollout_locator = (By.CSS_SELECTOR, 'button[data-testid="promote-rollout"]')
+    _back_to_draft_locator = (By.CSS_SELECTOR, "#back-to-draft-button")
     _header_slug = (By.CSS_SELECTOR, "#experiment-slug")
     _approve_request_button_locator = (By.CSS_SELECTOR, "#review-controls .btn-success")
     _reject_request_button_locator = (By.CSS_SELECTOR, "#reject-button")
@@ -198,6 +199,11 @@ class SummaryPage(ExperimenterBase):
 
     def launch_to_preview(self):
         self.wait_for_and_find_element(*self._launch_to_preview_locator).click()
+        return self
+
+    def back_to_draft(self):
+        self.wait_for_and_find_element(*self._back_to_draft_locator).click()
+        self.wait_for_and_find_element(*self._launch_to_preview_locator)
         return self
 
     @property

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -80,7 +80,7 @@ def test_check_telemetry_enrollment_unenrollment(
     summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
 
-    kinto_client.approve()
+    kinto_client().approve()
 
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
@@ -97,7 +97,7 @@ def test_check_telemetry_enrollment_unenrollment(
     # unenroll
     summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 
@@ -146,7 +146,7 @@ def test_check_telemetry_pref_flip(
     )
     summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
@@ -165,7 +165,7 @@ def test_check_telemetry_pref_flip(
     # unenroll
     summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 
@@ -218,7 +218,7 @@ def test_check_telemetry_sticky_targeting(
     )
     summary = SummaryPage(selenium, experiment_url).open()
     summary.launch_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
 
@@ -248,7 +248,7 @@ def test_check_telemetry_sticky_targeting(
     # unenroll
     summary = SummaryPage(selenium, experiment_url).open()
     summary.end_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_complete_status()
 

--- a/experimenter/tests/integration/nimbus/test_experimenter_ui.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_ui.py
@@ -123,7 +123,7 @@ def test_first_run_release_date_visible_for_mobile(
 
     summary.launch_and_approve()
 
-    kinto_client.approve()
+    kinto_client().approve()
 
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
@@ -150,7 +150,7 @@ def test_first_run_release_date_not_visible_for_non_mobile(
     audience.wait_until_first_run_not_found()
     summary = audience.navigate_to_summary()
     summary.launch_and_approve()
-    kinto_client.approve()
+    kinto_client().approve()
     summary = SummaryPage(selenium, experiment_url).open()
     summary.wait_for_live_status()
     summary.wait_for_timeline_visible()


### PR DESCRIPTION
Because

- We want to make sure we can publish and unpublish to preview correctly

This commit

- Adds a test to ensure we can publish and unpublish from preview
- Adds the ability to unpublish from preview for local environments including tests

Fixes #8436