### PR TITLE
chore(nimbus): add targeting for profiles

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3701,6 +3701,28 @@ BUILDID_20251006095753 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+PROFILES_NUM_ZERO = NimbusTargetingConfig(
+    name="Number of Profiles is Zero",
+    slug="number_of_profiles_is_zero",
+    description="Desktop users having zero profiles",
+    targeting="profileGroupProfileCount == 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+PROFILES_NUM_NON_ZERO = NimbusTargetingConfig(
+    name="Number of Profiles is Non-Zero",
+    slug="number_of_profiles_is_non_zero",
+    description="Desktop users having non-zero profiles",
+    targeting="profileGroupProfileCount > 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_CONFIGS = {


### PR DESCRIPTION
Becuase

* We want to launch some A/As to validate that experiments are functioning healthily for both profile and non profile users
* To do that we can launch two A/As: one for profile users, one for non profile users, and validate that both enroll and analyze correctly

This commit

* Adds targeting for both non-profile and profile users

fixes #13997

