### PR TITLE
fix(nimbus): fix absolute value called on nonexistent points

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1579,6 +1579,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         relative_data_list.sort(key=self.window_index_for_sort)
         rel_entries = []
         for i, data_point in enumerate(relative_data_list):
+            if not data_point:
+                continue
+
             lower = data_point.get("lower")
             upper = data_point.get("upper")
             avg_rel_change = (
@@ -1713,6 +1716,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     .get(reference_branch, {})
                     .get("all", [])
                 ):
+                    if not data_point:
+                        continue
+
                     lower = data_point.get("lower")
                     upper = data_point.get("upper")
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2673,15 +2673,7 @@ class TestNimbusExperiment(TestCase):
                                                 ]
                                             },
                                             "relative_uplift": {
-                                                "branch-a": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.3,
-                                                            "upper": 0.5,
-                                                            "point": 0.13,
-                                                        }
-                                                    ]
-                                                },
+                                                "branch-a": {"all": [{}]},
                                                 "branch-b": {"all": []},
                                             },
                                             "significance": {
@@ -2746,17 +2738,6 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             data_b.get("urlbar_amazon_search_count").get(branch_b.slug).get("absolute"),
             [{"lower": 1.24, "upper": 1.63, "significance": "positive"}],
-        )
-        self.assertEqual(
-            data_b.get("urlbar_amazon_search_count").get(branch_b.slug).get("relative"),
-            [
-                {
-                    "lower": -0.3,
-                    "upper": 0.5,
-                    "significance": "positive",
-                    "avg_rel_change": 0.13,
-                }
-            ],
         )
 
     @mock_valid_metrics
@@ -2938,7 +2919,163 @@ class TestNimbusExperiment(TestCase):
         self.assertIn("retained", metric_slugs)
         self.assertNotIn("search_count", metric_slugs)
 
-    def test_get_max_metric_value(self):
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                        "branch-b": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.12,
+                                                                    "upper": 0.15,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        },
+                                                        "branch-c": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.1,
+                                                                    "upper": 0.2,
+                                                                    "point": 0.03,
+                                                                }
+                                                            ]
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -2.3,
+                                                                    "upper": 2.1,
+                                                                    "point": 1.13,
+                                                                }
+                                                            ]
+                                                        },
+                                                        "branch-b": {"all": []},
+                                                        "branch-c": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.25,
+                                                                    "upper": 0.45,
+                                                                    "point": 0.1,
+                                                                }
+                                                            ]
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.3,
+                                                                    "upper": 1.68,
+                                                                    "point": 1.458,
+                                                                }
+                                                            ]
+                                                        },
+                                                        "branch-b": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.25,
+                                                                    "upper": 0.45,
+                                                                    "point": 0.1,
+                                                                }
+                                                            ]
+                                                        },
+                                                        "branch-c": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                2.3,
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                        "branch-b": {"all": [{}]},
+                                                        "branch-c": {"all": [{}]},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": [{}]},
+                                                        "branch-b": {"all": []},
+                                                        "branch-c": {"all": [{}]},
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": [{}]},
+                                                        "branch-b": {"all": [{}]},
+                                                        "branch-c": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                0,
+            ),
+        ]
+    )
+    def test_get_max_metric_value(self, results_data, expected_max_value):
         experiment = NimbusExperimentFactory.create()
         branch_a = NimbusBranchFactory.create(
             experiment=experiment, name="Branch A", slug="branch-a"
@@ -2950,103 +3087,7 @@ class TestNimbusExperiment(TestCase):
             experiment=experiment, name="Branch C", slug="branch-c"
         )
 
-        experiment.results_data = {
-            "v3": {
-                "overall": {
-                    "enrollments": {
-                        "all": {
-                            "branch-a": {
-                                "branch_data": {
-                                    "other_metrics": {
-                                        "retained": {
-                                            "relative_uplift": {
-                                                "branch-a": {"all": []},
-                                                "branch-b": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.12,
-                                                            "upper": 0.15,
-                                                            "point": 0.02,
-                                                        }
-                                                    ]
-                                                },
-                                                "branch-c": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.1,
-                                                            "upper": 0.2,
-                                                            "point": 0.03,
-                                                        }
-                                                    ]
-                                                },
-                                            },
-                                        }
-                                    }
-                                }
-                            },
-                            "branch-b": {
-                                "branch_data": {
-                                    "other_metrics": {
-                                        "retained": {
-                                            "relative_uplift": {
-                                                "branch-a": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -2.3,
-                                                            "upper": 2.1,
-                                                            "point": 1.13,
-                                                        }
-                                                    ]
-                                                },
-                                                "branch-b": {"all": []},
-                                                "branch-c": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.25,
-                                                            "upper": 0.45,
-                                                            "point": 0.1,
-                                                        }
-                                                    ]
-                                                },
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            "branch-c": {
-                                "branch_data": {
-                                    "other_metrics": {
-                                        "retained": {
-                                            "relative_uplift": {
-                                                "branch-a": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.3,
-                                                            "upper": 1.68,
-                                                            "point": 1.458,
-                                                        }
-                                                    ]
-                                                },
-                                                "branch-b": {
-                                                    "all": [
-                                                        {
-                                                            "lower": -0.25,
-                                                            "upper": 0.45,
-                                                            "point": 0.1,
-                                                        }
-                                                    ]
-                                                },
-                                                "branch-c": {"all": []},
-                                            },
-                                        }
-                                    }
-                                }
-                            },
-                        }
-                    }
-                }
-            }
-        }
+        experiment.results_data = results_data
 
         branch_a.save()
         branch_b.save()
@@ -3056,7 +3097,7 @@ class TestNimbusExperiment(TestCase):
         extreme_retained = experiment.get_max_metric_value(
             "enrollments", "all", "branch-a", "other_metrics", "retained"
         )
-        self.assertEqual(extreme_retained, 2.3)
+        self.assertEqual(extreme_retained, expected_max_value)
 
     def test_conclusion_recommendation_labels(self):
         recommendations = list(NimbusConstants.ConclusionRecommendation)


### PR DESCRIPTION
Because

- Some metrics do not provide relative_uplift data and instead of being an empty list they contain a list with a single empty object as a placeholder
- This causes the for loop that is meant to iterate over a list of valid points containing at least values for `lower` and `upper` to throw unexpected runtime errors

This commit

- Adds a continue statement to avoid performing operations if `data_point` is an empty object
- Adds a test that replicates the edge case where `relative_uplift = [{}]` for some metric

Fixes #14394 