### PR TITLE
feat(nimbus): add tooltips next to results page filters

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -119,6 +119,11 @@
         class="d-flex gap-4">
     <div class="col">
       <span class="fw-medium">Analysis Basis</span>
+      <i class="fa-regular fa-circle-question ps-1"
+         data-bs-toggle="tooltip"
+         data-bs-html="true"
+         data-bs-delay='{"hide":1000}'
+         title="Select the <strong>analysis basis</strong> whose results you want to see. See <a href='https://experimenter.info/jetstream/configuration/#defining-exposure-signals'>defining exposure signals</a> in the docs for more info."></i>
       <select name="analysis_basis"
               class="form-select bg-secondary-subtle"
               aria-label="Analysis Basis">
@@ -132,6 +137,10 @@
     </div>
     <div class="col">
       <span class="fw-medium">Reference branch</span>
+      <i class="fa-regular fa-circle-question ps-1"
+         data-bs-toggle="tooltip"
+         data-bs-html="true"
+         title="Select the <strong>reference branch</strong> to set it as the baseline for comparison results. By default this is the experiment's configured reference branch (commonly named 'control')."></i>
       <select name="reference_branch"
               class="form-select bg-secondary-subtle"
               aria-label="Reference Branch">
@@ -143,6 +152,11 @@
     </div>
     <div class="col">
       <span class="fw-medium">Segment</span>
+      <i class="fa-regular fa-circle-question ps-1"
+         data-bs-toggle="tooltip"
+         data-bs-html="true"
+         data-bs-delay='{"hide":1000}'
+         title="Select the <strong>analysis segment</strong> whose results you want to see. See <a href='https://experimenter.info/jetstream/configuration/#defining-segments'>defining segments</a> in the docs for more info."></i>
       <select name="segment"
               class="form-select bg-secondary-subtle"
               aria-label="Segment">


### PR DESCRIPTION
Because

- The filters on the new results page were missing the tooltips found on the old page

This commit

- Adds tooltips giving more information about each new results page filter

Fixes #14463 