### PR TITLE
chore(application-services): improve application services docker image layer caching

### DIFF
--- a/application-services/Dockerfile
+++ b/application-services/Dockerfile
@@ -1,12 +1,10 @@
 FROM debian:bullseye-20240130
 WORKDIR /application-services
 
-COPY . .
-
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y \
-    curl \
-    jq \
-    zip && \
-    ./fetch-application-services.sh
+    apt-get install -y curl jq zip
+
+COPY . .
+
+RUN ./fetch-application-services.sh


### PR DESCRIPTION
Because

- It's generally considered best practice to install packages before running `COPY . .` so that docker can reuse the image layer cache more often

This commit

- Changes application services docker image to install package dependencies before copying files