### PR TITLE
feat(nimbus): stricter status transitions

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -22,6 +22,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Name maps to a pre-existing slug, please choose another name."
     )
     ERROR_TAG_DUPLICATE_NAME = "Tag with this Name already exists."
+    ERROR_INVALID_STATE_TRANSITION = (
+        "Cannot perform this action: experiment must be in state {required_state}, "
+        "but is currently in state {current_state}."
+    )
 
     RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
     REVIEW_URL = "https://experimenter.info/access"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -29,11 +29,16 @@
   {% endif %}
   {% if update_status_form_errors %}
     <div class="alert alert-danger" role="alert">
-      <p class="mb-1">Could not request an update for this experiment:</p>
-      {{ update_status_form_errors }}
-      <p class="mb-0">
-        Please fix the above issues or ask in <code>#ask-experimenter</code>.
+      <p class="mb-2">
+        That action could not be completed because the experiment has changed.
+        <a class="text-decoration-none"
+           data-bs-toggle="collapse"
+           href="#error-details"
+           role="button"
+           aria-expanded="false"
+           aria-controls="error-details">See more <i class="fa-solid fa-chevron-down"></i></a>
       </p>
+      <div class="collapse mt-2" id="error-details">{{ update_status_form_errors }}</div>
     </div>
   {% endif %}
   {% with rejection=experiment.rejection_block %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -93,9 +93,9 @@ class LiveToEndEnrollmentViewTests(AuthTestCase):
             reverse("nimbus-ui-live-to-end-enrollment", kwargs={"slug": experiment.slug})
         )
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.context["update_status_form_errors"],
-            [NimbusExperiment.ERROR_CANNOT_PAUSE_NOT_LIVE],
+        self.assertIn(
+            "Cannot perform this action: experiment must be in state",
+            response.context["update_status_form_errors"][0],
         )
 
         experiment.refresh_from_db()
@@ -2336,7 +2336,7 @@ class TestLaunchViews(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
         self.assertEqual(experiment.status, NimbusExperiment.Status.PREVIEW)
-        self.assertEqual(experiment.status_next, NimbusExperiment.Status.PREVIEW)
+        self.assertEqual(experiment.status_next, None)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
 
         self.mock_klaatu_task.assert_called_once_with(experiment_id=experiment.id)
@@ -2362,7 +2362,7 @@ class TestLaunchViews(AuthTestCase):
     def test_preview_to_review(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.PREVIEW,
-            status_next=NimbusExperiment.Status.PREVIEW,
+            status_next=None,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
@@ -2378,7 +2378,7 @@ class TestLaunchViews(AuthTestCase):
     def test_preview_to_draft(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.PREVIEW,
-            status_next=NimbusExperiment.Status.PREVIEW,
+            status_next=None,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
         )
 
@@ -2388,7 +2388,7 @@ class TestLaunchViews(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
         self.assertEqual(experiment.status, NimbusExperiment.Status.DRAFT)
-        self.assertEqual(experiment.status_next, NimbusExperiment.Status.DRAFT)
+        self.assertEqual(experiment.status_next, None)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
 
         self.mock_preview_task.assert_called_once_with(countdown=5)
@@ -2406,7 +2406,7 @@ class TestLaunchViews(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
         self.assertEqual(experiment.status, NimbusExperiment.Status.DRAFT)
-        self.assertEqual(experiment.status_next, NimbusExperiment.Status.DRAFT)
+        self.assertEqual(experiment.status_next, None)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
 
     def test_review_to_approve_view(self):


### PR DESCRIPTION
Becuase

* With more experiments comes more collisions with multiple users pressing buttons quickly
* We do not have strict requirements for each status transition form
* This means things can be approved multiple times by multiple users concurrently
* This can leave experiments in broken states if users collide
* We should add strict conditions to every state transition form so a state transition can only occur once

This commit

* Adds required entry states for every status transition form based on the states defined in the diagrams
* Updates the UI to show more detailed information if a status collision occurs
* Updates tests

fixes #14227

