### PR TITLE
bug(nimbus): don't unset published_dto for experiments moving from preview to live

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -3087,6 +3087,8 @@ class NimbusChangeLog(FilterMixin, models.Model):
         COMPLETED = "Experiment is complete"
         RESULTS_UPDATED = "Experiment results updated"
         EXPIRED_FROM_PREVIEW = "Expired from preview collection after 30 days"
+        REMOVED_FROM_PREVIEW = "Removed from preview collection"
+        PUSHED_TO_PREVIEW = "Pushed to preview collection"
 
     def __str__(self):
         return self.message or (


### PR DESCRIPTION


Becuase

* We recently discovered a live experiment with no published_dto
* This breaks the state of the experiment and its ability to pause enrollment
* Looking at the changelogs it looks as if it was moved from preview to live very quickly
* It's possible the preview unpublish task accidentally unset the published_dto after the experiment was marked live

This commit

* Only unsets published_dto for experiments in draft when moving out of preview
* Wraps all kinto tasks in atomic transactions
* Generates a changelog for all kinto changes that modify the database for easier retroactive debugging

fixes #14184

