### PR TITLE
bug(experimenter): send glean opt outs in custom ping

### DIFF
--- a/experimenter/experimenter/glean/views.py
+++ b/experimenter/experimenter/glean/views.py
@@ -11,6 +11,7 @@ class OptOutView(UpdateView):
     template_name = "glean/opt_out_button.html"
 
     metrics = glean.load_metrics(settings.BASE_DIR / "telemetry" / "metrics.yaml")
+    pings = glean.load_pings(settings.BASE_DIR / "telemetry" / "pings.yaml")
 
     def get_object(self, queryset=None):
         if not hasattr(self.request.user, "glean_prefs"):
@@ -19,11 +20,8 @@ class OptOutView(UpdateView):
 
     def form_valid(self, form):
         if ("opt_out" in form.changed_data) and (form.cleaned_data["opt_out"] is True):
-            self.metrics.data_collection.opt_out.record(
-                self.metrics.data_collection.OptOutExtra(
-                    nimbus_user_id=str(self.request.user.id),
-                )
-            )
+            self.metrics.nimbus.nimbus_user_id.set(str(self.request.user.id))
+            self.pings.data_collection_opt_out.submit()
 
         self.object = form.save()
 

--- a/experimenter/experimenter/telemetry/metrics.yaml
+++ b/experimenter/experimenter/telemetry/metrics.yaml
@@ -39,6 +39,7 @@ nimbus:
     expires: never
     send_in_pings:
       - page-view
+      - data-collection-opt-out
   enrollments:
     type: object
     description: The list of enrollments associated with this page view as returned by Cirrus.
@@ -71,24 +72,3 @@ nimbus:
     expires: never
     send_in_pings:
       - page-view
-data_collection:
-  opt_out:
-    type: event
-    description: >
-      Recorded when a user has opted out of data collection.
-    extra_keys:
-      nimbus_user_id:
-        type: string
-        description: A unique identifier for User/Client sending a request to get feature configuration
-    bugs:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472
-    data_reviews:
-      - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472
-    data_sensitivity:
-      - technical
-    notification_emails:
-      - jlockhart@mozilla.com
-      - project-nimbus@mozilla.com
-    expires: never
-    send_in_pings:
-      - events

--- a/experimenter/experimenter/telemetry/pings.yaml
+++ b/experimenter/experimenter/telemetry/pings.yaml
@@ -14,3 +14,16 @@ page-view:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472
   data_reviews:
     - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472
+
+data-collection-opt-out:
+  description: >
+    A ping to record data collection opt outs. The purpose of this data
+    gathering is to act as a custom deletion request for nimbus_user_id.
+  include_client_id: false
+  notification_emails:
+    - jlockhart@mozilla.com
+    - project-nimbus@mozilla.com
+  bugs:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472
+  data_reviews:
+    - https://bugzilla.mozilla.org/show_bug.cgi?id=1977472


### PR DESCRIPTION
Because

- python glean doesn't send the events ping unless there's 500 outstanding events or we use [glean.Glean.handle_client_inactive](https://mozilla.github.io/glean/python/glean/index.html#glean.Glean.handle_client_inactive)

This commit

- Removes the data collection opt out event
- Adds a data collection opt out ping

Fixes #13828