### PR TITLE
bug(nimbus): Always generate docker tags with 9 characters of the SHA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -684,7 +684,7 @@ jobs:
             DOCKER_IMAGE="us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/experimenter"
             docker tag experimenter:deploy ${DOCKER_IMAGE}:latest
             docker push "${DOCKER_IMAGE}:latest"
-            GIT_SHA=$(git rev-parse --short HEAD)
+            GIT_SHA=$(git rev-parse --short=9 HEAD)
             docker tag experimenter:deploy ${DOCKER_IMAGE}:sha-${GIT_SHA}
             docker push ${DOCKER_IMAGE}:sha-${GIT_SHA}
 


### PR DESCRIPTION
Because:

- we previously used `git rev-parse --short` to generate the docker tags for images we push to GAR;
- the output of `git rev-parse --short` is variable; and
- we have started generating tags that are not being recognized by ArgoCD, as it expects 9 characters

this commit:

- ensures we always generate tags with 9 characters of the SHA.

Fixes #14004