### PR TITLE
fix(nimbus): fix absolute value being called on None

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1505,7 +1505,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         for i, data_point in enumerate(relative_data_list):
             lower = data_point.get("lower")
             upper = data_point.get("upper")
-            avg_rel_change = abs(data_point.get("point"))
+            avg_rel_change = (
+                abs(data_point.get("point")) if data_point.get("point") else None
+            )
             significance = significance_map.get(str(i + 1), "neutral")
             rel_entries.append(
                 {

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -335,6 +335,8 @@ def format_string(value, arg):
 
 @register.filter
 def to_percentage(value, precision=None):
+    if value is None or type(value) not in (int, float):
+        return "N/A"
     percentage_value = value * 100
 
     if precision is None:

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -160,6 +160,10 @@ class FilterTests(TestCase):
         self.assertEqual(to_percentage(0.123), "12.3%")
         self.assertEqual(to_percentage(0.12), "12.0%")
 
+    def test_to_percentage_invalid(self):
+        self.assertEqual(to_percentage("invalid"), "N/A")
+        self.assertEqual(to_percentage(None), "N/A")
+
     def test_dict_get(self):
         sample_dict = {"key1": "value1", "key2": "value2"}
         self.assertEqual(dict_get(sample_dict, "key1"), "value1")


### PR DESCRIPTION
Because

- Some metric points do not contain the `point` field and are throwing errors b/c the current code assumes otherwise
- The issue here is that `abs()` is attempting to be called on these values which throw errors when `point` is None

This commit

- Adds a guard to check if the accessed point is None before calling `abs`

Fixes #14240 