### PR TITLE
feat(cirrus): Add type hints for SDK.compute_enrollments

### DIFF
--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -16,7 +16,7 @@ RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | /bin/sh -s -- -y
 ENV PATH=$PATH:/root/.cargo/bin
 
 # Install poetry package management tool
-RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.1.1
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 2.2.1
 
 # Add poetry to PATH environment variable
 ENV PATH="/root/.local/bin:$PATH"

--- a/cirrus/server/poetry.lock
+++ b/cirrus/server/poetry.lock
@@ -37,7 +37,6 @@ files = [
 ]
 
 [package.dependencies]
-exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 
@@ -320,9 +319,6 @@ files = [
     {file = "coverage-7.13.0.tar.gz", hash = "sha256:a394aa27f2d7ff9bc04cf703817773a59ad6dfbd577032e690f961d2460ee936"},
 ]
 
-[package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
-
 [package.extras]
 toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
@@ -337,22 +333,6 @@ files = [
     {file = "diskcache-5.6.3-py3-none-any.whl", hash = "sha256:5e31b2d5fbad117cc363ebaf6b689474db18a1f6438bc82358b024abd4c2ca19"},
     {file = "diskcache-5.6.3.tar.gz", hash = "sha256:2c3a3fa2743d8535d832ec61c2054a1641f41775aa7c556758a109941e33e4fc"},
 ]
-
-[[package]]
-name = "exceptiongroup"
-version = "1.1.3"
-description = "Backport of PEP 654 (exception groups)"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "python_version < \"3.11\""
-files = [
-    {file = "exceptiongroup-1.1.3-py3-none-any.whl", hash = "sha256:343280667a4585d195ca1cf9cef84a4e178c4b6cf2274caef9859782b567d5e3"},
-    {file = "exceptiongroup-1.1.3.tar.gz", hash = "sha256:097acd85d473d75af5bb98e41b61ff7fe35efe6675e4f9370ec6ec5126d160e9"},
-]
-
-[package.extras]
-test = ["pytest (>=6)"]
 
 [[package]]
 name = "fastapi"
@@ -846,22 +826,24 @@ typing-extensions = ">=4.14.1"
 
 [[package]]
 name = "pyright"
-version = "1.1.372"
+version = "1.1.408"
 description = "Command line wrapper for pyright"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
 files = [
-    {file = "pyright-1.1.372-py3-none-any.whl", hash = "sha256:25b15fb8967740f0949fd35b963777187f0a0404c0bd753cc966ec139f3eaa0b"},
-    {file = "pyright-1.1.372.tar.gz", hash = "sha256:a9f5e0daa955daaa17e3d1ef76d3623e75f8afd5e37b437d3ff84d5b38c15420"},
+    {file = "pyright-1.1.408-py3-none-any.whl", hash = "sha256:090b32865f4fdb1e0e6cd82bf5618480d48eecd2eb2e70f960982a3d9a4c17c1"},
+    {file = "pyright-1.1.408.tar.gz", hash = "sha256:f28f2321f96852fa50b5829ea492f6adb0e6954568d1caa3f3af3a5f555eb684"},
 ]
 
 [package.dependencies]
 nodeenv = ">=1.6.0"
+typing-extensions = ">=4.1"
 
 [package.extras]
-all = ["twine (>=3.4.1)"]
+all = ["nodejs-wheel-binaries", "twine (>=3.4.1)"]
 dev = ["twine (>=3.4.1)"]
+nodejs = ["nodejs-wheel-binaries"]
 
 [[package]]
 name = "pytest"
@@ -877,11 +859,9 @@ files = [
 
 [package.dependencies]
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
-exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
 iniconfig = "*"
 packaging = "*"
 pluggy = ">=0.12,<2.0"
-tomli = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 testing = ["argcomplete", "attrs (>=19.2.0)", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
@@ -1305,19 +1285,6 @@ typing-extensions = {version = ">=4.10.0", markers = "python_version < \"3.13\""
 full = ["httpx (>=0.27.0,<0.29.0)", "itsdangerous", "jinja2", "python-multipart (>=0.0.18)", "pyyaml"]
 
 [[package]]
-name = "tomli"
-version = "2.0.1"
-description = "A lil' TOML parser"
-optional = false
-python-versions = ">=3.7"
-groups = ["main"]
-markers = "python_full_version <= \"3.11.0a6\""
-files = [
-    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
-    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
-]
-
-[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -1408,12 +1375,11 @@ files = [
 [package.dependencies]
 click = ">=7.0"
 h11 = ">=0.8"
-typing-extensions = {version = ">=4.0", markers = "python_version < \"3.11\""}
 
 [package.extras]
 standard = ["colorama (>=0.4) ; sys_platform == \"win32\"", "httptools (>=0.6.3)", "python-dotenv (>=0.13)", "pyyaml (>=5.1)", "uvloop (>=0.15.1) ; sys_platform != \"win32\" and sys_platform != \"cygwin\" and platform_python_implementation != \"PyPy\"", "watchfiles (>=0.13)", "websockets (>=10.4)"]
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.10.10"
-content-hash = "8702f089641db2aa28199f0af995fcb58adc2f6c254b301a8eb015753c14a89d"
+python-versions = "^3.11"
+content-hash = "a43883af774378cacca36e4f9cbf2c12f87ccafc5e784004dd34a55223d3701e"

--- a/cirrus/server/pyproject.toml
+++ b/cirrus/server/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Mozilla"]
 package-mode = false
 
 [tool.poetry.dependencies]
-python = "^3.10.10"
+python = "^3.11"
 ruff = "^0.14.0"
 coverage = "^7.13.0"
 fastapi = "^0.128.0"
@@ -14,7 +14,7 @@ uvicorn = "^0.40.0"
 pytest = "^7.2.2"
 httpx = "^0.28.0"
 pytest-cov = "^4.0.0"
-pyright = "^1.1.300"
+pyright = "^1.1.408"
 apscheduler = "^3.11.0"
 requests = "^2.32.4"
 pytest-asyncio = "^0.23.8"
@@ -36,7 +36,7 @@ exclude = [
     "cirrus/generate_docs.py",
 ]
 reportUnnecessaryTypeIgnoreComment = "warning"
-pythonVersion = "3.10"
+pythonVersion = "3.11"
 
 [tool.ruff]
 exclude = ["cirrus/glean"]


### PR DESCRIPTION
Because:

- The Cirrus API is stringly-typed;
- we had a case where the types were out of sync; and
- there were some misnamed variables, implying they were of a different
  type

this commit:

- updates poetry in the Cirrus docker image to 2.2.1;
- updates Cirrus to require Python 3.11 (which mostly just affects
  pyright);
- updates pyright to use Python 3.11;
- updates to the latest pyright; and
- adds type hints to the `SDK.compute_enrollments` method.

Fixes #13717