### PR TITLE
chore(nimbus): add devtools link to header

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -73,6 +73,15 @@
             </a>
           </li>
           <li>
+            <a href="https://github.com/mozilla-extensions/nimbus-devtools/releases/tag/release%2Fv0.3.0"
+               class="dropdown-item link-primary"
+               target="_blank"
+               rel="noreferrer">
+              <i class="fa-solid fa-wrench me-2"></i>
+              Nimbus Devtools
+            </a>
+          </li>
+          <li>
             <a href="{% url "nimbus-experiments-csv" %}"
                class="dropdown-item link-primary"
                target="_blank"


### PR DESCRIPTION
Becuase

* We should add a link to the devtools to the link drop down so users can find devtools easily

This commit

* Adds a link to devtools to the link dropdown

fixes #13996
