### PR TITLE
chore(nimbus): fix get_metric_areas intermittent coverage failure

### DIFF
--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2367,8 +2367,10 @@ class TestNimbusExperiment(TestCase):
 
     @mock_valid_outcomes
     def test_get_metric_data_returns_correct_data(self):
-        outcomes = Outcomes.all()
+        application = NimbusExperiment.Application.DESKTOP
+        outcomes = Outcomes.by_application(application)
         experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[outcomes[0].slug],
         )
         branch_a = NimbusBranchFactory.create(


### PR DESCRIPTION
Because

* We recently discovered an intermittent coverage failure in get_metric_areas
* We fixed it by specifying an outcome in the test factory to trigger the uncovered lines
* We forgot to also affix the application since that determines which outcomes to use

This commit

* Affixes both the application and outcome to trigger the uncovered lines

fixes #14163
