### PR TITLE
fix(nimbus): fix dbz errors on results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -814,7 +814,7 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
                     lower = relative[0].get("lower") * 100
                     upper = relative[0].get("upper") * 100
                     confidence_range = round(extreme_bound * 1000) / 10
-                    full_width = confidence_range * 2
+                    full_width = confidence_range * 2 if confidence_range != 0 else 1
                     bar_width = ((upper - lower) / full_width) * 100
                     left_percent = (abs(lower - confidence_range * -1) / full_width) * 100
                     left_bounds_percent = left_percent


### PR DESCRIPTION
Because

- `get_max_metric_value` can return 0, which results in a confidence_range of 0

This commit

- Adds a defensive fallback value in case `confidence_range` is 0 preventing divide by zero or invalid confidence computations

Fixes #14438 