### PR TITLE
bug(cirrus): use 9-character sha for docker image tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -733,7 +733,7 @@ jobs:
 
             gcloud auth configure-docker us-docker.pkg.dev --quiet
 
-            GIT_SHA=$(git rev-parse --short HEAD)
+            GIT_SHA=$(git rev-parse --short=9 HEAD)
 
             for DOCKER_IMAGE in "us-docker.pkg.dev/moz-fx-cirrus-prod/cirrus-prod/cirrus" "${DOCKERHUB_CIRRUS_REPO}"; do
               docker tag cirrus:deploy ${DOCKER_IMAGE}:latest


### PR DESCRIPTION
Because

- argocd only checks for images with 9 character sha

This commit

- Change GIT_SHA command for cirrus to specify 9 characters

Fixes #14307