### PR TITLE
feat(nimbus): add android language code mappings

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -342,6 +342,12 @@ class NimbusConstants:
 
     Application = Application
 
+    ANDROID_LANGUAGE_CODE_MAPPING = {
+        "he": "iw",
+        "id": "in",
+        "yi": "ji",
+    }
+
     class Type(models.TextChoices):
         EXPERIMENT = "Experiment"
         ROLLOUT = "Rollout"

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -707,6 +707,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             languages = [
                 language.code for language in sorted(languages, key=lambda l: l.code)
             ]
+            if self.application == self.Application.FENIX:
+                languages = [
+                    self.ANDROID_LANGUAGE_CODE_MAPPING.get(code, code)
+                    for code in languages
+                ]
             languages_expression = f"language in {languages}"
             if self.exclude_languages:
                 languages_expression = f"({languages_expression}) != true"

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1001,6 +1001,41 @@ class TestNimbusExperiment(TestCase):
         )
         validate_jexl_expr(experiment.targeting, experiment.application)
 
+    def test_targeting_with_android_language_codes_fenix(self):
+        language_he = LanguageFactory.create(code="he")
+        language_id = LanguageFactory.create(code="id")
+        language_yi = LanguageFactory.create(code="yi")
+        language_en = LanguageFactory.create(code="en")
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MOBILE_NEW_USERS,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
+            languages=[language_en, language_he, language_id, language_yi],
+        )
+        self.assertEqual(
+            experiment.targeting,
+            "(days_since_install < 7) && (language in ['en', 'iw', 'in', 'ji'])",
+        )
+        validate_jexl_expr(experiment.targeting, experiment.application)
+
+    def test_targeting_with_android_language_codes_non_fenix(self):
+        language_he = LanguageFactory.create(code="he")
+        language_id = LanguageFactory.create(code="id")
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            channels=[],
+            languages=[language_he, language_id],
+        )
+        self.assertIn("language in ['he', 'id']", experiment.targeting)
+        validate_jexl_expr(experiment.targeting, experiment.application)
+
     def test_targeting_with_projects(self):
         project_mdn = ProjectFactory.create(slug="mdn")
 


### PR DESCRIPTION
Becuase

* Android has some custom language code mappings that differ from the ISO 639 codes

This commit

* Adds the Android language code mappings
* Adds a test

fixes #14510

