### PR TITLE
feat(nimbus): update ui to display metrics grouped by area

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/sidebar_link.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/sidebar_link.html
@@ -24,7 +24,16 @@
             <ul class="nav flex-column ms-4">
               {% for subitem in item.subitems %}
                 <li class="nav-item w-100">
-                  <a class="nav-link text-reset" href="#">{{ subitem.title }}</a>
+                  <a href="#{{ experiment.slug }}-results-{{ item.title|slugify }}"
+                     class="text-reset text-decoration-none">
+                    <button class="nav-link text-start text-reset"
+                            data-bs-toggle="collapse"
+                            data-bs-target="#{{ experiment.slug }}-results-{{ item.title|slugify }}"
+                            aria-expanded="true"
+                            aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
+                      {{ subitem.title }}
+                    </button>
+                  </a>
                 </li>
               {% endfor %}
             </ul>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -198,131 +198,133 @@
   {% comment %} Metrics {% endcomment %}
   {% for area, metric_data_metadata in metric_area_data.items %}
     {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data.overall %}
-      <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
-        <button class="accordion-button bg-transparent shadow-none text-body d-flex collapsed"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#{{ experiment.slug }}-results-{{ area|slugify }}"
-                aria-expanded="true"
-                aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
-          <div class="pe-3">
-            <div class="d-flex align-items-center gap-3 mb-2">
-              <h4 class="mb-0">{{ area }}</h4>
-              {% if experiment.is_observation %}
-                <span class="badge rounded-pill bg-primary-subtle border border-1 border-secondary-subtle"><span class="text-black">In progress &middot; <span class="text-muted fw-medium">results still forming</span></span></span>
-              {% endif %}
+      {% if metric_data %}
+        <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
+          <button class="accordion-button bg-transparent shadow-none text-body d-flex collapsed"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#{{ experiment.slug }}-results-{{ area|slugify }}"
+                  aria-expanded="true"
+                  aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
+            <div class="pe-3">
+              <div class="d-flex align-items-center gap-3 mb-2">
+                <h4 class="mb-0">{{ area }}</h4>
+                {% if experiment.is_observation %}
+                  <span class="badge rounded-pill bg-primary-subtle border border-1 border-secondary-subtle"><span class="text-black">In progress &middot; <span class="text-muted fw-medium">results still forming</span></span></span>
+                {% endif %}
+              </div>
+              <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
+                {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
+                  <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
+                {% else %}
+                  {% for metric in metric_metadata %}
+                    <div>
+                      <small class="text-muted me-2">{{ metric.friendly_name }}</small>
+                      {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
+                    </div>
+                  {% endfor %}
+                {% endif %}
+              </div>
             </div>
-            <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
-              {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
-                <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
-              {% else %}
+          </button>
+          <div id="{{ experiment.slug }}-results-{{ area|slugify }}"
+               class="accordion-collapse collapse">
+            <div class="accordion-body d-flex">
+              <div class="col-2">
+                <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
+                <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
                 {% for metric in metric_metadata %}
-                  <div>
-                    <small class="text-muted me-2">{{ metric.friendly_name }}</small>
-                    {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
-                  </div>
-                {% endfor %}
-              {% endif %}
-            </div>
-          </div>
-        </button>
-        <div id="{{ experiment.slug }}-results-{{ area|slugify }}"
-             class="accordion-collapse collapse">
-          <div class="accordion-body d-flex">
-            <div class="col-2">
-              <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
-              <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-              {% for metric in metric_metadata %}
-                <button class="card p-3 {% if forloop.last %}mb-4{% endif %} mb-3 d-flex justify-content-center rounded-4 border-3 w-100 text-start nav-link-hover position-relative border-light-subtle"
-                        type="button"
-                        data-bs-toggle="modal"
-                        data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
-                        style="height: 100px">
-                  <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
-                  <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
-                </button>
-                {% for curr_metric_slug, metric_data in metric_data.items %}
-                  {% if curr_metric_slug == metric.slug %}
-                    {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
-                      {% if metric_ui_properties == curr_metric_slug %}
-                        {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
+                  <button class="card p-3 {% if forloop.last %}mb-4{% endif %} mb-3 d-flex justify-content-center rounded-4 border-3 w-100 text-start nav-link-hover position-relative border-light-subtle"
+                          type="button"
+                          data-bs-toggle="modal"
+                          data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
+                          style="height: 100px">
+                    <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
+                    <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
+                  </button>
+                  {% for curr_metric_slug, metric_data in metric_data.items %}
+                    {% if curr_metric_slug == metric.slug %}
+                      {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
+                        {% if metric_ui_properties == curr_metric_slug %}
+                          {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
 
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                {% endfor %}
-              {% endfor %}
-            </div>
-            <div class="col position-relative w-25 d-flex flex-column">
-              {% if experiment.is_enrolling %}
-                <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
-                  {% for branch in branch_data %}
-                    <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                      <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
-                      {% if branch.slug == selected_reference_branch %}
-                        <p class="fs-5 mb-3">Baseline</p>
-                      {% else %}
-                        <p class="fs-5">{{ branch.name }}</p>
-                      {% endif %}
-                    </div>
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
                   {% endfor %}
-                </div>
-                <div class="ms-4 bg-body-tertiary rounded-3 flex-grow-1 overflow-auto d-flex align-items-center mb-4">
-                  <span class="text-muted mx-auto">Metrics are on their way! Enrollment is in progress!</span>
-                </div>
-              {% else %}
-                <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
-                  {% if branch_data|length > 4 %}
-                    <div class="branch-fade branch-fade-left"></div>
-                    <div class="branch-fade branch-fade-right"></div>
-                  {% endif %}
-                  {% for branch in branch_data %}
-                    <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                      <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
-                      {% if branch.slug == selected_reference_branch %}
-                        <p class="fs-5 mb-3">Baseline</p>
-                      {% else %}
-                        <p class="fs-5">{{ branch.name }}</p>
-                      {% endif %}
-                      <div class="d-flex flex-column gap-3 w-100">
-                        {% for metric in metric_metadata %}
-                          {% for curr_metric_slug, metric_branch_data in metric_data.items %}
-                            {% if curr_metric_slug == metric.slug %}
-                              {% if metric.has_errors %}
-                                {% if forloop.parentloop.parentloop.first %}
-                                  <div class="d-flex align-items-center" style="height: 100px;">
-                                    <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
-                                      <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-                                      <p class="mb-0 fw-semibold">Metric unavailable</p>
-                                      <p class="mb-0">Other metrics are unaffected.</p>
-                                      <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
-                                        Contact Experimenter Support
-                                      </button>
-                                    </div>
-                                  </div>
-                                {% else %}
-                                  <div class="invisible" style="height: 100px;" aria-hidden="true"></div>
-                                {% endif %}
-                              {% else %}
-                                {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
-                                  {% if curr_branch_slug == branch.slug %}
-                                    {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
-
-                                  {% endif %}
-                                {% endfor %}
-                              {% endif %}
-                            {% endif %}
-                          {% endfor %}
-                        {% endfor %}
+                {% endfor %}
+              </div>
+              <div class="col position-relative w-25 d-flex flex-column">
+                {% if experiment.is_enrolling %}
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                    {% for branch in branch_data %}
+                      <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                        {% if branch.slug == selected_reference_branch %}
+                          <p class="fs-5 mb-3">Baseline</p>
+                        {% else %}
+                          <p class="fs-5">{{ branch.name }}</p>
+                        {% endif %}
                       </div>
-                    </div>
-                  {% endfor %}
-                </div>
-              {% endif %}
+                    {% endfor %}
+                  </div>
+                  <div class="ms-4 bg-body-tertiary rounded-3 flex-grow-1 overflow-auto d-flex align-items-center mb-4">
+                    <span class="text-muted mx-auto">Metrics are on their way! Enrollment is in progress!</span>
+                  </div>
+                {% else %}
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                    {% if branch_data|length > 4 %}
+                      <div class="branch-fade branch-fade-left"></div>
+                      <div class="branch-fade branch-fade-right"></div>
+                    {% endif %}
+                    {% for branch in branch_data %}
+                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                        {% if branch.slug == selected_reference_branch %}
+                          <p class="fs-5 mb-3">Baseline</p>
+                        {% else %}
+                          <p class="fs-5">{{ branch.name }}</p>
+                        {% endif %}
+                        <div class="d-flex flex-column gap-3 w-100">
+                          {% for metric in metric_metadata %}
+                            {% for curr_metric_slug, metric_branch_data in metric_data.items %}
+                              {% if curr_metric_slug == metric.slug %}
+                                {% if metric.has_errors %}
+                                  {% if forloop.parentloop.parentloop.first %}
+                                    <div class="d-flex align-items-center" style="height: 100px;">
+                                      <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                        <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                        <p class="mb-0 fw-semibold">Metric unavailable</p>
+                                        <p class="mb-0">Other metrics are unaffected.</p>
+                                        <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
+                                          Contact Experimenter Support
+                                        </button>
+                                      </div>
+                                    </div>
+                                  {% else %}
+                                    <div class="invisible" style="height: 100px;" aria-hidden="true"></div>
+                                  {% endif %}
+                                {% else %}
+                                  {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
+                                    {% if curr_branch_slug == branch.slug %}
+                                      {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
+
+                                    {% endif %}
+                                  {% endfor %}
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+                          {% endfor %}
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
             </div>
           </div>
         </div>
-      </div>
+      {% endif %}
     {% endwith %}
   {% endfor %}
 </div>


### PR DESCRIPTION
Because

- Metrics are grouped by the area on the backend but are not being rendered on the new results page

This commit

- Displays metrics grouped by their areas in addition to outcome
- Updates sidebar view to include the new metric areas
- Hides metric group cards if they are empty

Fixes #14256 