### PR TITLE
feat(nimbus): create popout for metrics

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -512,7 +512,7 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
     requires_restart = factory.LazyAttribute(
         lambda o: (random.choice([True, False]) if o.is_firefox_labs_opt_in else False)
     )
-    results_data = {"v3": {"overall": {"enrollments": {"all": [1]}}}}
+    results_data = {"v3": {"overall": {"enrollments": {"all": {}}}}}
 
     class Meta:
         model = NimbusExperiment

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -394,3 +394,7 @@ QA_ICON_FILTER_TYPE = "qa_icon_info"
 CHANNEL_ICON_FILTER_TYPE = "channel_icon_info"
 APPLICATION_ICON_FILTER_TYPE = "application_icon_info"
 STATUS_ICON_FILTER_TYPE = "status_icon_info"
+
+# Represents the minimum width percentage for the bar in metric popout cards to
+# adjust number bounds and prevent overlapping
+METRICS_MIN_BOUNDS_WIDTH = 22

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
@@ -1,9 +1,15 @@
+{% load nimbus_extras %}
+
 {% with sig=significance|default:"neutral" %}
   {% if slug == reference_branch %}
     <div class="card p-4 bg-body-tertiary text-muted border-0 text-center d-flex flex-row align-items-center justify-content-center"
          style="height: 100px">
       {% if absolute_lower %}
-        ({{ absolute_lower }} to {{ absolute_upper }})
+        {% if display_type == "percentage" %}
+          ({{ absolute_lower|to_percentage:1 }} to {{ absolute_upper|to_percentage:1 }})
+        {% else %}
+          ({{ absolute_lower|floatformat:2 }} to {{ absolute_upper|floatformat:2 }})
+        {% endif %}
       {% else %}
         Baseline
       {% endif %}
@@ -14,14 +20,20 @@
       <i class="fa-solid {% if sig == "positive" %}fa-arrow-up{% elif sig == "negative" %}fa-arrow-down{% else %}fa-arrow-left{% endif %}"></i>
       <div class="d-flex flex-column align-items-center">
         {% if sig == "positive" %}
-          <span class="fw-semibold">{{ percentage }}% increase</span>
+          <span class="fw-semibold">{{ percentage|to_percentage:1 }} increase</span>
         {% elif sig == "negative" %}
-          <span class="fw-semibold">{{ percentage }}% decrease</span>
+          <span class="fw-semibold">{{ percentage|to_percentage:1 }} decrease</span>
         {% else %}
           <span class="fw-semibold">No notable change</span>
         {% endif %}
         <span class="mb-0">
-          {% if absolute_lower %}({{ absolute_lower }} to {{ absolute_upper }}){% endif %}
+          {% if absolute_lower %}
+            {% if display_type == "percentage" %}
+              ({{ absolute_lower|to_percentage:1 }} to {{ absolute_upper|to_percentage:1 }})
+            {% else %}
+              ({{ absolute_lower|floatformat:2 }} to {{ absolute_upper|floatformat:2 }})
+            {% endif %}
+          {% endif %}
         </span>
       </div>
     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -1,0 +1,82 @@
