### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 147.0.20251114.194929 for desktop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3728,7 +3728,7 @@ FX_146_TRAINHOP = NimbusTargetingConfig(
 
 FX_146_1_TRAINHOP = NimbusTargetingConfig(
     name="New Tab Fx146 11-24 Trainhop",
-    slug="newtab-146-1124-trainhop",
+    slug="newtab-146-1-1124-trainhop",
     description=(
         "Desktop users having the New Tab 147.0.20251114.194929 train hop, "
         "which includes users of Fx145_0_1"


### PR DESCRIPTION
- Reason

This commit will allow us to create experiments targeting users of the latest New Tab trainhop that was released (2025-11-24) to Firefox 145 users on the release channel.

- Change

Fixes mozilla#14117