### PR TITLE
fix(nimbus): hide weekly metrics from displaying on results page popout card if not available

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1659,11 +1659,21 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     abs_list = branch_data.get("absolute") or []
                     rel_list = branch_data.get("relative") or []
 
-                    weekly_data[branch_slug] = list(
-                        zip_longest(abs_list, rel_list, fillvalue=None)
-                    )
+                    if abs_list or rel_list:
+                        weekly_data[branch_slug] = list(
+                            zip_longest(abs_list, rel_list, fillvalue=None)
+                        )
 
-                weekly_metric_data[metric_metadata["slug"]] = weekly_data
+                if weekly_data:
+                    weekly_metric_data[metric_metadata["slug"]] = {
+                        "has_weekly_data": True,
+                        "data": weekly_data,
+                    }
+                else:
+                    weekly_metric_data[metric_metadata["slug"]] = {
+                        "has_weekly_data": False,
+                        "data": {},
+                    }
 
         return weekly_metric_data
 

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -78,66 +78,68 @@
             </div>
           </div>
         </div>
-        <div class="accordion-item p-3 px-4 rounded-4 border border-1">
-          <h2 class="accordion-header">
-            <button class="accordion-button fw-bold shadow-none bg-transparent text-body"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse"
-                    aria-expanded="true"
-                    aria-controls="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
-              Weekly breakdown
-            </button>
-          </h2>
-          {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
-            <div class="accordion-collapse collapse show"
-                 id="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
-              <div class="accordion-body d-flex">
-                <div class="col-2">
-                  <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
-                  <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-                  {% with reference_branch_weekly=weekly_metric_data|dict_get:reference_branch %}
-                    {% for week in experiment.get_weekly_dates %}
-                      <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
-                           style="height: 100px">
-                        <small class="text-muted">Week {{ forloop.counter }}</small>
-                        <p class="mb-0">{{ week.0|date:"M j" }} - {{ week.1|date:"M j" }}</p>
-                      </div>
-                    {% endfor %}
-                  {% endwith %}
-                </div>
-                <div class="col position-relative w-25">
-                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
-                    {% if branch_data|length > 3 %}
-                      <div class="branch-fade branch-fade-left"></div>
-                      <div class="branch-fade branch-fade-right"></div>
-                    {% endif %}
-                    {% for branch in branch_data %}
-                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                        <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
-                        {% if branch.slug == selected_reference_branch %}
-                          <p class="fs-5 mb-3">Baseline</p>
-                        {% else %}
-                          <p class="fs-5">{{ branch.name }}</p>
-                        {% endif %}
-                        <div class="d-flex flex-column gap-3 w-100">
-                          {% for curr_branch_slug, branch_weekly_metric_data in weekly_metric_data.items %}
-                            {% if curr_branch_slug == branch.slug %}
-                              {% for weekly_data_point in branch_weekly_metric_data %}
-                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
-
-                              {% endfor %}
-                            {% endif %}
-                          {% endfor %}
+        {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
+          {% if weekly_metric_data.has_weekly_data %}
+            <div class="accordion-item p-3 px-4 rounded-4 border border-1">
+              <h2 class="accordion-header">
+                <button class="accordion-button fw-bold shadow-none bg-transparent text-body"
+                        type="button"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse"
+                        aria-expanded="true"
+                        aria-controls="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
+                  Weekly breakdown
+                </button>
+              </h2>
+              <div class="accordion-collapse collapse show"
+                   id="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
+                <div class="accordion-body d-flex">
+                  <div class="col-2">
+                    <p class="text-muted mb-0 invisible" aria-hidden="true">Metrics</p>
+                    <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+                    {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
+                      {% for week in experiment.get_weekly_dates %}
+                        <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                             style="height: 100px">
+                          <small class="text-muted">Week {{ forloop.counter }}</small>
+                          <p class="mb-0">{{ week.0|date:"M j" }} - {{ week.1|date:"M j" }}</p>
                         </div>
-                      </div>
-                    {% endfor %}
+                      {% endfor %}
+                    {% endwith %}
+                  </div>
+                  <div class="col position-relative w-25">
+                    <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
+                      {% if branch_data|length > 3 %}
+                        <div class="branch-fade branch-fade-left"></div>
+                        <div class="branch-fade branch-fade-right"></div>
+                      {% endif %}
+                      {% for branch in branch_data %}
+                        <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                          <p class="text-muted mb-0 text-truncate">{{ branch.name }}</p>
+                          {% if branch.slug == selected_reference_branch %}
+                            <p class="fs-5 mb-3">Baseline</p>
+                          {% else %}
+                            <p class="fs-5">{{ branch.name }}</p>
+                          {% endif %}
+                          <div class="d-flex flex-column gap-3 w-100">
+                            {% for curr_branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
+                              {% if curr_branch_slug == branch.slug %}
+                                {% for weekly_data_point in branch_weekly_metric_data %}
+                                  {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
+
+                                {% endfor %}
+                              {% endif %}
+                            {% endfor %}
+                          </div>
+                        </div>
+                      {% endfor %}
+                    </div>
                   </div>
                 </div>
               </div>
             </div>
-          {% endwith %}
-        </div>
+          {% endif %}
+        {% endwith %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
Because

- The current new results page ui assumes that all metrics contain weekly data which is not true. This results in empty "Weekly breakdown" sections that serve no purpose.

This commit

- Conditionally renders the "Weekly breakdown" component if the specific metric supports weekly results

Fixes #14257