### PR TITLE
feat: updated mozcloud-publish workflow to use 'pr-preview' label instead of 'preview'

### DIFF
--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'preview') &&
+        contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
         github.event.pull_request.head.repo.full_name == github.repository
       )
     runs-on: ubuntu-latest


### PR DESCRIPTION
Because

- We want to use the `pr-preview` label to trigger ephemeral environment provisioning instead of `preview`

This commit

- Updates the mozcloud-publish workflow to run when a pull request contains the `pr-preview` label instead of `preview`
