### PR TITLE
style(nimbus): turn collapsible elements inside modals static

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
@@ -59,8 +59,7 @@
         <form method="post"
               id="branch-screenshot-form-{{ experiment_slug }}-{{ branch.slug }}"
               hx-encoding="multipart/form-data"
-              hx-post="{% url "nimbus-ui-branch-leading-screenshot-upload" slug=experiment_slug branch_slug=branch.slug %}"
-              class="accordion">
+              hx-post="{% url "nimbus-ui-branch-leading-screenshot-upload" slug=experiment_slug branch_slug=branch.slug %}">
           {% csrf_token %}
           {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
             <div class="position-relative border border-secondary-subtle rounded h-100 mb-3">
@@ -75,26 +74,16 @@
           {% endif %}
           {{ screenshot_form.image }}
           {% if screenshot_form.instance.image %}
-            <div class="accordion-item border border-1 rounded mt-4">
-              <button class="accordion-button shadow-none bg-transparent text-body"
-                      type="button"
-                      data-bs-toggle="collapse"
-                      data-bs-target="#screenshot-form-{{ experiment_slug }}-{{ branch.slug }}"
-                      aria-expanded="true"
-                      aria-controls="screenshot-form-{{ experiment_slug }}-{{ branch.slug }}">
-                <div class="d-flex flex-column align-items-start">
-                  <h6 class="mb-1">Add image description</h6>
-                  <small class="text-muted">Add a short description so people who can't see the image know what it shows.</small>
-                </div>
-              </button>
-              <div id="screenshot-form-{{ experiment_slug }}-{{ branch.slug }}"
-                   class="accordion-collapse collapse show">
-                <div class="accordion-body pt-0">{{ screenshot_form.description }}</div>
+            <div class="border border-1 rounded mt-4 p-3">
+              <div class="d-flex flex-column align-items-start">
+                <h6 class="mb-1">Add image description</h6>
+                <small class="text-muted">Add a short description so people who can't see the image know what it shows.</small>
               </div>
+              <div id="screenshot-form-{{ experiment_slug }}-{{ branch.slug }}"
+                   class="mt-3">{{ screenshot_form.description }}</div>
             </div>
           {% endif %}
           <div class="d-flex justify-content-end gap-2 mt-4">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
             <button type="submit" class="btn btn-primary">Save changes</button>
           </div>
         </form>

--- a/experimenter/experimenter/nimbus_ui/templates/common/edit_outcome_summary_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/edit_outcome_summary_form.html
@@ -1,72 +1,47 @@
-<form class="accordion"
-      method="post"
+<form method="post"
       hx-post="{% url 'nimbus-ui-edit-outcome-summary' slug=experiment.slug %}"
       id="edit-summary-form-{{ experiment.slug }}">
   {% csrf_token %}
-  <div class="accordion-item border border-1 rounded-4 mt-4 py-4 px-5">
-    <button class="accordion-button shadow-none bg-transparent text-body"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#key-takeaways-{{ experiment_slug }}-{{ branch.slug }}"
-            aria-expanded="true"
-            aria-controls="key-takeaways-{{ experiment_slug }}-{{ branch.slug }}">
-      <div class="d-flex flex-column align-items-start">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <h5 class="mb-0">Key takeaways</h5>
-          {% if not experiment.takeaways_summary %}
-            <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
-          {% endif %}
-        </div>
-        <small class="text-muted">{{ NimbusUIConstants.KEY_TAKEAWAYS_EMPTY_TEXT }}</small>
+  <div class="border border-1 rounded-4 mt-4 py-4 px-5">
+    <div class="d-flex flex-column align-items-start">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <h5 class="mb-0">Key takeaways</h5>
+        {% if not experiment.takeaways_summary %}
+          <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
+        {% endif %}
       </div>
-    </button>
+      <small class="text-muted">{{ NimbusUIConstants.KEY_TAKEAWAYS_EMPTY_TEXT }}</small>
+    </div>
     <div id="key-takeaways-{{ experiment_slug }}-{{ branch.slug }}"
-         class="accordion-collapse collapse show">
-      <div class="accordion-body">{{ edit_outcome_summary_form.takeaways_summary }}</div>
+         class="mt-3">{{ edit_outcome_summary_form.takeaways_summary }}</div>
+  </div>
+  <div class="border border-1 rounded-4 mt-4 py-4 px-5">
+    <div class="d-flex flex-column align-items-start">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <h5 class="mb-0">Next Steps</h5>
+        {% if not experiment.next_steps %}
+          <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
+        {% endif %}
+      </div>
+      <small class="text-muted">{{ NimbusUIConstants.NEXT_STEPS_EMPTY_TEXT }}</small>
+    </div>
+    <div id="next-steps-{{ experiment_slug }}-{{ branch.slug }}"  class="mt-3">
+      {{ edit_outcome_summary_form.next_steps }}
     </div>
   </div>
-  <div class="accordion-item border border-1 rounded-4 mt-4 py-4 px-5">
-    <button class="accordion-button shadow-none bg-transparent text-body"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#next-steps-{{ experiment_slug }}-{{ branch.slug }}"
-            aria-expanded="true"
-            aria-controls="next-steps-{{ experiment_slug }}-{{ branch.slug }}">
-      <div class="d-flex flex-column align-items-start">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <h5 class="mb-0">Next Steps</h5>
-          {% if not experiment.next_steps %}
-            <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
-          {% endif %}
-        </div>
-        <small class="text-muted">{{ NimbusUIConstants.NEXT_STEPS_EMPTY_TEXT }}</small>
+  <div class="border border-1 rounded-4 mt-4 py-4 px-5">
+    <div class="d-flex flex-column align-items-start">
+      <div class="d-flex align-items-center gap-2 mb-2">
+        <h5 class="mb-0">Project Impact</h5>
+        {% if not experiment.project_impact %}
+          <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
+        {% endif %}
       </div>
-    </button>
-    <div id="next-steps-{{ experiment_slug }}-{{ branch.slug }}"
-         class="accordion-collapse collapse show">
-      <div class="accordion-body">{{ edit_outcome_summary_form.next_steps }}</div>
+      <small class="text-muted">{{ NimbusUIConstants.PROJECT_IMPACT_EMPTY_TEXT }}</small>
     </div>
-  </div>
-  <div class="accordion-item border border-1 rounded-4 mt-4 py-4 px-5">
-    <button class="accordion-button shadow-none bg-transparent text-body"
-            type="button"
-            data-bs-toggle="collapse"
-            data-bs-target="#project-impact-{{ experiment_slug }}-{{ branch.slug }}"
-            aria-expanded="true"
-            aria-controls="project-impact-{{ experiment_slug }}-{{ branch.slug }}">
-      <div class="d-flex flex-column align-items-start">
-        <div class="d-flex align-items-center gap-2 mb-2">
-          <h5 class="mb-0">Project Impact</h5>
-          {% if not experiment.project_impact %}
-            <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
-          {% endif %}
-        </div>
-        <small class="text-muted">{{ NimbusUIConstants.PROJECT_IMPACT_EMPTY_TEXT }}</small>
-      </div>
-    </button>
     <div id="project-impact-{{ experiment_slug }}-{{ branch.slug }}"
-         class="accordion-collapse collapse show">
-      <div class="accordion-body d-flex flex-column gap-4">
+         class="mt-3">
+      <div class="d-flex flex-column gap-4">
         {% for radio in edit_outcome_summary_form.project_impact %}
           <div class="project-impact-option {{ key }}">
             <label class="d-flex gap-3 align-items-center">
@@ -86,7 +61,6 @@
     </div>
   </div>
   <div class="modal-footer border-0">
-    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
     <button type="submit"
             class="btn btn-primary"
             form="edit-summary-form-{{ experiment.slug }}">Save changes</button>

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -17,117 +17,94 @@
                 data-bs-dismiss="modal"
                 aria-label="Close"></button>
       </div>
-      <div class="modal-body accordion d-flex flex-column gap-4"
+      <div class="modal-body d-flex flex-column gap-4"
            id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">
-        <div class="accordion-item p-3 px-4 rounded-4">
-          <h2 class="accordion-header">
-            <button class="accordion-button fw-bold shadow-none bg-transparent text-body"
-                    type="button"
-                    data-bs-toggle="collapse"
-                    data-bs-target="#{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse"
-                    aria-expanded="true"
-                    aria-controls="{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse">Overview</button>
-          </h2>
-          <div class="accordion-collapse collapse show"
-               data-bs-parent="#{{ experiment_slug }}-{{ metric_info.slug }}-accordion"
-               id="{{ experiment_slug }}-{{ metric_info.slug }}-overview-collapse">
-            <div class="accordion-body row row-cols-3 g-3">
-              <div class="col">
-                <p class="fw-bold text-center">Branches</p>
-                {% for branch in branch_data %}
-                  <div class="p-3 mb-3 d-flex justify-content-center text-start text-center"
-                       style="height: 75px">
-                    <div class="d-flex flex-column align-items-center">
-                      <small class="text-muted mb-0">{{ branch.name }}</small>
-                      <p class="mb-0">
-                        {% if branch.slug == reference_branch %}
-                          Baseline
-                        {% else %}
-                          {{ branch.name }}
-                        {% endif %}
-                      </p>
-                    </div>
-                  </div>
-                {% endfor %}
-              </div>
-              <div class="col">
-                <p class="fw-bold text-center">Absolute count</p>
-                {% for branch_slug, branch_data in metric_data.items %}
-                  {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
-
-                {% endfor %}
-              </div>
-              <div class="col">
-                <p class="fw-bold text-center">Relative change</p>
-                <div class="d-flex flex-column">
-                  {% for branch_slug, branch_data in metric_data.items %}
-                    {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
-                      {% if branch_slug == branch_relative_ui %}
-                        {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
-
+        <div class="border border-1 rounded py-4 px-5 rounded-4">
+          <h2 class="fs-6 fw-bold">Overview</h2>
+          <div class="row row-cols-3 g-3">
+            <div class="col">
+              <p class="fw-bold text-center">Branches</p>
+              {% for branch in branch_data %}
+                <div class="p-3 mb-3 d-flex justify-content-center text-start text-center"
+                     style="height: 75px">
+                  <div class="d-flex flex-column align-items-center">
+                    <small class="text-muted mb-0">{{ branch.name }}</small>
+                    <p class="mb-0">
+                      {% if branch.slug == reference_branch %}
+                        Baseline
+                      {% else %}
+                        {{ branch.name }}
                       {% endif %}
-                    {% endfor %}
-                    {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
-                    {% if branch_slug == reference_branch %}
-                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+                    </p>
+                  </div>
+                </div>
+              {% endfor %}
+            </div>
+            <div class="col">
+              <p class="fw-bold text-center">Absolute count</p>
+              {% for branch_slug, branch_data in metric_data.items %}
+                {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+
+              {% endfor %}
+            </div>
+            <div class="col">
+              <p class="fw-bold text-center">Relative change</p>
+              <div class="d-flex flex-column">
+                {% for branch_slug, branch_data in metric_data.items %}
+                  {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
+                    {% if branch_slug == branch_relative_ui %}
+                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
 
                     {% endif %}
                   {% endfor %}
-                </div>
+                  {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
+                  {% if branch_slug == reference_branch %}
+                    {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+
+                  {% endif %}
+                {% endfor %}
               </div>
             </div>
           </div>
         </div>
         {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
           {% if weekly_metric_data.has_weekly_data %}
-            <div class="accordion-item p-3 px-4 rounded-4 border border-1">
-              <h2 class="accordion-header">
-                <button class="accordion-button fw-bold shadow-none bg-transparent text-body"
-                        type="button"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse"
-                        aria-expanded="true"
-                        aria-controls="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
-                  Weekly breakdown
-                </button>
-              </h2>
-              <div class="accordion-collapse collapse show"
-                   id="{{ experiment_slug }}-{{ metric_info.slug }}-weekly-collapse">
-                <div class="accordion-body d-flex">
-                  <div class="col-2">
-                    <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-                    {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
-                      {% for week in experiment.get_weekly_dates %}
-                        <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
-                             style="height: 100px">
-                          <small class="text-muted">Week {{ forloop.counter }}</small>
-                          <p class="mb-0">{{ week.0|date:"M j" }} - {{ week.1|date:"M j" }}</p>
-                        </div>
-                      {% endfor %}
-                    {% endwith %}
-                  </div>
-                  <div class="col position-relative w-25">
-                    <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
-                      {% if branch_data|length > 3 %}
-                        <div class="branch-fade branch-fade-left"></div>
-                        <div class="branch-fade branch-fade-right"></div>
-                      {% endif %}
-                      {% for branch in branch_data %}
-                        <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                          <p class="fs-5">{{ branch.name }}</p>
-                          <div class="d-flex flex-column gap-3 w-100">
-                            {% for curr_branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
-                              {% if curr_branch_slug == branch.slug %}
-                                {% for weekly_data_point in branch_weekly_metric_data %}
-                                  {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
+            <div class="border border-1 rounded py-4 px-5 rounded-4">
+              <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
+              <div class="d-flex mt-3">
+                <div class="col-2">
+                  <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+                  {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
+                    {% for week in experiment.get_weekly_dates %}
+                      <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                           style="height: 100px">
+                        <small class="text-muted">Week {{ forloop.counter }}</small>
+                        <p class="mb-0">{{ week.0|date:"M j" }} - {{ week.1|date:"M j" }}</p>
+                      </div>
+                    {% endfor %}
+                  {% endwith %}
+                </div>
+                <div class="col position-relative w-25">
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
+                    {% if branch_data|length > 3 %}
+                      <div class="branch-fade branch-fade-left"></div>
+                      <div class="branch-fade branch-fade-right"></div>
+                    {% endif %}
+                    {% for branch in branch_data %}
+                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="fs-5">{{ branch.name }}</p>
+                        <div class="d-flex flex-column gap-3 w-100">
+                          {% for curr_branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
+                            {% if curr_branch_slug == branch.slug %}
+                              {% for weekly_data_point in branch_weekly_metric_data %}
+                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
 
-                                {% endfor %}
-                              {% endif %}
-                            {% endfor %}
-                          </div>
+                              {% endfor %}
+                            {% endif %}
+                          {% endfor %}
                         </div>
-                      {% endfor %}
-                    </div>
+                      </div>
+                    {% endfor %}
                   </div>
                 </div>
               </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -326,7 +326,7 @@
      tabindex="-1"
      aria-labelledby="edit-summary-{{ experiment.slug }}-label"
      aria-hidden="true">
-  <div class="modal-dialog modal-dialog-centered modal-xl">
+  <div class="modal-dialog modal-xl modal-dialog-scrollable">
     <div class="modal-content p-5">
       <div class="modal-header border-0">
         <h4 class="modal-title" id="edit-summary-{{ experiment.slug }}-label">Edit outcome summary</h4>


### PR DESCRIPTION
Because

- There were several instances in the new results page where collapsible elements were found within modals
- Having both is superfluous so we can get rid of the nested collapsiblses

This commit

- Turns all collapsible elements inside modals into static blocks

Fixes #14487 