### PR TITLE
chore(nimbus): remove partybal link

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -134,12 +134,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             tool to show message interaction details.""",
             "icon": "fa-solid fa-envelope-open-text",
         },
-        "Detailed Analysis": {
-            "url": "https://protosaur.dev/partybal/",
-            "tooltip": """Detailed Analysis is an advanced view into experiment
-            results.""",
-            "icon": "fa-solid fa-magnifying-glass-chart",
-        },
     }
     LIVE_MONITOR_TOOLTIP = """Live Monitoring shows enrollment/unenrollment for this
     delivery"""

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/sidebar.html
@@ -88,7 +88,7 @@
   </a>
   {% for title, link in NimbusUIConstants.SIDEBAR_COMMON_LINKS.items %}
     <a class="nav-link d-flex align-items-center nav-link-hover d-flex justify-content-between"
-       href="{% if title == 'Detailed Analysis' %}{{ analysis_link }}{% else %}{{ link.url }}{% endif %}">
+       href="{{ link.url }}">
       <div>
         <i class="{{ link.icon }} pe-2"></i>
         {{ title }}

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -1,5 +1,4 @@
 import json
-from urllib.parse import urljoin
 
 from deepdiff import DeepDiff
 from django.conf import settings
@@ -21,7 +20,6 @@ from experimenter.experiments.models import (
 )
 from experimenter.nimbus_ui.constants import (
     SCHEMA_DIFF_SIZE_CONFIG,
-    NimbusUIConstants,
 )
 from experimenter.nimbus_ui.filtersets import (
     STATUS_FILTERS,
@@ -156,17 +154,7 @@ class NimbusExperimentViewMixin:
             if experiment and experiment.slug
             else []
         )
-
         context["all_tags"] = Tag.objects.all().order_by("name")
-
-        slug_underscore = (
-            experiment.slug.replace("-", "_") if experiment and experiment.slug else ""
-        )
-
-        context["analysis_link"] = urljoin(
-            NimbusUIConstants.SIDEBAR_COMMON_LINKS["Detailed Analysis"]["url"],
-            slug_underscore + ".html",
-        )
         context["create_form"] = NimbusExperimentCreateForm()
 
         return context


### PR DESCRIPTION
Becuase

* At long last, partybal has been deprecated

This commit

* Removes the partybal 'detailed analysis' link from experiments

fixes #13983

