### PR TITLE
feat(nimbus): Add padding to home page card

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home.html
@@ -44,7 +44,7 @@
       </div>
       <!-- My Stuff Section -->
       <div id="my-deliveries"
-           class="mt-4 card shadow-sm border-0 px-3  h-100 rounded-3 bg-primary-subtle">
+           class="mt-4 pb-4 card shadow-sm border-0 px-3  h-100 rounded-3 bg-primary-subtle">
         <div class="d-flex justify-content-between align-items-center mb-3 ">
           <h5 class="fw-semibold">
             <img src="{% static 'assets/my-deliveries.svg' %}"


### PR DESCRIPTION
Because

- We're missing some bottom padding on the bottom card of the home page

This commit

- Adds padding to the bottom card to fix the layout

Fixes #14024 