### PR TITLE
feat(nimbus): wrap long segment names

### DIFF
--- a/experimenter/experimenter/results/src/components/PageResults/index.test.tsx
+++ b/experimenter/experimenter/results/src/components/PageResults/index.test.tsx
@@ -123,6 +123,7 @@ describe("PageResults", () => {
 
     const defaultSegment = "all";
     const otherSegment = "a_different_segment";
+    const otherSegmentLabel = "a different segment";
 
     expect(screen.getByText("Segment"));
     const segmentSelectParent = screen.getByTestId("segment-results-selector");
@@ -132,7 +133,7 @@ describe("PageResults", () => {
         `${defaultSegment}-segment-radio`,
       ),
     ).toBeChecked();
-    within(segmentSelectParent).getByText(otherSegment);
+    within(segmentSelectParent).getByText(otherSegmentLabel);
     expect(
       within(segmentSelectParent).getByTestId(`${otherSegment}-segment-radio`),
     ).not.toBeChecked();

--- a/experimenter/experimenter/results/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/results/src/components/PageResults/index.tsx
@@ -436,7 +436,7 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
                           radioGroup="segment-radio-group"
                           type="radio"
                           onChange={() => setSelectedSegment(segment)}
-                          label={segment}
+                          label={segment.replace(/_/g, " ")}
                           checked={segment === selectedSegment}
                           data-testid={`${segment}-segment-radio`}
                         />


### PR DESCRIPTION
Becuase

* Segments can have long names
* They use snake case so they will not line break
* This can cause long segment names to overflow the sidebar

This commit

* Replaces underscores with spaces so long segment names can wrap

fixes #14170

