### PR TITLE
fix(nimbus): fix failing intermittent test - test_get_weekly_metric_data

### DIFF
--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1391,6 +1391,7 @@ class TestNimbusExperiment(TestCase):
     @mock_valid_outcomes
     def test_get_weekly_metric_data(self):
         application = NimbusExperiment.Application.DESKTOP
+        Outcomes.clear_cache()
         outcomes = Outcomes.by_application(application)
         experiment = NimbusExperimentFactory.create(
             application=NimbusExperiment.Application.DESKTOP,
@@ -1497,7 +1498,6 @@ class TestNimbusExperiment(TestCase):
 
         expected_weekly_data = {
             "urlbar_amazon_search_count": {
-                "has_weekly_data": True,
                 "data": {
                     branch_a.slug: [
                         (
@@ -1517,32 +1517,33 @@ class TestNimbusExperiment(TestCase):
                         (
                             {"lower": 140, "upper": 160, "significance": "neutral"},
                             {
+                                "avg_rel_change": 15,
                                 "lower": 10,
                                 "upper": 20,
                                 "significance": "neutral",
-                                "avg_rel_change": 15,
                             },
                         ),
                         (
                             {"lower": 130, "upper": 150, "significance": "neutral"},
                             {
+                                "avg_rel_change": 10,
                                 "lower": 5,
                                 "upper": 15,
                                 "significance": "neutral",
-                                "avg_rel_change": 10,
                             },
                         ),
                         (
                             {"lower": 120, "upper": 140, "significance": "neutral"},
                             {
+                                "avg_rel_change": 5,
                                 "lower": 0,
                                 "upper": 10,
                                 "significance": "neutral",
-                                "avg_rel_change": 5,
                             },
                         ),
                     ],
                 },
+                "has_weekly_data": True,
             },
             "total_amazon_search_count": {
                 "data": {},
@@ -2594,6 +2595,7 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create(
             application=NimbusExperiment.Application.DESKTOP,
             primary_outcomes=[outcomes[0].slug],
+            secondary_outcomes=[],
         )
         branch_a = NimbusBranchFactory.create(
             experiment=experiment, name="Branch A", slug="branch-a"

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3164,6 +3164,11 @@ class TestResultsEditBranchImagesView(AuthTestCase):
 
 @mock_valid_outcomes
 class TestResultsView(AuthTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        Outcomes.clear_cache()
+
     def test_render_to_response(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
@@ -3284,6 +3289,7 @@ class TestResultsView(AuthTestCase):
         experiment = NimbusExperimentFactory.create(
             application=application,
             primary_outcomes=[outcomes[0].slug],
+            secondary_outcomes=[],
         )
         branch_a = NimbusBranchFactory.create(
             experiment=experiment, name="Branch A", slug="branch-a"


### PR DESCRIPTION
Because

- The `test_get_weekly_metric_data` was passing irregularly due to the way experiment factory randomly sets unspecified fields
- The mentioned test relies on the primary and secondary outcomes being defined however the latter was missing and thus led to intermittent failures

This commit

- Specifies that secondary outcomes remain empty 

Fixes #14375 