### PR TITLE
bug(nimbus): wait for redirect on promote rollout test

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -306,7 +306,11 @@ class SummaryPage(ExperimenterBase):
 
     def promote_first_branch_to_rollout(self):
         self.js_click(self.promote_to_rollout_buttons[0])
+        old_url = self.selenium.current_url
         self.js_click(self.promote_to_rollout_save)
+        # Wait for navigation to the new rollout page
+        self.wait.until(EC.url_changes(old_url))
+        self.wait_for_page_to_load()
 
     @property
     def takeaways_edit_button(self):


### PR DESCRIPTION
Becuase

* We have seen intermittent failures on the promote to rollout test
* It may be caused by attempting to find elements on the page before the post save redirect has completed

This commit

* Explicitly waits for the redirect to finish before attempting to look for elements on the post redirect page

fixes #14142

