### PR TITLE
chore(cirrus): remove support for remote settings records api

### DIFF
--- a/.env.integration-tests
+++ b/.env.integration-tests
@@ -50,8 +50,8 @@ STATSD_PORT=
 STATSD_PREFIX=experimenter
 UPLOADS_FILE_STORAGE=django.core.files.storage.FileSystemStorage
 CIRRUS_REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=1
-CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/records
-CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/records
+CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0
+CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/changeset?_expected=0
 CIRRUS_APP_ID=demo-app-beta
 CIRRUS_APP_NAME=demo_app
 CIRRUS_CHANNEL=release

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
-CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/records
-CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/records
+CIRRUS_REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0
+CIRRUS_REMOTE_SETTING_PREVIEW_URL=http://kinto:8888/v1/buckets/main-workspace/collections/nimbus-web-preview/changeset?_expected=0
 CIRRUS_REMOTE_SETTING_REFRESH_RATE_IN_SECONDS=10
 CIRRUS_APP_ID=test_app_id
 CIRRUS_APP_NAME=test_app_name

--- a/cirrus/server/cirrus/experiment_recipes.py
+++ b/cirrus/server/cirrus/experiment_recipes.py
@@ -19,6 +19,8 @@ class RecipeType(Enum):
 class RemoteSettings:
     def __init__(self, url: str, sdk: SDK):
         self.recipes: dict[str, list[Any]] = {"data": []}
+        if url.endswith("/records"):
+            raise ValueError("cirrus no longer supports remote settings records api")
         self.url: str = url
         self.sdk = sdk
 
@@ -46,8 +48,7 @@ class RemoteSettings:
             response = requests.get(self.url)
             response.raise_for_status()
             response_json = response.json()
-            # While moving from records api to changeset api, support both
-            data = response_json.get("changes", response_json.get("data"))
+            data = response_json.get("changes")
             if data is not None:
                 self.update_recipes({"data": data})
                 logger.info(f"Fetched resources: {data}")

--- a/cirrus/server/tests/test_experiment_recipes.py
+++ b/cirrus/server/tests/test_experiment_recipes.py
@@ -3,7 +3,20 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from cirrus.experiment_recipes import RecipeType
+from cirrus.experiment_recipes import RecipeType, RemoteSettings
+
+
+def test_remote_settings_url_check():
+    # check for no ValueError with changset api, and ValueError with records api
+    RemoteSettings(
+        url="http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0",
+        sdk=None,
+    )
+    with pytest.raises(ValueError):
+        RemoteSettings(
+            url="http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/records",
+            sdk=None,
+        )
 
 
 @pytest.mark.parametrize(
@@ -32,14 +45,10 @@ def test_update_recipes(remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "rs_response_key",
-    ["data", "changes"],
-)
-def test_empty_data_key(mock_get, remote_settings, rs_response_key):
+def test_empty_data_key(mock_get, remote_settings):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {rs_response_key: []}
+    mock_response.json.return_value = {"changes": []}
     mock_get.return_value = mock_response
 
     remote_settings.fetch_recipes()
@@ -52,15 +61,11 @@ def test_empty_data_key(mock_get, remote_settings, rs_response_key):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "rs_response_key",
-    ["data", "changes"],
-)
-def test_non_empty_data_key(mock_get, remote_settings, rs_response_key):
+def test_non_empty_data_key(mock_get, remote_settings):
     mock_response = MagicMock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
-        rs_response_key: [{"experiment1": True}, {"experiment2": False}]
+        "changes": [{"experiment1": True}, {"experiment2": False}]
     }
     mock_get.return_value = mock_response
 
@@ -76,14 +81,10 @@ def test_non_empty_data_key(mock_get, remote_settings, rs_response_key):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "rs_response_key",
-    ["data", "changes"],
-)
-def test_successful_response(mock_get, remote_settings, rs_response_key):
+def test_successful_response(mock_get, remote_settings):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {rs_response_key: []}
+    mock_response.json.return_value = {"changes": []}
     mock_get.return_value = mock_response
 
     remote_settings.fetch_recipes()
@@ -113,16 +114,10 @@ def test_failed_request(mock_get, remote_settings):
     ["remote_settings_live", "remote_settings_preview"],
     indirect=True,
 )
-@pytest.mark.parametrize(
-    "rs_response_key",
-    ["data", "changes"],
-)
-def test_empty_data_key_with_non_empty_recipes(
-    mock_get, remote_settings, rs_response_key
-):
+def test_empty_data_key_with_non_empty_recipes(mock_get, remote_settings):
     mock_response = MagicMock()
     mock_response.status_code = 200
-    mock_response.json.return_value = {rs_response_key: []}
+    mock_response.json.return_value = {"changes": []}
     mock_get.return_value = mock_response
 
     remote_settings.update_recipes({"data": [{"experiment1": True}]})

--- a/demo-app/README.md
+++ b/demo-app/README.md
@@ -18,7 +18,7 @@ The backend of the Demo App is accessible at: [http://localhost:3002](http://loc
 ## Env config used for the demo app
 
 ```
-REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/records
+REMOTE_SETTING_URL=http://kinto:8888/v1/buckets/main/collections/nimbus-web-experiments/changeset?_expected=0
 APP_ID=demo-app-beta
 APP_NAME=demo_app
 CHANNEL=beta


### PR DESCRIPTION
Because

- gcp has been updated to use changeset api

This commit

- Removes support for Cirrus remote settings urls that point at the records api

Fixes #14363