### PR TITLE
feat(nimbus): expire preview after 30 days

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2799,6 +2799,7 @@ class NimbusChangeLog(FilterMixin, models.Model):
         LIVE = "Experiment is live"
         COMPLETED = "Experiment is complete"
         RESULTS_FETCHED = "Experiment results fetched"
+        EXPIRED_FROM_PREVIEW = "Expired from preview collection after 30 days"
 
     def __str__(self):
         return self.message or (

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1349,6 +1349,60 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(
             bucket=settings.KINTO_BUCKET_WORKSPACE,
         )
 
+    def test_unpublishes_preview_experiments_older_than_30_days(self):
+        old_preview_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            slug="old_preview_experiment",
+            published_date=timezone.now(),
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        recent_preview_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            slug="recent_preview_experiment",
+            published_date=timezone.now(),
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        thirty_one_days_ago = timezone.now() - timezone.timedelta(days=31)
+        NimbusExperiment.objects.filter(id=old_preview_experiment.id).update(
+            _updated_date_time=thirty_one_days_ago
+        )
+
+        self.setup_kinto_get_main_records(
+            [old_preview_experiment.slug, recent_preview_experiment.slug]
+        )
+
+        tasks.nimbus_synchronize_preview_experiments_in_kinto()
+
+        old_preview_experiment.refresh_from_db()
+        self.assertIsNone(old_preview_experiment.published_date)
+        self.assertEqual(old_preview_experiment.status, NimbusExperiment.Status.DRAFT)
+        self.assertEqual(
+            old_preview_experiment.publish_status,
+            NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        expiration_changelog = old_preview_experiment.changes.filter(
+            message=NimbusChangeLog.Messages.EXPIRED_FROM_PREVIEW,
+            changed_by__email=settings.KINTO_DEFAULT_CHANGELOG_USER,
+        )
+        self.assertTrue(expiration_changelog.exists())
+
+        recent_preview_experiment.refresh_from_db()
+        self.assertIsNotNone(recent_preview_experiment.published_date)
+        self.assertEqual(
+            recent_preview_experiment.status, NimbusExperiment.Status.PREVIEW
+        )
+
+        self.mock_kinto_client.delete_record.assert_called_with(
+            id=old_preview_experiment.slug,
+            collection=NimbusExperiment.APPLICATION_CONFIGS[
+                NimbusExperiment.Application.DESKTOP
+            ].preview_collection,
+            bucket=settings.KINTO_BUCKET_WORKSPACE,
+        )
+
     def test_reraises_exception(self):
         self.mock_kinto_client.create_record.side_effect = Exception
         with self.assertRaises(Exception):


### PR DESCRIPTION
Becuase

* Users can push recipes to preview but forget to remove them
* Over time a growing number of recipes live in the preview collection
* This can cause testing in preview to become difficult if recipes collide or untentionally enroll
* We should expire recipes out of preview after 30 days

This commit

* Adds a step to the preview sync task to expire experiments that have been in preview for more than 30 days

fixes #8542

