### PR TITLE
fix(nimbus): fix custom metrics being grouped under None

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -332,8 +332,9 @@ class ExperimentResultsManager:
         for metric in remaining_metrics:
             area = MetricAreas.get(self.experiment.application, metric["slug"])
 
-            metric_areas[area].append(metric)
-            grouped_metrics.append(metric)
+            if area:
+                metric_areas[area].append(metric)
+                grouped_metrics.append(metric)
 
         metric_areas[NimbusUIConstants.OTHER_METRICS_AREA] = [
             m for m in remaining_metrics if m not in grouped_metrics

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -339,6 +339,7 @@ class TestExperimentResultsManager(TestCase):
                 "other_metrics": {
                     "other_metrics": {
                         "mock_engagement_metric": "Metric Name",
+                        "custom_metric": "Custom Metric Name",
                     }
                 },
             }
@@ -352,6 +353,7 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertIn("KPI Metrics", metric_areas)
         self.assertIn("Engagement", metric_areas)
+        self.assertIn("Other Metrics", metric_areas)
 
     def test_get_branch_data_returns_correct_data(self):
         self.experiment.results_data = {


### PR DESCRIPTION
Because

- Custom metrics do not belong to any specific metric area
- When we attempted to get its metric area there was no check to ensure that what was returned was valid
- This meant every remaining metric would be added to `grouped_metrics` and thus the "Other Metrics" area would always remain empty

This commit

- Adds a check to ensure the returned metric area is valid and allow for any ungrouped metrics to fall into the "Other Metrics" category

Fixes #14442 