### PR TITLE
feat(nimbus): Fix exclude options targeting

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -664,7 +664,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             locales = [locale.code for locale in sorted(locales, key=lambda l: l.code)]
             locales_expression = f"locale in {locales}"
             if self.exclude_locales:
-                locales_expression = f"!({locales_expression})"
+                locales_expression = f"({locales_expression}) != true"
             sticky_expressions.append(locales_expression)
 
         if languages := self.languages.all():
@@ -673,7 +673,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             ]
             languages_expression = f"language in {languages}"
             if self.exclude_languages:
-                languages_expression = f"!({languages_expression})"
+                languages_expression = f"({languages_expression}) != true"
             sticky_expressions.append(languages_expression)
 
         if countries := self.countries.all():
@@ -682,7 +682,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             ]
             countries_expression = f"region in {countries}"
             if self.exclude_countries:
-                countries_expression = f"!({countries_expression})"
+                countries_expression = f"({countries_expression}) != true"
             sticky_expressions.append(countries_expression)
 
         enrollments_map_key = "enrollments_map"

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -890,7 +890,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(
             experiment.targeting,
-            ("(os.isMac) && (!(locale in ['en-CA', 'en-US']))"),
+            ("(os.isMac) && ((locale in ['en-CA', 'en-US']) != true)"),
         )
         JEXLParser().parse(experiment.targeting)
 
@@ -933,7 +933,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(
             experiment.targeting,
-            ("(os.isMac) && (!(region in ['CA', 'US']))"),
+            ("(os.isMac) && ((region in ['CA', 'US']) != true)"),
         )
         JEXLParser().parse(experiment.targeting)
 
@@ -997,7 +997,7 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(
             experiment.targeting,
-            "(days_since_install < 7) && (!(language in ['en', 'es', 'fr']))",
+            "(days_since_install < 7) && ((language in ['en', 'es', 'fr']) != true)",
         )
         JEXLParser().parse(experiment.targeting)
 


### PR DESCRIPTION
Because

- When we use exclude option it is generating targeting like this 
`
(app_version|versionCompare('145.1.0') >= 0) && (!(language in ['ja']))
`
which is not working, but targeting in this format is working 
`(app_version|versionCompare('145.1.0') >= 0) && (language in ['ja']) != true
`
This commit

- Updates the logic of exclude targeting 

Fixes #13950
