### PR TITLE
feat(nimbus): Fix tooltip and button styling

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -37,13 +37,13 @@
       <div id="features-tables"
            class="card shadow-sm p-3 border-0 h-100 rounded-3 bg-primary-subtle">
         <div scope="row" class="row">
-          <div scope="col" class="col-2 pe-0 align-items-center">
-            <h5 class="fw-semibold mt-3">
+          <div scope="col" class="col-8 pe-0 align-items-center">
+            <h5 class="fw-semibold mt-3 d-flex align-items-center">
               <img src="{% static 'assets/feature-deliveries.svg' %}"
                    alt="Hugging Foxes"
                    style="width: 60px;
                           height: auto" />
-              Deliveries
+              <span class="me-2">Deliveries</span>
               <i class="fa-regular fa-circle-question"
                  data-bs-toggle="tooltip"
                  data-bs-placement="top"
@@ -51,7 +51,7 @@
             </h5>
           </div>
           <div scope="col"
-               class="col-4 ps-0 d-inline-flex align-items-center flex-nowrap ">
+               class="col-4 ps-0 d-flex align-items-center justify-content-end">
             <div id="feature-subscription-button">
               {% if selected_feature_config %}
                 {% include "nimbus_experiments/feature_subscribe_button.html" %}
@@ -204,7 +204,7 @@
                alt="Hugging Foxes"
                style="width: 60px;
                       height: auto" />
-          QA Runs
+          <span>QA Runs</span>
         </h5>
         <div>
           <div id="qa-info-table">
@@ -350,7 +350,7 @@
                alt="Fox opening a box"
                style="width: 60px;
                       height: auto" />
-          Feature Changes
+          <span>Feature Changes</span>
           <i class="fa-regular fa-circle-question"
              data-bs-toggle="tooltip"
              data-bs-placement="top"


### PR DESCRIPTION
Because

- Deliveries section and subscriber button tooltips are not properly aligned on the new feature page
- Subscriber button is at the very crowdy place on the feature page
 
This commit

- Adjust tooltip spacing
- Move subscriber button to right corner of the table

Fixes #14125 
