### PR TITLE
Update constants.py

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3024,8 +3024,8 @@ IS_DESKTOP_TIER_2_MID_RANGE = NimbusTargetingConfig(
     ),
     desktop_telemetry=(
         "metrics.quantity.system_memory >= 8192 "
-        "AND metrics.quantity.system_memory < 16384")
-    ,
+        "AND metrics.quantity.system_memory < 16384"
+    ),
     sticky_required=False,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),


### PR DESCRIPTION
We need new targeting criteria for Adaptive Performance, which will tune preferences based on device and session characteristics. This PR unlocks our immediate phase of experimentation around static device tiers.

Distinct from the two existing memory tier constants, these three use strategic thresholds informed by 2025 data and exact cutoffs of 16384 and 8192 (rather than 16000 and 8000), based on assessment of "gray areas" at 8GB and 16GB thresholds, where a collective 40% of devices may be allocated to higher tiers (analysis linked below). For Adaptive Performance, we want to intentionally err to the side of conservatism when applying optimizations on behalf of our users. User feedback also indicates a primary concern around resource usage and battery consumption, which is incidentally supported by biasing away from more aggressive resource allocation that we intend for "true" high end devices or "power users".

Side note, in relation to feedback received in experimenter office hours 16 Dec 2025: given that these thresholds may change after initial rounds of experimentation and feedback from engineering, we have not yet parameterized with code snippets.

Gray Zone Analysis: [bquxjob_6c46232d_19b24ca47d0.csv](https://github.com/user-attachments/files/24196785/bquxjob_6c46232d_19b24ca47d0.csv)