### PR TITLE
feat(nimbus): Add advanced targeting for VPN Early Access

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3916,6 +3916,27 @@ AI_TAB_GROUPING_ENABLED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+VPN_EARLY_ACCESS = NimbusTargetingConfig(
+    name="VPN Early Access",
+    slug="vpn_early_access",
+    description=(
+        "Users who are signed out, are not using new profile, "
+        "are not enterprise, are not using a proxy, and "
+        "are not Mozilla VPN subscribers"
+    ),
+    targeting=(
+        "isFxAEnabled && !isFxASignedIn && "
+        f"{NOT_NEW_PROFILE_CREATED.targeting} && "
+        f"{NO_ENTERPRISE.targeting} && "
+        "'network.proxy.type'|preferenceValue != 1 && "
+        '!("e6eb0d1e856335fc" in attachedFxAOAuthClients|mapToProperty("id"))'
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_CONFIGS = {


### PR DESCRIPTION
Because

- We want to be able to target users that are eligible for VPN early access 

This commit

- Adds the advanced targeting for users who are signed out, are not using new profile, are not enterprise, are not using a proxy, and are not Mozilla VPN subscribers.