### PR TITLE
feat(nimbus): open notable changes by default

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -11,315 +11,313 @@
     </div>
   </div>
   {% comment %} Overview {% endcomment %}
-  <div class="px-5 pt-4 pb-5 shadow-sm rounded-4 bg-body">
+  <div class="px-5 pt-4 pb-5 shadow-sm rounded-4 bg-body border border-1">
     <h4 class="mt-2">Overview</h4>
-  </button>
-  <div id="{{ experiment.slug }}-results-overview"
-       class="accordion-collapse collapse show">
-    <div class="d-flex flex-column gap-4">
-      <hr>
-      <div>
-        <div class="row">
-          <div class="col-xxl">
-            <h5>Hypothesis</h5>
-            {% with hyp=experiment.hypothesis|default:"No hypothesis set." %}
-              {% if hyp|length > 300 %}
-                <p>
-                  {{ hyp|truncatechars:300 }}
-                  <a href="{{ experiment.get_detail_url }}" class="ms-1">More</a>
-                </p>
-              {% else %}
-                <p>{{ hyp }}</p>
-              {% endif %}
-            {% endwith %}
-          </div>
-          <div class="col-xxl">
-            <div class="row">
-              <div class="col-4 d-flex flex-column">
-                <p class="text-muted mb-0">Product Owner</p>
-                <p>{{ experiment.owner|default:"No product owner set." }}</p>
-              </div>
-              <div class="col-4 d-flex flex-column">
-                <p class="text-muted mb-0">Advanced Targeting</p>
-                <p>{{ experiment.targeting_config.name }}</p>
-              </div>
-              <div class="col-4 d-flex flex-column">
-                <p class="text-muted mb-0">Application</p>
-                <p>{{ experiment.application|default:"Unknown" }}</p>
-              </div>
+    <div id="{{ experiment.slug }}-results-overview">
+      <div class="d-flex flex-column gap-4">
+        <hr>
+        <div>
+          <div class="row">
+            <div class="col-xxl">
+              <h5>Hypothesis</h5>
+              {% with hyp=experiment.hypothesis|default:"No hypothesis set." %}
+                {% if hyp|length > 300 %}
+                  <p>
+                    {{ hyp|truncatechars:300 }}
+                    <a href="{{ experiment.get_detail_url }}" class="ms-1">More</a>
+                  </p>
+                {% else %}
+                  <p>{{ hyp }}</p>
+                {% endif %}
+              {% endwith %}
             </div>
-            <div class="row">
-              <div class="col-4 d-flex flex-column">
-                <p class="text-muted mb-0">Localization</p>
-                {% for locale in experiment.locales.all %}
-                  <p class="mb-0">{{ locale.name }}</p>
-                {% empty %}
-                  <p class="mb-0">None</p>
-                {% endfor %}
+            <div class="col-xxl">
+              <div class="row">
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Product Owner</p>
+                  <p>{{ experiment.owner|default:"No product owner set." }}</p>
+                </div>
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Advanced Targeting</p>
+                  <p>{{ experiment.targeting_config.name }}</p>
+                </div>
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Application</p>
+                  <p>{{ experiment.application|default:"Unknown" }}</p>
+                </div>
               </div>
-              <div class="col-4 d-flex flex-column">
-                <p class="text-muted mb-0">Version</p>
-                <p>
-                  {{ experiment.firefox_min_version }}
-                  {% if experiment.firefox_max_version %}
-                    - {{ experiment.firefox_max_version }}
-                  {% else %}
-                    +
-                  {% endif %}
-                </p>
-              </div>
-              <div class="col-4 d-flex"></div>
-              <div class="row mt-2">
-                <p class="text-muted mb-0">Feature tags</p>
-                <div class="d-flex flex-wrap">
-                  {% for tag in experiment.tags.all %}
-                    <span class="badge bg-light text-dark mb-1">{{ tag.name }}</span>
+              <div class="row">
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Localization</p>
+                  {% for locale in experiment.locales.all %}
+                    <p class="mb-0">{{ locale.name }}</p>
                   {% empty %}
-                    <p>None</p>
+                    <p class="mb-0">None</p>
                   {% endfor %}
