### PR TITLE
feat(nimbus): Split tables on feature page 

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -57,12 +57,12 @@
               {% if selected_feature_config %}
                 {% include "nimbus_experiments/feature_subscribe_button.html" %}
 
-                {% endif %}
-              </div>
+              {% endif %}
             </div>
           </div>
-          <div>
-            <div id="deliveries-table">
+        </div>
+        <div>
+          <div id="deliveries-table">
             <div id="no-deliveries"></div>
             <table class="table table-hover table-borderless align-middle mb-3 mt-1">
               <thead>


### PR DESCRIPTION
Because

- Feature page has three tables in a single card which is not consistent with the existing design on the home page we have

This commit

- Splits the feature page tables into separate cards

Fixes #14025 