### PR TITLE
feat(nimbus): add localizations to summary page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -381,6 +381,30 @@
 
       {% endfor %}
     </div>
+    <!-- Localizations Card -->
+    {% if experiment.is_localized %}
+      <div class="card mb-3">
+        <div class="card-header">
+          <h4>Localizations</h4>
+        </div>
+        <div class="card-body">
+          <table class="table table-striped">
+            <tbody>
+              <tr>
+                <th>Is Localized</th>
+                <td colspan="3">{{ experiment.is_localized }}</td>
+              </tr>
+              <tr>
+                <th>Localizations JSON</th>
+                <td colspan="3">
+                  <textarea class="readonly-json">{{ experiment.localizations|default:"null" }}</textarea>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    {% endif %}
     <!-- QA Card -->
     {% include "nimbus_experiments/qa_card.html" %}
 


### PR DESCRIPTION
Becuase

* We should display the localizations info on the summary page because the branches page is no longer available after launch

This commit

* Adds localization info to the summary page

fixes #13070
