### PR TITLE
feat(nimbus): add targeting for accepting tou before and after partic…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -53,6 +53,9 @@ ACCEPTED_TOU_V4_OR_HIGHER = "'termsofuse.acceptedVersion'|preferenceValue >= 4"
 # 23:59 UTC on Dec 9, 2025 when an updated version of the privacy
 # notice was published.
 DEC_9_2025 = 1765324740000
+# Privacy Notification Published date of 12:00 PM UTC on Dec 15, 2025
+DEC_15_2025 = 1765800000000
+DEC_17_2025 = 1765972800000
 
 TOU_NOTIFICATION_BYPASS_ENABLED = "'termsofuse.bypassNotification'|preferenceValue"
 
@@ -3658,6 +3661,42 @@ ACCEPTED_TOU_ON_OR_AFTER_DEC_9_2025 = NimbusTargetingConfig(
         {HAS_TOU_ACCEPTED_DATE}
         &&
         ({TOU_ACCEPTED_DATE} >= {DEC_9_2025})
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+ACCEPTED_TOU_BEFORE_DEC_17_2025 = NimbusTargetingConfig(
+    name="Accepted TOU before Dec 17, 2025",
+    slug="accepted_tou_before_dec_17_2025",
+    description=("User accepted TOU before Dec 17, 2025 (excludes Linux)"),
+    targeting=f"""
+    (
+        !os.isLinux
+        &&
+        {HAS_TOU_ACCEPTED_DATE}
+        &&
+        ({TOU_ACCEPTED_DATE} < {DEC_17_2025})
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+ACCEPTED_TOU_ON_OR_AFTER_DEC_15_2025 = NimbusTargetingConfig(
+    name="Accepted TOU on or after Dec 15, 2025",
+    slug="accepted_tou_on_or_after_dec_15_2025",
+    description=("User accepted TOU on or after Dec 15, 2025"),
+    targeting=f"""
+    (
+        {HAS_TOU_ACCEPTED_DATE}
+        &&
+        ({TOU_ACCEPTED_DATE} >= {DEC_15_2025})
     )
     """,
     desktop_telemetry="",


### PR DESCRIPTION
Because

- we want to target users who have accepted TOU before and after particular dates

This commit

- adds targeting for users who have accepted TOU before and after particular dates

Fixes #14148