### PR TITLE
bug(experimenter): emit glean logs with unix nanosecond timestamp

### DIFF
--- a/experimenter/experimenter/glean/utils.py
+++ b/experimenter/experimenter/glean/utils.py
@@ -16,7 +16,7 @@ def get_request_ip(request) -> None | str:
 
 def emit_record(now: datetime, ping: dict[str, Any]):
     ping_envelope = {
-        "Timestamp": now.isoformat(),
+        "Timestamp": int(now.timestamp() * 1e9),
         "Logger": "glean",
         "Type": GLEAN_EVENT_MOZLOG_TYPE,
         "Fields": ping,


### PR DESCRIPTION
Because

- logs explorer shows experimenter logs that have nanosecond time, but none that come from glean in isoformat

This commit

- Changes glean logs from using `datetime.isoformat()` to `int(datetime.timestamp() * 1e9)`

Fixes #13893