### PR TITLE
chore(cirrus): use remote settings changeset api

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -59,8 +59,8 @@ CIRRUS_REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=10
 CIRRUS_REMOTE_SETTING_REFRESH_JITTER_IN_SECONDS=1
 CIRRUS_REMOTE_SETTING_REFRESH_RETRY_DELAY_IN_SECONDS=30
 CIRRUS_REMOTE_SETTING_REFRESH_MAX_ATTEMPTS=3
-CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/records
-CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/records
+CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0
+CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/changeset?_expected=0
 CIRRUS_APP_ID=demo-app-beta
 CIRRUS_APP_NAME=demo_app
 CIRRUS_CHANNEL=beta

--- a/cirrus/README.md
+++ b/cirrus/README.md
@@ -21,8 +21,8 @@ To set up the Cirrus environment, follow these steps:
 3. Open the `.env` file and modify the values of the following environment variables:
 
    ```plaintext
-   CIRRUS_REMOTE_SETTING_URL=https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/nimbus-web-experiments/records
-   CIRRUS_REMOTE_SETTING_PREVIEW_URL=https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/nimbus-web-preview/records
+   CIRRUS_REMOTE_SETTING_URL=https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0
+   CIRRUS_REMOTE_SETTING_PREVIEW_URL=https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/nimbus-web-preview/changeset?_expected=0
    CIRRUS_REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=10
    CIRRUS_REMOTE_SETTING_REFRESH_JITTER_IN_SECONDS=1
    CIRRUS_REMOTE_SETTING_REFRESH_RETRY_DELAY_IN_SECONDS=30

--- a/cirrus/server/cirrus/experiment_recipes.py
+++ b/cirrus/server/cirrus/experiment_recipes.py
@@ -45,7 +45,9 @@ class RemoteSettings:
         try:
             response = requests.get(self.url)
             response.raise_for_status()
-            data = response.json().get("data")
+            response_json = response.json()
+            # While moving from records api to changeset api, support both
+            data = response_json.get("changes", response_json.get("data"))
             if data is not None:
                 self.update_recipes({"data": data})
                 logger.info(f"Fetched resources: {data}")

--- a/cirrus/server/tests/test_experiment_recipes.py
+++ b/cirrus/server/tests/test_experiment_recipes.py
@@ -32,10 +32,14 @@ def test_update_recipes(remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-def test_empty_data_key(mock_get, remote_settings):
+@pytest.mark.parametrize(
+    "rs_response_key",
+    ["data", "changes"],
+)
+def test_empty_data_key(mock_get, remote_settings, rs_response_key):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"data": []}
+    mock_response.json.return_value = {rs_response_key: []}
     mock_get.return_value = mock_response
 
     remote_settings.fetch_recipes()
@@ -48,11 +52,15 @@ def test_empty_data_key(mock_get, remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-def test_non_empty_data_key(mock_get, remote_settings):
+@pytest.mark.parametrize(
+    "rs_response_key",
+    ["data", "changes"],
+)
+def test_non_empty_data_key(mock_get, remote_settings, rs_response_key):
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
-        "data": [{"experiment1": True}, {"experiment2": False}]
+        rs_response_key: [{"experiment1": True}, {"experiment2": False}]
     }
     mock_get.return_value = mock_response
 
@@ -68,10 +76,14 @@ def test_non_empty_data_key(mock_get, remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-def test_successful_response(mock_get, remote_settings):
+@pytest.mark.parametrize(
+    "rs_response_key",
+    ["data", "changes"],
+)
+def test_successful_response(mock_get, remote_settings, rs_response_key):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"data": []}
+    mock_response.json.return_value = {rs_response_key: []}
     mock_get.return_value = mock_response
 
     remote_settings.fetch_recipes()
@@ -101,10 +113,16 @@ def test_failed_request(mock_get, remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-def test_empty_data_key_with_non_empty_recipes(mock_get, remote_settings):
+@pytest.mark.parametrize(
+    "rs_response_key",
+    ["data", "changes"],
+)
+def test_empty_data_key_with_non_empty_recipes(
+    mock_get, remote_settings, rs_response_key
+):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {"data": []}
+    mock_response.json.return_value = {rs_response_key: []}
     mock_get.return_value = mock_response
 
     remote_settings.update_recipes({"data": [{"experiment1": True}]})


### PR DESCRIPTION
Because

- RS team advises readers are expected to use changeset api not records api

This commit

- Changes cirrus to expect a remote settings response with records under "changes" and temporarily fall back to "data" for backwards compatibility

For #14363