### PR TITLE
bug(nimbus): handle bucketsample targeting strings

### DIFF
--- a/experimenter/experimenter/experiments/jexl_utils.py
+++ b/experimenter/experimenter/experiments/jexl_utils.py
@@ -28,9 +28,11 @@ def format_jexl(expression):
         if isinstance(node, ArrayLiteral):
             return f"[{', '.join(node_to_str(a) for a in node.value)}]"
         if isinstance(node, Transform):
-            args_str = ", ".join(node_to_str(a) for a in node.args)
+            args_list = [node_to_str(a) or format_node(a, False, 0) for a in node.args]
+            args_str = ", ".join(args_list)
             args = f"({args_str})" if node.args else ""
-            return f"{node_to_str(node.subject)}|{node.name}{args}"
+            subject_str = node_to_str(node.subject) or format_node(node.subject, False, 0)
+            return f"{subject_str}|{node.name}{args}"
         if isinstance(node, FilterExpression):
             subject_str = node_to_str(node.subject) or format_node(node.subject, False, 0)
             expr_str = node_to_str(node.expression) or format_node(

--- a/experimenter/experimenter/experiments/tests/test_jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_utils.py
@@ -101,6 +101,10 @@ locale != "en-US\""""
         result = format_jexl('"test"|preferenceValue(true)')
         self.assertEqual(result, '"test"|preferenceValue(true)')
 
+    def test_transform_with_expression_arguments(self):
+        result = format_jexl('["a", b]|bucketSample(x / 1000, 7, 233)')
+        self.assertEqual(result, '["a", b]|bucketSample(x / 1000, 7, 233)')
+
     def test_filter_expression(self):
         result = format_jexl("items[0]")
         self.assertEqual(result, "items[0]")


### PR DESCRIPTION
Becuase

* Some recipes use complex targeting expressions like bucket samples with math
* This wasn't handled correctly in the new targeting string formatter

This commit

* Handles the case of math in a bucketsample in a targeting string

fixes #14433


