### PR TITLE
feat(nimbus): add changelog for jetstream fetch

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2798,6 +2798,7 @@ class NimbusChangeLog(FilterMixin, models.Model):
         REJECTED_FROM_KINTO = "Rejected from Remote Settings"
         LIVE = "Experiment is live"
         COMPLETED = "Experiment is complete"
+        RESULTS_FETCHED = "Experiment results fetched"
 
     def __str__(self):
         return self.message or (

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from mozilla_nimbus_schemas.jetstream import SampleSizes, SampleSizesFactory
 from parameterized import parameterized
 
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 from experimenter.jetstream import tasks
 from experimenter.jetstream.client import get_data
@@ -607,6 +607,11 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             tasks.fetch_experiment_data(experiment.id)
             experiment = NimbusExperiment.objects.get(id=experiment.id)
             self.assertEqual(experiment.results_data, FULL_DATA)
+            self.assertTrue(
+                experiment.changes.filter(
+                    message=NimbusChangeLog.Messages.RESULTS_FETCHED
+                ).exists()
+            )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Becuase

* Sometimes jetstream fetches can get lost or stuck, or need to be redone
* It would be helpful to see a log of the jetstream fetches in the experiment history page

This commit

* Adds a changelog for jetstream fetches

fixes #8529

