### PR TITLE
chore(nimbus): Use parallelism in remote settings job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -326,6 +326,7 @@ jobs:
           extension: xml
 
   integration_nimbus_remote_settings_all:
+    parallelism: 3
     machine:
       image: ubuntu-2204:2024.11.1
       docker_layer_caching: true
@@ -333,7 +334,7 @@ jobs:
     working_directory: ~/experimenter
     environment:
       FIREFOX_CHANNEL: release
-      PYTEST_ARGS: -k FIREFOX_DESKTOP -m remote_settings_all --reruns 1 --base-url https://nginx/nimbus/ -n 2
+      PYTEST_ARGS: -k FIREFOX_DESKTOP --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - checkout
@@ -344,6 +345,12 @@ jobs:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
+            # Split tests: experiments / rollouts / live updates
+            case $CIRCLE_NODE_INDEX in
+              0) export PYTEST_ARGS="$PYTEST_ARGS -m remote_settings_experiments" ;;
+              1) export PYTEST_ARGS="$PYTEST_ARGS -m remote_settings_rollouts" ;;
+              2) export PYTEST_ARGS="$PYTEST_ARGS -m remote_settings_live_updates" ;;
+            esac
             make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm

--- a/experimenter/tests/integration/nimbus/test_remote_settings.py
+++ b/experimenter/tests/integration/nimbus/test_remote_settings.py
@@ -29,7 +29,7 @@ def test_create_new_experiment_approve_remote_settings(
     HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_rollouts
 def test_create_new_rollout_approve_remote_settings(
     selenium,
     experiment_url,
@@ -53,7 +53,7 @@ def test_create_new_rollout_approve_remote_settings(
     HomePage(selenium, base_url).open().find_in_table(experiment_slug)
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_experiments
 def test_create_new_experiment_reject_remote_settings(
     selenium,
     experiment_url,
@@ -72,7 +72,7 @@ def test_create_new_experiment_reject_remote_settings(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_rollouts
 def test_create_new_rollout_reject_remote_settings(
     selenium,
     experiment_url,
@@ -93,7 +93,7 @@ def test_create_new_rollout_reject_remote_settings(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_experiments
 def test_end_experiment_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
@@ -125,7 +125,7 @@ def test_end_experiment_and_approve_end_set_takeaways(
     assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_rollouts
 def test_end_rollout_and_approve_end_set_takeaways(
     selenium,
     experiment_url,
@@ -159,7 +159,7 @@ def test_end_rollout_and_approve_end_set_takeaways(
     assert summary.takeaways_recommendation_badge_text == "Change course"
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_experiments
 def test_end_experiment_and_reject_end(
     selenium,
     experiment_url,
@@ -184,7 +184,7 @@ def test_end_experiment_and_reject_end(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_rollouts
 def test_end_rollout_and_reject_end(
     selenium,
     experiment_url,
@@ -211,7 +211,7 @@ def test_end_rollout_and_reject_end(
     SummaryPage(selenium, experiment_url).open().wait_for_rejected_alert()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_live_updates
 def test_rollout_live_update_approve(
     selenium,
     kinto_client,
@@ -241,7 +241,7 @@ def test_rollout_live_update_approve(
     kinto_client().approve()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_live_updates
 def test_rollout_live_update_approve_and_reject(
     selenium,
     kinto_client,
@@ -274,7 +274,7 @@ def test_rollout_live_update_approve_and_reject(
     summary.wait_for_rejection_notice_visible()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_live_updates
 def test_rollout_live_update_reject_on_experimenter(
     selenium,
     kinto_client,
@@ -309,7 +309,7 @@ def test_rollout_live_update_reject_on_experimenter(
     summary.wait_for_rejection_notice_visible()
 
 
-@pytest.mark.remote_settings_all
+@pytest.mark.remote_settings_experiments
 def test_create_new_experiment_timeout_remote_settings(
     selenium,
     application,

--- a/experimenter/tests/pytest.ini
+++ b/experimenter/tests/pytest.ini
@@ -7,7 +7,9 @@ markers =
     use_variables: marks tests that need to use pytest-variables
     run_targeting: run jexl targeting tests in firefox
     remote_settings_launch: a single test for launching to remote settings
-    remote_settings_all: a full suite of tests for remote settings integration
+    remote_settings_experiments: remote settings tests for experiments
+    remote_settings_rollouts: remote settings tests for rollouts (basic flows)
+    remote_settings_live_updates: remote settings tests for rollout live updates
     nimbus_ui: tests that only involve the UI, nothing else
     desktop_enrollment: tests that integrate with nimbus and external services
     cirrus_enrollment: tests that integrate with demo app and cirrus


### PR DESCRIPTION
Because

- The slowest integration test pass we have now is the Remote Settings tests which takes about 25 minutes to run, so 25 minutes on PR and then 25 minutes in a merge queue.

This commit

- Adds parallelization of 3 nodes
- Added markers to achieve parallelism 

Fixes #13994 

Note: With this able to reduce the time from 25 minutes to [12 minutes ](https://app.circleci.com/pipelines/github/mozilla/experimenter/65465/workflows/7281688d-2247-49b2-b37e-de7b6e81a708/jobs/401090)