### PR TITLE
bug(nimbus): Update the advanced targeting config for ANDROID_EXISTING_USERS_NOT_ACCEPTED_TERMS_OF_USE_OVER_ONE_POINT

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2779,7 +2779,7 @@ ANDROID_EXISTING_USERS_NOT_ACCEPTED_TERMS_OF_USE_OVER_ONE_POINT = NimbusTargetin
     targeting=(
         "user_accepted_tou == false && "
         "days_since_install >= 28 && "
-        "("
+        "(tou_points > 1 || "
         "("
         "tou_points == 1 && "
         "("
@@ -2794,7 +2794,7 @@ ANDROID_EXISTING_USERS_NOT_ACCEPTED_TERMS_OF_USE_OVER_ONE_POINT = NimbusTargetin
         "'kolesin.work@gmail.com' in addon_ids || "
         "'adblocker@pcmatic.com' in addon_ids || "
         "'{73a6fe31-595d-460b-a920-fcc0f8843232}' in addon_ids"
-        ")) || tou_points > 1)"
+        ")))"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
Because

The [PRD](https://docs.google.com/document/d/16ODO3B0_lx7eq665gFQBaEv3j1CjKElTVbyad_iqQK4/edit?tab=t.e4ljry1ncpj#heading=h.ecl5dqo18xu9) says a user is assigned a point for each of these categories:

1. Non-default privacy settings
2. Disabled sponsored content
3. Ad blocker extension

But the `ANDROID_EXISTING_USERS_NOT_ACCEPTED_TERMS_OF_USE_OVER_ONE_POINT` logic assumes a user can't have `tou_point == 2` and requires an ad blocker extension. 

We need to allow a user to have `tou_points` is 2 or more, whether they have an ad blocker extension installed or not.

This commit

- Adds a condition that explicitly checks if the user has at least 2 points if the first check with the ad blocker fails.

Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=2009357