### PR TITLE
chore(nimbus): force toasts to stay on top

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -406,7 +406,7 @@
 
   </div>
   {% if save_failed %}
-    <div class="toast text-bg-danger position-fixed top-0 end-0 m-3 w-auto"
+    <div class="toast text-bg-danger position-fixed top-0 end-0 m-3 w-auto z-3"
          role="alert"
          aria-live="assertive"
          aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -271,7 +271,7 @@
       </div>
       {% if form.is_bound %}
         {% if form.is_valid %}
-          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">
@@ -282,7 +282,7 @@
           </div>
         {% endif %}
         {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -392,7 +392,7 @@
       </div>
       {% if form.is_bound %}
         {% if form.is_valid %}
-          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">
@@ -403,7 +403,7 @@
           </div>
         {% endif %}
         {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -109,7 +109,7 @@
       </div>
       {% if form.is_bound %}
         {% if form.is_valid %}
-          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">
@@ -120,7 +120,7 @@
           </div>
         {% endif %}
         {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -199,7 +199,7 @@
       </div>
       {% if form.is_bound %}
         {% if form.is_valid %}
-          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto"
+          <div class="toast text-bg-success position-fixed top-0 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">
@@ -210,7 +210,7 @@
           </div>
         {% endif %}
         {% if not form.is_valid or validation_errors %}
-          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto"
+          <div class="toast text-bg-danger position-fixed top-1 end-0 m-3 w-auto z-3"
                role="alert"
                aria-live="assertive"
                aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -78,7 +78,7 @@
     </div>
   </div>
   <div id="slug-toast"
-       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto"
+       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto z-3"
        role="alert"
        aria-live="assertive"
        aria-atomic="true">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -292,7 +292,7 @@
   </form>
 </div>
 <div id="preview-toast"
-     class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto"
+     class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto z-3"
      role="alert"
      aria-live="assertive"
      aria-atomic="true">


### PR DESCRIPTION
Becuase

* The toasts were getting covered by content if you scroll

This commit

* Forces toasts to the top

fixes #13908