+<div class="modal fade"
+     id="{{ experiment_slug }}-{{ metric_info.slug }}"
+     tabindex="-1"
+     aria-labelledby="exampleModalLabel"
+     aria-hidden="true">
+  <div class="modal-dialog modal-dialog modal-dialog-centered modal-dialog-scrollable modal-xl">
+    <div class="modal-content p-4">
+      <div class="modal-header align-items-baseline border-0">
+        <div>
+          <h1 class="modal-title fs-4" id="exampleModalLabel">{{ metric_info.friendly_name }}</h1>
+          <p class="text-muted mt-2">{{ metric_info.description }}</p>
+        </div>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"></button>
+      </div>
+      <div class="modal-body accordion"
+           id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">
+        <div class="accordion-item p-3">
+          <h2 class="accordion-header">
+            <button class="accordion-button fw-bold shadow-none bg-transparent text-body"
+                    type="button"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse"
+                    aria-expanded="true"
+                    aria-controls="{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse">Overview</button>
+          </h2>
+          <div class="accordion-collapse collapse show"
+               data-bs-parent="#{{ experiment_slug }}-{{ metric_info.slug }}-accordion"
+               id="{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse">
+            <div class="accordion-body row row-cols-3 g-3">
+              <div class="col">
+                <p class="fw-bold text-center">Branches</p>
+                {% for branch in branch_data %}
+                  <div class="p-3 mb-3 d-flex justify-content-center text-start text-center"
+                       style="height: 75px">
+                    <div class="d-flex flex-column align-items-center">
+                      <small class="text-muted mb-0">{{ branch.name }}</small>
+                      <p class="mb-0">
+                        {% if branch.slug == reference_branch %}
+                          Baseline
+                        {% else %}
+                          {{ branch.name }}
+                        {% endif %}
+                      </p>
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+              <div class="col">
+                <p class="fw-bold text-center">Absolute count</p>
+                {% for branch_slug, branch_data in metric_data.items %}
+                  {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+
+                {% endfor %}
+              </div>
+              <div class="col">
+                <p class="fw-bold text-center">Relative change</p>
+                <div class="d-flex flex-column">
+                  {% for branch_slug, branch_data in metric_data.items %}
+                    {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
+                      {% if branch_slug == branch_relative_ui %}
+                        {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
+
+                      {% endif %}
+                    {% endfor %}
+                    {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
+                    {% if branch_slug == reference_branch %}
+                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+
+                    {% endif %}
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout_card.html
@@ -1,0 +1,67 @@
+{% load nimbus_extras %}
+
+{% with sig=significance|default:"neutral" %}
+  {% if type == "absolute" %}
+    <div class="card p-3 bg-body-tertiary border-0 text-center d-flex flex-row align-items-center justify-content-center mb-3 fw-semibold {% if sig == "positive" %}bg-success-subtle text-success{% elif sig == "negative" %}bg-danger-subtle text-danger{% else %}bg-body-tertiary text-muted{% endif %}"
+         style="height: 75px">
+      {% if not absolute_lower or reference_branch == branch_slug %}
+        <i class="fa-solid fa-house me-2"></i>
+      {% else %}
+        <i class="fa-solid me-2 {% if sig == "positive" %}fa-arrow-up{% elif sig == "negative" %}fa-arrow-down{% else %}fa-arrow-left{% endif %}"></i>
+      {% endif %}
+      {% if absolute_lower %}
+        {% if display_type == "percentage" %}
+          <span class="mb-0 me-1"
+                data-bs-toggle="tooltip"
+                data-bs-title="{{ absolute_lower|to_percentage }}">{{ absolute_lower|to_percentage:1 }}</span>
+          to
+          <p class="mb-0 ms-1"
+             data-bs-toggle="tooltip"
+             data-bs-title="{{ absolute_upper|to_percentage }}">
+            {{ absolute_upper|to_percentage:1 }}
+          </span>
+        {% else %}
+          <span class="mb-0 me-1"
+                data-bs-toggle="tooltip"
+                data-bs-title="{{ absolute_lower }}">{{ absolute_lower|floatformat:2 }}</span>
+          to
+          <p class="mb-0 ms-1"
+             data-bs-toggle="tooltip"
+             data-bs-title="{{ absolute_upper }}">
+            {{ absolute_upper|floatformat:2 }}
+          </span>
+        {% endif %}
+      {% else %}
+        Baseline
+      {% endif %}
+    </div>
+  {% elif type == "relative" %}
+    <div class="card pt-3 mx-5 mb-3 border-0 position-relative overflow-visible"
+         style="height: 75px">
+      <div class="w-100 border-bottom my-auto "></div>
+      {% if branch_relative_ui_properties %}
+        <div class="d-flex flex-row flex-nowrap justify-content-between position-absolute {% if sig == "positive" %}text-success{% elif sig == "negative" %}text-danger{% else %}text-body-tertiary{% endif %}"
+             style="width: {{ branch_relative_ui_properties.bounds_width }}%;
+                    left: {{ branch_relative_ui_properties.left_bounds_percent }}%">
+          <small class="fw-semibold"
+                 data-bs-toggle="tooltip"
+                 data-bs-title="{{ lower_relative|to_percentage }}">{{ lower_relative|to_percentage:1 }}</small>
+          <small class="fw-semibold"
+                 data-bs-toggle="tooltip"
+                 data-bs-title="{{ upper_relative|to_percentage }}">{{ upper_relative|to_percentage:1 }}</small>
+        </div>
+        <div class="position-absolute border border-2 border-top-0 {% if sig == "positive" %}border-success{% elif sig == "negative" %}border-danger{% else %}border-light-subtle{% endif %}"
+             style="height: 10px;
+                    width: {{ branch_relative_ui_properties.bar_width }}%;
+                    left: {{ branch_relative_ui_properties.left_percent }}%;
+                    bottom: 32%"></div>
+        <div class="position-absolute bg-gradient rounded-1 rounded-top-0 {% if sig == "positive" %}bg-success{% elif sig == "negative" %}bg-danger{% else %}bg-secondary-subtle{% endif %}"
+             style="height: 10px;
+                    width: {{ branch_relative_ui_properties.bar_width }}%;
+                    left: {{ branch_relative_ui_properties.left_percent }}%;
+                    bottom: 25%;
+                    transform: translateY(-10%)"></div>
+      {% endif %}
+    </div>
+  {% endif %}
+{% endwith %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -125,10 +125,22 @@
           {% for metric in metric_metadata %}
             <button class="card p-3 {% if forloop.last %}mb-4{% endif %} mb-3 d-flex justify-content-center rounded-4 border-3 w-100 text-start nav-link-hover position-relative border-light-subtle"
                     type="button"
+                    data-bs-toggle="modal"
+                    data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}"
                     style="height: 100px">
               <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
               <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
             </button>
+            {% for curr_metric_slug, metric_data in metric_data.items %}
+              {% if curr_metric_slug == metric.slug %}
+                {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
+                  {% if metric_ui_properties == curr_metric_slug %}
+                    {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
+
+                  {% endif %}
+                {% endfor %}
+              {% endif %}
+            {% endfor %}
           {% endfor %}
         </div>
         <div class="col position-relative w-25">
@@ -139,22 +151,24 @@
             {% endif %}
             {% for branch in branch_data %}
               <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                <p class="text-muted mb-0">{{ branch.name }}</p>
+                <small class="text-muted mb-0">{{ branch.name }}</small>
                 {% if branch.slug == selected_reference_branch %}
-                  <p class="fs-5 mb-3">Baseline</p>
+                  <p class="mb-3">Baseline</p>
                 {% else %}
-                  <p class="fs-5">{{ branch.name }}</p>
+                  <p>{{ branch.name }}</p>
                 {% endif %}
                 <div class="d-flex flex-column gap-3 w-100">
-                  {% for k, v in metric_data.items %}
-                    {% if k == branch.slug %}
-                      {% with branch_metric_data=v %}
-                        {% for metric, values in branch_metric_data.items %}
-                          {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=values.absolute.0.lower absolute_upper=values.absolute.0.upper significance=values.relative.0.significance percentage=values.relative.0.avg_rel_change %}
+                  {% for metric in metric_metadata %}
+                    {% for curr_metric_slug, metric_branch_data in metric_data.items %}
+                      {% if curr_metric_slug == metric.slug %}
+                        {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
+                          {% if curr_branch_slug == branch.slug %}
+                            {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
 
+                          {% endif %}
                         {% endfor %}
-                      {% endwith %}
-                    {% endif %}
+                      {% endif %}
+                    {% endfor %}
                   {% endfor %}
                 </div>
               </div>

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -331,3 +331,14 @@ def format_string(value, arg):
         {{ "Subscribe to {text}"|format_string:feature.name }}
     """
     return value.format(text=arg)
+
+
+@register.filter
+def to_percentage(value, precision=None):
+    percentage_value = value * 100
+
+    if precision is None:
+        return f"{percentage_value}%"
+
+    format_string = f"{{:.{precision}f}}%"
+    return format_string.format(percentage_value)

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -42,6 +42,7 @@ from experimenter.nimbus_ui.templatetags.nimbus_extras import (
     render_channel_icons,
     short_number,
     status_icon_info,
+    to_percentage,
 )
 from experimenter.nimbus_ui.templatetags.nimbus_extras import (
     should_show_remote_settings_pending as filter_should_show_remote_settings_pending,
@@ -147,6 +148,16 @@ class FilterTests(TestCase):
     def test_format_string_with_no_placeholder(self):
         result = format_string("Subscribe for updates", "Picture-in-Picture")
         self.assertEqual(result, "Subscribe for updates")
+
+    def test_to_percentage_precision_specified(self):
+        self.assertEqual(to_percentage(0.123456, 4), "12.3456%")
+        self.assertEqual(to_percentage(0.123, 2), "12.30%")
+        self.assertEqual(to_percentage(0.12, 0), "12%")
+
+    def test_to_percentage_no_precision_specified(self):
+        self.assertEqual(to_percentage(0.123456), "12.3456%")
+        self.assertEqual(to_percentage(0.123), "12.3%")
+        self.assertEqual(to_percentage(0.12), "12.0%")
 
 
 class TestHomeFilters(AuthTestCase):


### PR DESCRIPTION
Because

- Metric have in depth information that can be accessed by clicking their cards

This commit

- Creates the metric popout view displaying overview data

Fixes #13943 