### PR TITLE
feat(nimbus): Fix pagination targeting on home page sections

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/home_experiments_layout.html
@@ -51,8 +51,9 @@
                 <button class="page-link"
                         type="button"
                         hx-get="?{{ pagination_param }}={{ page_obj.previous_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
-                        hx-target="#draft-preview-ready-for-attention"
-                        hx-select="#draft-preview-ready-for-attention"
+                        hx-target="{% if pagination_param == 'draft_page' %}#draft-preview{% elif pagination_param == 'attention_page' %}#ready-for-attention{% endif %}"
+                        hx-select="{% if pagination_param == 'draft_page' %}#draft-preview{% elif pagination_param == 'attention_page' %}#ready-for-attention{% endif %}"
+                        hx-swap="outerHTML"
                         hx-push-url="true">
                   <i class="fa-solid fa-angle-left"></i>
                 </button>
@@ -72,8 +73,9 @@
                 <button class="page-link"
                         type="button"
                         hx-get="?{{ pagination_param }}={{ page_obj.next_page_number }}{% if pagination_param != 'draft_page' and request.GET.draft_page %}&draft_page={{ request.GET.draft_page }}{% endif %}{% if pagination_param != 'attention_page' and request.GET.attention_page %}&attention_page={{ request.GET.attention_page }}{% endif %}{% if pagination_param != 'my_deliveries_page' and request.GET.my_deliveries_page %}&my_deliveries_page={{ request.GET.my_deliveries_page }}{% endif %}"
-                        hx-target="#draft-preview-ready-for-attention"
-                        hx-select="#draft-preview-ready-for-attention"
+                        hx-target="{% if pagination_param == 'draft_page' %}#draft-preview{% elif pagination_param == 'attention_page' %}#ready-for-attention{% endif %}"
+                        hx-select="{% if pagination_param == 'draft_page' %}#draft-preview{% elif pagination_param == 'attention_page' %}#ready-for-attention{% endif %}"
+                        hx-swap="outerHTML"
                         hx-push-url="true">
                   <i class="fa-solid fa-angle-right"></i>
                 </button>


### PR DESCRIPTION
Because
- Pagination on Draft/Preview and Ready for Attention sections was causing layout shifts
- HTMX was targeting the parent container of both sections, causing both cards to re-render
- Default innerHTML swap was creating duplicate nested divs with the same ID

This commit
- Changes pagination hx-target to specific section IDs (#draft-preview or #ready-for-attention)
- Adds hx-swap="outerHTML" to properly replace entire target element
- Ensures pagination only updates the clicked section without affecting the other

Fixes #13751 