### PR TITLE
feat(nimbus): add fallback text when segments are missing

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -37,6 +37,8 @@
         {% for segment in segments %}
           <option value="{{ segment }}"
                   {% if segment == selected_segment %}selected{% endif %}>{{ segment }}</option>
+        {% empty %}
+          <option value="" selected>No segments available</option>
         {% endfor %}
       </select>
     </div>


### PR DESCRIPTION
Because

- Not all experiments have segments set up and in those cases the segment filter is blank. It should instead show some helpful text

This commit

- Adds a fallback option for this case

Fixes #13940 