### PR TITLE
feat(nimbus): link contact experimenter support button to ask-experimenter slack channel

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -10,12 +10,12 @@
           <p class="text-muted">
             Your experiment is still running. Results for some metrics aren't available, but others are unaffected.
           </p>
-          <button class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold">
-            Contact Experimenter Support
-          </button>
+          <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
+             target="_blank"
+             href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
         </div>
         <div class="col">
-          <div class="card bg-warning bg-opacity-25 px-4 py-3 rounded-4 h-100 d-flex justify-content-center">
+          <div class="bg-warning bg-opacity-25 px-4 py-3 rounded-4 h-100 d-flex flex-column justify-content-start text-body">
             <p class="text-muted mb-2">Possible Issues</p>
             <ul class="list-unstyled mb-0">
               {% for error_group, error_list in experiment.results_data.v3.errors.items %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -296,9 +296,8 @@
                                         <i class="fa-solid fa-triangle-exclamation fs-5"></i>
                                         <p class="mb-0 fw-semibold">Metric unavailable</p>
                                         <p class="mb-0">Other metrics are unaffected.</p>
-                                        <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
-                                          Contact Experimenter Support
-                                        </button>
+                                        <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                           href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
                                       </div>
                                     </div>
                                   {% else %}

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -786,6 +786,8 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
         )
         context["metric_area_data"] = all_metrics
 
+        context["ask_experimenter_slack_link"] = settings.ASK_EXPERIMENTER_SLACK_LINK
+
         relative_metric_changes = {}
 
         for metric_data in all_metrics.values():

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -582,3 +582,8 @@ SUMMERNOTE_CONFIG = {
         ],
     },
 }
+
+ASK_EXPERIMENTER_SLACK_LINK = config(
+    "ASK_EXPERIMENTER_SLACK_LINK",
+    default="https://experimenter.info/",
+)


### PR DESCRIPTION
Because

- "Contact Experimenter Support" button which appears when an experiment has errors wasn't functional

This commit

- Makes clicking on the "Contact Experimenter Support" button take you to the ask-experimenter slack channel

Fixes #14373 