### PR TITLE
feat(nimbus): display when secure collection reviewers required

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/approval_rejection_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/approval_rejection_controls.html
@@ -33,6 +33,11 @@
         <p>
           <strong>{{ experiment.latest_review_requested_by|add:" requested to" }} {{ experiment.review_messages }}</strong>
         </p>
+        {% if uses_secure_collection %}
+          <p class="mb-2">
+            <strong>Note:</strong> This must be reviewed by a member of the Release Management Team.
+          </p>
+        {% endif %}
         <button type="button"
                 class="btn btn-success"
                 hx-post="{% url approval_url slug=experiment.slug %}"

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1473,6 +1473,24 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
             "`is_ready_to_launch` should be False when the review serializer is invalid",
         )
 
+    def test_uses_secure_collection_context_for_prefflips_feature(self):
+        secure_feature = NimbusFeatureConfigFactory.create(
+            slug="prefFlips",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create(
+            slug="secure-experiment",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[secure_feature],
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.context["uses_secure_collection"])
+
 
 class TestNimbusExperimentsCreateView(AuthTestCase):
     def test_post_creates_experiment(self):

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -291,6 +291,9 @@ def build_experiment_context(experiment):
         "primary_outcome_links": primary_outcome_links,
         "secondary_outcome_links": secondary_outcome_links,
         "segment_links": segment_links,
+        "uses_secure_collection": (
+            experiment.kinto_collection == settings.KINTO_COLLECTION_NIMBUS_SECURE
+        ),
     }
     return context
 


### PR DESCRIPTION
Because

* Some features require reviews by relman in the secure collection
* It would be handy to display that on the review controls so a reviewer knows

This commit

* Adds a note to the review controls when review by relman in the secure collection is required

fixes #14037

