### PR TITLE
chore(nimbus): readonly changelogs in admin

### DIFF
--- a/experimenter/experimenter/experiments/templates/admin/changelog_display.html
+++ b/experimenter/experimenter/experiments/templates/admin/changelog_display.html
@@ -1,0 +1,26 @@
+<table class="listing">
+    <thead>
+        <tr>
+            <th>Changed On</th>
+            <th>Changed By</th>
+            <th>Old Status</th>
+            <th>New Status</th>
+            <th>Old Publish Status</th>
+            <th>New Publish Status</th>
+            <th>Message</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for change in changes %}
+        <tr class="{% cycle 'row1' 'row2' %}">
+            <td>{{ change.changed_on }}</td>
+            <td>{{ change.changed_by.email|default:"Unknown" }}</td>
+            <td>{{ change.old_status|default:"-" }}</td>
+            <td>{{ change.new_status|default:"-" }}</td>
+            <td>{{ change.old_publish_status|default:"-" }}</td>
+            <td>{{ change.new_publish_status|default:"-" }}</td>
+            <td>{{ change.message|default:"No message" }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>


### PR DESCRIPTION
Becuase

* We had inline formsets for changelogs in the admin
* These are very slow to render especially for experiments with lots of changes
* We don't actually need to be able to edit changelogs in the admin, they really should be read only
* We can just display their values for reference purpose in the admin, this should be much faster to render

This commit

* Replaces NimbusExperimentAdmin changelog inline formsets with a read only table

fixes #14164
