### PR TITLE
chore(experimenter): fix server-side glean

### DIFF
--- a/experimenter/experimenter/glean/middleware.py
+++ b/experimenter/experimenter/glean/middleware.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 
+from experimenter.base import app_version
 from experimenter.glean.generated.server_events import (
     create_page_view_server_event_logger,
 )
@@ -15,7 +16,7 @@ class GleanMiddleware:
         self.get_response = get_response
         self.page_view_ping = create_page_view_server_event_logger(
             application_id=settings.GLEAN_APP_ID,
-            app_display_version=settings.APP_VERSION,
+            app_display_version=app_version(),
             channel=settings.GLEAN_APP_CHANNEL,
         )
         # override glean's emit_record method to make writes to stdout atomic
@@ -41,7 +42,7 @@ class GleanMiddleware:
             self.page_view_ping.record(
                 user_agent=request.META.get("HTTP_USER_AGENT"),
                 ip_address=get_request_ip(request),
-                nimbus_enrollments=enrollments,
+                nimbus_enrollments=enrollments or [],
                 nimbus_nimbus_user_id=str(request.user.id),
                 url_path=request.path,
                 events=[],

--- a/experimenter/experimenter/glean/tests/test_middleware.py
+++ b/experimenter/experimenter/glean/tests/test_middleware.py
@@ -29,7 +29,7 @@ class GleanMiddlewareTests(TestCase):
                 mock.call(
                     user_agent=None,
                     ip_address=None,
-                    nimbus_enrollments=None,
+                    nimbus_enrollments=[],
                     nimbus_nimbus_user_id="123",
                     url_path="/some/path",
                     events=[],

--- a/experimenter/experimenter/glean/views.py
+++ b/experimenter/experimenter/glean/views.py
@@ -1,6 +1,7 @@
 from django.conf import settings
 from django.views.generic.edit import UpdateView
 
+from experimenter.base import app_version
 from experimenter.glean.generated.server_events import (
     create_data_collection_opt_out_server_event_logger,
 )
@@ -22,7 +23,7 @@ class OptOutView(UpdateView):
     data_collection_opt_out_ping = patch_emit_record(
         create_data_collection_opt_out_server_event_logger(
             application_id=settings.GLEAN_APP_ID,
-            app_display_version=settings.APP_VERSION,
+            app_display_version=app_version(),
             channel=settings.GLEAN_APP_CHANNEL,
         )
     )

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -72,7 +72,7 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 CIRRUS_URL = config("CIRRUS_URL", default=None)
 
-GLEAN_APP_ID = config("GLEAN_APP_ID", default="experimenter.backend")
+GLEAN_APP_ID = config("GLEAN_APP_ID", default="experimenter-backend")
 
 GLEAN_APP_CHANNEL = config("GLEAN_APP_CHANNEL", default="developer")
 


### PR DESCRIPTION
Because

- settings.APP_VERSION is None, and glean app_display_version must not be None
- glean application_id must use a `-` separator not `.`
- nimbus enrollments must be a list

This commit

- Changes from `settings.APP_VERSION` to `experimenter.base.app_version()`
- Changes glean app id from `experimenter.backend` to `experimenter-backend`
- Changes nimbus enrollments fallback value from `None` to `[]`

Fixes #13858