### PR TITLE
feat(nimbus): use readonly codemirror for jexl targeting

### DIFF
--- a/experimenter/experimenter/experiments/jexl_utils.py
+++ b/experimenter/experimenter/experiments/jexl_utils.py
@@ -1,0 +1,88 @@
+import json
+
+from pyjexl.jexl import JEXLConfig
+from pyjexl.operators import default_binary_operators, default_unary_operators
+from pyjexl.parser import (
+    ArrayLiteral,
+    BinaryExpression,
+    FilterExpression,
+    Identifier,
+    Literal,
+    Parser,
+    Transform,
+    UnaryExpression,
+    jexl_grammar,
+)
+
+
+def format_jexl(expression):
+    if not expression or expression == "true":
+        return expression
+
+    def node_to_str(node):
+        if isinstance(node, Identifier):
+            subject = f"{node_to_str(node.subject)}." if node.subject else ""
+            return f"{'.{subject}' if node.relative else subject}{node.value}"
+        if isinstance(node, Literal):
+            return json.dumps(node.value)
+        if isinstance(node, ArrayLiteral):
+            return f"[{', '.join(node_to_str(a) for a in node.value)}]"
+        if isinstance(node, Transform):
+            args_str = ", ".join(node_to_str(a) for a in node.args)
+            args = f"({args_str})" if node.args else ""
+            return f"{node_to_str(node.subject)}|{node.name}{args}"
+        if isinstance(node, FilterExpression):
+            subject_str = node_to_str(node.subject) or format_node(node.subject, False, 0)
+            expr_str = node_to_str(node.expression) or format_node(
+                node.expression, False, 0
+            )
+            return f"{subject_str}[{expr_str}]"
+        return None
+
+    def format_node(node, needs_parens=False, indent=0):
+        if isinstance(node, BinaryExpression):
+            if node.operator.symbol in ("&&", "||"):
+
+                def child_needs_parens(child):
+                    return (
+                        isinstance(child, BinaryExpression)
+                        and child.operator.symbol in ("&&", "||")
+                        and child.operator.symbol != node.operator.symbol
+                    )
+
+                left_needs = child_needs_parens(node.left)
+                right_needs = child_needs_parens(node.right)
+
+                left_indent = indent + 1 if left_needs else indent
+                right_indent = indent + 1 if right_needs else indent
+
+                left = format_node(node.left, left_needs, left_indent)
+                right = format_node(node.right, right_needs, right_indent)
+
+                right_indented = "\n".join(
+                    "  " * indent + line for line in right.split("\n")
+                )
+
+                result = f"{left} {node.operator.symbol}\n{right_indented}"
+
+                if needs_parens:
+                    close = f"\n{'  ' * (indent - 1)})"
+                    return f"(\n{'  ' * indent}{result}{close}"
+                return result
+            left = node_to_str(node.left) or format_node(node.left, False, indent)
+            right = node_to_str(node.right) or format_node(node.right, False, indent)
+            return f"{left} {node.operator.symbol} {right}"
+        if isinstance(node, UnaryExpression):
+            right = node_to_str(node.right) or format_node(node.right, False, indent)
+            return f"{node.operator.symbol}({right})"
+        return node_to_str(node) or str(node)
+
+    jexl_config = JEXLConfig({}, default_unary_operators, default_binary_operators)
+
+    class JEXLParser(Parser):
+        grammar = jexl_grammar(jexl_config)
+
+        def __init__(self):
+            super().__init__(jexl_config)
+
+    return format_node(JEXLParser().parse(expression))

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -32,6 +32,7 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
+from experimenter.experiments.jexl_utils import format_jexl
 from experimenter.jetstream.results_manager import ExperimentResultsManager
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.projects.models import Project
@@ -790,6 +791,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             if expressions
             else "true"
         )
+
+    @property
+    def targeting_formatted(self):
+        return format_jexl(self.targeting)
 
     @property
     def application_config(self):

