### PR TITLE
bug(nimbus): update missing details when saving

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/with_sidebar.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div id="content" class="container-fluid">
-    <div class="row">
+    <div id="content-with-sidebar" class="row">
       <div class="col-xl-2 col-xxl-2 pe-3">
         <div class="offcanvas-xl offcanvas-start bg-body-tertiary sticky-xl-top pt-xl-4"
              tabindex="-1"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -20,8 +20,9 @@
     <form id="audience-form"
           {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
           hx-post="{% url 'nimbus-ui-update-audience' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-          hx-select="#audience-form"
-          hx-target="#audience-form">
+          hx-select="#content-with-sidebar"
+          hx-target="#content-with-sidebar"
+          hx-swap="innerHTML">
       {% csrf_token %}
       <div class="card mb-3">
         <div class="card-header">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -22,9 +22,9 @@
           {% if form.is_bound %}class="was-validated"{% endif %}
           hx-encoding="multipart/form-data"
           hx-post="{% url 'nimbus-ui-update-branches' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-          hx-select="#branches-form"
-          hx-target="#branches-form"
-          hx-swap="outerHTML">
+          hx-select="#content-with-sidebar"
+          hx-target="#content-with-sidebar"
+          hx-swap="innerHTML">
       {% csrf_token %}
       <div class="card mb-3">
         <div class="card-header">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -18,9 +18,9 @@
     <!-- Experiment Details Card -->
     <form id="metrics-form"
           hx-post="{% url 'nimbus-ui-update-metrics' experiment.slug %}"
-          hx-select="#metrics-form"
-          hx-target="#metrics-form"
-          hx-swap="outerHTML">
+          hx-select="#content-with-sidebar"
+          hx-target="#content-with-sidebar"
+          hx-swap="innerHTML">
       {% csrf_token %}
       {{ form.errors }}
       <div class="card mb-3">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -20,9 +20,9 @@
     <form id="overview-form"
           {% if form.is_bound and form.is_valid %}class="was-validated"{% endif %}
           hx-post="{% url 'nimbus-ui-update-overview' experiment.slug %}{% if request.GET.show_errors == 'true' %}?show_errors=true{% endif %}"
-          hx-select="#overview-form"
-          hx-target="#overview-form"
-          hx-swap="outerHTML">
+          hx-select="#content-with-sidebar"
+          hx-target="#content-with-sidebar"
+          hx-swap="innerHTML">
       {% csrf_token %}
       <div class="card mb-3">
         <div class="card-header">


### PR DESCRIPTION
Becuase

* If you go to a form that is missing details and fill them in and save
* The missing details does not update unless you refresh the page or navigate away
* This is confusing

This commit

* Updates the sidebar and form on save so the missing details section updates as well

fixes #14062

