### PR TITLE
fix(nimbus): fix results page throwing error for delivery w/o results

### DIFF
--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -728,7 +728,7 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
         context = super().get_context_data(**kwargs)
         experiment = self.get_object()
 
-        analysis_data = experiment.results_data.get("v3", {})
+        analysis_data = (experiment.results_data or {}).get("v3", {})
 
         selected_reference_branch = self.request.GET.get(
             "reference_branch", experiment.reference_branch.slug


### PR DESCRIPTION
Because

- Accessing the new results page for an experiment w/o results_data throws an exception 

This commit

- Adds a safe fallback value for when results_data is missing

Fixes #14111 