### PR TITLE
chore(ci): Pin integration test image.

### DIFF
--- a/docker-compose-integration-test.yml
+++ b/docker-compose-integration-test.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   firefox:
-    image: selenium/standalone-firefox
+    image: selenium/standalone-firefox:4.37.0-20251020
     env_file: .env
     platform: linux/amd64
     environment:


### PR DESCRIPTION
Because

- The selenium docker image has updated to python 3.14 and have made some changes that are breaking our tests

This commit

- Pins the version to the last known working version for us until we bump to python 3.14 as well. The pinned version is 4.37.0-20251020

Fixes #13864
