### PR TITLE
chore(nimbus): consistent table widths on detail page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
@@ -31,7 +31,7 @@
     <table class="table table-striped mb-0">
       <tbody>
         <tr>
-          <th scope="row">QA Signoff</th>
+          <th scope="row" class="w-25">QA Signoff</th>
           <td class="d-flex align-items-center">
             {% if edit %}
               {{ form.qa_signoff }}
@@ -47,7 +47,7 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">VP Signoff</th>
+          <th scope="row" class="w-25">VP Signoff</th>
           <td class="d-flex align-items-center">
             {% if edit %}
               {{ form.vp_signoff }}
@@ -63,7 +63,7 @@
           </td>
         </tr>
         <tr>
-          <th scope="row" class="border-bottom-0">Legal Signoff</th>
+          <th scope="row" class="w-25 border-bottom-0">Legal Signoff</th>
           <td class="d-flex align-items-center border-bottom-0">
             {% if edit %}
               {{ form.legal_signoff }}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/qa_container_content.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/qa_container_content.html
@@ -3,15 +3,15 @@
 <table class="table table-striped mb-0">
   <tbody>
     <tr>
-      <th>QA Status</th>
+      <th class="w-25">QA Status</th>
       <td colspan="3">{{ experiment.get_qa_status_display }}</td>
     </tr>
     <tr>
-      <th>QA Comment</th>
+      <th class="w-25">QA Comment</th>
       <td colspan="3">{{ experiment.qa_comment|default:"No comment" }}</td>
     </tr>
     <tr>
-      <th>Test Scenarios/Suites URL</th>
+      <th class="w-25">Test Scenarios/Suites URL</th>
       <td colspan="3">
         {% if experiment.qa_run_test_plan_url %}
           <a href="{{ experiment.qa_run_test_plan_url }}"
@@ -23,7 +23,7 @@
       </td>
     </tr>
     <tr>
-      <th class="border-bottom-0">TestRail Results URL</th>
+      <th class="w-25 border-bottom-0">TestRail Results URL</th>
       <td colspan="3" class="border-bottom-0">
         {% if experiment.qa_run_testrail_url %}
           <a href="{{ experiment.qa_run_testrail_url }}"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
@@ -29,7 +29,7 @@
     <table class="table table-striped mb-0">
       <tbody>
         <tr>
-          <th scope="row">QA Signoff</th>
+          <th scope="row" class="w-25">QA Signoff</th>
           <td class="d-flex align-items-center">
             {% if edit %}
               {{ form.qa_signoff }}
@@ -45,7 +45,7 @@
           </td>
         </tr>
         <tr>
-          <th scope="row">VP Signoff</th>
+          <th scope="row" class="w-25">VP Signoff</th>
           <td class="d-flex align-items-center">
             {% if edit %}
               {{ form.vp_signoff }}
@@ -61,7 +61,7 @@
           </td>
         </tr>
         <tr>
-          <th scope="row" class="border-bottom-0">Legal Signoff</th>
+          <th scope="row" class="w-25 border-bottom-0">Legal Signoff</th>
           <td class="d-flex align-items-center border-bottom-0">
             {% if edit %}
               {{ form.legal_signoff }}


### PR DESCRIPTION
Becuase

* It's nicer when things line up
* There was a couple misalignments on the detail page in the signoff and qa cards

This commit

* Applies the same table width styling to signoff and qa cards as the rest of the detail page cards

fixes #14450