+                </div>
+                <div class="col-4 d-flex flex-column">
+                  <p class="text-muted mb-0">Version</p>
+                  <p>
+                    {{ experiment.firefox_min_version }}
+                    {% if experiment.firefox_max_version %}
+                      - {{ experiment.firefox_max_version }}
+                    {% else %}
+                      +
+                    {% endif %}
+                  </p>
+                </div>
+                <div class="col-4 d-flex"></div>
+                <div class="row mt-2">
+                  <p class="text-muted mb-0">Feature tags</p>
+                  <div class="d-flex flex-wrap">
+                    {% for tag in experiment.tags.all %}
+                      <span class="badge bg-light text-dark mb-1">{{ tag.name }}</span>
+                    {% empty %}
+                      <p>None</p>
+                    {% endfor %}
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
-      </div>
-      <hr>
-      <div>
-        <div class="row row-cols-2 row-cols-xxl-3 g-4">
-          {% for branch in branch_data %}
-            <div class="col">
-              {% for branch_slug, branch_leading_screenshot_form in branch_leading_screenshot_forms.items %}
-                {% if branch_slug == branch.slug %}
-                  {% include "common/branch_card.html" with branch=branch experiment_slug=experiment.slug screenshot_form=branch_leading_screenshot_form %}
+        <hr>
+        <div>
+          <div class="row row-cols-2 row-cols-xxl-3 g-4">
+            {% for branch in branch_data %}
+              <div class="col">
+                {% for branch_slug, branch_leading_screenshot_form in branch_leading_screenshot_forms.items %}
+                  {% if branch_slug == branch.slug %}
+                    {% include "common/branch_card.html" with branch=branch experiment_slug=experiment.slug screenshot_form=branch_leading_screenshot_form %}
 
-                {% endif %}
-              {% endfor %}
-            </div>
-          {% endfor %}
+                  {% endif %}
+                {% endfor %}
+              </div>
+            {% endfor %}
+          </div>
         </div>
