### PR TITLE
bug(nimbus): fix show more/less buttons on readonly json

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -45,21 +45,17 @@
               <td colspan="3"
                   id="preview-recipe-json"
                   class="collapsed-json {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
-                <div style="max-height: 120px; overflow: hidden;">
-                  {% include "common/readonly_json.html" with json_content=feature_value.value %}
+                {% include "common/readonly_json.html" with json_content=feature_value.value %}
 
-                </div>
                 <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
                   <i class="fa-solid fa-plus"></i> Show more
                 </button>
               </td>
               <td colspan="3"
                   id="preview-recipe-json"
-                  class="expanded-json d-none mw-0 {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
-                <div class="text-break">
-                  {% include "common/readonly_json.html" with json_content=feature_value.value %}
+                  class="expanded-json d-none {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
+                {% include "common/readonly_json.html" with json_content=feature_value.value %}
 
-                </div>
                 <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
                   <i class="fa-solid fa-minus"></i> Show less
                 </button>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
@@ -23,10 +23,10 @@
   <table class="table table-striped mb-0">
     <tbody>
       <tr>
-        <th>Channel</th>
-        <td>{{ experiment.get_channel_display|default:"No Channel" }}</td>
-        <th>Advanced Targeting</th>
-        <td>{{ experiment.targeting_config.name }}</td>
+        <th class="w-25">Channel</th>
+        <td class="w-25">{{ experiment.get_channel_display|default:"No Channel" }}</td>
+        <th class="w-25">Advanced Targeting</th>
+        <td class="w-25">{{ experiment.targeting_config.name }}</td>
       </tr>
       <tr>
         <th>Minimum version</th>
@@ -137,21 +137,17 @@
         <td colspan="3"
             id="preview-recipe-json"
             class="collapsed-json border-bottom-0">
-          <div style="max-height: 120px; overflow: hidden;">
-            {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+          {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
 
-          </div>
           <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
             <i class="fa-solid fa-plus"></i> Show more
           </button>
         </td>
         <td colspan="3"
             id="preview-recipe-json"
-            class="expanded-json d-none mw-0 border-bottom-0">
-          <div class="text-break">
-            {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+            class="expanded-json d-none border-bottom-0">
+          {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
 
-          </div>
           <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
             <i class="fa-solid fa-minus"></i> Show less
           </button>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_localizations.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_localizations.html
@@ -7,16 +7,24 @@
   <table class="table table-striped mb-0">
     <tbody>
       <tr>
-        <th>Is Localized</th>
+        <th class="w-25">Is Localized</th>
         <td colspan="3">{{ experiment.is_localized }}</td>
       </tr>
       <tr>
         <th class="border-bottom-0">Localizations JSON</th>
-        <td colspan="3" class="mw-0 border-bottom-0">
-          <div class="mw-100 overflow-auto">
-            {% include "common/readonly_json.html" with json_content=experiment.localizations|default:"null" %}
+        <td colspan="3" class="collapsed-json border-bottom-0">
+          {% include "common/readonly_json.html" with json_content=experiment.localizations|default:"null" %}
 
-          </div>
+          <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
+            <i class="fa-solid fa-plus"></i> Show more
+          </button>
+        </td>
+        <td colspan="3" class="expanded-json d-none border-bottom-0">
+          {% include "common/readonly_json.html" with json_content=experiment.localizations|default:"null" %}
+
+          <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
+            <i class="fa-solid fa-minus"></i> Show less
+          </button>
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
Becuase

* We recently added some content copy buttons to the read only json
* We accidentally broke the show more/less buttons

This commit

* Restores the show/more less buttons
* Fixes the width of the readonly json fields on the detail page so they line up more nicely

fixes #14358

