### PR TITLE
bug(cirrus): always make nimbus_nimbus_user_id a string

### DIFF
--- a/cirrus/server/cirrus/sdk.py
+++ b/cirrus/server/cirrus/sdk.py
@@ -34,7 +34,7 @@ class CirrusMetricsHandler(MetricsHandler):
         self.enrollment_status_ping.record(
             user_agent=None,
             ip_address=None,
-            nimbus_nimbus_user_id=nimbus_user_id,
+            nimbus_nimbus_user_id=nimbus_user_id or "",
             events=[
                 {
                     "category": "cirrus_events",


### PR DESCRIPTION
Because

- telemetry pipeline is throwing out enrollment status pings with null nimbus.nimbus_user_id as errors

This commit

- Changes fallback value of nimbus_nimbus_user_id from None to ""

Fixes #14325