### PR TITLE
fix(nimbus): reduce weekly range end dates in metric popout by 1

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1375,8 +1375,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if not self.is_rollout:
             if self._enrollment_end_date:
                 date = self._enrollment_end_date
-                while (date + datetime.timedelta(days=7)) <= self.computed_end_date:
-                    weekly_dates.append((date, date + datetime.timedelta(days=7)))
+                while (date + datetime.timedelta(days=6)) <= self.computed_end_date:
+                    weekly_dates.append((date, date + datetime.timedelta(days=6)))
                     date += datetime.timedelta(days=7)
 
         return weekly_dates

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1416,16 +1416,16 @@ class TestNimbusExperiment(TestCase):
                 datetime.date(2025, 1, 1),
                 datetime.date(2025, 1, 30),
                 [
-                    (datetime.date(2025, 1, 1), datetime.date(2025, 1, 8)),
-                    (datetime.date(2025, 1, 8), datetime.date(2025, 1, 15)),
-                    (datetime.date(2025, 1, 15), datetime.date(2025, 1, 22)),
-                    (datetime.date(2025, 1, 22), datetime.date(2025, 1, 29)),
+                    (datetime.date(2025, 1, 1), datetime.date(2025, 1, 7)),
+                    (datetime.date(2025, 1, 8), datetime.date(2025, 1, 14)),
+                    (datetime.date(2025, 1, 15), datetime.date(2025, 1, 21)),
+                    (datetime.date(2025, 1, 22), datetime.date(2025, 1, 28)),
                 ],
             ],
             [
                 datetime.date(2025, 1, 1),
                 datetime.date(2025, 1, 8),
-                [(datetime.date(2025, 1, 1), datetime.date(2025, 1, 8))],
+                [(datetime.date(2025, 1, 1), datetime.date(2025, 1, 7))],
             ],
             [datetime.date(2025, 1, 1), datetime.date(2025, 1, 3), []],
         ]


### PR DESCRIPTION
Because

- Weekly metric dates were slightly off 

This commit

- Adjusts the end date by reducing it by 1 preventing the dates from overlapping

Fixes #14465