### PR TITLE
feat(nimbus): Add links to subscriptions and my deliveries under profile drop down

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -124,21 +124,21 @@
         </a>
         <ul class="dropdown-menu dropdown-menu-end">
           <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllOwned"
+            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllOwned#my-deliveries"
                class="dropdown-item link-primary">
               <i class="fa-solid fa-user me-2"></i>
               My Deliveries
             </a>
           </li>
           <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllSubscribed"
+            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllSubscribed#my-deliveries"
                class="dropdown-item link-primary">
               <i class="fa-solid fa-bell me-2"></i>
               My Subscribed Deliveries
             </a>
           </li>
           <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=FeatureSubscribed"
+            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=FeatureSubscribed#my-deliveries"
                class="dropdown-item link-primary">
               <i class="fa-solid fa-boxes-stacked me-2"></i>
               My Subscribed Features


### PR DESCRIPTION

Because

- We have a home page which allows you to go to all owned, all subscriber and all features subscribed deliveries section, but we have to visit the home page and filter sections manually

This commit

- Under profile sections, allows direct access to all owned, subscribed and feature-subscribed deliveries.

Fixes #14027 