### PR TITLE
feat(nimbus): add outcomes to overview section on new results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -66,6 +66,15 @@
                     {% endif %}
                   </p>
                 </div>
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Outcomes</p>
+                  {% for outcome, url in experiment_context.primary_outcome_links %}
+                    <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ outcome.title|remove_underscores }}</a>
+                  {% endfor %}
+                  {% for outcome, url in experiment_context.secondary_outcome_links %}
+                    <a href="{{ url }}" target="_blank" rel="noopener noreferrer">{{ outcome.title|remove_underscores }}</a>
+                  {% endfor %}
+                </div>
                 <div class="col-4 d-flex"></div>
                 <div class="row mt-2">
                   <p class="text-muted mb-0">Feature tags</p>

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3511,6 +3511,24 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(experiment.next_steps, "<p>Next steps paragraph</p>")
         self.assertEqual(experiment.project_impact, "HIGH")
 
+    def test_experiment_outcome_links(self):
+        application = NimbusExperiment.Application.DESKTOP
+        outcome_1 = Outcomes.get_by_slug_and_application("desktop_outcome_1", application)
+        outcome_2 = Outcomes.get_by_slug_and_application("desktop_outcome_2", application)
+        experiment = NimbusExperimentFactory.create(
+            application=application,
+            primary_outcomes=[outcome_1.slug],
+            secondary_outcomes=[outcome_2.slug],
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-new-results", kwargs={"slug": experiment.slug}),
+        )
+        self.assertEqual(response.status_code, 200)
+
+        self.assertIn("primary_outcome_links", response.context["experiment_context"])
+        self.assertIn("secondary_outcome_links", response.context["experiment_context"])
+
 
 class TestBranchScreenshotCreateView(AuthTestCase):
     def test_post_creates_screenshot(self):

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -751,6 +751,8 @@ class NewResultsView(NimbusExperimentViewMixin, DetailView):
         experiment = self.get_object()
         results_manager = ExperimentResultsManager(experiment)
 
+        context["experiment_context"] = build_experiment_context(self.object)
+
         analysis_data = (experiment.results_data or {}).get("v3", {})
 
         selected_reference_branch = self.request.GET.get(


### PR DESCRIPTION
Because

- Currently the summary page is the only place where you can see exactly what outcomes are associated with an experiment

This commit

- Adds outcomes along with links to metric-hub on overview section

Fixes #14520 