### PR TITLE
chore(nimbus): auto rerun failed integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -950,6 +950,7 @@ workflows:
       - update_firefox_fennec_release
 
   build:
+    max_auto_reruns: 1
     jobs:
       - check_experimenter_x86_64:
           name: Check Experimenter x86_64


### PR DESCRIPTION
Becuase

* Integration tests can intermittently fail for any number of reasons including intermittent network/build/test failures
* Often we have to rerun the failed tests by hand to get them to pass
* We can have circle automatically rerun once if a test fails, which should reduce manual toil

This commit

* Adds the auto rerun flag for all integration tests in circleci

fixes #14191
