### PR TITLE
feat(nimbus): add copy button to readonly json

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
@@ -68,6 +68,23 @@ export const setupReadonlyJsonEditors = () => {
     const view = createReadonlyJsonEditor(textarea);
     if (view) {
       setupCodemirrorCollapsibleDisplay(textarea);
+      setupCopyButton(textarea, view);
     }
+  });
+};
+
+const setupCopyButton = (textarea, view) => {
+  const copyButton = textarea.parentNode.querySelector(".codemirror-copy-btn");
+  if (!copyButton) return;
+
+  copyButton.addEventListener("click", () => {
+    const content = view.state.doc.toString();
+    navigator.clipboard.writeText(content).then(() => {
+      const toast = document.getElementById("json-copy-toast");
+      if (toast) {
+        const bsToast = window.bootstrap.Toast.getOrCreateInstance(toast);
+        bsToast.show();
+      }
+    });
   });
 };

--- a/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
@@ -1,0 +1,8 @@
+<div class="position-relative">
+  <textarea class="readonly-json">{{ json_content }}</textarea>
+  <button type="button"
+          class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-1 py-0 px-1 codemirror-copy-btn"
+          aria-label="Copy JSON">
+    <i class="fa-solid fa-copy"></i>
+  </button>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -46,7 +46,8 @@
                   id="preview-recipe-json"
                   class="collapsed-json {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
                 <div style="max-height: 120px; overflow: hidden;">
-                  <textarea class="readonly-json">{{ feature_value.value }}</textarea>
+                  {% include "common/readonly_json.html" with json_content=feature_value.value %}
+
                 </div>
                 <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
                   <i class="fa-solid fa-plus"></i> Show more
@@ -56,7 +57,8 @@
                   id="preview-recipe-json"
                   class="expanded-json d-none mw-0 {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
                 <div class="text-break">
-                  <textarea class="readonly-json w-100">{{ feature_value.value }}</textarea>
+                  {% include "common/readonly_json.html" with json_content=feature_value.value %}
+
                 </div>
                 <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
                   <i class="fa-solid fa-minus"></i> Show less

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
@@ -138,7 +138,8 @@
             id="preview-recipe-json"
             class="collapsed-json border-bottom-0">
           <div style="max-height: 120px; overflow: hidden;">
-            <textarea class="readonly-json">{{ experiment.recipe_json }}</textarea>
+            {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+
           </div>
           <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
             <i class="fa-solid fa-plus"></i> Show more
@@ -148,7 +149,8 @@
             id="preview-recipe-json"
             class="expanded-json d-none mw-0 border-bottom-0">
           <div class="text-break">
-            <textarea class="readonly-json w-100">{{ experiment.recipe_json }}</textarea>
+            {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+
           </div>
           <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
             <i class="fa-solid fa-minus"></i> Show less

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_localizations.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_localizations.html
@@ -14,7 +14,8 @@
         <th class="border-bottom-0">Localizations JSON</th>
         <td colspan="3" class="mw-0 border-bottom-0">
           <div class="mw-100 overflow-auto">
-            <textarea class="readonly-json">{{ experiment.localizations|default:"null" }}</textarea>
+            {% include "common/readonly_json.html" with json_content=experiment.localizations|default:"null" %}
+
           </div>
         </td>
       </tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -75,6 +75,16 @@
       Slug copied to clipboard!
     </div>
   </div>
+  <div id="json-copy-toast"
+       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto z-3"
+       role="alert"
+       aria-live="assertive"
+       aria-atomic="true">
+    <div class="toast-body">
+      <i class="fa-regular fa-circle-check"></i>
+      JSON copied to clipboard!
+    </div>
+  </div>
   <div class="modal fade"
        id="cloneModal"
        tabindex="-1"


### PR DESCRIPTION
Becuase

* It would be handy to be able to copy the contents of any read only json field
* It's difficult to select the text directly

This commit

* Adds a copy button to every read only json field

fixes #14202

