### PR TITLE
bug(cirrus): add nimbus user id as separate metric for shredder

### DIFF
--- a/cirrus/server/cirrus/main.py
+++ b/cirrus/server/cirrus/main.py
@@ -200,10 +200,13 @@ def collate_enrollment_metric_data(
     return data
 
 
-async def record_metrics(enrollment_data: list[EnrollmentMetricData]):
+async def record_metrics(
+    enrollment_data: list[EnrollmentMetricData], nimbus_user_id: str
+):
     app.state.enrollment_ping.record(
         user_agent=None,
         ip_address=None,
+        nimbus_nimbus_user_id=nimbus_user_id,
         events=[
             {
                 "category": "cirrus_events",
@@ -267,7 +270,7 @@ async def compute_features_enrollments(
     )
 
     # Record metrics
-    await record_metrics(enrollment_data)
+    await record_metrics(enrollment_data, request_data.client_id)
 
     return {
         "features": client_feature_configuration,

--- a/cirrus/server/cirrus/sdk.py
+++ b/cirrus/server/cirrus/sdk.py
@@ -19,9 +19,22 @@ class CirrusMetricsHandler(MetricsHandler):
     def record_enrollment_statuses(
         self, enrollment_status_extras: list[EnrollmentStatusExtraDef]
     ):
+        self.record_enrollment_statuses_v2(
+            enrollment_status_extras=enrollment_status_extras,
+            nimbus_user_id=(
+                enrollment_status_extras[0].user_id if enrollment_status_extras else None
+            ),
+        )
+
+    def record_enrollment_statuses_v2(
+        self,
+        enrollment_status_extras: list[EnrollmentStatusExtraDef],
+        nimbus_user_id: str | None,
+    ):
         self.enrollment_status_ping.record(
             user_agent=None,
             ip_address=None,
+            nimbus_nimbus_user_id=nimbus_user_id,
             events=[
                 {
                     "category": "cirrus_events",

--- a/cirrus/server/telemetry/metrics.yaml
+++ b/cirrus/server/telemetry/metrics.yaml
@@ -104,3 +104,21 @@ cirrus_events:
     send_in_pings:
       - startup
 
+nimbus:
+  nimbus_user_id:
+    description: The ID of the user requesting enrollment
+    type: string
+    bugs:
+      - https://mozilla-hub.atlassian.net/browse/EXP-6305
+      - https://github.com/mozilla/experimenter/issues/14279
+    data_reviews:
+      - https://github.com/mozilla/experimenter/pull/9081#issuecomment-1625751843
+    data_sensitivity:
+      - technical
+    notification_emails:
+      - jlockhart@mozilla.com
+      - project-nimbus@mozilla.com
+    expires: never
+    send_in_pings:
+      - enrollment
+      - enrollment-status

--- a/cirrus/server/tests/test_telemetry.py
+++ b/cirrus/server/tests/test_telemetry.py
@@ -38,11 +38,12 @@ async def test_enrollment_metrics_recorded_with_record_metrics(mocker, recipes):
         ),
     ]
 
-    await record_metrics(enrollment_data)
+    await record_metrics(enrollment_data, "test_client_id")
 
     record_mock.assert_called_once_with(
         user_agent=None,
         ip_address=None,
+        nimbus_nimbus_user_id="test_client_id",
         events=[
             {
                 "category": "cirrus_events",
@@ -151,7 +152,9 @@ async def test_enrollment_metrics_recorded_with_compute_features_v1(
     response = client.post("/v1/features/", json=request_data)
     assert response.status_code == 200
     record_spy.assert_called_once()
-    assert len(events := record_spy.mock_calls[0].kwargs["events"]) == 2
+    call = record_spy.mock_calls[0]
+    assert call.kwargs.get("nimbus_nimbus_user_id") == "test_client_id"
+    assert len(events := call.kwargs["events"]) == 2
     assert events[0]["extra"]["is_preview"] == "false"
     assert events[1]["extra"]["is_preview"] == "false"
 
@@ -162,7 +165,9 @@ async def test_enrollment_metrics_recorded_with_compute_features_v1(
     response = client.post("/v1/features/?nimbus_preview=true", json=request_data)
     assert response.status_code == 200
     record_spy.assert_called_once()
-    assert len(events := record_spy.mock_calls[0].kwargs["events"]) == 2
+    call = record_spy.mock_calls[0]
+    assert call.kwargs.get("nimbus_nimbus_user_id") == "test_client_id"
+    assert len(events := call.kwargs["events"]) == 2
     assert events[0]["extra"]["is_preview"] == "true"
     assert events[1]["extra"]["is_preview"] == "true"
 
@@ -198,7 +203,9 @@ async def test_enrollment_metrics_recorded_with_compute_features_v2(
     response = client.post("/v2/features/", json=request_data)
     assert response.status_code == 200
     record_spy.assert_called_once()
-    assert len(events := record_spy.mock_calls[0].kwargs["events"]) == 2
+    call = record_spy.mock_calls[0]
+    assert call.kwargs.get("nimbus_nimbus_user_id") == "test_client_id"
+    assert len(events := call.kwargs["events"]) == 2
     assert events[0]["extra"]["is_preview"] == "false"
     assert events[1]["extra"]["is_preview"] == "false"
 
@@ -209,7 +216,9 @@ async def test_enrollment_metrics_recorded_with_compute_features_v2(
     response = client.post("/v2/features/?nimbus_preview=true", json=request_data)
     assert response.status_code == 200
     record_spy.assert_called_once()
-    assert len(events := record_spy.mock_calls[0].kwargs["events"]) == 2
+    call = record_spy.mock_calls[0]
+    assert call.kwargs.get("nimbus_nimbus_user_id") == "test_client_id"
+    assert len(events := call.kwargs["events"]) == 2
     assert events[0]["extra"]["is_preview"] == "true"
     assert events[1]["extra"]["is_preview"] == "true"
 


### PR DESCRIPTION
Because

- shredder needs nimbus user id to be accessible in a non-map field (i.e. not in event extras)

This commit

- Changes cirrus to send nimbus user id metric on enrollment and enrollment-status pings
- Adds a new record_enrollment_statuses_v2 method on CirrusMetricsHandler so that rust can pass nimbus user id in when there's no events

Fixes #14279