### PR TITLE
 feat(nimbus): create timeline view for experiments in enrollment and observation phases

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1019,6 +1019,39 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 return self._end_date
 
     @property
+    def days_since_enrollment_start(self):
+        if self.enrollment_start_date is not None:
+            return (datetime.date.today() - self.enrollment_start_date).days
+
+    @property
+    def enrollment_percent_completion(self):
+        if self.days_since_enrollment_start is not None and self.computed_enrollment_days:
+            percent = (
+                self.days_since_enrollment_start / self.computed_enrollment_days
+            ) * 100
+            return min(round(percent), 100.0)
+
+    @property
+    def days_since_observation_start(self):
+        if (
+            enrollment_end_date := (
+                self.actual_enrollment_end_date or self.computed_enrollment_end_date
+            )
+        ) is not None:
+            return (datetime.date.today() - enrollment_end_date).days
+
+    @property
+    def observation_percent_completion(self):
+        if (
+            self.days_since_observation_start is not None
+            and self.computed_observations_days
+        ):
+            percent = (
+                self.days_since_observation_start / self.computed_observations_days
+            ) * 100
+            return min(round(percent), 100.0)
+
+    @property
     def proposed_enrollment_end_date(self):
         if (
             self.proposed_enrollment is not None

--- a/experimenter/experimenter/nimbus_ui/templates/common/cancel_review_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/cancel_review_button.html
@@ -1,0 +1,9 @@
+<button type="button"
+        class="btn btn-secondary"
+        hx-post="{% url cancel_reject_url slug=experiment.slug %}?fragment={{ fragment }}"
+        hx-select="{{ replaced_element|default:"#content" }}"
+        hx-target="{{ replaced_element|default:"#content" }}"
+        hx-swap="outerHTML"
+        hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
+  Cancel Review
+</button>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/approval_rejection_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/approval_rejection_controls.html
@@ -36,24 +36,20 @@
         <button type="button"
                 class="btn btn-success"
                 hx-post="{% url approval_url slug=experiment.slug %}"
-                hx-select="#content"
-                hx-target="#content"
+                hx-select="{{ replaced_element|default:"#content" }}"
+                hx-target="{{ replaced_element|default:"#content" }}"
+                hx-vals='{"fragment": "{{ fragment }}"}'
                 hx-swap="outerHTML">Approve and {{ action_label }}</button>
         <button type="button" class="btn btn-danger" id="reject-button">Reject</button>
       </div>
     {% endif %}
   {% endif %}
-  <div class="alert alert-primary">
-    <button type="button"
-            class="btn btn-secondary"
-            hx-post="{% url cancel_reject_url slug=experiment.slug %}"
-            hx-select="#content"
-            hx-target="#content"
-            hx-swap="outerHTML"
-            hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
-      Cancel Review
-    </button>
-  </div>
+  {% if not replaced_element %}
+    <div class="alert alert-primary">
+      {% include "common/cancel_review_button.html" %}
+
+    </div>
+  {% endif %}
 </div>
 <!-- Rejection Form -->
 <div id="reject-form-container" class="d-none alert alert-warning">
@@ -69,8 +65,9 @@
           id="submit-rejection-button"
           class="btn btn-danger mt-2"
           hx-post="{% url cancel_reject_url slug=experiment.slug %}"
-          hx-select="#content"
-          hx-target="#content"
+          hx-select="{{ replaced_element|default:"#content" }}"
+          hx-target="{{ replaced_element|default:"#content" }}"
+          hx-vals='{"fragment": "{{ fragment }}"}'
           hx-swap="outerHTML"
           hx-include="[name='changelog_message']">Submit Rejection</button>
   <button type="button" class="btn btn-secondary mt-2" id="cancel">Cancel</button>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
@@ -1,0 +1,198 @@
+{% load nimbus_extras %}
+
+<div id="{{ experiment.slug }}-progress-card">
+  {% with rejection=experiment.rejection_block %}
+    {% if rejection %}
+      <div class="alert alert-warning"
+           id="rejection-reason"
+           data-testid="rejection-notice">
+        <div class="text-body">
+          <p class="mb-2">
+            The request to {{ rejection.action }} was <strong>Rejected</strong> due to:
+          </p>
+          <p class="mb-2">{{ rejection.email }} on {{ rejection.date|date:"F j, Y" }}:</p>
+          <p class="bg-light text-dark rounded border p-2 mb-0">{{ rejection.message }}</p>
+        </div>
+      </div>
+    {% endif %}
+  {% endwith %}
+  {% if experiment|should_show_remote_settings_pending:user %}
+    <div class="alert alert-danger" role="alert">
+      <p>
+        <strong>Action required:</strong>
+        Please review this change in Remote Settings to {{ experiment.remote_settings_pending_message }}.
+      </p>
+      <a href="{{ experiment.review_url }}"
+         class="btn btn-primary"
+         target="_blank"
+         rel="noopener noreferrer">Open Remote Settings</a>
+    </div>
+  {% else %}
+    <form>
+      {% csrf_token %}
+      {% if experiment.is_rollout_update_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Update Rollout" approval_url="nimbus-ui-approve-update-rollout" cancel_reject_url="nimbus-ui-cancel-update-rollout" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+      {% elif experiment.is_enrollment_pause_requested %}
+        {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Enrollment" approval_url="nimbus-ui-approve-end-enrollment" cancel_reject_url="nimbus-ui-cancel-end-enrollment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+      {% elif experiment.is_end_experiment_requested %}
+        {% if experiment.is_rollout %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Rollout" approval_url="nimbus-ui-approve-end-experiment" cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+        {% else %}
+          {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-ui-approve-end-experiment" cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+        {% endif %}
+      {% endif %}
+    </form>
+  {% endif %}
+  {% if experiment.is_enrolling %}
+    <div class="card bg-info-subtle p-4 mb-0 rounded-4">
+      <div class="row align-items-stretch">
+        <div class="col-5 py-4 mt-0">
+          <h5>Enrollment in progress — don't forget to close it</h5>
+          <p class="text-muted mb-0">
+            Enrollment is when participants can join your experiment. You'll need to end it yourself once enough people have joined, or when the time you set for enrollment has passed — it won't close automatically.
+          </p>
+          {% if experiment.should_show_end_enrollment %}
+            <div class="mt-4">
+              <form>
+                {% csrf_token %}
+                {% if experiment.is_rollout_update_requested %}
+                  {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-update-rollout" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+                {% elif experiment.is_enrollment_pause_requested %}
+                  {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-enrollment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+                {% elif experiment.is_end_experiment_requested %}
+                  {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+                {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
+                  {% if experiment.should_show_end_enrollment %}
+                    <button type="button"
+                            hx-post="{% url 'nimbus-ui-live-to-end-enrollment' slug=experiment.slug %}?fragment=progress_card"
+                            hx-select="#{{ experiment.slug }}-progress-card"
+                            hx-target="#{{ experiment.slug }}-progress-card"
+                            hx-swap="outerHTML"
+                            class="btn btn-primary end-enrollment_btn"
+                            {% if experiment.is_rollout_dirty %}disabled{% endif %}>Close Enrollment</button>
+                  {% endif %}
+                  {% if experiment.should_show_end_experiment %}
+                    <button type="button"
+                            hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
+                            hx-select="#{{ experiment.slug }}-progress-card"
+                            hx-target="#{{ experiment.slug }}-progress-card"
+                            hx-swap="outerHTML"
+                            id="end-experiment"
+                            class="btn btn-primary m-1 end_experiment_btn">
+                      End
+                      {% if experiment.is_rollout %}
+                        Rollout
+                      {% else %}
+                        Experiment
+                      {% endif %}
+                    </button>
+                  {% endif %}
+                {% endif %}
+              </form>
+            </div>
+          {% endif %}
+        </div>
+        <div class="col">
+          <div class="card p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4 h-100 d-flex justify-content-center">
+            <h6>{{ experiment.enrollment_percent_completion }}% of enrollment complete</h6>
+            <div class="progress mb-2 bg-secondary-subtle"
+                 role="progressbar"
+                 aria-label="{{ experiment.name }} enrollment progress"
+                 aria-valuenow="{{ experiment.enrollment_percent_completion }}"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 style="height: 10px">
+              <div class="progress-bar"
+                   style="width: {{ experiment.enrollment_percent_completion }}%"></div>
+            </div>
+            <div class="text-muted d-flex gap-2 align-items-center mb-1">
+              <i class="fa-regular fa-calendar"></i>
+              <small>{{ experiment.days_since_enrollment_start }}/{{ experiment.proposed_enrollment }} days before end of enrollment</small>
+            </div>
+            <div class="text-muted d-flex gap-2 align-items-center">
+              <i class="fa-regular fa-circle-user"></i>
+              <small><a href="{{ experiment.monitoring_dashboard_url }}" class="text-reset">Check participant enrollment count</a></small>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  {% elif experiment.is_observation %}
+    <div class="card bg-primary-subtle p-4 mb-0 rounded-4">
+      <div class="row align-items-center">
+        <div class="col-5 py-4 mt-0">
+          <h5>Observing — results still forming</h5>
+          <p class="text-muted mb-0">
+            Your experiment is officially in progress, and early numbers are starting to come in. These results are just for checking that everything's running correctly — they aren't reliable for decisions until the monitoring period is complete. <a href="https://experimenter.info/observing">
+            Learn more
+          </p>
+        </a>
+        <div class="mt-4">
+          <form>
+            {% csrf_token %}
+            {% if experiment.is_rollout_update_requested %}
+              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-update-rollout" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+            {% elif experiment.is_enrollment_pause_requested %}
+              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-enrollment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+            {% elif experiment.is_end_experiment_requested %}
+              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+
+            {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
+              {% if experiment.should_show_end_experiment %}
+                <button type="button"
+                        hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
+                        hx-select="#{{ experiment.slug }}-progress-card"
+                        hx-target="#{{ experiment.slug }}-progress-card"
+                        hx-swap="outerHTML"
+                        id="end-experiment"
+                        class="btn btn-primary m-1 end_experiment_btn">
+                  End
+                  {% if experiment.is_rollout %}
+                    rollout
+                  {% else %}
+                    experiment
+                  {% endif %}
+                  early
+                </button>
+              {% endif %}
+            {% endif %}
+          </form>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4">
+          <h6>{{ experiment.days_since_observation_start }}/{{ experiment.computed_observations_days }} days monitored</h6>
+          <div class="progress mb-2 bg-secondary-subtle"
+               role="progressbar"
+               aria-label="{{ experiment.name }} enrollment progress"
+               aria-valuenow="{{ experiment.observation_percent_completion }}"
+               aria-valuemin="0"
+               aria-valuemax="100"
+               style="height: 10px">
+            <div class="progress-bar"
+                 style="width: {{ experiment.observation_percent_completion }}%"></div>
+          </div>
+          <div class="text-muted d-flex gap-2 align-items-center mb-1">
+            <i class="fa-solid fa-chart-line"></i>
+            <small>Results become reliable after {{ experiment.computed_observations_days }} days</small>
+          </div>
+          <div class="text-muted d-flex gap-2 align-items-center">
+            {% comment %} TODO(gh-13723): check if there are any metric errors and show them here {% endcomment %}
+            <i class="fa-solid fa-circle-check text-success"></i>
+            <small>Metrics reporting correctly</small>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+{% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -41,6 +41,7 @@
       </select>
     </div>
   </form>
+  {% include "nimbus_experiments/launch_controls_v2.html" %}
   {% include "nimbus_experiments/results-new-inner.html" %}
 
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -138,7 +138,12 @@
                 aria-expanded="true"
                 aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
           <div class="pe-3">
-            <h4>{{ area }}</h4>
+            <div class="d-flex align-items-center gap-3 mb-2">
+              <h4 class="mb-0">{{ area }}</h4>
+              {% if experiment.is_observation %}
+                <span class="badge rounded-pill bg-primary-subtle border border-1 border-secondary-subtle"><span class="text-black">In progress &middot; <span class="text-muted fw-medium">results still forming</span></span></span>
+              {% endif %}
+            </div>
             <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
               {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
                 <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
@@ -180,37 +185,55 @@
                 {% endfor %}
               {% endfor %}
             </div>
-            <div class="col position-relative w-25">
-              <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
-                {% if branch_data|length > 4 %}
-                  <div class="branch-fade branch-fade-left"></div>
-                  <div class="branch-fade branch-fade-right"></div>
-                {% endif %}
-                {% for branch in branch_data %}
-                  <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                    <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
-                    {% if branch.slug == selected_reference_branch %}
-                      <p class="fs-5 mb-3">Baseline</p>
-                    {% else %}
-                      <p class="fs-5">{{ branch.name }}</p>
-                    {% endif %}
-                    <div class="d-flex flex-column gap-3 w-100">
-                      {% for metric in metric_metadata %}
-                        {% for curr_metric_slug, metric_branch_data in metric_data.items %}
-                          {% if curr_metric_slug == metric.slug %}
-                            {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
-                              {% if curr_branch_slug == branch.slug %}
-                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
-
-                              {% endif %}
-                            {% endfor %}
-                          {% endif %}
-                        {% endfor %}
-                      {% endfor %}
+            <div class="col position-relative w-25 d-flex flex-column">
+              {% if experiment.is_enrolling %}
+                <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                  {% for branch in branch_data %}
+                    <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                      <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                      {% if branch.slug == selected_reference_branch %}
+                        <p class="fs-5 mb-3">Baseline</p>
+                      {% else %}
+                        <p class="fs-5">{{ branch.name }}</p>
+                      {% endif %}
                     </div>
-                  </div>
-                {% endfor %}
-              </div>
+                  {% endfor %}
+                </div>
+                <div class="ms-4 bg-body-tertiary rounded-3 flex-grow-1 overflow-auto d-flex align-items-center mb-4">
+                  <span class="text-muted mx-auto">Metrics are on their way! Enrollment is in progress!</span>
+                </div>
+              {% else %}
+                <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                  {% if branch_data|length > 4 %}
+                    <div class="branch-fade branch-fade-left"></div>
+                    <div class="branch-fade branch-fade-right"></div>
+                  {% endif %}
+                  {% for branch in branch_data %}
+                    <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                      <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                      {% if branch.slug == selected_reference_branch %}
+                        <p class="fs-5 mb-3">Baseline</p>
+                      {% else %}
+                        <p class="fs-5">{{ branch.name }}</p>
+                      {% endif %}
+                      <div class="d-flex flex-column gap-3 w-100">
+                        {% for metric in metric_metadata %}
+                          {% for curr_metric_slug, metric_branch_data in metric_data.items %}
+                            {% if curr_metric_slug == metric.slug %}
+                              {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
+                                {% if curr_branch_slug == branch.slug %}
+                                  {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
+
+                                {% endif %}
+                              {% endfor %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endfor %}
+                      </div>
+                    </div>
+                  {% endfor %}
+                </div>
+              {% endif %}
             </div>
           </div>
         </div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -64,6 +64,22 @@ class AuthTestCase(TestCase):
 
 
 class LiveToEndEnrollmentViewTests(AuthTestCase):
+    def test_htmx_progress_card_renders_fragment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-live-to-end-enrollment", kwargs={"slug": experiment.slug}),
+            {"fragment": "progress_card"},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        template_names = [t.name for t in response.templates if getattr(t, "name", None)]
+        self.assertIn("nimbus_experiments/launch_controls_v2.html", template_names)
+
     def test_invalid_submission(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -603,10 +603,20 @@ class FeatureUnsubscribeView(FeatureSubscriberViewMixin):
 class StatusUpdateView(RequestFormMixin, RenderResponseMixin, NimbusExperimentDetailView):
     fields = None
 
-    def get_context_data(self, *, form, **kwargs):
-        context = super().get_context_data(form=form, **kwargs)
+    def get_template_names(self):
+        if self.request.headers.get("HX-Request"):
+            fragment = self.request.GET.get("fragment") or self.request.POST.get(
+                "fragment"
+            )
 
-        if self.request.method in ("POST", "PUT") and not form.is_valid():
+            if fragment == "progress_card":
+                return ["nimbus_experiments/launch_controls_v2.html"]
+
+        return [self.template_name]
+
+    def get_context_data(self, *, form=None, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+        if self.request.method in ("POST", "PUT") and form and not form.is_valid():
             context["update_status_form_errors"] = form.errors["__all__"]
 
         return context


### PR DESCRIPTION
Because

- New results page should be viewable while an experiment is still enrolling as well as observing

This commit

- Creates a timeline card that shows how far along an experiment is in the enrollment and observation stages
- Enrollment can be closed and experiments can be ended early from this results page

Fixes #14089 