### PR TITLE
feat(nimbus): Remove duplicate mentions from slack messages

### DIFF
--- a/experimenter/experimenter/slack/notification.py
+++ b/experimenter/experimenter/slack/notification.py
@@ -50,6 +50,8 @@ def send_slack_notification(
     requesting_user_mention = ""
     if requesting_user_email:
         requesting_user_mention = _get_user_mentions(client, [requesting_user_email])
+        # Exclude requesting_user_email from email_addresses to avoid duplicate mentions
+        email_addresses = [e for e in email_addresses if e and e != requesting_user_email]
 
     mentions = _get_user_mentions(client, email_addresses)
 


### PR DESCRIPTION
Because

- We are seeing duplicate users mentions in the slack messages like `@Yashika Requests launch: preview-test @yashika user 1 user2`

This commit

- Filter duplicates from the slack messages (If we have requesting user already in the prefix of the message, filter out the user from the postfix mentions)
- Now it should send as `@Yashika Requests launch: preview-test user 1 user2`


Fixes #14162 