### PR TITLE
bug(nimbus): fix indonesian language code

### DIFF
--- a/experimenter/experimenter/base/fixtures/languages.json
+++ b/experimenter/experimenter/base/fixtures/languages.json
@@ -524,7 +524,7 @@
     "model": "base.language",
     "fields": {
       "name": "Indonesian",
-      "code": "pk"
+      "code": "id"
     }
   },
   {

--- a/experimenter/experimenter/base/migrations/0006_fix_indonesian_language_code.py
+++ b/experimenter/experimenter/base/migrations/0006_fix_indonesian_language_code.py
@@ -1,0 +1,17 @@
+from django.db import migrations
+
+
+def fix_indonesian_language_code(apps, schema_editor):
+    Language = apps.get_model("base", "Language")
+
+    Language.objects.filter(code="pk").update(code="id")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("base", "0005_jajpmacos"),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_indonesian_language_code),
+    ]

--- a/experimenter/experimenter/base/tests/test_migrations.py
+++ b/experimenter/experimenter/base/tests/test_migrations.py
@@ -1,0 +1,27 @@
+from django_test_migrations.contrib.unittest_case import MigratorTestCase
+
+
+class TestFixIndonesianLanguageCodeMigration(MigratorTestCase):
+    migrate_from = ("base", "0005_jajpmacos")
+    migrate_to = ("base", "0006_fix_indonesian_language_code")
+
+    def prepare(self):
+        """Prepare test data before the migration."""
+        Language = self.old_state.apps.get_model("base", "Language")
+
+        # Create a Language with the incorrect "pk" code
+        Language.objects.create(name="Indonesian", code="pk")
+
+        # Create another language to ensure migration is targeted
+        Language.objects.create(name="Polish", code="pl")
+
+    def test_migration(self):
+        Language = self.new_state.apps.get_model("base", "Language")
+
+        # Check that Indonesian code was fixed
+        indonesian = Language.objects.get(name="Indonesian")
+        self.assertEqual(indonesian.code, "id")
+
+        # Check that other languages were not affected
+        polish = Language.objects.get(name="Polish")
+        self.assertEqual(polish.code, "pl")


### PR DESCRIPTION
Becuase

* When we updated the language fixtures file we accidentally changed the indonesian language code from id to pk

This commit

* Creates a data migration to update the code for Indonesian language
* Fixes the languages fixture

fixes #14502

