### PR TITLE
feat(nimbus): sort versions semantically

### DIFF
--- a/experimenter/experimenter/nimbus_ui/filtersets.py
+++ b/experimenter/experimenter/nimbus_ui/filtersets.py
@@ -14,6 +14,22 @@ from experimenter.nimbus_ui.forms import MultiSelectWidget
 from experimenter.targeting.constants import TargetingConstants
 
 
+class VersionSortMixin:
+    def _get_version_sort_key(self, experiment):
+        if experiment.firefox_min_version:
+            return NimbusConstants.Version.parse(experiment.firefox_min_version)
+        return NimbusConstants.Version.parse(NimbusConstants.Version.NO_VERSION)
+
+    def sort_by_version(self, queryset, reverse=False):
+        experiments = list(queryset)
+        experiments.sort(key=self._get_version_sort_key, reverse=reverse)
+        sorted_ids = [e.id for e in experiments]
+        preserved_order = models.Case(
+            *[models.When(pk=pk, then=pos) for pos, pk in enumerate(sorted_ids)]
+        )
+        return queryset.filter(id__in=sorted_ids).order_by(preserved_order)
+
+
 class StatusChoices(models.TextChoices):
     DRAFT = NimbusExperiment.Status.DRAFT
     PREVIEW = NimbusExperiment.Status.PREVIEW
@@ -105,7 +121,7 @@ class DateRangeChoices(models.TextChoices):
     CUSTOM = "custom", "Custom Date Range"
 
 
-class NimbusExperimentFilter(django_filters.FilterSet):
+class NimbusExperimentFilter(VersionSortMixin, django_filters.FilterSet):
     sort = django_filters.ChoiceFilter(
         method="filter_sort",
         choices=SortChoices.choices,
@@ -281,6 +297,11 @@ class NimbusExperimentFilter(django_filters.FilterSet):
         ]
 
     def filter_sort(self, queryset, name, value):
+        if value in (SortChoices.VERSIONS_UP, SortChoices.VERSIONS_DOWN):
+            return self.sort_by_version(
+                queryset, reverse=(value == SortChoices.VERSIONS_DOWN)
+            )
+
         return queryset.order_by(value, "slug")
 
     def filter_status(self, queryset, name, value):
@@ -371,7 +392,7 @@ class HomeSortChoices(models.TextChoices):
         return headers
 
 
-class NimbusExperimentsHomeFilter(django_filters.FilterSet):
+class NimbusExperimentsHomeFilter(VersionSortMixin, django_filters.FilterSet):
     my_deliveries_status = django_filters.ChoiceFilter(
         label="",
         method="filter_my_deliveries",
@@ -488,6 +509,11 @@ class NimbusExperimentsHomeFilter(django_filters.FilterSet):
                 return queryset  # Default = All Deliveries
 
     def filter_sort(self, queryset, name, value):
+        if value in (HomeSortChoices.VERSIONS_UP, HomeSortChoices.VERSIONS_DOWN):
+            return self.sort_by_version(
+                queryset, reverse=(value == HomeSortChoices.VERSIONS_DOWN)
+            )
+
         return queryset.order_by(value, "slug")
 
     def filter_status(self, queryset, name, values):

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -942,13 +942,20 @@ class NimbusExperimentsListViewTest(AuthTestCase):
         )
 
     def test_sort_by_versions(self):
-        experiment1 = NimbusExperimentFactory.create(
+        experiment_95 = NimbusExperimentFactory.create(
+            slug="firefox-95",
+            status=NimbusExperiment.Status.LIVE,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_95,
+        )
+        experiment_100 = NimbusExperimentFactory.create(
+            slug="firefox-100",
             status=NimbusExperiment.Status.LIVE,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
         )
-        experiment2 = NimbusExperimentFactory.create(
+        experiment_no_version = NimbusExperimentFactory.create(
+            slug="no-version",
             status=NimbusExperiment.Status.LIVE,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_101,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
         )
 
         response = self.client.get(
@@ -960,7 +967,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
-            [experiment1.slug, experiment2.slug],
+            [experiment_no_version.slug, experiment_95.slug, experiment_100.slug],
         )
 
         response = self.client.get(
@@ -972,7 +979,7 @@ class NimbusExperimentsListViewTest(AuthTestCase):
 
         self.assertEqual(
             [e.slug for e in response.context["experiments"]],
-            [experiment2.slug, experiment1.slug],
+            [experiment_100.slug, experiment_95.slug, experiment_no_version.slug],
         )
 
     def test_sort_by_start_date(self):


### PR DESCRIPTION
Becuase

* We have version sorting on the home and list pages
* We've been sorting them lexigraphically which does not work with semantic versioning
* We should sort them semantically

This commit

* Updates the home and list filters to sort versions semantically

fixes #8030

