### PR TITLE
bug(nimbus): update to live to complete to support paused

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1611,7 +1611,7 @@ class LiveToCompleteForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
-    required_is_paused = False
+    required_is_paused = None
 
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.COMPLETE


### PR DESCRIPTION
Becuase

* When we added the strict transitions we missed making paused optional for going from live to complete

This commit

* Removes the paused requirement from live to complete status transition form

fixes #14346

