### PR TITLE
feat(nimbus): Add application and features in a path

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -17,7 +17,6 @@
             hx-swap="outerHTML"
             hx-select-oob="#features-tables"
             hx-push-url="true">
-        {% csrf_token %}
         <div class="card mb-3">
           <div class="card-body bg-primary-subtle">
             <div class="row mb-4">


### PR DESCRIPTION
Because

- If we select the application and feature on a feature page and then refresh the page, we lose the selected feature as we do not preserve it in the url

This commit

- Push the selected application and feature in url params to maintain the state

Fixes #14022 