### PR TITLE
feat(nimbus): add results indicator next to metric slug in metric area headers

### DIFF
--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -419,18 +419,21 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "retained",
                         "description": "Percentage of users who returned to Firefox two weeks later.",  # noqa E501
                         "display_type": "percentage",
+                        "overall_change": "neutral",
                     },
                     {
                         "group": "search_metrics",
                         "friendly_name": "Search Count",
                         "slug": "search_count",
                         "description": "Daily mean number of searches per user.",
+                        "overall_change": "neutral",
                     },
                     {
                         "group": "other_metrics",
                         "friendly_name": "Daily Active Users",
                         "slug": "client_level_daily_active_users_v2",
                         "description": "Average number of client that sent a main ping per day.",  # noqa E501
+                        "overall_change": "neutral",
                     },
                 ],
             ),
@@ -443,18 +446,21 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "retained",
                         "description": "Percentage of users who returned to Firefox two weeks later.",  # noqa E501
                         "display_type": "percentage",
+                        "overall_change": "neutral",
                     },
                     {
                         "group": "search_metrics",
                         "friendly_name": "Search Count",
                         "slug": "search_count",
                         "description": "Daily mean number of searches per user.",
+                        "overall_change": "neutral",
                     },
                     {
                         "group": "other_metrics",
                         "friendly_name": "Days of Use",
                         "slug": "days_of_use",
                         "description": "Average number of days each client sent a main ping.",  # noqa E501
+                        "overall_change": "neutral",
                     },
                 ],
             ),
@@ -764,6 +770,7 @@ class TestExperimentResultsManager(TestCase):
                 "slug": "client_level_daily_active_users_v2",
                 "description": "Average number of client that sent a main ping per day.",
                 "has_errors": True,
+                "overall_change": "neutral",
             },
             kpi_metrics,
         )
@@ -945,5 +952,389 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertEqual(
             self.results_manager.get_window_results("enrollments", "all", window),
+            expected,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "neutral",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "positive",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "negative"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "negative",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "negative"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "mixed",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "negative"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-b": {
+                                                            "overall": {"1": "neutral"},
+                                                            "weekly": {},
+                                                        },
+                                                        "branch-c": {
+                                                            "overall": {},
+                                                            "weekly": {},
+                                                        },
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                "mixed",
+            ),
+        ]
+    )
+    def test_get_overall_change(self, results_data, expected):
+        self.experiment.results_data = results_data
+        self.experiment.save()
+
+        self.assertEqual(
+            self.results_manager.get_overall_change(
+                "other_metrics",
+                "urlbar_amazon_search_count",
+                "enrollments",
+                "all",
+                "branch-a",
+            ),
             expected,
         )

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -217,7 +217,13 @@
               {% else %}
                 {% for metric in metric_metadata %}
                   <div>
-                    <small class="text-muted me-2">{{ metric.friendly_name }}</small>
+                    <small class="text-muted">{{ metric.friendly_name }}</small>
+                    <small>
+                      <i class="fa-solid ms-1 me-2 {% if metric.overall_change == 'positive' %}fa-up-long text-success{% elif metric.overall_change == 'negative' %}fa-down-long text-danger{% elif metric.overall_change == 'mixed' %}fa-up-down text-warning{% elif metric.overall_change == 'neutral' %}fa-left-long text-muted{% else %}fa-triangle-exclamation text-warning{% endif %}"
+                         data-bs-toggle="tooltip"
+                         title="{% if metric.overall_change == 'positive' %}Positive changes{% elif metric.overall_change == 'negative' %}Negative changes{% elif metric.overall_change == 'mixed' %}Mixed changes{% elif metric.overall_change == 'neutral' %}No notable change{% endif %}">
+                      </i>
+                    </small>
                     {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
                   </div>
                 {% endfor %}


### PR DESCRIPTION
Because

- Upon first visiting the new results page it is unclear the results of the experiment and whether there were any significant changes

This commit

- Adds an arrow indicator next to the metric names to indicate how that experiment affected that particular metric
- Fixed an issue where metrics would incorrectly be placed in the "Notable Changes" section

Fixes #14460 