### PR TITLE
bug(nimbus): remove duplicate dom ids for collapsible json

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -43,7 +43,6 @@
                 {% endif %}
               </th>
               <td colspan="3"
-                  id="preview-recipe-json"
                   class="collapsed-json {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
                 {% include "common/readonly_json.html" with json_content=feature_value.value %}
 
@@ -52,7 +51,6 @@
                 </button>
               </td>
               <td colspan="3"
-                  id="preview-recipe-json"
                   class="expanded-json d-none {% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
                 {% include "common/readonly_json.html" with json_content=feature_value.value %}
 

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
@@ -134,18 +134,14 @@
       </tr>
       <tr>
         <th id="recipe-json" class="border-bottom-0">Recipe JSON</th>
-        <td colspan="3"
-            id="preview-recipe-json"
-            class="collapsed-json border-bottom-0">
+        <td colspan="3" class="collapsed-json border-bottom-0">
           {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
 
           <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
             <i class="fa-solid fa-plus"></i> Show more
           </button>
         </td>
-        <td colspan="3"
-            id="preview-recipe-json"
-            class="expanded-json d-none border-bottom-0">
+        <td colspan="3" class="expanded-json d-none border-bottom-0">
           {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
 
           <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">


### PR DESCRIPTION
Because

* We recently updated the collapsible json fields to be more reusable
* We accidentally created duplicate dom ids on the read only fields
* HTMX will deduplicate dom elements by id which broke the collapsible fields after an HTMX swap

This commit

* Removes the unnecessary duplicate dom ids which fixes the collapsible buttons

fixes #14366