--- a/experimenter/experimenter/experiments/tests/test_jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_utils.py
@@ -1,0 +1,163 @@
+from django.test import TestCase
+
+from experimenter.experiments.jexl_utils import format_jexl
+
+
+class TestFormatJexl(TestCase):
+    def test_empty_string(self):
+        self.assertEqual(format_jexl(""), "")
+
+    def test_none_value(self):
+        self.assertEqual(format_jexl(None), None)
+
+    def test_true_expression(self):
+        self.assertEqual(format_jexl("true"), "true")
+
+    def test_simple_expression_no_operators(self):
+        result = format_jexl("version >= 100")
+        self.assertEqual(result, "version >= 100")
+
+    def test_simple_and_expression(self):
+        result = format_jexl("a == 1 && b == 2")
+        expected = "a == 1 &&\nb == 2"
+        self.assertEqual(result, expected)
+
+    def test_simple_or_expression(self):
+        result = format_jexl("a == 1 || b == 2")
+        expected = "a == 1 ||\nb == 2"
+        self.assertEqual(result, expected)
+
+    def test_multiple_and_expressions(self):
+        result = format_jexl("a == 1 && b == 2 && c == 3")
+        expected = "a == 1 &&\nb == 2 &&\nc == 3"
+        self.assertEqual(result, expected)
+
+    def test_multiple_or_expressions(self):
+        result = format_jexl("a == 1 || b == 2 || c == 3")
+        expected = "a == 1 ||\nb == 2 ||\nc == 3"
+        self.assertEqual(result, expected)
+
+    def test_nested_or_inside_and(self):
+        result = format_jexl("a == 1 && (b == 2 || c == 3)")
+        expected = """a == 1 &&
+(
+  b == 2 ||
+  c == 3
+)"""
+        self.assertEqual(result, expected)
+
+    def test_nested_and_inside_or(self):
+        result = format_jexl("a == 1 || (b == 2 && c == 3)")
+        expected = """a == 1 ||
+(
+  b == 2 &&
+  c == 3
+)"""
+        self.assertEqual(result, expected)
+
+    def test_deeply_nested_expressions(self):
+        result = format_jexl("a == 1 && (b == 2 || (c == 3 && d == 4))")
+        expected = """a == 1 &&
+(
+  b == 2 ||
+  (
+      c == 3 &&
+      d == 4
+    )
+)"""
+        self.assertEqual(result, expected)
+
+    def test_complex_real_world_expression(self):
+        expression = (
+            'channel == "release" && '
+            "(slug in activeRollouts || (isFirstStartup && version >= 100)) && "
+            'locale != "en-US"'
+        )
+        result = format_jexl(expression)
+        expected = """channel == "release" &&
+(
+  slug in activeRollouts ||
+  (
+      isFirstStartup &&
+      version >= 100
+    )
+) &&
+locale != "en-US\""""
+        self.assertEqual(result, expected)
+
+    def test_identifier_with_dots(self):
+        result = format_jexl('browserSettings.update.channel == "release"')
+        self.assertEqual(result, 'browserSettings.update.channel == "release"')
+
+    def test_array_literal(self):
+        result = format_jexl("value in [1, 2, 3]")
+        self.assertEqual(result, "value in [1, 2, 3]")
+
+    def test_transform_filter(self):
+        result = format_jexl('"test"|preferenceValue')
+        self.assertEqual(result, '"test"|preferenceValue')
+
+    def test_transform_with_arguments(self):
+        result = format_jexl('"test"|preferenceValue(true)')
+        self.assertEqual(result, '"test"|preferenceValue(true)')
+
+    def test_filter_expression(self):
+        result = format_jexl("items[0]")
+        self.assertEqual(result, "items[0]")
+
+    def test_filter_expression_with_comparison(self):
+        result = format_jexl("items[index > 5]")
+        self.assertEqual(result, "items[index > 5]")
+
+    def test_unary_operator(self):
+        result = format_jexl("!value")
+        self.assertEqual(result, "!(value)")
+
+    def test_unary_with_logical_operators(self):
+        result = format_jexl("!a && b")
+        expected = "!(a) &&\nb"
+        self.assertEqual(result, expected)
+
+    def test_comparison_operators(self):
+        result = format_jexl("a > 5 && b < 10 && c >= 3 && d <= 7 && e != 2")
+        expected = "a > 5 &&\nb < 10 &&\nc >= 3 &&\nd <= 7 &&\ne != 2"
+        self.assertEqual(result, expected)
+
+    def test_string_literals(self):
+        result = format_jexl('name == "test-value" && type == "experiment"')
+        expected = 'name == "test-value" &&\ntype == "experiment"'
+        self.assertEqual(result, expected)
+
+    def test_numeric_literals(self):
+        result = format_jexl("version >= 100 && build >= 18362")
+        expected = "version >= 100 &&\nbuild >= 18362"
+        self.assertEqual(result, expected)
+
+    def test_boolean_literals(self):
+        result = format_jexl("enabled == true && verified == false")
+        expected = "enabled == true &&\nverified == false"
+        self.assertEqual(result, expected)
+
+    def test_mixed_operators_multiple_levels(self):
+        expression = "(a || b) && (c || d) && e"
+        result = format_jexl(expression)
+        expected = """(
+  a ||
+  b
+) &&
+(
+  c ||
+  d
+) &&
+e"""
+        self.assertEqual(result, expected)
+
+    def test_same_and_operator_no_parens(self):
+        result = format_jexl("a && b && c")
+        expected = "a &&\nb &&\nc"
+        self.assertEqual(result, expected)
+
+    def test_same_or_operator_no_parens(self):
+        result = format_jexl("a || b || c")
+        expected = "a ||\nb ||\nc"
+        self.assertEqual(result, expected)

--- a/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
@@ -1,8 +1,7 @@
 import { basicSetup } from "codemirror";
 import { EditorView } from "@codemirror/view";
 import { EditorState } from "@codemirror/state";
-import { json, jsonParseLinter } from "@codemirror/lang-json";
-import { linter } from "@codemirror/lint";
+import { json } from "@codemirror/lang-json";
 import {
   themeCompartment,
   getThemeExtensions,
@@ -28,7 +27,6 @@ export const createReadonlyJsonEditor = (textarea, maxLines = null) => {
     extensions: [
       basicSetup,
       json(),
-      linter(jsonParseLinter()),
       EditorState.readOnly.of(true),
       EditorView.editable.of(false),
       EditorView.lineWrapping,

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
@@ -130,7 +130,10 @@
       </tr>
       <tr>
         <th>Full targeting expression</th>
-        <td colspan="3">{{ experiment.targeting }}</td>
+        <td colspan="3">
+          {% include "common/readonly_json.html" with json_content=experiment.targeting_formatted %}
+
+        </td>
       </tr>
       <tr>
         <th id="recipe-json" class="border-bottom-0">Recipe JSON</th>


### PR DESCRIPTION
Because

* It is very hard to read long JEXL targeting expressions without proper formatting
* We have the codemirror utility for displaying code in the UI
* We have the PyJEXL library that has an AST parser
* We can combine those to parse and format JEXL targeting more nicely

This commit

* Adds a JEXL formatter using the PyJEXL parser library similar to how we used it in the integration tests
* Adds a readonly codemirror to display the formatted JEXL targeting
* Adds tests

fixes #14391
