### PR TITLE
feat(nimbus): require min 148+ for ai experiments

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -953,6 +953,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Ensure this value is less than or equal to the maximum version"
     )
     ERROR_FIREFOX_VERSION_MIN_SUPPORTED = "The minimum targetable Firefox version is 105"
+    ERROR_FIREFOX_VERSION_MIN_148_FOR_AI_RISK = (
+        "Experiments using AI features require Firefox version 148 or higher"
+    )
     ERROR_FIREFOX_VERSION_MAX = (
         "Ensure this value is greater than or equal to the minimum version"
     )
@@ -1027,6 +1030,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     MIN_REQUIRED_VERSION = Version.FIREFOX_105
 
     EXCLUDED_REQUIRED_MIN_VERSION = Version.FIREFOX_116
+
+    AI_RISK_MIN_VERSION = Version.FIREFOX_148
 
     MULTIFEATURE_MAX_FEATURES = 20
     ERROR_MULTIFEATURE_TOO_MANY_FEATURES = (

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -774,13 +774,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 )
             )
 
-        if (
-            self.risk_ai
-            and self.is_desktop
-            and self.firefox_min_version
-            and NimbusExperiment.Version.parse(self.firefox_min_version)
-            >= NimbusExperiment.Version.parse(NimbusExperiment.Version.FIREFOX_148)
-        ):
+        if self.risk_ai and self.is_desktop:
             expressions.append(
                 "'browser.ai.control.default'|preferenceValue == 'available'"
             )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -5293,3 +5293,79 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
         )
 
         self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_risk_ai_requires_firefox_148_desktop(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_147,
+            risk_ai=True,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "firefox_min_version": [
+                    NimbusConstants.ERROR_FIREFOX_VERSION_MIN_148_FOR_AI_RISK
+                ],
+            },
+        )
+
+    def test_risk_ai_accepts_firefox_148_desktop(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_148,
+            risk_ai=True,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_risk_ai_false_allows_any_version(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            risk_ai=False,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_risk_ai_mobile_allows_any_version(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            risk_ai=True,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1386,51 +1386,17 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            (
-                True,
-                NimbusExperiment.Application.DESKTOP,
-                NimbusExperiment.Version.FIREFOX_148,
-                True,
-            ),
-            (
-                False,
-                NimbusExperiment.Application.DESKTOP,
-                NimbusExperiment.Version.FIREFOX_148,
-                False,
-            ),
-            (
-                None,
-                NimbusExperiment.Application.DESKTOP,
-                NimbusExperiment.Version.FIREFOX_148,
-                False,
-            ),
-            (
-                True,
-                NimbusExperiment.Application.FENIX,
-                NimbusExperiment.Version.NO_VERSION,
-                False,
-            ),
-            (
-                True,
-                NimbusExperiment.Application.DESKTOP,
-                NimbusExperiment.Version.FIREFOX_147,
-                False,
-            ),
-            (
-                True,
-                NimbusExperiment.Application.DESKTOP,
-                NimbusExperiment.Version.NO_VERSION,
-                False,
-            ),
+            (True, NimbusExperiment.Application.DESKTOP, True),
+            (False, NimbusExperiment.Application.DESKTOP, False),
+            (None, NimbusExperiment.Application.DESKTOP, False),
+            (True, NimbusExperiment.Application.FENIX, False),
         ]
     )
-    def test_targeting_with_risk_ai(
-        self, risk_ai, application, firefox_min_version, should_include_targeting
-    ):
+    def test_targeting_with_risk_ai(self, risk_ai, application, should_include_targeting):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=application,
-            firefox_min_version=firefox_min_version,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_148,
             firefox_max_version=NimbusExperiment.Version.NO_VERSION,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
             channels=[],


### PR DESCRIPTION
Becuase

* We added a risk question for whether an experiment involves AI
* We added a targeting filter against the AI killswitch pref that's available in 148+
* This leaves open the possibility for an AI experiment to launch against 147 without the targeting filter and continue enrolling clients in 148 regardless of their AI killswitch setting
* We can require AI experiments to target minimum 148 and then always include the pref filter and just preclude launching AI experiments to 147

This commit

* Removes the version check on the targeting filter for AI
* Adds a review check that requires minimum 148+ for AI experiments

fixes #14436

