### PR TITLE
feat(nimbus): add loading spinner to list page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/experiment_list.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/experiment_list.js
@@ -1,3 +1,17 @@
+document.body.addEventListener("htmx:beforeRequest", function () {
+  const spinner = document.querySelector("#htmx-table-spinner");
+  if (spinner) {
+    spinner.style.opacity = "1";
+  }
+});
+
+document.body.addEventListener("htmx:afterRequest", function () {
+  const spinner = document.querySelector("#htmx-table-spinner");
+  if (spinner) {
+    spinner.style.opacity = "0";
+  }
+});
+
 document.body.addEventListener("htmx:afterSwap", function () {
   // After reloading the table, we must update the values for status and sort in the sidebar form
   // since it will not have been reloaded in the htmx get call

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
@@ -1,6 +1,6 @@
 {% load nimbus_extras %}
 
-<div class="col-12 p-0 border-bottom d-flex flex-column flex-md-row justify-content-between align-items-center">
+<div class="col-12 p-0 border-bottom d-flex flex-column flex-md-row align-items-center">
   <div class="order-2 order-md-1">
     <ul class="nav nav-tabs border-0 flex-nowrap">
       {% include "common/list_tab.html" with status="Live" count=status_counts.Live icon="fa-regular fa-circle-play" %}
@@ -12,6 +12,12 @@
       {% include "common/list_tab.html" with status="MyExperiments" count=status_counts.MyExperiments icon="fa-solid fa-heart" %}
 
     </ul>
+  </div>
+  <div id="htmx-table-spinner"
+       class="order-1 order-md-2 p-2"
+       style="opacity: 0;
+              pointer-events: none">
+    <i class="fa-solid fa-spinner fa-spin fa-lg text-primary"></i>
   </div>
 </div>
 <div id="experiment-list"></div>


### PR DESCRIPTION
Becuase

* Updates on the list page can be very slow
* It's not clear to a user if a request is in flight
* On other pages we put a loading overlay overtop the loading elements
* We don't need to put an overlay on top of the list becuase we don't need to prevent user input
* We can just use a spinner

This commit

* Adds a loading spinner to the list page

fixes #13944

