### PR TITLE
chore(experimenter): don't buffer python writes to stdout

### DIFF
--- a/experimenter/.dockerignore
+++ b/experimenter/.dockerignore
@@ -16,3 +16,4 @@ experimenter/legacy/legacy-ui/assets
 experimenter/nimbus-ui/build
 experimenter/reporting/reporting-ui/assets/
 experimenter/served/
+Dockerfile

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -148,6 +148,7 @@ COPY --from=ui /experimenter/experimenter/results/build/ /experimenter/experimen
 COPY --from=ui /experimenter/experimenter/nimbus_ui/static/dist/ /experimenter/experimenter/nimbus_ui/static/dist/
 
 ENV PYTHONPATH=$PYTHONPATH:/application-services/
+ENV PYTHONUNBUFFERED=1
 
 # Ensure the non-root user owns the required directories
 RUN chown -R app:app /experimenter /application-services


### PR DESCRIPTION
Because

- Without this glean pings may only be flushed to stdout on shutdown

This commit

- Sets `PYTHONUNBUFFERED=1` on experimenter
- Adds Dockerfile to .dockerignore, so that changes to the docker file don't rebuild unnecessary stages of the image 

Fixes #13893