### PR TITLE
feat(nimbus): create cards for other experiment metrics

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -995,10 +995,6 @@ We believe this because we have observed <this> via <data source, UR, survey>.
 Optional - We believe this outcome will <describe impact> on <core metric>
     """  # noqa
 
-    KPI_AREA = "KPI Metrics"
-    NOTABLE_CHANGES_AREA = "Notable Changes"
-    DEFAULT_METRIC_AREAS = [NOTABLE_CHANGES_AREA, KPI_AREA]
-
     DAILY_ACTIVE_USERS = "client_level_daily_active_users_v2"
     DAYS_OF_USE = "days_of_use"
     RETENTION = "retained"

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2300,25 +2300,6 @@ class TestNimbusExperiment(TestCase):
                         f"{link['title']} should not be active for path {path}",
                     )
 
-    def test_default_metrics_set_on_creation(self):
-        experiment = NimbusExperimentFactory.create()
-
-        experiment.results_data = {
-            "v3": {
-                "other_metrics": {"group": {"metricA": "Metric A"}},
-                "metadata": {
-                    "metrics": {"metricA": {"friendlyName": "Friendly Metric A"}},
-                },
-            }
-        }
-
-        experiment.save()
-
-        self.assertEqual(
-            experiment.default_metrics,
-            {"metricA": "Friendly Metric A"},
-        )
-
     def test_get_branch_data_returns_correct_data(self):
         experiment = NimbusExperimentFactory.create()
         branch_a = NimbusBranchFactory.create(
@@ -2653,6 +2634,37 @@ class TestNimbusExperiment(TestCase):
         kpi_metrics = experiment.get_kpi_metrics("enrollments", "all", branch_a.slug)
 
         self.assertListEqual(kpi_metrics, expected_kpi_metrics)
+
+    def test_get_defaults_metrics_with_exclusions(self):
+        experiment = NimbusExperimentFactory.create()
+
+        experiment.results_data = {
+            "v3": {
+                "metadata": {
+                    "metrics": {
+                        "metricA": {
+                            "retained": "Retained",
+                            "search_count": "Search Count",
+                        }
+                    },
+                },
+                "other_metrics": {
+                    "other_metrics": {
+                        "retained": "2 Week Retention",
+                        "search_count": "Search Count",
+                    }
+                },
+            }
+        }
+        experiment.save()
+
+        remaining_metrics = experiment.get_remaining_metrics_metadata(
+            exclude_slugs=["search_count"]
+        )
+        metric_slugs = [metric.get("slug") for metric in remaining_metrics]
+
+        self.assertIn("retained", metric_slugs)
+        self.assertNotIn("search_count", metric_slugs)
 
     def test_get_max_metric_value(self):
         experiment = NimbusExperimentFactory.create()

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -145,6 +145,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Next steps",
         "Project impact",
     ]
+    KPI_AREA = "KPI Metrics"
+    OTHER_METRICS_AREA = "Other Metrics"
+    NOTABLE_METRIC_AREA = "Notable Changes"
     FEATURE_PAGE_LINKS = {
         "feature_learn_more_url": "https://experimenter.info/for-product#track-your-feature-health",
         "deliveries_table_tooltip": """This shows all Nimbus experiments, rollouts, Labs

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -1,5 +1,5 @@
 <div class="modal fade"
-     id="{{ experiment_slug }}-{{ metric_info.slug }}"
+     id="{{ experiment_slug }}-{{ metric_info.slug }}-{{ area|slugify }}"
      tabindex="-1"
      aria-labelledby="exampleModalLabel"
      aria-hidden="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -1,181 +1,216 @@
