### PR TITLE
bug(nimbus): move loading overlay out of form div

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -8,283 +8,293 @@
 {% block title %}{{ experiment.name }} - Audience{% endblock %}
 
 {% block main_content %}
-  <form id="audience-form"
-        {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
-        hx-post="{% url 'nimbus-ui-update-audience' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-        hx-select="#audience-form"
-        hx-target="#audience-form">
-    {% csrf_token %}
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Audience</h4>
-        <a target="_blank" href="{{ experiment.audience_url }}">Explore matching audiences</a>
+  <div class="position-relative">
+    <!-- Full form overlay -->
+    <div id="htmx-loading-overlay"
+         class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
+      <div class="text-center text-white">
+        <i class="fa-solid fa-spinner fa-spin-pulse fa-3x mb-3"></i>
+        <div class="fs-5">Saving changes...</div>
       </div>
-      <div class="card-body">
-        <div class="row mb-3">
-          <div class="col-4">
-            {% if experiment.is_desktop %}
-              <label for="id_channels" class="form-label">Channels</label>
-              {{ form.channels|add_class:"form-control"|add_error_class:"is-invalid" }}
-              {% for error in form.channels.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.channels %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            {% else %}
-              <label for="id_channel" class="form-label">Channel</label>
-              {{ form.channel|add_class:"form-control"|add_error_class:"is-invalid" }}
-              {% for error in form.channel.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.channel %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            {% endif %}
-          </div>
-          <div class="col-4">
-            <label for="id_firefox_min_version" class="form-label">Min Version</label>
-            {{ form.firefox_min_version|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.firefox_min_version.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.firefox_min_version %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-          <div class="col-4">
-            <label for="id_firefox_max_version" class="form-label">Max Version</label>
-            {{ form.firefox_max_version|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.firefox_max_version.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.firefox_max_version %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
+    </div>
+    <form id="audience-form"
+          {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
+          hx-post="{% url 'nimbus-ui-update-audience' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+          hx-select="#audience-form"
+          hx-target="#audience-form">
+      {% csrf_token %}
+      <div class="card mb-3">
+        <div class="card-header">
+          <h4>Audience</h4>
+          <a target="_blank" href="{{ experiment.audience_url }}">Explore matching audiences</a>
         </div>
-        <div class="row mb-3">
-          <div data-testid="locales" class="col-6">
-            {% if experiment.is_desktop %}
-              <label for="id_locales" class="form-label">Locales</label>
-              {{ form.locales|add_class:"form-control"|add_error_class:"is-invalid" }}
-              <label for="id_exclude_locales" class="form-label mt-2">
-                {{ form.exclude_locales|add_error_class:"is-invalid" }}
-                Exclude selected locales
-              </label>
-              {% for error in form.locales.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.locales %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            {% else %}
-              <label for="id_languages" class="form-label">Languages</label>
-              {{ form.languages|add_class:"form-control"|add_error_class:"is-invalid" }}
-              <label for="id_exclude_languages" class="form-label mt-2">
-                {{ form.exclude_languages|add_error_class:"is-invalid" }}
-                Exclude selected languages
-              </label>
-              {% for error in form.languages.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.languages %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            {% endif %}
+        <div class="card-body">
+          <div class="row mb-3">
+            <div class="col-4">
+              {% if experiment.is_desktop %}
+                <label for="id_channels" class="form-label">Channels</label>
+                {{ form.channels|add_class:"form-control"|add_error_class:"is-invalid" }}
+                {% for error in form.channels.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.channels %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% else %}
+                <label for="id_channel" class="form-label">Channel</label>
+                {{ form.channel|add_class:"form-control"|add_error_class:"is-invalid" }}
+                {% for error in form.channel.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.channel %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% endif %}
+            </div>
+            <div class="col-4">
+              <label for="id_firefox_min_version" class="form-label">Min Version</label>
+              {{ form.firefox_min_version|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.firefox_min_version.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.firefox_min_version %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+            <div class="col-4">
+              <label for="id_firefox_max_version" class="form-label">Max Version</label>
+              {{ form.firefox_max_version|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.firefox_max_version.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.firefox_max_version %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
           </div>
-          <div data-testid="countries" class="col-6">
-            <label for="id_countries" class="form-label">Countries</label>
-            {{ form.countries|add_class:"form-control"|add_error_class:"is-invalid" }}
-            <label for="id_exclude_countries" class="form-label mt-2">
-              {{ form.exclude_countries|add_error_class:"is-invalid" }}
-              Exclude selected countries
-            </label>
-            {% for error in form.countries.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.countries %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+          <div class="row mb-3">
+            <div data-testid="locales" class="col-6">
+              {% if experiment.is_desktop %}
+                <label for="id_locales" class="form-label">Locales</label>
+                {{ form.locales|add_class:"form-control"|add_error_class:"is-invalid" }}
+                <label for="id_exclude_locales" class="form-label mt-2">
+                  {{ form.exclude_locales|add_error_class:"is-invalid" }}
+                  Exclude selected locales
+                </label>
+                {% for error in form.locales.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.locales %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% else %}
+                <label for="id_languages" class="form-label">Languages</label>
+                {{ form.languages|add_class:"form-control"|add_error_class:"is-invalid" }}
+                <label for="id_exclude_languages" class="form-label mt-2">
+                  {{ form.exclude_languages|add_error_class:"is-invalid" }}
+                  Exclude selected languages
+                </label>
+                {% for error in form.languages.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.languages %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% endif %}
+            </div>
+            <div data-testid="countries" class="col-6">
+              <label for="id_countries" class="form-label">Countries</label>
+              {{ form.countries|add_class:"form-control"|add_error_class:"is-invalid" }}
+              <label for="id_exclude_countries" class="form-label mt-2">
+                {{ form.exclude_countries|add_error_class:"is-invalid" }}
+                Exclude selected countries
+              </label>
+              {% for error in form.countries.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.countries %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
           </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_targeting_config_slug"
-                   class="form-label d-flex align-items-center">
-              Advanced Targeting
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_targeting_config_slug"
+                     class="form-label d-flex align-items-center">
+                Advanced Targeting
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.targeting_criteria_request_url }}"
+                   class="ms-2"
+                   style="font-size: 0.9em">file targeting criteria request</a>
+                <i class="fa-regular fa-circle-question fa-sm ps-2 text-muted"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="right"
+                   title="{{ NimbusUIConstants.TARGETING_CRITERIA_REQUEST_INFO }}">
+                </i>
+                <a href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.custom_audiences_url }}"
+                   target="_blank"
+                   class="ms-1 text-decoration-none"
+                   style="font-size: 0.9em">(guidance)</a>
+              </label>
+              {{ form.targeting_config_slug|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.targeting_config_slug.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.targeting_config_slug %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_excluded_experiments" class="form-label">
+                Exclude users enrolled in any of these experiments/rollouts (past or present)
+              </label>
+              {{ form.excluded_experiments_branches|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.excluded_experiments_branches.errors %}
+                <div class="invalid-feedback">{{ error }}</div>
+              {% endfor %}
+              {% for error in validation_errors.excluded_experiments_branches %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_required_experiments" class="form-label">
+                Require users to be enrolled in any of these experiments/rollouts (past or present)
+              </label>
+              {{ form.required_experiments_branches|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.required_experiments_branches.errors %}
+                <div class="invalid-feedback">{{ error }}</div>
+              {% endfor %}
+              {% for error in validation_errors.required_experiments_branches %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-4">
+            <div class="col">
+              {{ form.is_sticky|add_error_class:"is-invalid" }}
+              <label for="id_is_sticky">Sticky Targeting (Clients remain enrolled even if they no longer meet the targeting)</label>
               <a target="_blank"
-                 href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.targeting_criteria_request_url }}"
-                 class="ms-2"
-                 style="font-size: 0.9em">file targeting criteria request</a>
-              <i class="fa-regular fa-circle-question fa-sm ps-2 text-muted"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="right"
-                 title="{{ NimbusUIConstants.TARGETING_CRITERIA_REQUEST_INFO }}">
-              </i>
-              <a href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.custom_audiences_url }}"
-                 target="_blank"
-                 class="ms-1 text-decoration-none"
-                 style="font-size: 0.9em">(guidance)</a>
-            </label>
-            {{ form.targeting_config_slug|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.targeting_config_slug.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.targeting_config_slug %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
+                 href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.sticky_targeting_url }}">Learn more</a>
+              {% for error in form.is_sticky.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.is_sticky %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
           </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_excluded_experiments" class="form-label">
-              Exclude users enrolled in any of these experiments/rollouts (past or present)
-            </label>
-            {{ form.excluded_experiments_branches|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.excluded_experiments_branches.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
-            {% for error in validation_errors.excluded_experiments_branches %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_required_experiments" class="form-label">
-              Require users to be enrolled in any of these experiments/rollouts (past or present)
-            </label>
-            {{ form.required_experiments_branches|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.required_experiments_branches.errors %}
-              <div class="invalid-feedback">{{ error }}</div>
-            {% endfor %}
-            {% for error in validation_errors.required_experiments_branches %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-        </div>
-        <div class="row mb-4">
-          <div class="col">
-            {{ form.is_sticky|add_error_class:"is-invalid" }}
-            <label for="id_is_sticky">Sticky Targeting (Clients remain enrolled even if they no longer meet the targeting)</label>
-            <a target="_blank"
-               href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.sticky_targeting_url }}">Learn more</a>
-            {% for error in form.is_sticky.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.is_sticky %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        {% if experiment.is_mobile %}
-          <div id="first-run-fields">
-            <div class="row mb-4">
-              <div class="col">
-                {{ form.is_first_run|add_error_class:"is-invalid" }}
-                <label for="id_is_first_run">First run experiment</label>
-                {% for error in form.is_first_run.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-                {% for error in validation_errors.is_first_run %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+          {% if experiment.is_mobile %}
+            <div id="first-run-fields">
+              <div class="row mb-4">
+                <div class="col">
+                  {{ form.is_first_run|add_error_class:"is-invalid" }}
+                  <label for="id_is_first_run">First run experiment</label>
+                  {% for error in form.is_first_run.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                  {% for error in validation_errors.is_first_run %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                </div>
+              </div>
+              <div class="row mb-4">
+                <div class="col">
+                  <label class="mb-2" for="id_proposed_release_date">
+                    First Run Release Date
+                    <a href="https://whattrainisitnow.com/" target="_blank">
+                      <i class="fa-regular fa-circle-question"
+                         data-bs-toggle="tooltip"
+                         data-bs-placement="top"
+                         data-bs-title="This is the approximate release date of the version that is being targeted. Click here to find your date!"></i>
+                    </a>
+                  </label>
+                  {% if experiment.is_first_run %}
+                    {{ form.proposed_release_date|add_error_class:"is-invalid" }}
+                  {% else %}
+                    {{ form.proposed_release_date|add_error_class:"is-invalid"|attr:"disabled:disabled" }}
+                  {% endif %}
+                  {% for error in form.proposed_release_date.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                  {% for error in validation_errors.proposed_release_date %}
+                    <div class="form-text text-danger">{{ error }}</div>
+                  {% endfor %}
+                </div>
               </div>
             </div>
-            <div class="row mb-4">
+          {% endif %}
+          <div class="card bg-body-tertiary border-0 p-4">
+            <p class="text-secondary mb-4">
+              Please ask a data scientist to help you determine these values.
+              <a target="_blank"
+                 href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.experimentation_office_hours_url }}">Learn more</a>
+            </p>
+            <div class="row">
+              <div class="col-6 d-flex flex-column">
+                <label for="id_population_percent">Percent of clients</label>
+              </div>
+            </div>
+            <div class="row">
+              <div class="col d-flex flex-column">
+                <input id="id_population_percent_slider"
+                       min="0"
+                       max="100"
+                       step="5"
+                       type="range"
+                       id="populationPercent"
+                       class="pb-4 form-control-range"
+                       value="{{ experiment.population_percent }}">
+              </div>
               <div class="col">
-                <label class="mb-2" for="id_proposed_release_date">
-                  First Run Release Date
-                  <a href="https://whattrainisitnow.com/" target="_blank">
-                    <i class="fa-regular fa-circle-question"
-                       data-bs-toggle="tooltip"
-                       data-bs-placement="top"
-                       data-bs-title="This is the approximate release date of the version that is being targeted. Click here to find your date!"></i>
-                  </a>
-                </label>
-                {% if experiment.is_first_run %}
-                  {{ form.proposed_release_date|add_error_class:"is-invalid" }}
-                {% else %}
-                  {{ form.proposed_release_date|add_error_class:"is-invalid"|attr:"disabled:disabled" }}
-                {% endif %}
-                {% for error in form.proposed_release_date.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-                {% for error in validation_errors.proposed_release_date %}
+                <label for="id_total_enrolled_clients">Expected number of clients</label>
+              </div>
+            </div>
+            <div class="row mb-3">
+              <div class="col d-flex flex-column">
+                <div class="input-group">
+                  {{ form.population_percent|add_error_class:"is-invalid" }}
+                  <span class="input-group-text">%</span>
+                  {% for error in form.population_percent.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                </div>
+                {% for error in validation_errors.population_percent %}
+                  <div class="form-text text-danger">{{ error }}</div>
+                {% endfor %}
+              </div>
+              <div class="col">
+                {{ form.total_enrolled_clients|add_class:"form-control"|add_error_class:"is-invalid" }}
+                {% for error in form.total_enrolled_clients.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.total_enrolled_clients %}
                   <div class="form-text text-danger">{{ error }}</div>
                 {% endfor %}
               </div>
             </div>
-          </div>
-        {% endif %}
-        <div class="card bg-body-tertiary border-0 p-4">
-          <p class="text-secondary mb-4">
-            Please ask a data scientist to help you determine these values.
-            <a target="_blank"
-               href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.experimentation_office_hours_url }}">Learn more</a>
-          </p>
-          <div class="row">
-            <div class="col-6 d-flex flex-column">
-              <label for="id_population_percent">Percent of clients</label>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col d-flex flex-column">
-              <input id="id_population_percent_slider"
-                     min="0"
-                     max="100"
-                     step="5"
-                     type="range"
-                     id="populationPercent"
-                     class="pb-4 form-control-range"
-                     value="{{ experiment.population_percent }}">
-            </div>
-            <div class="col">
-              <label for="id_total_enrolled_clients">Expected number of clients</label>
-            </div>
-          </div>
-          <div class="row mb-3">
-            <div class="col d-flex flex-column">
-              <div class="input-group">
-                {{ form.population_percent|add_error_class:"is-invalid" }}
-                <span class="input-group-text">%</span>
-                {% for error in form.population_percent.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+            <div class="row">
+              <div class="col">
+                <label class="mb-2" for="id_proposed_enrollment">Enrollment period</label>
+                <div class="input-group">
+                  {{ form.proposed_enrollment|add_class:"form-control"|add_error_class:"is-invalid" }}
+                  <span class="input-group-text">days</span>
+                  {% for error in form.proposed_enrollment.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                </div>
+                {% for error in validation_errors.proposed_enrollment %}
+                  <div class="form-text text-danger">{{ error }}</div>
+                {% endfor %}
               </div>
-              {% for error in validation_errors.population_percent %}
-                <div class="form-text text-danger">{{ error }}</div>
-              {% endfor %}
-            </div>
-            <div class="col">
-              {{ form.total_enrolled_clients|add_class:"form-control"|add_error_class:"is-invalid" }}
-              {% for error in form.total_enrolled_clients.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.total_enrolled_clients %}
-                <div class="form-text text-danger">{{ error }}</div>
-              {% endfor %}
-            </div>
-          </div>
-          <div class="row">
-            <div class="col">
-              <label class="mb-2" for="id_proposed_enrollment">Enrollment period</label>
-              <div class="input-group">
-                {{ form.proposed_enrollment|add_class:"form-control"|add_error_class:"is-invalid" }}
-                <span class="input-group-text">days</span>
-                {% for error in form.proposed_enrollment.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              <div class="col">
+                <label class="mb-2" for="id_proposed_duration">Experiment duration</label>
+                <div class="input-group">
+                  {{ form.proposed_duration|add_class:"form-control"|add_error_class:"is-invalid" }}
+                  <span class="input-group-text">days</span>
+                  {% for error in form.proposed_duration.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                </div>
+                {% for error in validation_errors.proposed_duration %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
               </div>
-              {% for error in validation_errors.proposed_enrollment %}
-                <div class="form-text text-danger">{{ error }}</div>
-              {% endfor %}
-            </div>
-            <div class="col">
-              <label class="mb-2" for="id_proposed_duration">Experiment duration</label>
-              <div class="input-group">
-                {{ form.proposed_duration|add_class:"form-control"|add_error_class:"is-invalid" }}
-                <span class="input-group-text">days</span>
-                {% for error in form.proposed_duration.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              </div>
-              {% for error in validation_errors.proposed_duration %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="d-flex justify-content-end">
-      <button type="submit" class="btn btn-primary" id="save-button">Save</button>
-      <button type="submit"
-              name="save_action"
-              value="continue"
-              id="save-and-continue-button"
-              class="btn btn-secondary ms-2">Save and Continue</button>
-    </div>
-    {% if form.is_bound %}
-      {% if form.is_valid %}
-        <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-check"></i>
-            Audience saved!
+      <div class="d-flex justify-content-end">
+        <button type="submit" class="btn btn-primary" id="save-button">Save</button>
+        <button type="submit"
+                name="save_action"
+                value="continue"
+                id="save-and-continue-button"
+                class="btn btn-secondary ms-2">Save and Continue</button>
+      </div>
+      {% if form.is_bound %}
+        {% if form.is_valid %}
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-check"></i>
+              Audience saved!
+            </div>
           </div>
-        </div>
-      {% endif %}
-      {% if not form.is_valid or validation_errors %}
-        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-xmark"></i>
-            Please fix the errors
+        {% endif %}
+        {% if not form.is_valid or validation_errors %}
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-xmark"></i>
+              Please fix the errors
+            </div>
           </div>
-        </div>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </form>
+    </form>
+  </div>
 {% endblock main_content %}
 
 {% block extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -9,15 +9,7 @@
 {% block title %}{{ experiment.name }} - Branches{% endblock %}
 
 {% block main_content %}
-  <form id="branches-form"
-        {% if form.is_bound %}class="was-validated"{% endif %}
-        hx-encoding="multipart/form-data"
-        hx-post="{% url 'nimbus-ui-update-branches' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-        hx-select="#branches-form"
-        hx-target="#branches-form"
-        hx-swap="outerHTML"
-        class="position-relative">
-    {% csrf_token %}
+  <div class="position-relative">
     <!-- Full form overlay -->
     <div id="htmx-loading-overlay"
          class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
@@ -26,377 +18,386 @@
         <div class="fs-5">Saving changes...</div>
       </div>
     </div>
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Branches</h4>
-      </div>
-      <div class="card-body">
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_feature_configs" class="form-label">
-              You must select at least one feature configuration for your experiment.
-              <a target="_blank" href="https://experimenter.info/feature-definition/">Learn more</a>
-            </label>
-            {{ form.feature_configs }}
-            {% for error in validation_errors.feature_configs %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
+    <form id="branches-form"
+          {% if form.is_bound %}class="was-validated"{% endif %}
+          hx-encoding="multipart/form-data"
+          hx-post="{% url 'nimbus-ui-update-branches' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+          hx-select="#branches-form"
+          hx-target="#branches-form"
+          hx-swap="outerHTML">
+      {% csrf_token %}
+      <div class="card mb-3">
+        <div class="card-header">
+          <h4>Branches</h4>
         </div>
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.is_rollout }}
-              <label class="form-check-label" for="id_is_rollout">This is a rollout (single branch)</label>
-              <a target="_blank"
-                 href="https://experimenter.info/deep-dives/experimenter/rollouts">Learn more</a>
-            </div>
-            {% for error in validation_errors.is_rollout %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.warn_feature_schema }}
-              <label class="form-check-label" for="id_warn_feature_schema">Warn only on feature schema validation failure</label>
-            </div>
-            {% for error in validation_errors.warn_feature_schema %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.equal_branch_ratio }}
-              <label class="form-check-label" for="id_equal_branch_ratio">Users should be split evenly between all branches</label>
-            </div>
-            {% for error in validation_errors.equal_branch_ratio %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.prevent_pref_conflicts }}
-              <label class="form-check-label" for="id_prevent_pref_conflicts">
-                Prevent enrollment if users have changed any prefs set by this experiment
+        <div class="card-body">
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_feature_configs" class="form-label">
+                You must select at least one feature configuration for your experiment.
+                <a target="_blank" href="https://experimenter.info/feature-definition/">Learn more</a>
               </label>
-              {% if form.prevent_pref_conflicts.field.disabled %}
-                <div class="form-text">This option is required for rollouts to prevent re-enrollment after pref changes.</div>
-              {% endif %}
+              {{ form.feature_configs }}
+              {% for error in validation_errors.feature_configs %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
-            {% for error in validation_errors.prevent_pref_conflicts %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
           </div>
-        </div>
-        <div id="branches">
-          {{ form.branches.management_form }}
-          {% for branch_form in form.branches %}
-            <div class="card bg-body-tertiary mb-3 {% if branch_form.errors %}border border-danger{% endif %}">
-              <div class="card-body position-relative">
-                {{ branch_form.id }}
-                <div class="row">
-                  <div class="col-3">
-                    <label class="d-block">Branch Name</label>
-                    {{ branch_form.name|add_error_class:"is-invalid" }}
-                    {% for error in branch_form.name.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                  </div>
-                  <div class="col-7">
-                    <label class="d-block">Description</label>
-                    {{ branch_form.description|add_error_class:"is-invalid" }}
-                    {% for error in branch_form.description.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                    {% get_branch_errors validation_errors forloop.first forloop.counter0|add:"-1" as branch_errors %}
-                    {% for error in branch_errors.description %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                  </div>
-                  <div class="col-2">
-                    <label class="d-block">Ratio</label>
-                    <div class="d-flex align-items-end">
-                      {% if form.instance.equal_branch_ratio %}
-                        <input type="text" class="form-control text-center" value="Equal" disabled>
-                      {% else %}
-                        {{ branch_form.ratio|add_class:"form-control text-center"|add_error_class:"is-invalid" }}
-                        {% for error in branch_form.ratio.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      {% endif %}
-                      {% if not forloop.first %}
-                        <button type="button"
-                                id="delete-branch-{{ branch_form.instance.id }}"
-                                class="btn btn-link ms-3 px-0"
-                                data-bs-toggle="tooltip"
-                                data-bs-placement="top"
-                                data-bs-title="Delete Branch"
-                                hx-post="{% url 'nimbus-ui-delete-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-                                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                                hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
-                                hx-select="#branches-form"
-                                hx-target="#branches-form"
-                                hx-disabled-elt="this">
-                          <i class="fa-solid fa-trash"></i>
-                        </button>
-                      {% endif %}
-                    </div>
-                  </div>
-                </div>
-                {{ branch_form.branch_feature_values.management_form }}
-                {% for branch_feature_values_form in branch_form.branch_feature_values %}
-                  {{ branch_feature_values_form.id }}
-                  <div class="row mt-3">
-                    <div class="col">
-                      <label class="form-label">
-                        {{ branch_feature_values_form.instance.feature_config.name }}
-                        {% if branch_feature_values_form.instance.allow_coenrollment %}
-                          <div class="form-text">{{ NimbusUIConstants.COENROLLMENT_NOTE }}</div>
-                        {% endif %}
-                      </label>
-                      {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
-                      {% for error in branch_feature_values_form.value.errors %}
-                        <div class="invalid-feedback d-block">{{ error }}</div>
-                      {% endfor %}
-                      {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
-                      {% with fv_error=branch_errors.feature_values|get_item:forloop.counter0 %}
-                        {% for error in fv_error.value %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                      {% endwith %}
-                    </div>
-                  </div>
-                {% endfor %}
-                <div class="mt-3">
-                  <label class="d-block">Screenshots</label>
-                  {{ branch_form.screenshot_formset.management_form }}
-                  {% for screenshot_form in branch_form.screenshot_formset %}
-                    {% with forloop.counter0 as screenshot_index %}
-                      {{ screenshot_form.id }}
-                      <div class="row mb-2 align-items-start">
-                        <div class="col-4">
-                          {{ screenshot_form.image|add_error_class:"is-invalid" }}
-                          {% for error in screenshot_form.image.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-                          {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
-                          {% with ss_error=branch_errors.screenshots|get_item:forloop.counter0 %}
-                            {% for error in ss_error.image %}<div class="invalid-feedback d-block">Image: {{ error }}</div>{% endfor %}
-                          {% endwith %}
-                        </div>
-                        <div class="col-8">
-                          <div class=" d-flex align-items-end">
-                            {{ screenshot_form.description|add_error_class:"is-invalid" }}
-                            <button type="button"
-                                    id="delete-screenshot-{{ screenshot_form.instance.id }}"
-                                    class="btn btn-link ms-3 px-0"
-                                    data-bs-toggle="tooltip"
-                                    data-bs-placement="top"
-                                    data-bs-title="Delete Screenshot"
-                                    hx-post="{% url 'nimbus-ui-delete-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-                                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                                    hx-vals='{"screenshot_id": {{ screenshot_form.instance.id }} }'
-                                    hx-select="#branches-form"
-                                    hx-target="#branches-form"
-                                    hx-disabled-elt="this">
-                              <i class="fa-solid fa-trash"></i>
-                            </button>
-                          </div>
-                          {% for error in screenshot_form.description.errors %}
-                            <div class="invalid-feedback d-block">{{ error }}</div>
-                          {% endfor %}
-                          {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
-                          {% with ss_error=branch_errors.screenshots|get_item:forloop.counter0 %}
-                            {% for error in ss_error.description %}
-                              <div class="invalid-feedback d-block">Description: {{ error }}</div>
-                            {% endfor %}
-                          {% endwith %}
-                        </div>
-                      </div>
-                      {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
-                        <div class="row mb-3">
-                          <div class="col-12">
-                            <img src="{{ screenshot_form.instance.image.url }}"
-                                 alt="Screenshot"
-                                 style="max-width: 200px;
-                                        max-height: 120px">
-                          </div>
-                        </div>
-                      {% endif %}
-                    {% endwith %}
-                  {% endfor %}
-                  <button type="button"
-                          id="add-screenshot-button"
-                          class="btn btn-outline-primary btn-sm"
-                          hx-post="{% url 'nimbus-ui-create-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
-                          hx-select="#branches-form"
-                          hx-target="#branches-form"
-                          hx-disabled-elt="this">
-                    +
-                    Add Screenshot
-                  </button>
-                </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
+                {{ form.is_rollout }}
+                <label class="form-check-label" for="id_is_rollout">This is a rollout (single branch)</label>
+                <a target="_blank"
+                   href="https://experimenter.info/deep-dives/experimenter/rollouts">Learn more</a>
               </div>
+              {% for error in validation_errors.is_rollout %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
-          {% endfor %}
-          {% if not experiment.is_rollout or not experiment.reference_branch %}
-            <div class="row mb-3">
-              <div class="col-12">
-                {% if experiment.branches.count < 20 %}
-                  <button class="btn btn-outline-primary btn-sm"
-                          type="button"
-                          id="add-branch-button"
-                          hx-post="{% url 'nimbus-ui-create-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-select="#branches-form"
-                          hx-target="#branches-form"
-                          hx-disabled-elt="this">
-                    + Add
-                    Branch
-                  </button>
-                {% else %}
-                  <p class="form-text">An experiment may have no more than 20 branches.</p>
-                  <button class="btn btn-outline-primary btn-sm disabled" type="button">+ Add Branch</button>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
+                {{ form.warn_feature_schema }}
+                <label class="form-check-label" for="id_warn_feature_schema">Warn only on feature schema validation failure</label>
+              </div>
+              {% for error in validation_errors.warn_feature_schema %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
+                {{ form.equal_branch_ratio }}
+                <label class="form-check-label" for="id_equal_branch_ratio">Users should be split evenly between all branches</label>
+              </div>
+              {% for error in validation_errors.equal_branch_ratio %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
+                {{ form.prevent_pref_conflicts }}
+                <label class="form-check-label" for="id_prevent_pref_conflicts">
+                  Prevent enrollment if users have changed any prefs set by this experiment
+                </label>
+                {% if form.prevent_pref_conflicts.field.disabled %}
+                  <div class="form-text">This option is required for rollouts to prevent re-enrollment after pref changes.</div>
                 {% endif %}
               </div>
-            </div>
-          {% endif %}
-        </div>
-      </div>
-    </div>
-    <div id="localization" class="card mb-3">
-      <div class="card-header">
-        <h4>Localization</h4>
-      </div>
-      <div class="card-body">
-        <div class="row mb-3">
-          <div class="col">
-            <div class="form-check">
-              {{ form.is_localized }}
-              <label class="form-check-label" for="id_is_localized">Is this a localized experiment?</label>
-            </div>
-            {% for error in validation_errors.is_localized %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        {% if experiment.is_localized %}
-          <div class="row">
-            <div class="col">
-              <label class="d-block">
-                Localization Substitutions
-                {{ form.localizations|add_error_class:"is-invalid" }}
-              </label>
-              {% for error in form.localizations.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.localizations %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.prevent_pref_conflicts %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
             </div>
           </div>
-        {% endif %}
+          <div id="branches">
+            {{ form.branches.management_form }}
+            {% for branch_form in form.branches %}
+              <div class="card bg-body-tertiary mb-3 {% if branch_form.errors %}border border-danger{% endif %}">
+                <div class="card-body position-relative">
+                  {{ branch_form.id }}
+                  <div class="row">
+                    <div class="col-3">
+                      <label class="d-block">Branch Name</label>
+                      {{ branch_form.name|add_error_class:"is-invalid" }}
+                      {% for error in branch_form.name.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                    </div>
+                    <div class="col-7">
+                      <label class="d-block">Description</label>
+                      {{ branch_form.description|add_error_class:"is-invalid" }}
+                      {% for error in branch_form.description.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                      {% get_branch_errors validation_errors forloop.first forloop.counter0|add:"-1" as branch_errors %}
+                      {% for error in branch_errors.description %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                    </div>
+                    <div class="col-2">
+                      <label class="d-block">Ratio</label>
+                      <div class="d-flex align-items-end">
+                        {% if form.instance.equal_branch_ratio %}
+                          <input type="text" class="form-control text-center" value="Equal" disabled>
+                        {% else %}
+                          {{ branch_form.ratio|add_class:"form-control text-center"|add_error_class:"is-invalid" }}
+                          {% for error in branch_form.ratio.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                        {% endif %}
+                        {% if not forloop.first %}
+                          <button type="button"
+                                  id="delete-branch-{{ branch_form.instance.id }}"
+                                  class="btn btn-link ms-3 px-0"
+                                  data-bs-toggle="tooltip"
+                                  data-bs-placement="top"
+                                  data-bs-title="Delete Branch"
+                                  hx-post="{% url 'nimbus-ui-delete-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+                                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                  hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
+                                  hx-select="#branches-form"
+                                  hx-target="#branches-form"
+                                  hx-disabled-elt="this">
+                            <i class="fa-solid fa-trash"></i>
+                          </button>
+                        {% endif %}
+                      </div>
+                    </div>
+                  </div>
+                  {{ branch_form.branch_feature_values.management_form }}
+                  {% for branch_feature_values_form in branch_form.branch_feature_values %}
+                    {{ branch_feature_values_form.id }}
+                    <div class="row mt-3">
+                      <div class="col">
+                        <label class="form-label">
+                          {{ branch_feature_values_form.instance.feature_config.name }}
+                          {% if branch_feature_values_form.instance.allow_coenrollment %}
+                            <div class="form-text">{{ NimbusUIConstants.COENROLLMENT_NOTE }}</div>
+                          {% endif %}
+                        </label>
+                        {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
+                        {% for error in branch_feature_values_form.value.errors %}
+                          <div class="invalid-feedback d-block">{{ error }}</div>
+                        {% endfor %}
+                        {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
+                        {% with fv_error=branch_errors.feature_values|get_item:forloop.counter0 %}
+                          {% for error in fv_error.value %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                        {% endwith %}
+                      </div>
+                    </div>
+                  {% endfor %}
+                  <div class="mt-3">
+                    <label class="d-block">Screenshots</label>
+                    {{ branch_form.screenshot_formset.management_form }}
+                    {% for screenshot_form in branch_form.screenshot_formset %}
+                      {% with forloop.counter0 as screenshot_index %}
+                        {{ screenshot_form.id }}
+                        <div class="row mb-2 align-items-start">
+                          <div class="col-4">
+                            {{ screenshot_form.image|add_error_class:"is-invalid" }}
+                            {% for error in screenshot_form.image.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                            {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
+                            {% with ss_error=branch_errors.screenshots|get_item:forloop.counter0 %}
+                              {% for error in ss_error.image %}<div class="invalid-feedback d-block">Image: {{ error }}</div>{% endfor %}
+                            {% endwith %}
+                          </div>
+                          <div class="col-8">
+                            <div class=" d-flex align-items-end">
+                              {{ screenshot_form.description|add_error_class:"is-invalid" }}
+                              <button type="button"
+                                      id="delete-screenshot-{{ screenshot_form.instance.id }}"
+                                      class="btn btn-link ms-3 px-0"
+                                      data-bs-toggle="tooltip"
+                                      data-bs-placement="top"
+                                      data-bs-title="Delete Screenshot"
+                                      hx-post="{% url 'nimbus-ui-delete-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+                                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                                      hx-vals='{"screenshot_id": {{ screenshot_form.instance.id }} }'
+                                      hx-select="#branches-form"
+                                      hx-target="#branches-form"
+                                      hx-disabled-elt="this">
+                                <i class="fa-solid fa-trash"></i>
+                              </button>
+                            </div>
+                            {% for error in screenshot_form.description.errors %}
+                              <div class="invalid-feedback d-block">{{ error }}</div>
+                            {% endfor %}
+                            {% get_branch_errors validation_errors forloop.parentloop.first forloop.parentloop.counter0|add:"-1" as branch_errors %}
+                            {% with ss_error=branch_errors.screenshots|get_item:forloop.counter0 %}
+                              {% for error in ss_error.description %}
+                                <div class="invalid-feedback d-block">Description: {{ error }}</div>
+                              {% endfor %}
+                            {% endwith %}
+                          </div>
+                        </div>
+                        {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
+                          <div class="row mb-3">
+                            <div class="col-12">
+                              <img src="{{ screenshot_form.instance.image.url }}"
+                                   alt="Screenshot"
+                                   style="max-width: 200px;
+                                          max-height: 120px">
+                            </div>
+                          </div>
+                        {% endif %}
+                      {% endwith %}
+                    {% endfor %}
+                    <button type="button"
+                            id="add-screenshot-button"
+                            class="btn btn-outline-primary btn-sm"
+                            hx-post="{% url 'nimbus-ui-create-branch-screenshot' slug=experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-vals='{"branch_id": {{ branch_form.instance.id }} }'
+                            hx-select="#branches-form"
+                            hx-target="#branches-form"
+                            hx-disabled-elt="this">
+                      +
+                      Add Screenshot
+                    </button>
+                  </div>
+                </div>
+              </div>
+            {% endfor %}
+            {% if not experiment.is_rollout or not experiment.reference_branch %}
+              <div class="row mb-3">
+                <div class="col-12">
+                  {% if experiment.branches.count < 20 %}
+                    <button class="btn btn-outline-primary btn-sm"
+                            type="button"
+                            id="add-branch-button"
+                            hx-post="{% url 'nimbus-ui-create-branch' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-select="#branches-form"
+                            hx-target="#branches-form"
+                            hx-disabled-elt="this">
+                      + Add
+                      Branch
+                    </button>
+                  {% else %}
+                    <p class="form-text">An experiment may have no more than 20 branches.</p>
+                    <button class="btn btn-outline-primary btn-sm disabled" type="button">+ Add Branch</button>
+                  {% endif %}
+                </div>
+              </div>
+            {% endif %}
+          </div>
+        </div>
       </div>
-    </div>
-    {% if experiment.is_desktop %}
-      <div id="labs" class="card mb-3">
+      <div id="localization" class="card mb-3">
         <div class="card-header">
-          <h4>Firefox Labs</h4>
+          <h4>Localization</h4>
         </div>
         <div class="card-body">
           <div class="row mb-3">
             <div class="col">
               <div class="form-check">
-                {{ form.is_firefox_labs_opt_in }}
-                <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
+                {{ form.is_localized }}
+                <label class="form-check-label" for="id_is_localized">Is this a localized experiment?</label>
               </div>
-              {% for error in validation_errors.is_firefox_labs_opt_in %}
-                <div class="form-text text-danger">{{ error }}</div>
-              {% endfor %}
+              {% for error in validation_errors.is_localized %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
           </div>
-          {% if experiment.is_firefox_labs_opt_in %}
-            <div class="row mb-3">
+          {% if experiment.is_localized %}
+            <div class="row">
               <div class="col">
                 <label class="d-block">
-                  The title to display in Firefox Labs (Fluent ID)
-                  {{ form.firefox_labs_title }}
+                  Localization Substitutions
+                  {{ form.localizations|add_error_class:"is-invalid" }}
                 </label>
-                {{ form.firefox_labs_title.errors }}
-                {% for error in validation_errors.firefox_labs_title %}
-                  <div class="form-text text-danger">{{ error }}</div>
-                {% endfor %}
-              </div>
-            </div>
-            <div class="row mb-3">
-              <div class="col">
-                <label class="d-block">
-                  The description to display in Firefox Labs (Fluent ID)
-                  {{ form.firefox_labs_description }}
-                </label>
-                {{ form.firefox_labs_description.errors }}
-                {% for error in validation_errors.firefox_labs_description %}
-                  <div class="form-text text-danger">{{ error }}</div>
-                {% endfor %}
-              </div>
-            </div>
-            <div class="row mb-3">
-              <div class="col">
-                <label class="d-block">
-                  Description Links (JSON)
-                  {{ form.firefox_labs_description_links }}
-                </label>
-                {{ form.firefox_labs_description_links.errors }}
-                {% for error in validation_errors.firefox_labs_description_links %}
-                  <div class="form-text text-danger">{{ error }}</div>
-                {% endfor %}
-              </div>
-            </div>
-            <div class="row mb-3">
-              <div class="col">
-                <label class="d-block">
-                  Firefox Labs Group
-                  {{ form.firefox_labs_group }}
-                </label>
-                {{ form.firefox_labs_group.errors }}
-                {% for error in validation_errors.firefox_labs_group %}
-                  <div class="form-text text-danger">{{ error }}</div>
-                {% endfor %}
-              </div>
-            </div>
-            <div class="row mb-3">
-              <div class="col">
-                <div class="form-check">
-                  {{ form.requires_restart }}
-                  <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
-                </div>
-                {{ form.requires_restart.errors }}
-                {% for error in validation_errors.requires_restart %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                {% for error in form.localizations.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+                {% for error in validation_errors.localizations %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
               </div>
             </div>
           {% endif %}
         </div>
       </div>
-    {% endif %}
-    <div class="d-flex justify-content-end">
-      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
-      <button type="submit"
-              name="save_action"
-              value="continue"
-              id="save-and-continue-button"
-              class="btn btn-secondary ms-2">Save and Continue</button>
-    </div>
-    {% if form.is_bound %}
-      {% if form.is_valid %}
-        <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-check"></i>
-            Branches saved!
+      {% if experiment.is_desktop %}
+        <div id="labs" class="card mb-3">
+          <div class="card-header">
+            <h4>Firefox Labs</h4>
+          </div>
+          <div class="card-body">
+            <div class="row mb-3">
+              <div class="col">
+                <div class="form-check">
+                  {{ form.is_firefox_labs_opt_in }}
+                  <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
+                </div>
+                {% for error in validation_errors.is_firefox_labs_opt_in %}
+                  <div class="form-text text-danger">{{ error }}</div>
+                {% endfor %}
+              </div>
+            </div>
+            {% if experiment.is_firefox_labs_opt_in %}
+              <div class="row mb-3">
+                <div class="col">
+                  <label class="d-block">
+                    The title to display in Firefox Labs (Fluent ID)
+                    {{ form.firefox_labs_title }}
+                  </label>
+                  {{ form.firefox_labs_title.errors }}
+                  {% for error in validation_errors.firefox_labs_title %}
+                    <div class="form-text text-danger">{{ error }}</div>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <label class="d-block">
+                    The description to display in Firefox Labs (Fluent ID)
+                    {{ form.firefox_labs_description }}
+                  </label>
+                  {{ form.firefox_labs_description.errors }}
+                  {% for error in validation_errors.firefox_labs_description %}
+                    <div class="form-text text-danger">{{ error }}</div>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <label class="d-block">
+                    Description Links (JSON)
+                    {{ form.firefox_labs_description_links }}
+                  </label>
+                  {{ form.firefox_labs_description_links.errors }}
+                  {% for error in validation_errors.firefox_labs_description_links %}
+                    <div class="form-text text-danger">{{ error }}</div>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <label class="d-block">
+                    Firefox Labs Group
+                    {{ form.firefox_labs_group }}
+                  </label>
+                  {{ form.firefox_labs_group.errors }}
+                  {% for error in validation_errors.firefox_labs_group %}
+                    <div class="form-text text-danger">{{ error }}</div>
+                  {% endfor %}
+                </div>
+              </div>
+              <div class="row mb-3">
+                <div class="col">
+                  <div class="form-check">
+                    {{ form.requires_restart }}
+                    <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+                  </div>
+                  {{ form.requires_restart.errors }}
+                  {% for error in validation_errors.requires_restart %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                </div>
+              </div>
+            {% endif %}
           </div>
         </div>
       {% endif %}
-      {% if not form.is_valid or validation_errors %}
-        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-xmark"></i>
-            Please fix the errors
+      <div class="d-flex justify-content-end">
+        <button type="submit" id="save-button" class="btn btn-primary">Save</button>
+        <button type="submit"
+                name="save_action"
+                value="continue"
+                id="save-and-continue-button"
+                class="btn btn-secondary ms-2">Save and Continue</button>
+      </div>
+      {% if form.is_bound %}
+        {% if form.is_valid %}
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-check"></i>
+              Branches saved!
+            </div>
           </div>
-        </div>
+        {% endif %}
+        {% if not form.is_valid or validation_errors %}
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-xmark"></i>
+              Please fix the errors
+            </div>
+          </div>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </form>
+    </form>
+  </div>
 {% endblock main_content %}
 
 {% block extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -6,121 +6,131 @@
 {% block title %}{{ experiment.name }} - Metrics{% endblock %}
 
 {% block main_content %}
-  <!-- Experiment Details Card -->
-  <form id="metrics-form"
-        hx-post="{% url 'nimbus-ui-update-metrics' experiment.slug %}"
-        hx-select="#metrics-form"
-        hx-target="#metrics-form"
-        hx-swap="outerHTML">
-    {% csrf_token %}
-    {{ form.errors }}
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Metrics</h4>
-      </div>
-      <div class="card-body">
-        <div class="row">
-          <div class="col">
-            <p>
-              Every experiment analysis automatically includes how your experiment has impacted Retention, Search Count, and Ad Click metrics. Get more information on <a href="https://experimenter.info/deep-dives/jetstream/metrics/">Core Firefox Metrics</a>.
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <label for="primary_outcomes" class="form-label">
-              Primary Outcomes
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.metrics_hub_url }}">
-                <i class="fa-regular fa-circle-question"
-                   data-bs-toggle="tooltip"
-                   data-bs-placement="top"
-                   data-bs-title="Specific metrics you’d like to impact in your experiment, which will be part of the analysis."></i>
-              </a>
-              {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
-            </label>
-            <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
-              {{ form.primary_outcomes }}
-            </div>
-            {% for error in validation_errors.primary_outcomes %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            <p class="form-text">
-              Select the user action or feature that you are measuring with this experiment. You may select up to 2 primary outcomes.
-            </p>
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <label for="secondary_outcomes" class="form-label">
-              Secondary Outcomes
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.metrics_hub_url }}">
-                <i class="fa-regular fa-circle-question"
-                   data-bs-toggle="tooltip"
-                   data-bs-placement="top"
-                   data-bs-title="Specific metrics that you are interested in observing in your experiment but they don't affect the results of your experiment."></i>
-              </a>
-              {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
-            </label>
-            <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
-              {{ form.secondary_outcomes }}
-            </div>
-            {% for error in validation_errors.secondary_outcomes %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-            <p class="form-text">Select the user action or feature that you are measuring with this experiment.</p>
-          </div>
-        </div>
-        <hr>
-        <div class="row">
-          <div class="col">
-            <label for="segments" class="form-label">
-              Segments
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.segment_metrics_hub_url }}">
-                <i class="fa-regular fa-circle-question"
-                   data-bs-toggle="tooltip"
-                   data-bs-placement="top"
-                   data-bs-title="Select user segments if you want to view your results sliced by specific sub-groups of users."></i>
-              </a>
-              {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
-            </label>
-            <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">{{ form.segments }}</div>
-            <p class="form-text">Select the user segments you wish to analyze.</p>
-          </div>
-        </div>
+  <div class="position-relative">
+    <!-- Full form overlay -->
+    <div id="htmx-loading-overlay"
+         class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
+      <div class="text-center text-white">
+        <i class="fa-solid fa-spinner fa-spin-pulse fa-3x mb-3"></i>
+        <div class="fs-5">Saving changes...</div>
       </div>
     </div>
-    <div class="d-flex justify-content-end">
-      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
-      <button type="submit"
-              name="save_action"
-              value="continue"
-              id="save-and-continue-button"
-              class="btn btn-secondary ms-2">Save and Continue</button>
-    </div>
-    {% if form.is_bound %}
-      {% if form.is_valid %}
-        <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-check"></i>
-            Metrics saved!
+    <!-- Experiment Details Card -->
+    <form id="metrics-form"
+          hx-post="{% url 'nimbus-ui-update-metrics' experiment.slug %}"
+          hx-select="#metrics-form"
+          hx-target="#metrics-form"
+          hx-swap="outerHTML">
+      {% csrf_token %}
+      {{ form.errors }}
+      <div class="card mb-3">
+        <div class="card-header">
+          <h4>Metrics</h4>
+        </div>
+        <div class="card-body">
+          <div class="row">
+            <div class="col">
+              <p>
+                Every experiment analysis automatically includes how your experiment has impacted Retention, Search Count, and Ad Click metrics. Get more information on <a href="https://experimenter.info/deep-dives/jetstream/metrics/">Core Firefox Metrics</a>.
+              </p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <label for="primary_outcomes" class="form-label">
+                Primary Outcomes
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.metrics_hub_url }}">
+                  <i class="fa-regular fa-circle-question"
+                     data-bs-toggle="tooltip"
+                     data-bs-placement="top"
+                     data-bs-title="Specific metrics you’d like to impact in your experiment, which will be part of the analysis."></i>
+                </a>
+                {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
+              </label>
+              <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
+                {{ form.primary_outcomes }}
+              </div>
+              {% for error in validation_errors.primary_outcomes %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              <p class="form-text">
+                Select the user action or feature that you are measuring with this experiment. You may select up to 2 primary outcomes.
+              </p>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <label for="secondary_outcomes" class="form-label">
+                Secondary Outcomes
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.metrics_hub_url }}">
+                  <i class="fa-regular fa-circle-question"
+                     data-bs-toggle="tooltip"
+                     data-bs-placement="top"
+                     data-bs-title="Specific metrics that you are interested in observing in your experiment but they don't affect the results of your experiment."></i>
+                </a>
+                {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
+              </label>
+              <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">
+                {{ form.secondary_outcomes }}
+              </div>
+              {% for error in validation_errors.secondary_outcomes %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+              <p class="form-text">Select the user action or feature that you are measuring with this experiment.</p>
+            </div>
+          </div>
+          <hr>
+          <div class="row">
+            <div class="col">
+              <label for="segments" class="form-label">
+                Segments
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.METRICS_PAGE_LINKS.segment_metrics_hub_url }}">
+                  <i class="fa-regular fa-circle-question"
+                     data-bs-toggle="tooltip"
+                     data-bs-placement="top"
+                     data-bs-title="Select user segments if you want to view your results sliced by specific sub-groups of users."></i>
+                </a>
+                {% if form.is_bound %}<i class="fa-solid fa-check text-success"></i>{% endif %}
+              </label>
+              <div class="rounded border border-1 p-0 {% if form.is_bound %}border-success{% endif %}">{{ form.segments }}</div>
+              <p class="form-text">Select the user segments you wish to analyze.</p>
+            </div>
           </div>
         </div>
-      {% endif %}
-      {% if not form.is_valid or validation_errors %}
-        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-xmark"></i>
-            Please fix the errors
+      </div>
+      <div class="d-flex justify-content-end">
+        <button type="submit" id="save-button" class="btn btn-primary">Save</button>
+        <button type="submit"
+                name="save_action"
+                value="continue"
+                id="save-and-continue-button"
+                class="btn btn-secondary ms-2">Save and Continue</button>
+      </div>
+      {% if form.is_bound %}
+        {% if form.is_valid %}
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-check"></i>
+              Metrics saved!
+            </div>
           </div>
-        </div>
+        {% endif %}
+        {% if not form.is_valid or validation_errors %}
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-xmark"></i>
+              Please fix the errors
+            </div>
+          </div>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </form>
+    </form>
+  </div>
 {% endblock main_content %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -8,14 +8,7 @@
 {% block title %}{{ experiment.name }} - Overview{% endblock %}
 
 {% block main_content %}
-  <form id="overview-form"
-        {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
-        hx-post="{% url 'nimbus-ui-update-overview' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-        hx-select="#overview-form"
-        hx-target="#overview-form"
-        hx-swap="outerHTML"
-        class="position-relative">
-    {% csrf_token %}
+  <div class="position-relative">
     <!-- Full form overlay -->
     <div id="htmx-loading-overlay"
          class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
@@ -24,202 +17,210 @@
         <div class="fs-5">Saving changes...</div>
       </div>
     </div>
-    <div class="card mb-3">
-      <div class="card-header">
-        <h4>Overview</h4>
-      </div>
-      <div class="card-body">
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_name" class="form-label">Public Name</label>
-            {{ form.name|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.name.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.name %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            <p class="form-text">This name will be public to users in about:studies.</p>
-          </div>
+    <form id="overview-form"
+          {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
+          hx-post="{% url 'nimbus-ui-update-overview' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
+          hx-select="#overview-form"
+          hx-target="#overview-form"
+          hx-swap="outerHTML">
+      {% csrf_token %}
+      <div class="card mb-3">
+        <div class="card-header">
+          <h4>Overview</h4>
         </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_hypothesis" class="form-label">Hypothesis</label>
-            {{ form.hypothesis|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.hypothesis.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.hypothesis %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            <p class="form-text">You can add any supporting documents here.</p>
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col-10">
-            <label for="id_risk_brand" class="form-label">
-              If the public, users or press, were to discover this experiment and description, do you think it could negatively impact their perception of the brand?
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.risk_link }}">Learn more</a>
-            </label>
-          </div>
-          <div class="col-2 text-end">
-            {{ form.risk_brand|add_error_class:"is-invalid" }}
-            {% for error in form.risk_brand.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.risk_brand %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col-10">
-            <label for="id_risk_message" class="form-label">
-              Does your experiment include ANY messages? If yes, this requires the
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Consult</a>
-            </label>
-          </div>
-          <div class="col-2 text-end">
-            {{ form.risk_message|add_error_class:"is-invalid" }}
-            {% for error in form.risk_message.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.risk_message %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_application" class="form-label">Application</label>
-            <input class="form-control"
-                   value="{{ experiment.get_application_display }}"
-                   disabled>
-            <p class="form-text">
-              Experiments can only target one Application at a time.
-              <br>
-              Application can not be changed after an experiment is created.
-            </p>
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col">
-            <label for="id_public_description" class="form-label">Public Description</label>
-            {{ form.public_description|add_class:"form-control"|add_error_class:"is-invalid" }}
-            {% for error in form.public_description.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.public_description %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-            <p class="form-text">This description will be public to users on about:studies</p>
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col-10">
-            <label for="id_risk_revenue" class="form-label">
-              Does this experiment have a risk to negatively impact revenue (e.g. search, Pocket revenue)?
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.revenue_risk_link }}">Learn more</a>
-            </label>
-          </div>
-          <div class="col-2 text-end">
-            {{ form.risk_revenue|add_error_class:"is-invalid" }}
-            {% for error in form.risk_revenue.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.risk_revenue %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-          </div>
-        </div>
-        <div class="row mb-3">
-          <div class="col-10">
-            <label for="id_risk_partner_related" class="form-label">
-              Does this experiment rely on AI (e.g. ML, chatbot), impact or rely on a partner or outside company (e.g. Google, Amazon), or deliver any encryption or VPN?
-              <a target="_blank"
-                 href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.partner_related_risk_link }}">Learn more</a>
-            </label>
-          </div>
-          <div class="col-2 text-end">
-            {{ form.risk_partner_related|add_error_class:"is-invalid" }}
-            {% for error in form.risk_partner_related.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-            {% for error in validation_errors.risk_partner_related %}
-              <div class="form-text text-danger">{{ error }}</div>
-            {% endfor %}
-          </div>
-        </div>
-        <div class="row mb-2">
-          <div class="col-12">
-            <div>
-              Additional Links
-              <i class="fa-regular fa-circle-question"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 data-bs-title="Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief."></i>
+        <div class="card-body">
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_name" class="form-label">Public Name</label>
+              {{ form.name|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.name.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.name %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              <p class="form-text">This name will be public to users in about:studies.</p>
             </div>
           </div>
-        </div>
-        <div id="documentation-links">
-          {{ form.documentation_links.management_form }}
-          {% for link_form in form.documentation_links %}
-            <div class="form-group">
-              {{ link_form.id }}
-              <div class="row mb-3">
-                <div class="col-4">
-                  {{ link_form.title|add_class:"form-control"|add_error_class:"is-invalid" }}
-                  {% for error in link_form.title.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-                </div>
-                <div class="col-8 d-flex align-items-start">
-                  <div class="flex-grow-1 me-2">
-                    {{ link_form.link|add_class:"form-control"|add_error_class:"is-invalid" }}
-                    {% for error in link_form.link.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_hypothesis" class="form-label">Hypothesis</label>
+              {{ form.hypothesis|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.hypothesis.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.hypothesis %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              <p class="form-text">You can add any supporting documents here.</p>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-10">
+              <label for="id_risk_brand" class="form-label">
+                If the public, users or press, were to discover this experiment and description, do you think it could negatively impact their perception of the brand?
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.risk_link }}">Learn more</a>
+              </label>
+            </div>
+            <div class="col-2 text-end">
+              {{ form.risk_brand|add_error_class:"is-invalid" }}
+              {% for error in form.risk_brand.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.risk_brand %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-10">
+              <label for="id_risk_message" class="form-label">
+                Does your experiment include ANY messages? If yes, this requires the
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Consult</a>
+              </label>
+            </div>
+            <div class="col-2 text-end">
+              {{ form.risk_message|add_error_class:"is-invalid" }}
+              {% for error in form.risk_message.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.risk_message %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_application" class="form-label">Application</label>
+              <input class="form-control"
+                     value="{{ experiment.get_application_display }}"
+                     disabled>
+              <p class="form-text">
+                Experiments can only target one Application at a time.
+                <br>
+                Application can not be changed after an experiment is created.
+              </p>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <label for="id_public_description" class="form-label">Public Description</label>
+              {{ form.public_description|add_class:"form-control"|add_error_class:"is-invalid" }}
+              {% for error in form.public_description.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.public_description %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+              <p class="form-text">This description will be public to users on about:studies</p>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-10">
+              <label for="id_risk_revenue" class="form-label">
+                Does this experiment have a risk to negatively impact revenue (e.g. search, Pocket revenue)?
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.revenue_risk_link }}">Learn more</a>
+              </label>
+            </div>
+            <div class="col-2 text-end">
+              {{ form.risk_revenue|add_error_class:"is-invalid" }}
+              {% for error in form.risk_revenue.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.risk_revenue %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-10">
+              <label for="id_risk_partner_related" class="form-label">
+                Does this experiment rely on AI (e.g. ML, chatbot), impact or rely on a partner or outside company (e.g. Google, Amazon), or deliver any encryption or VPN?
+                <a target="_blank"
+                   href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.partner_related_risk_link }}">Learn more</a>
+              </label>
+            </div>
+            <div class="col-2 text-end">
+              {{ form.risk_partner_related|add_error_class:"is-invalid" }}
+              {% for error in form.risk_partner_related.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.risk_partner_related %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          </div>
+          <div class="row mb-2">
+            <div class="col-12">
+              <div>
+                Additional Links
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   data-bs-title="Any additional links you would like to add, for example, Jira DS Ticket, Jira QA ticket, or experiment brief."></i>
+              </div>
+            </div>
+          </div>
+          <div id="documentation-links">
+            {{ form.documentation_links.management_form }}
+            {% for link_form in form.documentation_links %}
+              <div class="form-group">
+                {{ link_form.id }}
+                <div class="row mb-3">
+                  <div class="col-4">
+                    {{ link_form.title|add_class:"form-control"|add_error_class:"is-invalid" }}
+                    {% for error in link_form.title.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
                   </div>
-                  <button type="button"
-                          class="btn btn-link ms-3 px-0"
-                          data-bs-toggle="tooltip"
-                          data-bs-placement="top"
-                          data-bs-title="Delete Link"
-                          hx-post="{% url 'nimbus-ui-delete-documentation-link' slug=experiment.slug %}"
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-vals='{"link_id": {{ link_form.instance.id }} }'
-                          hx-select="#overview-form"
-                          hx-target="#overview-form"
-                          hx-disabled-elt="this">
-                    <i class="fa-solid fa-trash"></i>
-                  </button>
+                  <div class="col-8 d-flex align-items-start">
+                    <div class="flex-grow-1 me-2">
+                      {{ link_form.link|add_class:"form-control"|add_error_class:"is-invalid" }}
+                      {% for error in link_form.link.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+                    </div>
+                    <button type="button"
+                            class="btn btn-link ms-3 px-0"
+                            data-bs-toggle="tooltip"
+                            data-bs-placement="top"
+                            data-bs-title="Delete Link"
+                            hx-post="{% url 'nimbus-ui-delete-documentation-link' slug=experiment.slug %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-vals='{"link_id": {{ link_form.instance.id }} }'
+                            hx-select="#overview-form"
+                            hx-target="#overview-form"
+                            hx-disabled-elt="this">
+                      <i class="fa-solid fa-trash"></i>
+                    </button>
+                  </div>
+                </div>
+                <div class="row mb-3">
+                  <div class="col-8 d-flex justify-content-between align-items-center"></div>
                 </div>
               </div>
-              <div class="row mb-3">
-                <div class="col-8 d-flex justify-content-between align-items-center"></div>
-              </div>
+            {% endfor %}
+          </div>
+          <div class="row mb-3">
+            <div class="col-12 text-end">
+              <button class="btn btn-outline-primary btn-sm"
+                      type="button"
+                      id="add-additional-links-button"
+                      hx-post="{% url 'nimbus-ui-create-documentation-link' slug=experiment.slug %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-select="#overview-form"
+                      hx-target="#overview-form">+ Add Link</button>
             </div>
-          {% endfor %}
-        </div>
-        <div class="row mb-3">
-          <div class="col-12 text-end">
-            <button class="btn btn-outline-primary btn-sm"
-                    type="button"
-                    id="add-additional-links-button"
-                    hx-post="{% url 'nimbus-ui-create-documentation-link' slug=experiment.slug %}"
-                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-select="#overview-form"
-                    hx-target="#overview-form">+ Add Link</button>
           </div>
         </div>
       </div>
-    </div>
-    <div class="d-flex justify-content-end">
-      <button type="submit" id="save-button" class="btn btn-primary">Save</button>
-      <button type="submit"
-              name="save_action"
-              value="continue"
-              id="save-and-continue-button"
-              class="btn btn-secondary ms-2">Save and Continue</button>
-    </div>
-    {% if form.is_bound %}
-      {% if form.is_valid %}
-        <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-check"></i>
-            Overview saved!
+      <div class="d-flex justify-content-end">
+        <button type="submit" id="save-button" class="btn btn-primary">Save</button>
+        <button type="submit"
+                name="save_action"
+                value="continue"
+                id="save-and-continue-button"
+                class="btn btn-secondary ms-2">Save and Continue</button>
+      </div>
+      {% if form.is_bound %}
+        {% if form.is_valid %}
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-check"></i>
+              Overview saved!
+            </div>
           </div>
-        </div>
-      {% endif %}
-      {% if not form.is_valid or validation_errors %}
-        <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
-             role="alert"
-             aria-live="assertive"
-             aria-atomic="true">
-          <div class="toast-body">
-            <i class="fa-regular fa-circle-xmark"></i>
-            Please fix the errors
+        {% endif %}
+        {% if not form.is_valid or validation_errors %}
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body">
+              <i class="fa-regular fa-circle-xmark"></i>
+              Please fix the errors
+            </div>
           </div>
-        </div>
+        {% endif %}
       {% endif %}
-    {% endif %}
-  </form>
+    </form>
+  </div>
 {% endblock main_content %}


### PR DESCRIPTION
Becuase

* We had put the form loading overlays inside the form element
* This means after an htmx swap it broke and rendered incorrectly

This commit

* Moves the loading overlays outside of the forms so they remain intact after htmx swaps

fixes #13604

