### PR TITLE
chore(nimbus): Run sdk targeting tests parallely

### DIFF
--- a/experimenter/tests/nimbus_rust_tests.sh
+++ b/experimenter/tests/nimbus_rust_tests.sh
@@ -14,5 +14,6 @@ poetry -C experimenter/tests/integration \
     --base-url https://nginx/nimbus/ \
     --html=test-reports/report.htm \
     --self-contained-html \
+    -n 3 \
     /code/experimenter/tests/integration/nimbus/test_mobile_targeting.py \
     -vvv


### PR DESCRIPTION
Because

- SDK targeting intergration tests are taking about 25 minutes of time to run
- [Example](https://app.circleci.com/pipelines/github/mozilla/experimenter/65730/workflows/dfd284d8-8849-450b-99bd-8eb426dd1b75/jobs/403318)

This commit

- Use parallel workers to reduce the time
-  Should reduce time to 10-12 minutes now

Fixes #14063 