### PR TITLE
bug(experimenter): unset published_dto when unpublishing from preview

### DIFF
--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -455,6 +455,7 @@ def nimbus_synchronize_preview_experiments_in_kinto():
             kinto_client = kinto_clients[experiment.application]
             kinto_client.delete_record(experiment.slug)
             experiment.published_date = None
+            experiment.published_dto = None
             experiment.save()
             logger.info(f"{experiment.slug} is being removed from preview")
 

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1332,6 +1332,7 @@ class TestNimbusSynchronizePreviewExperimentsInKinto(
         )
 
         self.assertIsNone(should_unpublish_experiment.published_date)
+        self.assertIsNone(should_unpublish_experiment.published_dto)
 
         self.mock_kinto_client.create_record.assert_called_with(
             data=data,


### PR DESCRIPTION
Becuase

* We cache the recipe when an experiment goes to preview or live
* We use the cached targeting string to display on the summary page
* When an experiment is unpublished from preview, we must unset the cached recipe
* This must have been missed resulting in the cached recipe being displayed even after moving back to draft

This commit

* Sets the published_dto field to None when unpublishing from preview

fixes #13968

