### PR TITLE
feat(nimbus): show feature schemas on branch page

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2374,6 +2374,13 @@ class NimbusBranchFeatureValue(models.Model):
         ).schemas
         return all(schema.allow_coenrollment for schema in schemas)
 
+    @property
+    def unversioned_schema(self):
+        try:
+            return self.feature_config.schemas.get(version=None).schema
+        except NimbusVersionedSchema.DoesNotExist:
+            return None
+
 
 class NimbusBranchScreenshot(models.Model):
     branch = models.ForeignKey(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -105,6 +105,37 @@ class TestNimbusBranchFeatureValue(TestCase):
             ).allow_coenrollment
         )
 
+    def test_unversioned_schema_returns_schema_when_exists(self):
+        feature = NimbusFeatureConfig.objects.get(slug="someFeature")
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature],
+        )
+        branch_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature
+        )
+        unversioned_schema = feature.schemas.get(version=None)
+        self.assertEqual(
+            branch_feature_value.unversioned_schema, unversioned_schema.schema
+        )
+
+    def test_unversioned_schema_returns_none_when_not_exists(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="feature-without-schema",
+            name="Feature Without Schema",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[feature],
+        )
+        feature.schemas.filter(version=None).delete()
+
+        branch_feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature
+        )
+        self.assertIsNone(branch_feature_value.unversioned_schema)
+
 
 class TestNimbusExperimentManager(TestCase):
     def test_sorted_by_latest_change(self):

--- a/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
@@ -1,5 +1,6 @@
 import { basicSetup } from "codemirror";
 import { EditorView } from "@codemirror/view";
+import { EditorState } from "@codemirror/state";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
 import { linter } from "@codemirror/lint";
 import { autocompletion } from "@codemirror/autocomplete";
@@ -104,10 +105,61 @@ const setupCodeMirrorLocalizations = () => {
   setupCodemirror(selector, textarea, []);
 };
 
+const initializeSchemaCodeMirror = (textarea) => {
+  if (!textarea || textarea.dataset.is_rendered) return;
+
+  textarea.dataset.is_rendered = true;
+
+  const extensions = [
+    basicSetup,
+    json(),
+    linter(jsonParseLinter()),
+    EditorState.readOnly.of(true),
+    EditorView.editable.of(false),
+    themeCompartment.of(getThemeExtensions()),
+  ];
+
+  const view = new EditorView({
+    doc: textarea.value,
+    extensions,
+    parent: textarea.parentNode,
+  });
+
+  view.dom.style.border = "1px solid #ccc";
+  textarea.parentNode.insertBefore(view.dom, textarea);
+  textarea.style.display = "none";
+
+  registerView(view);
+};
+
+const setupSchemaToggleButtons = () => {
+  const form = document.getElementById("branches-form");
+  if (!form || form.dataset.schemaToggleSetup) return;
+  form.dataset.schemaToggleSetup = "true";
+
+  form.addEventListener("click", (event) => {
+    const button = event.target.closest(".toggle-schema-btn");
+    if (!button) return;
+
+    const schemaDisplay = document.getElementById(button.dataset.target);
+    const container = button.parentNode;
+    const isHidden = schemaDisplay.classList.contains("d-none");
+
+    schemaDisplay.classList.toggle("d-none");
+    container.querySelector(".show-schema-btn").classList.toggle("d-none");
+    container.querySelector(".hide-schema-btn").classList.toggle("d-none");
+
+    if (isHidden) {
+      initializeSchemaCodeMirror(schemaDisplay.querySelector(".readonly-json"));
+    }
+  });
+};
+
 const initializeAllEditors = () => {
   setupCodemirrorFeatures();
   setupCodemirrorLabs();
   setupCodeMirrorLocalizations();
+  setupSchemaToggleButtons();
 };
 
 $(() => {

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -156,6 +156,24 @@
                         {% with fv_error=branch_errors.feature_values|get_item:forloop.counter0 %}
                           {% for error in fv_error.value %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
                         {% endwith %}
+                        {% if branch_feature_values_form.instance.unversioned_schema %}
+                          <div class="mt-2">
+                            <button type="button"
+                                    class="btn btn-outline-secondary btn-sm toggle-schema-btn show-schema-btn"
+                                    data-target="schema-{{ forloop.parentloop.counter0 }}-{{ forloop.counter0 }}">
+                              <i class="fa-solid fa-chevron-down"></i> Show Schema
+                            </button>
+                            <button type="button"
+                                    class="btn btn-outline-secondary btn-sm toggle-schema-btn hide-schema-btn d-none"
+                                    data-target="schema-{{ forloop.parentloop.counter0 }}-{{ forloop.counter0 }}">
+                              <i class="fa-solid fa-chevron-up"></i> Hide feature schema
+                            </button>
+                            <div id="schema-{{ forloop.parentloop.counter0 }}-{{ forloop.counter0 }}"
+                                 class="schema-display d-none mt-2">
+                              <textarea class="readonly-json">{{ branch_feature_values_form.instance.unversioned_schema }}</textarea>
+                            </div>
+                          </div>
+                        {% endif %}
                       </div>
                     </div>
                   {% endfor %}


### PR DESCRIPTION
Becuase

* While editing a feature value, it would be handy to have the schema for reference
* We can put a readonly codemirror of the schema next to each feature value input

This commit

* Adds a showable/hideable feature schema codemirror under every feature value input

fixes #7217
