### PR TITLE
fix(nimbus): fix exposures being default for experiments without correct data

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1158,6 +1158,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         EmailType.ENROLLMENT_END: "⏸️ Is ready to end enrollment",
     }
 
+    EXPOSURE_CLIENT_CUTOFF = 10
+
 
 EXTERNAL_URLS = {
     "SIGNOFF_QA": "https://experimenter.info/qa-sign-off",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1710,16 +1710,45 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def has_exposures(self):
-        # True if there are any exposures in the results data
+        # Returns the enum corresponding to exposures state:
+        # - VALID when exposures exist for all branches
+        # - INVALID when exposures exist for some but not all branches
+        # - NO_EXPOSURES when no exposures data is present
+
         if self.results_data and "v3" in self.results_data:
             results_data = self.results_data["v3"]
             for window in ["overall", "weekly"]:
                 if results_data.get(window):
-                    exposure_data = results_data[window].get("exposures", {}).get("all")
-                    if exposure_data is not None:
-                        return True
+                    exposures_branch_data = (
+                        results_data[window].get("exposures", {}).get("all", {})
+                    )
+                    branches_with_exposures = 0
 
-        return False
+                    for branch_data in exposures_branch_data.values():
+                        client_count = (
+                            branch_data.get("branch_data", {})
+                            .get("other_metrics", {})
+                            .get("identity", {})
+                            .get("absolute", {})
+                            .get("first", {})
+                            .get("point", 0)
+                        )
+
+                        # Treat a branch as having meaningful exposures only when the
+                        # client_count exceeds a set cutoff. Manual testing can produce
+                        # tiny non-zero counts, so we use EXPOSURE_CLIENT_CUTOFF as an
+                        # arbitrary threshold to avoid false positives.
+                        if client_count > NimbusConstants.EXPOSURE_CLIENT_CUTOFF:
+                            branches_with_exposures += 1
+
+                    if branches_with_exposures == self.branches.all().count():
+                        return NimbusUIConstants.ExposuresStatus.VALID
+                    # Handles the case where exposures were only implemented for some but
+                    # not all branches.
+                    elif branches_with_exposures > 0:
+                        return NimbusUIConstants.ExposuresStatus.INVALID
+
+        return NimbusUIConstants.ExposuresStatus.NO_EXPOSURES
 
     @property
     def show_results_url(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3450,20 +3450,104 @@ class TestNimbusExperiment(TestCase):
         self.assertTrue(experiment.has_displayable_results)
 
     def test_has_exposures_results_true(self):
+        results_data = {
+            "v3": {
+                "overall": {
+                    "exposures": {
+                        "all": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 120,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "treatment": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 120,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        experiment = NimbusExperimentFactory.create()
+        experiment.results_data = results_data
+        experiment.save()
+
+        self.assertEqual(
+            experiment.has_exposures, NimbusUIConstants.ExposuresStatus.VALID
+        )
+
+    def test_has_exposures_results_false(self):
         results_data = {"v3": {"overall": {"exposures": {"all": {}}}}}
         experiment = NimbusExperimentFactory.create()
         experiment.results_data = results_data
         experiment.save()
 
-        self.assertTrue(experiment.has_exposures)
+        self.assertEqual(
+            experiment.has_exposures, NimbusUIConstants.ExposuresStatus.NO_EXPOSURES
+        )
 
-    def test_has_exposures_results_false(self):
-        results_data = {"v3": {"overall": {"enrollments": {"all": {}}}}}
+    def test_has_exposures_missing_data(self):
+        results_data = {
+            "v3": {
+                "overall": {
+                    "exposures": {
+                        "all": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 0,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "treatment": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 120,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
         experiment = NimbusExperimentFactory.create()
         experiment.results_data = results_data
         experiment.save()
 
-        self.assertFalse(experiment.has_exposures)
+        self.assertEqual(
+            experiment.has_exposures, NimbusUIConstants.ExposuresStatus.INVALID
+        )
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 
 from experimenter.experiments.constants import NimbusConstants
 
@@ -213,6 +213,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         LAUNCH_ROLLOUT = "launch this rollout"
         UPDATE_ROLLOUT = "update this rollout"
         END_ROLLOUT = "end this rollout"
+
+    class ExposuresStatus(IntEnum):
+        NO_EXPOSURES = 0
+        VALID = 1
+        INVALID = 2
 
 
 def _get_qa_status_icon_map():

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -107,6 +107,25 @@
       </div>
     </div>
   {% endif %}
+  {% if experiment.has_exposures == invalid_exposure_status %}
+    <div class="alert p-4 mb-0 rounded-4 alert-warning" role="alert">
+      <div class="d-flex flex-column gap-2 align-items-start">
+        <div class="d-flex align-items-center mb-2 gap-2">
+          <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+          <h5 class="mb-0">Exposure data misconfigured</h5>
+        </div>
+        <p class="text-muted">
+          Some branches are missing exposure data while others have them. Exposure-based
+          analysis may be incomplete. You can still view available results — try switching
+          the analysis basis to "Exposures" to inspect what's present, or contact Experimenter
+          Support if you need help fixing the data.
+        </p>
+        <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
+           target="_blank"
+           href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+      </div>
+    </div>
+  {% endif %}
   {% if experiment.is_enrolling or experiment.is_observation %}
     {% include "nimbus_experiments/launch_controls_v2.html" %}
 
@@ -124,10 +143,12 @@
               aria-label="Analysis Basis">
         <option value="enrollments"
                 {% if selected_analysis_basis == "enrollments" %}selected{% endif %}>Enrollments</option>
-        {% if experiment.has_exposures %}
-          <option value="exposures"
-                  {% if selected_analysis_basis == "exposures" %}selected{% endif %}>Exposures</option>
-        {% endif %}
+        <option value="exposures"
+                {% if selected_analysis_basis == "exposures" %}selected{% endif %}
+                {% if not experiment.has_exposures %}disabled{% endif %}>
+          Exposures
+          {% if not experiment.has_exposures %}(No exposure data){% endif %}
+        </option>
       </select>
     </div>
     <div class="col">

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3192,11 +3192,36 @@ class TestResultsView(AuthTestCase):
                         },
                         "overall": {
                             "enrollments": {"all": {}},
-                            "exposures": {"all": {}},
-                        },
-                        "weekly": {
-                            "enrollments": {"all": {}},
-                            "exposures": {"all": {}},
+                            "exposures": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "point": 210,
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "treatment": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "point": 210,
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
                         },
                     }
                 },
@@ -3210,6 +3235,25 @@ class TestResultsView(AuthTestCase):
                             "metrics": {"metricA": {"friendlyName": "Friendly Metric A"}},
                         },
                         "overall": {"enrollments": {"all": {}}},
+                    }
+                },
+                "enrollments",
+            ),
+            (
+                {
+                    "v3": {
+                        "other_metrics": {"group": {"metricA": "Metric A"}},
+                        "metadata": {
+                            "metrics": {"metricA": {"friendlyName": "Friendly Metric A"}},
+                        },
+                        "overall": {
+                            "enrollments": {"all": {}},
+                            "exposures": {"all": {}},
+                        },
+                        "weekly": {
+                            "enrollments": {"all": {}},
+                            "exposures": {"all": {}},
+                        },
                     }
                 },
                 "enrollments",

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -22,6 +22,7 @@ from experimenter.jetstream.results_manager import ExperimentResultsManager
 from experimenter.nimbus_ui.constants import (
     METRICS_MIN_BOUNDS_WIDTH,
     SCHEMA_DIFF_SIZE_CONFIG,
+    NimbusUIConstants,
 )
 from experimenter.nimbus_ui.filtersets import (
     STATUS_FILTERS,
@@ -763,9 +764,14 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
         context["segments"] = segments
 
         analysis_basis = self.request.GET.get(
-            "analysis_basis", "exposures" if experiment.has_exposures else "enrollments"
+            "analysis_basis",
+            "exposures"
+            if experiment.has_exposures == NimbusUIConstants.ExposuresStatus.VALID
+            else "enrollments",
         )
         context["selected_analysis_basis"] = analysis_basis
+
+        context["invalid_exposure_status"] = NimbusUIConstants.ExposuresStatus.INVALID
 
         context["branch_data"] = results_manager.get_branch_data(
             analysis_basis, selected_segment


### PR DESCRIPTION
Because

- Previously exposure data was simply checked for by verifying whether the results data object had a non-null value for its exposure field
- This check was not enough as some experiments contain invalid exposure data in the form of missing metrics and containing only values of `{ "point": 0 }`

This commit

- Updates the `has_exposures` method to perform a deeper check of exposure data validity by validating that the client count for each exposure branch is at least 10
- Shows an error if experiments have exposures incorrectly setup by only enrolling clients into a proper subset of branches

Fixes #14418 