### PR TITLE
feat(nimbus): use fml linter in branches form

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -446,6 +446,22 @@ class NimbusBranchFeatureValueForm(forms.ModelForm):
             self.fields["value"].initial = ""
 
         if (
+            self.instance is not None
+            and self.instance.branch_id is not None
+            and self.instance.branch.experiment
+            and self.instance.branch.experiment.application
+            != NimbusExperiment.Application.DESKTOP
+        ):
+            self.fields["value"].widget.attrs["data-experiment-slug"] = (
+                self.instance.branch.experiment.slug
+            )
+
+            if self.instance.feature_config:
+                self.fields["value"].widget.attrs["data-feature-slug"] = (
+                    self.instance.feature_config.slug
+                )
+
+        if (
             self.instance.id is not None
             and self.instance.feature_config
             and (

--- a/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
@@ -24,7 +24,7 @@ import {
 } from "@codemirror/search";
 import { defaultKeymap, historyKeymap, history } from "@codemirror/commands";
 import { tags } from "@lezer/highlight";
-import { schemaAutocomplete, schemaLinter } from "./validator.js";
+import { schemaAutocomplete, schemaLinter, fmlLinter } from "./validator.js";
 import $ from "jquery";
 
 const setupCodemirror = (selector, textarea, extraExtensions) => {
@@ -85,7 +85,27 @@ const setupCodemirrorFeatures = () => {
   textareas.forEach((textarea) => {
     const extensions = [];
 
-    if (textarea.dataset.schema) {
+    const hasFmlValidation =
+      textarea.dataset.experimentSlug && textarea.dataset.featureSlug;
+    const hasJsonSchema = textarea.dataset.schema;
+
+    if (hasFmlValidation) {
+      extensions.push(
+        linter(
+          fmlLinter(
+            textarea.dataset.experimentSlug,
+            textarea.dataset.featureSlug,
+          ),
+        ),
+      );
+
+      if (hasJsonSchema) {
+        const jsonSchema = JSON.parse(textarea.dataset.schema);
+        extensions.push(
+          autocompletion({ override: [schemaAutocomplete(jsonSchema)] }),
+        );
+      }
+    } else if (hasJsonSchema) {
       const jsonSchema = JSON.parse(textarea.dataset.schema);
 
       extensions.push(


### PR DESCRIPTION
Becuase

* In the old nimbus-ui, we called out to an API to do FML validation for non desktop feature values
* This was lost when we setup the new nimbus-ui

This commit

* Adds a linter to the new feature values form that calls the FML linting API

fixes #12968

