### PR TITLE
feat(nimbus): add loading screen to review controls

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/review_controls.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/review_controls.js
@@ -54,3 +54,19 @@ document.addEventListener("DOMContentLoaded", initializeRejectApproveListeners);
 document.body.addEventListener("htmx:afterSwap", () => {
   initializeRejectApproveListeners();
 });
+
+document.body.addEventListener("htmx:beforeRequest", (event) => {
+  const launchControls = document.getElementById("launch-controls");
+  const overlay = launchControls?.querySelector("#htmx-loading-overlay");
+  if (overlay && event.target.closest("#launch-controls")) {
+    overlay.style.display = "flex";
+  }
+});
+
+document.body.addEventListener("htmx:afterRequest", (event) => {
+  const launchControls = document.getElementById("launch-controls");
+  const overlay = launchControls?.querySelector("#htmx-loading-overlay");
+  if (overlay && event.target.closest("#launch-controls")) {
+    overlay.style.display = "none";
+  }
+});

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -1,6 +1,14 @@
 {% load nimbus_extras %}
 
-<div id="launch-controls">
+<div id="launch-controls" class="position-relative">
+  <!-- Loading overlay -->
+  <div id="htmx-loading-overlay"
+       class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
+    <div class="text-center text-white">
+      <i class="fa-solid fa-spinner fa-spin-pulse fa-3x mb-3"></i>
+      <div class="fs-5">Processing...</div>
+    </div>
+  </div>
   {% if non_page_errors %}
     <div class="alert alert-danger" role="alert">
       <p class="mb-1">This experiment cannot be launched due to the following validation errors:</p>


### PR DESCRIPTION
Becuase

* It can be slow to submit the review controls
* While they're in flight we should block interacting with the controls so nobody accidentally clicks a button twice

This commit

* Adds a loading overlay to the review controls

fixes #13823

