### PR TITLE
feat(nimbus): Support pausing enrollment for Firefox Labs deliveries

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1232,6 +1232,16 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FIREFOX_LABS_REQUIRED_FIELD = "This field is requried for Firefox Labs Opt-Ins."
     ERROR_FIREFOX_LABS_ROLLOUT_REQUIRED = "Firefox Labs opt-ins must be rollouts."
 
+    ERROR_CANNOT_PAUSE_NOT_LIVE = "Cannot end enrollment: experiment is not live"
+    ERROR_CANNOT_PAUSE_UNPUBLISHED = (
+        "Cannot end enrollment: there are unpublished changes"
+    )
+    ERROR_CANNOT_PAUSE_PAUSED = "Cannot end enrollment: enrollment has already ended"
+    ERROR_CANNOT_PAUSE_ROLLOUT = (
+        "Cannot end enrollment: rollouts do not support this behaviour"
+    )
+    ERROR_CANNOT_PAUSE_INVALID = "Cannot end enrollment at this time"
+
 
 EXTERNAL_URLS = {
     "SIGNOFF_QA": "https://experimenter.info/qa-sign-off",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -911,7 +911,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def should_show_end_enrollment(self):
-        return self.is_enrolling and not self.is_rollout
+        # If these conditions change then you must update
+        # `LiveToEndEnrollmentForm.clean`.
+        return self.is_enrolling and (not self.is_rollout or self.is_firefox_labs_opt_in)
 
     @property
     def should_show_end_experiment(self):
@@ -1148,7 +1150,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def is_live_rollout(self):
-        return self.is_rollout and self.is_enrolling
+        return self.is_rollout and (self.is_enrolling or self.is_observation)
 
     @property
     def is_missing_takeaway_info(self):
@@ -1168,7 +1170,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.is_draft
 
     def can_edit_audience(self):
-        return self.is_draft or self.is_live_rollout
+        return self.is_draft or (self.is_live_rollout and self.is_enrolling)
 
     def sidebar_links(self, current_path):
         return [

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -27,6 +27,15 @@
       </p>
     </div>
   {% endif %}
+  {% if update_status_form_errors %}
+    <div class="alert alert-danger" role="alert">
+      <p class="mb-1">Could not request an update for this experiment:</p>
+      {{ update_status_form_errors }}
+      <p class="mb-0">
+        Please fix the above issues or ask in <code>#ask-experimenter</code>.
+      </p>
+    </div>
+  {% endif %}
   {% with rejection=experiment.rejection_block %}
     {% if rejection %}
       <div class="alert alert-warning"
@@ -243,7 +252,8 @@
                     hx-select="#content"
                     hx-target="#content"
                     hx-swap="outerHTML"
-                    class="btn btn-primary m-2 end-enrollment_btn">End Enrollment</button>
+                    class="btn btn-primary m-1 end-enrollment_btn"
+                    {% if experiment.is_rollout_dirty %}disabled{% endif %}>End Enrollment</button>
           {% endif %}
           {% if experiment.should_show_end_experiment %}
             <button type="button"
@@ -252,7 +262,7 @@
                     hx-target="#content"
                     hx-swap="outerHTML"
                     id="end-experiment"
-                    class="btn btn-primary end_experiment_btn">
+                    class="btn btn-primary m-1 end_experiment_btn">
               End
               {% if experiment.is_rollout %}
                 Rollout
@@ -267,7 +277,7 @@
                     hx-select="#content"
                     hx-target="#content"
                     hx-swap="outerHTML"
-                    class="btn btn-primary"
+                    class="btn btn-primary m-1"
                     id="request-update-button"
                     {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
           {% endif %}

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -602,6 +602,14 @@ class FeatureUnsubscribeView(FeatureSubscriberViewMixin):
 class StatusUpdateView(RequestFormMixin, RenderResponseMixin, NimbusExperimentDetailView):
     fields = None
 
+    def get_context_data(self, *, form, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+
+        if self.request.method in ("POST", "PUT") and not form.is_valid():
+            context["update_status_form_errors"] = form.errors["__all__"]
+
+        return context
+
 
 class DraftToPreviewView(StatusUpdateView):
     form_class = DraftToPreviewForm


### PR DESCRIPTION
Because:

- we are going to graduate our first Firefox Labs feature into a real feature (auto-pip);
- we want to prevent additional enrollment in the feature when we graduate this feature in Firefox 147; and
- we can accomplish this via supporting ending enrollment for Firefox Labs delivries

this commit:

- adds support for ending enrollment to Firefox Labs rollouts; and
- adds additional error handling to the LiveToEndEnrollmentForm to prevent updating the status via a stale page.

Fixes #14064