-      </div>
-      <hr>
-      <div>
-        {% if experiment.takeaways_summary or experiment.next_steps %}
-          <div class="row">
-            <div class="col">
-              <h5>Key takeaways</h5>
-              {% if experiment.takeaways_summary %}
-                <div>{{ experiment.takeaways_summary|safe }}</div>
-              {% else %}
-                <p class="text-muted">
-                  {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
-                </p>
-              {% endif %}
-            </div>
-            <div class="col d-flex flex-column gap-4">
-              <div>
-                <h5>Next steps</h5>
-                {% if experiment.next_steps %}
-                  <div>{{ experiment.next_steps|safe }}</div>
+        <hr>
+        <div>
+          {% if experiment.takeaways_summary or experiment.next_steps %}
+            <div class="row">
+              <div class="col">
+                <h5>Key takeaways</h5>
+                {% if experiment.takeaways_summary %}
+                  <div>{{ experiment.takeaways_summary|safe }}</div>
                 {% else %}
                   <p class="text-muted">
-                    {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
+                    {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
                   </p>
                 {% endif %}
               </div>
-              <div>
+              <div class="col d-flex flex-column gap-4">
+                <div>
+                  <h5>Next steps</h5>
+                  {% if experiment.next_steps %}
+                    <div>{{ experiment.next_steps|safe }}</div>
+                  {% else %}
+                    <p class="text-muted">
+                      {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
+                    </p>
+                  {% endif %}
+                </div>
+                <div>
+                  <div class="d-flex align-items-start gap-2">
+                    <h5>Project Impact</h5>
+                    {% if not experiment.project_impact %}
+                      <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
+                    {% endif %}
+                  </div>
+                  {% if experiment.project_impact %}
+                    <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact experiment</span>
+                  {% else %}
+                    <p class="text-muted">
+                      {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
+                    </p>
+                  {% endif %}
+                </div>
+              </div>
+              <div class="d-flex justify-content-end align-items-start col-1">
+                <button type="button"
+                        class="bg-transparent border-0"
+                        data-bs-toggle="modal"
+                        data-bs-target="#edit-summary-{{ experiment.slug }}">
+                  <i class="fa-solid fa-pencil text-muted fs-5"></i>
+                </button>
+              </div>
+            </div>
+          {% else %}
+            <div class="row">
+              <div class="col">
+                <h5>Key takeaways</h5>
+                <p class="text-muted">
+                  {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
+                </p>
+              </div>
+              <div class="col">
+                <h5>Next steps</h5>
+                <p class="text-muted">
+                  {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
+                </p>
+              </div>
+              <div class="col">
                 <div class="d-flex align-items-start gap-2">
                   <h5>Project Impact</h5>
                   {% if not experiment.project_impact %}
                     <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
                   {% endif %}
                 </div>
-                {% if experiment.project_impact %}
-                  <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact experiment</span>
-                {% else %}
-                  <p class="text-muted">
-                    {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
-                  </p>
-                {% endif %}
+                <p class="text-muted">
+                  {% if experiment.project_impact %}
+                    <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact experiment</span>
+                  {% else %}
+                    <p class="text-muted">
+                      {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
+                    </p>
+                  {% endif %}
+                </p>
+              </div>
+              <div class="col-1 d-flex justify-content-end align-items-start">
+                <button type="button"
+                        class="bg-transparent border-0"
+                        data-bs-toggle="modal"
+                        data-bs-target="#edit-summary-{{ experiment.slug }}">
+                  <i class="fa-solid fa-pencil text-muted fs-5"></i>
+                </button>
               </div>
             </div>
-            <div class="d-flex justify-content-end align-items-start col-1">
-              <button type="button"
-                      class="bg-transparent border-0"
-                      data-bs-toggle="modal"
-                      data-bs-target="#edit-summary-{{ experiment.slug }}">
-                <i class="fa-solid fa-pencil text-muted fs-5"></i>
-              </button>
-            </div>
-          </div>
-        {% else %}
-          <div class="row">
-            <div class="col">
-              <h5>Key takeaways</h5>
-              <p class="text-muted">
-                {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
-              </p>
-            </div>
-            <div class="col">
-              <h5>Next steps</h5>
-              <p class="text-muted">
-                {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}
-              </p>
-            </div>
-            <div class="col">
-              <div class="d-flex align-items-start gap-2">
-                <h5>Project Impact</h5>
-                {% if not experiment.project_impact %}
-                  <span class="badge rounded-pill text-bg-warning bg-opacity-25 border border-secondary-subtle">Incomplete</span>
-                {% endif %}
-              </div>
-              <p class="text-muted">
-                {% if experiment.project_impact %}
-                  <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact experiment</span>
-                {% else %}
-                  <p class="text-muted">
-                    {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.project_impact }}
-                  </p>
-                {% endif %}
-              </p>
-            </div>
-            <div class="col-1 d-flex justify-content-end align-items-start">
-              <button type="button"
-                      class="bg-transparent border-0"
-                      data-bs-toggle="modal"
-                      data-bs-target="#edit-summary-{{ experiment.slug }}">
-                <i class="fa-solid fa-pencil text-muted fs-5"></i>
-              </button>
-            </div>
-          </div>
-        {% endif %}
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
-</div>
-{% comment %} Metrics {% endcomment %}
-{% for area, metric_data_metadata in metric_area_data.items %}
-  {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data.overall %}
-    {% if metric_data %}
-      <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
-        <button class="accordion-button bg-transparent shadow-none text-body d-flex collapsed"
-                type="button"
-                data-bs-toggle="collapse"
-                data-bs-target="#{{ experiment.slug }}-results-{{ area|slugify }}"
-                aria-expanded="true"
-                aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
-          <div class="pe-3">
-            <div class="d-flex align-items-center gap-3 mb-2">
-              <h4 class="mb-0">{{ area }}</h4>
-              {% if experiment.is_observation %}
-                <span class="badge rounded-pill bg-primary-subtle border border-1 border-secondary-subtle"><span class="text-black">In progress &middot; <span class="text-muted fw-medium">results still forming</span></span></span>
-              {% endif %}
+  {% comment %} Metrics {% endcomment %}
+  {% for area, metric_data_metadata in metric_area_data.items %}
+    {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data.overall %}
+      {% if metric_data %}
+        <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
+          <button class="accordion-button bg-transparent shadow-none text-body d-flex {% if not area == NimbusUIConstants.NOTABLE_METRIC_AREA %}collapsed{% endif %}"
+                  type="button"
+                  data-bs-toggle="collapse"
+                  data-bs-target="#{{ experiment.slug }}-results-{{ area|slugify }}"
+                  aria-expanded="{% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}true{% else %}false{% endif %}"
+                  aria-controls="{{ experiment.slug }}-results-{{ area|slugify }}">
+            <div class="pe-3">
+              <div class="d-flex align-items-center gap-3 mb-2">
+                <h4 class="mb-0">{{ area }}</h4>
+                {% if experiment.is_observation %}
+                  <span class="badge rounded-pill bg-primary-subtle border border-1 border-secondary-subtle"><span class="text-black">In progress &middot; <span class="text-muted fw-medium">results still forming</span></span></span>
+                {% endif %}
+              </div>
+              <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
+                {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
+                  <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
+                {% else %}
+                  {% for metric in metric_metadata %}
+                    <div>
+                      <small class="text-muted">{{ metric.friendly_name }}</small>
+                      <small>
+                        <i class="fa-solid ms-1 me-2 {% if metric.overall_change == 'positive' %}fa-up-long text-success{% elif metric.overall_change == 'negative' %}fa-down-long text-danger{% elif metric.overall_change == 'mixed' %}fa-up-down text-warning{% elif metric.overall_change == 'neutral' %}fa-left-long text-muted{% else %}fa-triangle-exclamation text-warning{% endif %}"
+                           data-bs-toggle="tooltip"
+                           title="{% if metric.overall_change == 'positive' %}Positive changes{% elif metric.overall_change == 'negative' %}Negative changes{% elif metric.overall_change == 'mixed' %}Mixed changes{% elif metric.overall_change == 'neutral' %}No notable change{% endif %}">
+                        </i>
+                      </small>
+                      {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
+                    </div>
+                  {% endfor %}
+                {% endif %}
+              </div>
             </div>
-            <div class="d-inline-flex gap-3 flex-wrap row-gap-1">
-              {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
-                <small class="text-muted">All statistically significant changes that have occurred in the experiment</small>
-              {% else %}
+          </button>
+          <div id="{{ experiment.slug }}-results-{{ area|slugify }}"
+               class="accordion-collapse collapse {% if area == NimbusUIConstants.NOTABLE_METRIC_AREA %}show{% endif %}">
+            <div class="accordion-body d-flex">
+              <div class="col-2">
+                <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
                 {% for metric in metric_metadata %}
-                  <div>
-                    <small class="text-muted">{{ metric.friendly_name }}</small>
-                    <small>
-                      <i class="fa-solid ms-1 me-2 {% if metric.overall_change == 'positive' %}fa-up-long text-success{% elif metric.overall_change == 'negative' %}fa-down-long text-danger{% elif metric.overall_change == 'mixed' %}fa-up-down text-warning{% elif metric.overall_change == 'neutral' %}fa-left-long text-muted{% else %}fa-triangle-exclamation text-warning{% endif %}"
-                         data-bs-toggle="tooltip"
-                         title="{% if metric.overall_change == 'positive' %}Positive changes{% elif metric.overall_change == 'negative' %}Negative changes{% elif metric.overall_change == 'mixed' %}Mixed changes{% elif metric.overall_change == 'neutral' %}No notable change{% endif %}">
-                      </i>
-                    </small>
-                    {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
-                  </div>
-                {% endfor %}
-              {% endif %}
-            </div>
-          </div>
-        </button>
-        <div id="{{ experiment.slug }}-results-{{ area|slugify }}"
-             class="accordion-collapse collapse">
-          <div class="accordion-body d-flex">
-            <div class="col-2">
-              <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-              {% for metric in metric_metadata %}
-                <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle nav-link-hover "
-                        type="button"
-                        data-bs-toggle="modal"
-                        data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
-                        style="height: 100px">
-                  <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
-                  <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
-                </button>
-                {% for curr_metric_slug, metric_data in metric_data.items %}
-                  {% if curr_metric_slug == metric.slug %}
-                    {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
-                      {% if metric_ui_properties == curr_metric_slug %}
-                        {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
+                  <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle nav-link-hover "
+                          type="button"
+                          data-bs-toggle="modal"
+                          data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
+                          style="height: 100px">
+                    <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
+                    <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
+                  </button>
+                  {% for curr_metric_slug, metric_data in metric_data.items %}
+                    {% if curr_metric_slug == metric.slug %}
+                      {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
+                        {% if metric_ui_properties == curr_metric_slug %}
+                          {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
 
-                      {% endif %}
-                    {% endfor %}
-                  {% endif %}
-                {% endfor %}
-              {% endfor %}
-            </div>
-            <div class="col position-relative w-25 d-flex flex-column">
-              {% if experiment.is_enrolling %}
-                <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
-                  {% for branch in branch_data %}
-                    <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                      <p class="fs-5">{{ branch.name }}</p>
-                    </div>
+                        {% endif %}
+                      {% endfor %}
+                    {% endif %}
                   {% endfor %}
-                </div>
-                <div class="ms-4 bg-body-tertiary rounded-3 flex-grow-1 overflow-auto d-flex align-items-center mb-4">
-                  <span class="text-muted mx-auto">Metrics are on their way! Enrollment is in progress!</span>
-                </div>
-              {% else %}
-                <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
-                  {% if branch_data|length > 4 %}
-                    <div class="branch-fade branch-fade-left"></div>
-                    <div class="branch-fade branch-fade-right"></div>
-                  {% endif %}
-                  {% for branch in branch_data %}
-                    <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                      <p class="fs-5">{{ branch.name }}</p>
-                      <div class="d-flex flex-column gap-3 w-100">
-                        {% for metric in metric_metadata %}
-                          {% for curr_metric_slug, metric_branch_data in metric_data.items %}
-                            {% if curr_metric_slug == metric.slug %}
-                              {% if metric.has_errors %}
-                                {% if forloop.parentloop.parentloop.first %}
-                                  <div class="d-flex align-items-center" style="height: 100px;">
-                                    <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
-                                      <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-                                      <p class="mb-0 fw-semibold">Metric unavailable</p>
-                                      <p class="mb-0">Other metrics are unaffected.</p>
-                                      <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
-                                        Contact Experimenter Support
-                                      </button>
-                                    </div>
-                                  </div>
-                                {% else %}
-                                  <div class="invisible" style="height: 100px;" aria-hidden="true"></div>
-                                {% endif %}
-                              {% else %}
-                                {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
-                                  {% if curr_branch_slug == branch.slug %}
-                                    {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
-
-                                  {% endif %}
-                                {% endfor %}
-                              {% endif %}
-                            {% endif %}
-                          {% endfor %}
-                        {% endfor %}
+                {% endfor %}
+              </div>
+              <div class="col position-relative w-25 d-flex flex-column">
+                {% if experiment.is_enrolling %}
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                    {% for branch in branch_data %}
+                      <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="fs-5">{{ branch.name }}</p>
                       </div>
-                    </div>
-                  {% endfor %}
-                </div>
-              {% endif %}
+                    {% endfor %}
+                  </div>
+                  <div class="ms-4 bg-body-tertiary rounded-3 flex-grow-1 overflow-auto d-flex align-items-center mb-4">
+                    <span class="text-muted mx-auto">Metrics are on their way! Enrollment is in progress!</span>
+                  </div>
+                {% else %}
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 4 %}mx-4{% endif %}">
+                    {% if branch_data|length > 4 %}
+                      <div class="branch-fade branch-fade-left"></div>
+                      <div class="branch-fade branch-fade-right"></div>
+                    {% endif %}
+                    {% for branch in branch_data %}
+                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="fs-5">{{ branch.name }}</p>
+                        <div class="d-flex flex-column gap-3 w-100">
+                          {% for metric in metric_metadata %}
+                            {% for curr_metric_slug, metric_branch_data in metric_data.items %}
+                              {% if curr_metric_slug == metric.slug %}
+                                {% if metric.has_errors %}
+                                  {% if forloop.parentloop.parentloop.first %}
+                                    <div class="d-flex align-items-center" style="height: 100px;">
+                                      <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                        <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                        <p class="mb-0 fw-semibold">Metric unavailable</p>
+                                        <p class="mb-0">Other metrics are unaffected.</p>
+                                        <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
+                                          Contact Experimenter Support
+                                        </button>
+                                      </div>
+                                    </div>
+                                  {% else %}
+                                    <div class="invisible" style="height: 100px;" aria-hidden="true"></div>
+                                  {% endif %}
+                                {% else %}
+                                  {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
+                                    {% if curr_branch_slug == branch.slug %}
+                                      {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
+
+                                    {% endif %}
+                                  {% endfor %}
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+                          {% endfor %}
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                {% endif %}
+              </div>
             </div>
           </div>
         </div>
-      </div>
-    {% endif %}
-  {% endwith %}
-{% endfor %}
+      {% endif %}
+    {% endwith %}
+  {% endfor %}
 </div>
 <div class="modal fade"
      id="edit-summary-{{ experiment.slug }}"


### PR DESCRIPTION
Because

- It is not immediately clear what the results of an experiment are b/c all the dropdowns start closed

This commit

- Sets the notable changes dropdown to be opened by default
- Removes an unpaired `</button>` tag from `results-new-inner`

Fixes #14473 