### PR TITLE
chore(cirrus): use cirrus image built by make in docker compose

### DIFF
--- a/docker-compose-cirrus.yml
+++ b/docker-compose-cirrus.yml
@@ -2,11 +2,7 @@ version: "3"
 
 services:
   cirrus:
-    build:
-      additional_contexts:
-        - fml=experimenter/experimenter/features/manifests/
-      context: cirrus/server/
-      dockerfile: Dockerfile
+    image: cirrus:deploy
     env_file: .env
     depends_on:
       - kinto

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,11 +129,7 @@ services:
       - "8000:8000"
 
   cirrus-experimenter:
-    build:
-      additional_contexts:
-        - fml=experimenter/experimenter/features/manifests/
-      context: cirrus/server/
-      dockerfile: Dockerfile
+    image: cirrus:deploy
     env_file: .env
     environment:
       CIRRUS_APP_ID: experimenter.cirrus


### PR DESCRIPTION
Because

- outdated cirrus docker images should be automatically built by make

This commit

- Changes make targets to depend on `cirrus_build`
- Changes the docker compose files to use the image generated from `make cirrus_build`, which matches how experimenter does it
- Changes make targets that don't need dependencies use `--no-deps` so they don't need to depend on `cirrus_build` because cirrus won't be started
- Adds make target `cirrus_up_detached`

Fixes #14269