### PR TITLE
feat(nimbus): add changelog on nimbusexperiment admin changes

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -456,6 +456,8 @@ class NimbusConstants:
         "qa_comment",
     )
 
+    CHANGELOG_MESSAGE_ADMIN_EDIT = "Modified by an administrator."
+
     class QAStatus(models.TextChoices):
         RED = "RED", "QA: Red"
         YELLOW = "YELLOW", "QA: Yellow"


### PR DESCRIPTION
Becuase

* An administrator may have to make an emergency edit to an experiment from the admin
* In this case it is still helpful to see the changes in the history for later auditing or debugging

This commit

* Adds a changelog to the NimbusExperiment admin save

fixes #14190
