### PR TITLE
feat(nimbus): move selected options to top

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -42,6 +42,14 @@ from experimenter.targeting.constants import NimbusTargetingConfig
 metrics = markus.get_metrics("experimenter.nimbus_ui_forms")
 
 
+class SelectedFirstMixin:
+    def optgroups(self, name, value, attrs=None):
+        groups = super().optgroups(name, value, attrs)
+        selected = [g for g in groups if any(o.get("selected") for o in g[1])]
+        unselected = [g for g in groups if not any(o.get("selected") for o in g[1])]
+        return [*selected, *unselected]
+
+
 class NimbusChangeLogFormMixin:
     def __init__(self, *args, request: HttpRequest = None, **kwargs):
         super().__init__(*args, **kwargs)
@@ -301,7 +309,7 @@ class SignoffForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return f"{self.request.user} updated sign off"
 
 
-class MultiSelectWidget(forms.SelectMultiple):
+class MultiSelectWidget(SelectedFirstMixin, forms.SelectMultiple):
     class_attrs = "selectpicker form-control"
 
     def __init__(self, *args, attrs=None, **kwargs):
@@ -317,7 +325,7 @@ class MultiSelectWidget(forms.SelectMultiple):
         super().__init__(*args, attrs=attrs, **kwargs)
 
 
-class SingleSelectWidget(forms.Select):
+class SingleSelectWidget(SelectedFirstMixin, forms.Select):
     class_attrs = "selectpicker form-control"
 
     def __init__(self, *args, attrs=None, **kwargs):

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -146,6 +146,27 @@ class MetricsMockMixin:
         self.addCleanup(self.mock_metrics.stop)
 
 
+class TestSelectedFirstMixin(TestCase):
+    def test_selected_options_appear_first(self):
+        LocaleFactory.create(code="en-US", name="English (US)")
+        LocaleFactory.create(code="de-DE", name="German (Germany)")
+        locale1 = LocaleFactory.create(code="fr-FR", name="French (France)")
+        locale2 = LocaleFactory.create(code="es-ES", name="Spanish (Spain)")
+
+        experiment = NimbusExperimentFactory.create()
+        experiment.locales.set([locale1, locale2])
+
+        form = AudienceForm(instance=experiment)
+        bound_field = form["locales"]
+
+        first_two_ids = {
+            int(str(bound_field[0].data["value"])),
+            int(str(bound_field[1].data["value"])),
+        }
+
+        self.assertEqual(first_two_ids, {locale1.id, locale2.id})
+
+
 class TestNimbusExperimentCreateForm(RequestFormTestCase):
     def test_valid_form_creates_experiment_with_changelog(self):
         data = {


### PR DESCRIPTION
Becuase

* The bootstrap select widget we're using doesn't have any easy way to unselect options
* You have to scroll way down to find the selected options
* This is tough on long lists

This commit

* Moves selected otions to the top to make them easy to find

fixes #14315

