### PR TITLE
fix(nimbus): fix null window access for older experiments

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -420,12 +420,9 @@ class ExperimentResultsManager:
 
     def get_window_results(self, analysis_basis, segment, window="overall"):
         return (
-            (
-                self.experiment.results_data.get("v3", {})
-                .get(window, {})
-                .get(analysis_basis, {})
-                .get(segment, {})
-            )
+            (self.experiment.results_data.get("v3", {}).get(window, {}) or {})
+            .get(analysis_basis, {})
+            .get(segment, {})
             if self.experiment.results_data
             else {}
         )

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -765,3 +765,183 @@ class TestExperimentResultsManager(TestCase):
             },
             kpi_metrics,
         )
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 1.49,
+                                                                "upper": 1.74,
+                                                                "point": 1.62,
+                                                            }
+                                                        ]
+                                                    },
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "overall",
+                {
+                    "branch-a": {
+                        "branch_data": {
+                            "other_metrics": {
+                                "urlbar_amazon_search_count": {
+                                    "absolute": {
+                                        "all": [
+                                            {
+                                                "lower": 1.49,
+                                                "upper": 1.74,
+                                                "point": 1.62,
+                                            }
+                                        ]
+                                    },
+                                    "percent": 12,
+                                }
+                            }
+                        }
+                    },
+                },
+            ),
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                            },
+                                                            {
+                                                                "lower": 130,
+                                                                "upper": 150,
+                                                                "point": 140,
+                                                            },
+                                                        ]
+                                                    },
+                                                }
+                                            }
+                                        },
+                                    },
+                                }
+                            }
+                        },
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 1.49,
+                                                                "upper": 1.74,
+                                                                "point": 1.62,
+                                                            }
+                                                        ]
+                                                    },
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "weekly",
+                {
+                    "branch-a": {
+                        "branch_data": {
+                            "other_metrics": {
+                                "urlbar_amazon_search_count": {
+                                    "absolute": {
+                                        "all": [
+                                            {
+                                                "lower": 140,
+                                                "upper": 160,
+                                                "point": 150,
+                                            },
+                                            {
+                                                "lower": 130,
+                                                "upper": 150,
+                                                "point": 140,
+                                            },
+                                        ]
+                                    },
+                                }
+                            }
+                        },
+                    },
+                },
+            ),
+            (
+                {
+                    "v3": {
+                        "weekly": None,
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 1.49,
+                                                                "upper": 1.74,
+                                                                "point": 1.62,
+                                                            }
+                                                        ]
+                                                    },
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "weekly",
+                {},
+            ),
+        ]
+    )
+    def test_get_window_results(self, results_data, window, expected):
+        self.experiment.results_data = results_data
+        self.experiment.save()
+
+        self.assertEqual(
+            self.results_manager.get_window_results("enrollments", "all", window),
+            expected,
+        )


### PR DESCRIPTION
Because

- Some older experiments have their weekly results_data fields set to None
- Currently the code for the new results page does not have a way to handle this and ends up raises errors when this null field has any attempts to access its value

This commit

- Adds a proper fallback after accessing the window field in results data in case it ever returns None
- Adds tests that mimic this edge case found in older experiments

Fixes #14447 