### PR TITLE
bug(experimenter): give glean a unique data dir per pid

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/1.9/ref/settings/
 """
 
+import os
 from pathlib import Path
 from urllib.parse import urljoin
 
@@ -74,7 +75,7 @@ CIRRUS_URL = config("CIRRUS_URL", default=None)
 
 GLEAN_UPLOAD_ENABLED = config("GLEAN_UPLOAD_ENABLED", default=False, cast=bool)
 
-GLEAN_DATA_DIR = config("GLEAN_DATA_DIR", default="/var/glean")
+GLEAN_DATA_DIR = Path(config("GLEAN_DATA_DIR", default="/var/glean")) / str(os.getpid())
 
 # Application definition
 


### PR DESCRIPTION
Because

- glean must have a unique data dir per pid

This commit

- Adds a process id subdir to the glean data dir path

Fixes #13788