### PR TITLE
feat(nimbus): revamp sidebar view for results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/sidebar_link.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/sidebar_link.html
@@ -1,9 +1,36 @@
-<a {% if external %}target="_blank"{% endif %}
-   class="nav-link mb-2 {% if request.path == link %}active{% endif %} nav-link-hover {% if disabled %}disabled{% endif %}"
-   data-testid="nav-edit-{{ title|lower }}"
-   href="{{ link }}"
-   {% if data_bs_toggle %}data-bs-toggle="{{ data_bs_toggle }}"{% endif %}
-   {% if data_bs_target %}data-bs-target="{{ data_bs_target }}"{% endif %}>
-  <i class="{{ icon }} pe-2"></i>
-  <span>{{ title }}</span>
-</a>
+<div>
+  <a {% if external %}target="_blank"{% endif %}
+     class="nav-link mb-2 {% if request.path == link %}active{% endif %} nav-link-hover {% if disabled %}disabled{% endif %}"
+     data-testid="nav-edit-{{ title|lower }}"
+     href="{{ link }}"
+     {% if data_bs_toggle %}data-bs-toggle="{{ data_bs_toggle }}"{% endif %}
+     {% if data_bs_target %}data-bs-target="{{ data_bs_target }}"{% endif %}>
+    <i class="{{ icon }} pe-2"></i>
+    <span>{{ title }}</span>
+  </a>
+  {% if request.path == new_results_url %}
+    <div class="accordion ms-2" id="{{ title|lower|cut:" " }}-accordion">
+      {% for item in subsection %}
+        <div class="accordion-item ms-4 text-secondary bg-transparent border-0 {% if forloop.last %}mb-3{% endif %}">
+          <button class="accordion-button collapsed bg-transparent p-2 text-reset fw-bold shadow-none"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#collapse{{ item.title|lower|cut:" " }}"
+                  aria-expanded="false"
+                  aria-controls="collapse{{ item.title|lower|cut:" " }}">{{ item.title }}</button>
+          <div class="accordion-collapse collapse"
+               id="collapse{{ item.title|lower|cut:" " }}"
+               data-bs-parent="#{{ title|lower|cut:" " }}-accordion">
+            <ul class="nav flex-column ms-4">
+              {% for subitem in item.subitems %}
+                <li class="nav-item w-100">
+                  <a class="nav-link text-reset" href="#">{{ subitem.title }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          </div>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
@@ -4,7 +4,7 @@
       <strong class="ms-3">{{ item.title }}</strong>
       <hr class="my-0 mb-2">
     {% else %}
-      {% include "common/sidebar_link.html" with title=item.title link=item.link icon=item.icon active=item.active disabled=item.disabled %}
+      {% include "common/sidebar_link.html" with title=item.title link=item.link icon=item.icon active=item.active disabled=item.disabled new_results_url=item.new_results_url subsection=item.subsections %}
 
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Because

- Sidebar requires updates for results page redesign

This commit

- Creates "quick links" section underneath results sidebar link to navigate to specific sections within results page
- These quick links only show when on the new results page

Fixes #13778 