### PR TITLE
bug(nimbus): fix version filtering on list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -155,7 +155,7 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ),
     )
     firefox_min_version = django_filters.MultipleChoiceFilter(
-        choices=reversed(NimbusExperiment.Version.choices),
+        choices=list(reversed(NimbusExperiment.Version.choices)),
         widget=IconMultiSelectWidget(
             icon="fa-solid fa-code-branch",
             attrs={

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -436,24 +436,35 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         )
 
     def test_filter_version(self):
-        version = NimbusExperiment.Version.FIREFOX_120
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE, firefox_min_version=version
+        experiment_120 = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            slug="firefox-120-experiment",
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
         )
-        [
-            NimbusExperimentFactory.create(
-                status=NimbusExperiment.Status.LIVE, firefox_min_version=v
-            )
-            for v in {*list(NimbusExperiment.Version)} - {version}
-        ]
+        experiment_130 = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            slug="firefox-130-experiment",
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_130,
+        )
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            slug="firefox-140-experiment",
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_140,
+        )
 
         response = self.client.get(
             reverse("nimbus-list"),
-            {"status": NimbusExperiment.Status.LIVE, "firefox_min_version": version},
+            {
+                "firefox_min_version": [
+                    NimbusExperiment.Version.FIREFOX_120.value,
+                    NimbusExperiment.Version.FIREFOX_130.value,
+                ],
+            },
         )
 
         self.assertEqual(
-            {e.slug for e in response.context["experiments"]}, {experiment.slug}
+            {e.slug for e in response.context["experiments"]},
+            {experiment_120.slug, experiment_130.slug},
         )
 
     def test_filter_feature_config(self):


### PR DESCRIPTION
Becuase

* We added version filtering on the list page
* It worked if you select a single version, but not if you select multiple
* Turns out using reversed() in choices is silently buggy because it returns an iterator which only works once but needs to be accessed multiple times
* Wrapping it in list() solves the issue
* This wasn't caught becuase the existing test only filtered on a single version

This commit

* Updates the test to filter on multiple versions
* Wraps the reversed choices in a list so it can be accessed multiple times

fixes #13904

