### PR TITLE
bug(nimbus): strictly order branches on edit branches page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -2937,6 +2937,31 @@ class TestNimbusBranchesForm(RequestFormTestCase):
             {"branches": [{}, {"name": [NimbusUIConstants.ERROR_SLUG_DUPLICATE_BRANCH]}]},
         )
 
+    def test_branches_ordered_by_id_with_reference_branch_first(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        experiment.branches.all().delete()
+
+        branch_a = NimbusBranchFactory.create(
+            experiment=experiment, name="A Branch", slug="a-branch"
+        )
+        branch_b = NimbusBranchFactory.create(
+            experiment=experiment, name="B Branch", slug="b-branch"
+        )
+        branch_c = NimbusBranchFactory.create(
+            experiment=experiment, name="C Branch", slug="c-branch"
+        )
+        experiment.reference_branch = branch_b
+        experiment.save()
+
+        form = NimbusBranchesForm(instance=experiment, request=self.request)
+
+        expected_branch_ids = [branch.slug for branch in form.branches.get_queryset()]
+        self.assertEqual(
+            expected_branch_ids, [branch_b.slug, branch_a.slug, branch_c.slug]
+        )
+
 
 class TestNimbusBranchCreateForm(RequestFormTestCase):
     def test_form_saves_branches(self):


### PR DESCRIPTION
Becuase

* The NimbusBranch model uses slug as its default ordering
* No stable ordering was defined on the edit branches page
* This means that if a branch is renamed, it will get reordered on the page
* We also did not force the control branch to appear first
* The control branch cannot be deleted
* By renaming branches the control branch could be moved out of the first position and have a delete button even though it cannot be deleted

This commit

* Adds a stable ordering to the branches forms that forces the control branch to be first and the remaining branches to be ordered by id so they remain in the same order they are created

fixes #13760

