### PR TITLE
bug(nimbus): handle v2 results data in new results page

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1455,11 +1455,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     branch_data.get("branch_data", {}).get(group, {}).get(slug, {})
                 )
                 for branch_significance in metric_data.get("significance", {}).values():
-                    if (
-                        "positive" in branch_significance.get(window, {}).values()
-                        or "negative" in branch_significance.get(window, {}).values()
-                    ):
-                        return True
+                    window_data = branch_significance.get(window, {})
+                    if isinstance(window_data, dict):
+                        if (
+                            "positive" in window_data.values()
+                            or "negative" in window_data.values()
+                        ):
+                            return True
+                    elif isinstance(window_data, list):
+                        if "positive" in window_data or "negative" in window_data:
+                            return True
             return False
 
         for metrics in metric_areas.values():
@@ -1615,11 +1620,15 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             branch_results = window_results.get(branch.slug, {}).get("branch_data", {})
             metric_src = branch_results.get(group, {}).get(slug, {})
 
-            significance_map = (
+            significance_data = (
                 metric_src.get("significance", {})
                 .get(reference_branch, {})
                 .get(window, {})
             )
+            if isinstance(significance_data, list):
+                significance_map = {}
+            else:
+                significance_map = significance_data
 
             abs_entries = self.format_absolute_entries(metric_src, significance_map)
             rel_entries = self.format_relative_entries(


### PR DESCRIPTION
Becuase

* Older experiments have an older structure of data called v2
* Some fields in this older data have a different format than the newer v3 data
* Some fields may be lists where a dict is expected

This commit

* Checks whether a field is a list or dict and handles either case
* Adds a test

fixes #14403

