### PR TITLE
feat(nimbus): Update advanced targeting for OLD_SIDEBAR_USERS to excl…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3319,7 +3319,9 @@ OLD_SIDEBAR_USERS = NimbusTargetingConfig(
     name="Users that use the old sidebar",
     slug="old_sidebar_users",
     description="Target users who use the old sidebar",
-    targeting="!('sidebar.revamp'|preferenceValue)",
+    targeting="!('sidebar.revamp'|preferenceValue) && "
+        "'browser.uiCustomization.state'|preferenceValue('')|regExpMatch"
+        "('sidebar-button') != null",
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
…ude users without a sidebar-button

Because

- We need to exclude users without a sidebar button in their toolbar as it is needed to anchor the callout.

This commit

- Updates advanced targeting for OLD_SIDEBAR_USERS
