### PR TITLE
feat(nimbus): Show test url even if QA status is not set

### DIFF
--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -911,7 +911,9 @@ class NimbusFeaturesView(TemplateView):
         deliveries_page_obj = deliveries_paginator.get_page(deliveries_page_number)
 
         experiments_with_qa_status = qs.exclude(
-            qa_status=NimbusExperiment.QAStatus.NOT_SET.value
+            qa_status=NimbusExperiment.QAStatus.NOT_SET.value,
+            qa_run_test_plan_url__isnull=True,
+            qa_run_testrail_url__isnull=True,
         )
 
         qa_runs_paginator = Paginator(experiments_with_qa_status, 5)


### PR DESCRIPTION
Because

- If you set the new test rail url fields but leave QA Status as 'not set', no urls appear in in the 'qa runs' table on the feature page.

This commit

- Enables the entry of QA section if we have the urls available

Fixes #14235