### PR TITLE
bug(nimbus): Fix saving changesets via NimbusExperimentChangeLogInlineAdmin

### DIFF
--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -244,9 +244,6 @@ class NimbusExperimentChangeLogInlineAdmin(
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         if db_field.name == "changed_by":
-            # Provide an empty queryset to the form field so that it will not do
-            # a query.
-            kwargs["queryset"] = User.objects.none()
             field = super().formfield_for_foreignkey(db_field, request, **kwargs)
             if field is not None:
                 field.choices = self._get_changed_by_choices(request)


### PR DESCRIPTION
Because:

- we were passing an empty queryset to prevent querying for the field choices; and
- this did not affect the number of queries to generate the field choices since we were caching them and instead prevented saving the form

this commit:

- updates the inline admin to not pass an empty queryset, fixing saving.

Fixes #14054