### PR TITLE
bug(nimbus): fix intermittent coverage

### DIFF
--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -58,6 +58,8 @@ from experimenter.features import Features
 from experimenter.features.tests import mock_valid_features
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.openidc.tests.factories import UserFactory
+from experimenter.outcomes import Outcomes
+from experimenter.outcomes.tests import mock_valid_outcomes
 from experimenter.projects.tests.factories import ProjectFactory
 
 
@@ -2363,8 +2365,12 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(second["num_participants"], 75)
         self.assertEqual(second["description"], branch_b.description)
 
+    @mock_valid_outcomes
     def test_get_metric_data_returns_correct_data(self):
-        experiment = NimbusExperimentFactory.create()
+        outcomes = Outcomes.all()
+        experiment = NimbusExperimentFactory.create(
+            primary_outcomes=[outcomes[0].slug],
+        )
         branch_a = NimbusBranchFactory.create(
             experiment=experiment, name="Branch A", slug="branch-a"
         )

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3025,6 +3025,7 @@ class TestSaveAndContinueMixin(AuthTestCase):
         )
 
 
+@mock_valid_outcomes
 class TestResultsView(AuthTestCase):
     def test_render_to_response(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Becuase

* We recently added logic and tests for generating the results data
* One section depends on there being outcomes
* The factories will randomly assign outcomes, but possibly set empty outcomes
* If all the tests set empty outcomes, some lines are uncovered by tests which fails test coverage

This commit

* Explicitly sets outcomes on a test to force coverage for the relevant lines

fixes #14146

