### PR TITLE
chore(ci): Switch enrollment integration tests to use Firefox Nightly.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,7 +361,7 @@ jobs:
     resource_class: large
     working_directory: ~/experimenter
     environment:
-      FIREFOX_CHANNEL: nightly
+      FIREFOX_CHANNEL: release
       PYTEST_ARGS: -k FIREFOX_DESKTOP -m desktop_enrollment --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:


### PR DESCRIPTION
Because

- Our enrollment tests have been using nightly

This commit

- Switches them to Firefox release (which we track).

Fixes #13806 