### PR TITLE
bug(nimbus): only set is_paused on ending enrollment forms

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1441,7 +1441,6 @@ class DraftToPreviewForm(UpdateStatusForm):
     status = NimbusExperiment.Status.PREVIEW
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
-    is_paused = False
 
     def get_changelog_message(self):
         return f"{self.request.user} launched experiment to Preview"
@@ -1464,7 +1463,6 @@ class DraftToReviewForm(SlackNotificationMixin, UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
-    is_paused = False
 
     slack_action = NimbusConstants.SLACK_ACTION_LAUNCH_REQUEST
 
@@ -1481,7 +1479,6 @@ class PreviewToReviewForm(SlackNotificationMixin, UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
-    is_paused = False
 
     slack_action = NimbusConstants.SLACK_ACTION_LAUNCH_REQUEST
 
@@ -1498,7 +1495,6 @@ class PreviewToDraftForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
-    is_paused = False
 
     def get_changelog_message(self):
         return f"{self.request.user} moved the experiment back to Draft"
@@ -1519,7 +1515,6 @@ class ReviewToDraftForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
-    is_paused = False
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000
@@ -1547,7 +1542,6 @@ class ReviewToApproveForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.APPROVED
-    is_paused = False
 
     def get_changelog_message(self):
         return f"{self.request.user} approved the review."
@@ -1600,7 +1594,6 @@ class ApproveEndEnrollmentForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.APPROVED
-    is_paused = True
 
     def get_changelog_message(self):
         return f"{self.request.user} approved the end enrollment request"
@@ -1623,7 +1616,6 @@ class LiveToCompleteForm(SlackNotificationMixin, UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.COMPLETE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
-    is_paused = False
 
     slack_action = NimbusConstants.SLACK_ACTION_END_EXPERIMENT_REQUEST
 
@@ -1640,7 +1632,6 @@ class ApproveEndExperimentForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.COMPLETE
     publish_status = NimbusExperiment.PublishStatus.APPROVED
-    is_paused = True
 
     def get_changelog_message(self):
         return f"{self.request.user} approved the end experiment request"
@@ -1722,7 +1713,6 @@ class LiveToUpdateRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
-    is_paused = False
 
     slack_action = NimbusConstants.SLACK_ACTION_UPDATE_REQUEST
 
@@ -1739,7 +1729,6 @@ class CancelUpdateRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
-    is_paused = False
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000
@@ -1767,7 +1756,6 @@ class ApproveUpdateRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.APPROVED
-    is_paused = False
 
     def get_changelog_message(self):
         return f"{self.request.user} approved the update review request"

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -1628,7 +1628,7 @@ class TestLiveToCompleteForm(SlackNotificationMockMixin, RequestFormTestCase):
         self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
         self.assertEqual(experiment.status_next, NimbusExperiment.Status.COMPLETE)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
-        self.assertFalse(experiment.is_paused)
+        self.assertTrue(experiment.is_paused)
 
         changelog = experiment.changes.latest("changed_on")
         self.assertEqual(changelog.changed_by, self.user)
@@ -1745,7 +1745,7 @@ class TestApproveEndExperimentForm(KintoPushQueueMockMixin, RequestFormTestCase)
         self.assertEqual(
             experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
         )
-        self.assertTrue(experiment.is_paused)
+        self.assertFalse(experiment.is_paused)
 
         changelog = experiment.changes.latest("changed_on")
         self.assertEqual(changelog.changed_by, self.user)


### PR DESCRIPTION
Becuase

* We have a nice reusable set of status transition forms for the UI
* We specify the entrance and exit statuses on each form
* When we set them up we specified is_paused on all of them except that can erroneously overwrite is_paused when it shouldn't
* We should actually only set is_paused=True when requesting end enrollment, and is_paused=False when canceling that request, and leave it unchanged in all other cases

This commit

* Removes is_paused from all status transition forms except request end enrollment and cancel end enrollment
* Updates tests assertions

fixes #14455

