### PR TITLE
bug(experimenter): make glean writes to stdout more atomic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       - redis
     volumes:
       - ./experimenter:/experimenter
+      - /experimenter/experimenter/glean/generated/
       - ${GOOGLE_ADC_FILE}:${GOOGLE_APPLICATION_CREDENTIALS}:ro
     command: bash -c "/experimenter/bin/wait-for-it.sh db:5432 -- celery -A experimenter worker -l DEBUG"
 
@@ -84,6 +85,7 @@ services:
       - redis
     volumes:
       - ./experimenter:/experimenter
+      - /experimenter/experimenter/glean/generated/
       - ${GOOGLE_ADC_FILE}:${GOOGLE_APPLICATION_CREDENTIALS}:ro
     command: bash -c "/experimenter/bin/wait-for-it.sh db:5432 -- celery -A experimenter beat -s /tmp/celerybeat-schedule -l DEBUG"
 

--- a/experimenter/experimenter/glean/middleware.py
+++ b/experimenter/experimenter/glean/middleware.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from experimenter.glean.generated.server_events import (
     create_page_view_server_event_logger,
 )
-from experimenter.glean.utils import get_request_ip
+from experimenter.glean.utils import emit_record, get_request_ip
 
 
 class GleanMiddleware:
@@ -18,6 +18,8 @@ class GleanMiddleware:
             app_display_version=settings.APP_VERSION,
             channel=settings.GLEAN_APP_CHANNEL,
         )
+        # override glean's emit_record method to make writes to stdout atomic
+        self.page_view_ping.emit_record = emit_record
 
     def __call__(self, request):
         if (

--- a/experimenter/experimenter/glean/utils.py
+++ b/experimenter/experimenter/glean/utils.py
@@ -1,6 +1,25 @@
+import json
+from datetime import datetime
+from sys import stdout
+from typing import Any
+
+from experimenter.glean.generated.server_events import GLEAN_EVENT_MOZLOG_TYPE
+
+
 def get_request_ip(request) -> None | str:
     if xff := request.META.get("HTTP_X_FORWARDED_FOR"):
         # Only trust the last 3 values in XFF because they are added by the Google Cloud
         # Load Balancer and nginx, and use the least recent of those values.
         return xff.rsplit(",", 4)[-3:][0]
     return request.META.get("REMOTE_ADDR")
+
+
+def emit_record(now: datetime, ping: dict[str, Any]):
+    ping_envelope = {
+        "Timestamp": now.isoformat(),
+        "Logger": "glean",
+        "Type": GLEAN_EVENT_MOZLOG_TYPE,
+        "Fields": ping,
+    }
+    ping_envelope_serialized = f"{json.dumps(ping_envelope)}\n"
+    stdout.write(ping_envelope_serialized)

--- a/experimenter/experimenter/glean/views.py
+++ b/experimenter/experimenter/glean/views.py
@@ -5,7 +5,13 @@ from experimenter.glean.generated.server_events import (
     create_data_collection_opt_out_server_event_logger,
 )
 from experimenter.glean.models import Prefs
-from experimenter.glean.utils import get_request_ip
+from experimenter.glean.utils import emit_record, get_request_ip
+
+
+def patch_emit_record(glean_logger):
+    """Override glean's emit_record method to make writes to stdout atomic."""
+    glean_logger.emit_record = emit_record
+    return glean_logger
 
 
 class OptOutView(UpdateView):
@@ -13,10 +19,12 @@ class OptOutView(UpdateView):
     fields = ["opt_out"]
     template_name = "glean/opt_out_button.html"
 
-    data_collection_opt_out_ping = create_data_collection_opt_out_server_event_logger(
-        application_id=settings.GLEAN_APP_ID,
-        app_display_version=settings.APP_VERSION,
-        channel=settings.GLEAN_APP_CHANNEL,
+    data_collection_opt_out_ping = patch_emit_record(
+        create_data_collection_opt_out_server_event_logger(
+            application_id=settings.GLEAN_APP_ID,
+            app_display_version=settings.APP_VERSION,
+            channel=settings.GLEAN_APP_CHANNEL,
+        )
     )
 
     def get_object(self, queryset=None):


### PR DESCRIPTION
Because

- In prod glean pings are coming out as `{ping}{ping}\n\n` instead of `{ping}\n{ping}\n` and markh suggested this might fix it

This commit

- Overrides the glean generated emit_record methods to use `stdout.write(f"{ping}\n")` instead of `print(ping)`

Fixes #13893 