### PR TITLE
chore(nimbus): reorder detail header

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_response.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_response.html
@@ -2,4 +2,4 @@
 {% include "common/tag_button.html" with tag_count=experiment.tags.count %}
 
 <!-- This updates the tags display using out-of-band swap -->
-{% include "nimbus_experiments/experiment_tags.html" with hx_swap_oob=True %}
+{% include "nimbus_experiments/experiment_tags.html" with hx_swap_oob=True show_status_badges=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -7,7 +7,7 @@
 
 {% endblock %}
 {% block main_content_header %}
-  <div class="d-flex justify-content-between flex-column flex-xxl-row column-gap-3">
+  <div class="d-flex justify-content-between flex-column flex-xxl-row column-gap-3 mb-2">
     <div>
       <h4 class="mb-0">{{ experiment.name }}</h4>
       <div class="d-flex align-items-center">
@@ -19,11 +19,8 @@
           <i class="fa-solid fa-copy"></i>
         </button>
       </div>
-      <span id="qa-status-header" class="{{ experiment.qa_status_badge_class }}">
-        QA Status: {{ experiment.qa_status|default:"Not Set"|title }}
-      </span>
       {% if experiment.parent %}
-        <p class="text-secondary small mb-0 mt-2">
+        <p class="text-secondary small mb-0">
           Cloned from
           <a href="{% url 'nimbus-ui-detail' experiment.parent.slug %}"
              target="_blank"
@@ -38,18 +35,8 @@
     </div>
   </div>
   <div class="row mb-2">
-    <div class="col-lg-8">
-      {% if experiment.is_archived %}
-        <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
-      {% endif %}
-      {% if experiment.is_rollout %}<span class="badge rounded-pill bg-primary" id="rollout-badge">Rollout</span>{% endif %}
-      {% if experiment.project_impact %}
-        <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact</span>
-      {% endif %}
-      {% if experiment.is_rollout_dirty %}
-        <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
-      {% endif %}
-      {% include "nimbus_experiments/experiment_tags.html" %}
+    <div class="col-lg-8 d-flex flex-wrap gap-1 align-items-center">
+      {% include "nimbus_experiments/experiment_tags.html" with show_status_badges=True %}
 
     </div>
     <div class="col-lg-4 d-flex align-items-start justify-content-lg-end">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -1,16 +1,29 @@
 <div id="experiment-tags"
-     class="mt-2"
+     class="d-flex flex-wrap gap-1 align-items-center"
      {% if hx_swap_oob %}hx-swap-oob="true"{% endif %}>
+  {% if show_status_badges %}
+    <span id="qa-status-header" class="{{ experiment.qa_status_badge_class }}">
+      QA Status: {{ experiment.qa_status|default:"Not Set"|title }}
+    </span>
+    {% if experiment.is_archived %}
+      <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
+    {% endif %}
+    {% if experiment.is_rollout %}<span class="badge rounded-pill bg-primary" id="rollout-badge">Rollout</span>{% endif %}
+    {% if experiment.project_impact %}
+      <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact</span>
+    {% endif %}
+    {% if experiment.is_rollout_dirty %}
+      <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
+    {% endif %}
+  {% endif %}
   {% if experiment.tags.exists %}
-    <div class="d-flex flex-wrap gap-1">
-      {% for tag in experiment.tags.all %}
-        <span class="badge"
-              style="background-color: {{ tag.color }};
-                     color: white;
-                     font-size: 0.75rem">{{ tag.name }}</span>
-      {% endfor %}
-    </div>
-  {% elif not hide_no_tags %}
+    {% for tag in experiment.tags.all %}
+      <span class="badge rounded-pill"
+            style="background-color: {{ tag.color }};
+                   color: white;
+                   font-size: 0.75rem">{{ tag.name }}</span>
+    {% endfor %}
+  {% elif not hide_no_tags and not show_status_badges %}
     <span class="text-muted small">No tags assigned</span>
   {% endif %}
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/table.html
@@ -42,7 +42,8 @@
       {% for experiment in experiments %}
         <tr>
           <th scope="row">
-            <a href="{% url "nimbus-ui-detail" slug=experiment.slug %}">{{ experiment.name }}</a>
+            <a href="{% url "nimbus-ui-detail" slug=experiment.slug %}"
+               class="d-block mb-1">{{ experiment.name }}</a>
             {% include "nimbus_experiments/experiment_tags.html" with hide_no_tags=True %}
 
             {% if active_status == "MyExperiments" %}


### PR DESCRIPTION
Becuase

* We can clean up the detail header a bit more if we put all the badges together on one line

This fix

* Moves the qa status and rollout badges in with the tags
* Applies the same styling to all badges for consistency

fixes #14309

