### PR TITLE
fix(nimbus): fix sidebar using null values

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1281,18 +1281,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     {"title": "Project Impact"},
                 ],
             },
-            *[
-                {
-                    "title": area,
-                    "subitems": [
-                        {"title": metric["friendly_name"], "slug": metric["slug"]}
-                        for metric in metrics
-                    ],
-                }
-                for area, metrics in self.get_metric_areas(
-                    "enrollments", "all", self.reference_branch
-                ).items()
-            ],
         ]
 
     def timeline(self):


### PR DESCRIPTION
Because

- The sidebar is attempting to get the metric areas which are only obtainable for experiments with results data
- Because the sidebar is visible on all experiment pages it attempts to get the metric areas and falls through code that expects non-null values and thus throws errors

This commit

- Removes the block of code that tries to get the metric areas

Fixes #14304