-{% comment %} Overview {% endcomment %}
-<div class="card px-5 py-4 shadow-sm">
-  <h3>Overview</h3>
-  <div class="d-inline-flex gap-3">
-    {% for section in NimbusUIConstants.OVERVIEW_SECTIONS %}
-      <p class="text-muted">{{ section }}</p>
-      {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
-    {% endfor %}
-  </div>
-  <div class="d-flex flex-column gap-4">
-    <div class="card p-5 mt-4">
-      <div class="row">
-        <div class="col-xxl">
-          <h5>Hypothesis</h5>
-          {% with hyp=experiment.hypothesis|default:"No hypothesis set." %}
-            {% if hyp|length > 300 %}
-              <p>
-                {{ hyp|truncatechars:300 }}
-                <a href="{{ experiment.get_detail_url }}" class="ms-1">More</a>
-              </p>
-            {% else %}
-              <p>{{ hyp }}</p>
-            {% endif %}
-          {% endwith %}
-        </div>
-        <div class="col-xxl">
-          <div class="row">
-            <div class="col">
-              <p class="text-muted mb-0">Product Owner</p>
-              <p>{{ experiment.owner|default:"No product owner set." }}</p>
+<div class="accordion d-flex flex-column gap-4"
+     id="{{ experiment.slug }}-results-accordion">
+  {% comment %} Overview {% endcomment %}
+  <div class="accordion-item p-3 px-4 shadow-sm rounded-4">
+    <button class="accordion-button bg-transparent shadow-none text-body d-flex"
+            type="button"
+            data-bs-toggle="collapse"
+            data-bs-target="#{{ experiment.slug }}-results-overview"
+            aria-expanded="true"
+            aria-controls="{{ experiment.slug }}-results-overview">
+      <div class="pe-3">
+        <h4>Overview</h4>
+        <div class="d-inline-flex gap-3">
+          {% for section in NimbusUIConstants.OVERVIEW_SECTIONS %}
+            <div>
+              <small class="text-muted me-2">{{ section }}</small>
+              {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
             </div>
-            <div class="col">
-              <p class="text-muted mb-0">Advanced Targeting</p>
-              <p>{{ experiment.targeting_config.name }}</p>
-            </div>
-            <div class="col">
-              <p class="text-muted mb-0">Application</p>
-              <p>{{ experiment.application|default:"Unknown" }}</p>
-            </div>
-          </div>
-          <div class="row">
-            <div class="col">
-              <p class="text-muted mb-0">Feature tags</p>
-              {% for tag in experiment.tags.all %}
-                <span class="badge bg-light text-dark">{{ tag.name }}</span>
-              {% empty %}
-                <p>None</p>
-              {% endfor %}
-            </div>
-            <div class="col">
-              <p class="text-muted mb-0">Localization</p>
-              {% for locale in experiment.locales.all %}
-                <p class="mb-0">{{ locale.name }}</p>
-              {% empty %}
-                <p class="mb-0">None</p>
-              {% endfor %}
-            </div>
-            <div class="col">
-              <p class="text-muted mb-0">Version</p>
-              <p>
-                {{ experiment.firefox_min_version }}
-                {% if experiment.firefox_max_version %}
-                  - {{ experiment.firefox_max_version }}
-                {% else %}
-                  +
-                {% endif %}
-              </p>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="card p-5">
-      <div class="row row-cols-2 row-cols-xxl-3 g-4">
-        {% for branch in branch_data %}
-          <div class="col">
-            {% include "common/branch_card.html" with branch=branch %}
-
-          </div>
-        {% endfor %}
-      </div>
-    </div>
-    <div class="card p-5">
-      <div class="row">
-        <div class="col">
-          <h5>Key takeaways</h5>
-          <p class="text-muted">
-            {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
-          </p>
-        </div>
-        <div class="col">
-          <h5>Next steps</h5>
-          <p class="text-muted">
-            {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
-          </p>
-        </div>
-        <div class="col">
-          <div class="d-flex align-items-start gap-2">
-            <h5>Project Impact</h5>
-            <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
-          </div>
-          <p class="text-muted">
-            {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
-          </p>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-{% comment %} Metrics {% endcomment %}
-{% for area, metric_data_metadata in metric_area_data.items %}
-  {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data %}
-    <div class="card px-5 py-4 shadow-sm">
-      <h3>{{ area }}</h3>
-      <div class="d-inline-flex gap-3 mb-4">
-        {% for metric in metric_metadata %}
-          <p class="text-muted">{{ metric.friendly_name }}</p>
-          {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
-        {% endfor %}
-      </div>
-      <div class="d-flex">
-        <div class="col-2">
-          <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
-          <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-          {% for metric in metric_metadata %}
-            <button class="card p-3 {% if forloop.last %}mb-4{% endif %} mb-3 d-flex justify-content-center rounded-4 border-3 w-100 text-start nav-link-hover position-relative border-light-subtle"
-                    type="button"
-                    data-bs-toggle="modal"
-                    data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}"
-                    style="height: 100px">
-              <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
-              <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
-            </button>
-            {% for curr_metric_slug, metric_data in metric_data.items %}
-              {% if curr_metric_slug == metric.slug %}
-                {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
-                  {% if metric_ui_properties == curr_metric_slug %}
-                    {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
-
-                  {% endif %}
-                {% endfor %}
-              {% endif %}
-            {% endfor %}
           {% endfor %}
         </div>
-        <div class="col position-relative w-25">
-          <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
-            {% if branch_data|length > 4 %}
-              <div class="branch-fade branch-fade-left"></div>
-              <div class="branch-fade branch-fade-right"></div>
-            {% endif %}
-            {% for branch in branch_data %}
-              <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                <small class="text-muted mb-0">{{ branch.name }}</small>
-                {% if branch.slug == selected_reference_branch %}
-                  <p class="mb-3">Baseline</p>
+      </div>
+    </button>
+    <div id="{{ experiment.slug }}-results-overview"
+         class="accordion-collapse collapse show">
+      <div class="accordion-body d-flex flex-column gap-4">
+        <div class="card p-5">
+          <div class="row">
+            <div class="col-xxl">
+              <h5>Hypothesis</h5>
+              {% with hyp=experiment.hypothesis|default:"No hypothesis set." %}
+                {% if hyp|length > 300 %}
+                  <p>
+                    {{ hyp|truncatechars:300 }}
+                    <a href="{{ experiment.get_detail_url }}" class="ms-1">More</a>
+                  </p>
                 {% else %}
-                  <p>{{ branch.name }}</p>
+                  <p>{{ hyp }}</p>
                 {% endif %}
-                <div class="d-flex flex-column gap-3 w-100">
-                  {% for metric in metric_metadata %}
-                    {% for curr_metric_slug, metric_branch_data in metric_data.items %}
-                      {% if curr_metric_slug == metric.slug %}
-                        {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
-                          {% if curr_branch_slug == branch.slug %}
-                            {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
-
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    {% endfor %}
+              {% endwith %}
+            </div>
+            <div class="col-xxl">
+              <div class="row">
+                <div class="col">
+                  <p class="text-muted mb-0">Product Owner</p>
+                  <p>{{ experiment.owner|default:"No product owner set." }}</p>
+                </div>
+                <div class="col">
+                  <p class="text-muted mb-0">Advanced Targeting</p>
+                  <p>{{ experiment.targeting_config.name }}</p>
+                </div>
+                <div class="col">
+                  <p class="text-muted mb-0">Application</p>
+                  <p>{{ experiment.application|default:"Unknown" }}</p>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col">
+                  <p class="text-muted mb-0">Feature tags</p>
+                  {% for tag in experiment.tags.all %}
+                    <span class="badge bg-light text-dark">{{ tag.name }}</span>
+                  {% empty %}
+                    <p>None</p>
                   {% endfor %}
                 </div>
+                <div class="col">
+                  <p class="text-muted mb-0">Localization</p>
+                  {% for locale in experiment.locales.all %}
+                    <p class="mb-0">{{ locale.name }}</p>
+                  {% empty %}
+                    <p class="mb-0">None</p>
+                  {% endfor %}
+                </div>
+                <div class="col">
+                  <p class="text-muted mb-0">Version</p>
+                  <p>
+                    {{ experiment.firefox_min_version }}
+                    {% if experiment.firefox_max_version %}
+                      - {{ experiment.firefox_max_version }}
+                    {% else %}
+                      +
+                    {% endif %}
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="card p-5">
+          <div class="row row-cols-2 row-cols-xxl-3 g-4">
+            {% for branch in branch_data %}
+              <div class="col">
+                {% include "common/branch_card.html" with branch=branch %}
+
               </div>
             {% endfor %}
           </div>
         </div>
+        <div class="card p-5">
+          <div class="row">
+            <div class="col">
+              <h5>Key takeaways</h5>
+              <p class="text-muted">
+                {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
+              </p>
+            </div>
+            <div class="col">
+              <h5>Next steps</h5>
+              <p class="text-muted">
+                {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
+              </p>
+            </div>
+            <div class="col">
+              <div class="d-flex align-items-start gap-2">
+                <h5>Project Impact</h5>
+                <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
+              </div>
+              <p class="text-muted">
+                {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
+              </p>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
-  {% endwith %}
-{% endfor %}
+  </div>
+  {% comment %} Metrics {% endcomment %}
+  {% for area, metric_data_metadata in metric_area_data.items %}
+    {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data %}
+      <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
+        <button class="accordion-button bg-transparent shadow-none text-body d-flex collapsed"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#{{ experiment.slug }}-results-{{ area|slugify }}"
+                aria-expanded="true"
+                aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
+          <div class="pe-3">
+            <h4>{{ area }}</h4>
+            <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
+              {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
+                <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
+              {% else %}
+                {% for metric in metric_metadata %}
+                  <div>
+                    <small class="text-muted me-2">{{ metric.friendly_name }}</small>
+                    {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
+                  </div>
+                {% endfor %}
+              {% endif %}
+            </div>
+          </div>
+        </button>
+        <div id="{{ experiment.slug }}-results-{{ area|slugify }}"
+             class="accordion-collapse collapse">
+          <div class="accordion-body d-flex">
+            <div class="col-2">
+              <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
+              <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+              {% for metric in metric_metadata %}
+                <button class="card p-3 {% if forloop.last %}mb-4{% endif %} mb-3 d-flex justify-content-center rounded-4 border-3 w-100 text-start nav-link-hover position-relative border-light-subtle"
+                        type="button"
+                        data-bs-toggle="modal"
+                        data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
+                        style="height: 100px">
+                  <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
+                  <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
+                </button>
+                {% for curr_metric_slug, metric_data in metric_data.items %}
+                  {% if curr_metric_slug == metric.slug %}
+                    {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
+                      {% if metric_ui_properties == curr_metric_slug %}
+                        {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
+
+                      {% endif %}
+                    {% endfor %}
+                  {% endif %}
+                {% endfor %}
+              {% endfor %}
+            </div>
+            <div class="col position-relative w-25">
+              <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                {% if branch_data|length > 4 %}
+                  <div class="branch-fade branch-fade-left"></div>
+                  <div class="branch-fade branch-fade-right"></div>
+                {% endif %}
+                {% for branch in branch_data %}
+                  <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                    <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                    {% if branch.slug == selected_reference_branch %}
+                      <p class="fs-5 mb-3">Baseline</p>
+                    {% else %}
+                      <p class="fs-5">{{ branch.name }}</p>
+                    {% endif %}
+                    <div class="d-flex flex-column gap-3 w-100">
+                      {% for metric in metric_metadata %}
+                        {% for curr_metric_slug, metric_branch_data in metric_data.items %}
+                          {% if curr_metric_slug == metric.slug %}
+                            {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
+                              {% if curr_branch_slug == branch.slug %}
+                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
+
+                              {% endif %}
+                            {% endfor %}
+                          {% endif %}
+                        {% endfor %}
+                      {% endfor %}
+                    </div>
+                  </div>
+                {% endfor %}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endwith %}
+  {% endfor %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3058,7 +3058,6 @@ class TestResultsView(AuthTestCase):
                     }
                 },
                 "exposures",
-                {"metricA": "Friendly Metric A"},
             ),
             (
                 {
@@ -3071,12 +3070,11 @@ class TestResultsView(AuthTestCase):
                     }
                 },
                 "enrollments",
-                {"metricA": "Friendly Metric A"},
             ),
         ]
     )
     def test_results_view_context_and_defaults(
-        self, results_data, selected_analysis_basis, default_metrics
+        self, results_data, selected_analysis_basis
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
@@ -3093,7 +3091,6 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(
             response.context["results_data"], experiment.results_data.get("v3")
         )
-        self.assertEqual(response.context["default_metrics"], default_metrics)
         self.assertEqual(
             response.context["selected_reference_branch"],
             experiment.reference_branch.slug,

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -685,8 +685,6 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
 
         analysis_data = experiment.results_data.get("v3", {})
 
-        context["default_metrics"] = experiment.default_metrics
-
         selected_reference_branch = self.request.GET.get(
             "reference_branch", experiment.reference_branch.slug
         )

--- a/experimenter/experimenter/outcomes/__init__.py
+++ b/experimenter/experimenter/outcomes/__init__.py
@@ -91,6 +91,13 @@ class Outcomes:
     def by_application(cls, application):
         return [o for o in cls.all() if o.application == application]
 
+    @classmethod
+    def get_by_slug_and_application(cls, slug, application):
+        for outcome in cls.all():
+            if outcome.slug == slug and outcome.application == application:
+                return outcome
+        return None
+
 
 @register()
 def check_outcome_tomls(app_configs, **kwargs):

--- a/experimenter/experimenter/outcomes/tests/test_outcomes.py
+++ b/experimenter/experimenter/outcomes/tests/test_outcomes.py
@@ -106,6 +106,20 @@ class TestOutcomes(TestCase):
             desktop_outcomes,
         )
 
+    def test_get_outcome_by_slug_and_application(self):
+        outcome = Outcomes.get_by_slug_and_application(
+            "fenix_outcome",
+            application=NimbusExperiment.Application.FENIX,
+        )
+        self.assertIsNotNone(outcome)
+        self.assertEqual(outcome.friendly_name, "Fenix config")
+
+        missing_outcome = Outcomes.get_by_slug_and_application(
+            "non_existent_outcome",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        self.assertIsNone(missing_outcome)
+
 
 class TestCheckOutcomeTOMLs(TestCase):
     def setUp(self):


### PR DESCRIPTION
Because

- Results page was only showing kpi metrics
- Cards were not collapsible

This commit

- Displays all the metrics associated with an experiment (kpi, outcomes, defaults)
- Groups metrics by outcomes (for now) and alphabetically
- Adds a "Notable Changes" section where only metrics that have at least once branch with a stat significance change are shown

Fixes #13721 