### PR TITLE
feat(nimbus): add loading state when changing filters on new results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-fragment.html
@@ -1,4 +1,4 @@
-<div class="d-flex flex-column gap-4 mt-4" id="experiment-results-page">
+<div class="d-flex flex-column gap-4 mt-3" id="experiment-results-page">
   {% if experiment.has_results_errors %}
     <div class="alert p-4 py-3 mb-0 rounded-4 alert-warning" role="alert">
       <div class="row align-items-center">
@@ -115,7 +115,7 @@
         hx-push-url="true"
         hx-trigger="change"
         hx-target="#experiment-results-page"
-        hx-swap="innerHTML"
+        hx-swap="outerHTML"
         class="d-flex gap-4">
     <div class="col">
       <span class="fw-medium">Analysis Basis</span>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -1,7 +1,15 @@
 {% load nimbus_extras %}
 
-<div class="accordion d-flex flex-column gap-4"
+<div class="accordion d-flex flex-column gap-4 position-relative"
      id="{{ experiment.slug }}-results-accordion">
+  {% comment %} Loading overlay {% endcomment %}
+  <div id="htmx-loading-overlay"
+       class="position-absolute bg-secondary top-0 start-0 w-100 h-100 d-flex align-items-center justify-content-center rounded">
+    <div class="text-center text-white">
+      <i class="fa-solid fa-spinner fa-spin-pulse fa-3x mb-3"></i>
+      <div class="fs-5">Loading...</div>
+    </div>
+  </div>
   {% comment %} Overview {% endcomment %}
   <div class="accordion-item p-3 px-4 shadow-sm rounded-4">
     <button class="accordion-button bg-transparent shadow-none text-body d-flex"


### PR DESCRIPTION
Because

- Changing filters from the new results page ui makes htmx network requests each time that have small delays before being fulfilled
-  There isn't any feedback from the ui letting the user know whether or not the request they made is being processed or not

This commit

- Adds a loading overlay in between filter changes

Fixes #14462 