### PR TITLE
fix(nimbus): fix incorrect metric result indicator for default metrics

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -283,7 +283,7 @@ class ExperimentResultsManager:
                             slug, analysis_basis, segment
                         ),
                         "overall_change": self.get_overall_change(
-                            "other_metrics",
+                            group,
                             slug,
                             analysis_basis,
                             segment,

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -532,7 +532,76 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertListEqual(kpi_metrics, expected_kpi_metrics)
 
-    def test_get_defaults_metrics_with_exclusions(self):
+    def test_get_default_metrics_overall_change(self):
+        self.experiment.results_data = {
+            "v3": {
+                "metadata": {
+                    "metrics": {
+                        "metricA": {
+                            "search_count": "Search Count",
+                        }
+                    },
+                },
+                "other_metrics": {
+                    "search_metrics": {
+                        "search_count": "Search Count",
+                    }
+                },
+                "overall": {
+                    "enrollments": {
+                        "all": {
+                            "branch-a": {
+                                "branch_data": {
+                                    "search_metrics": {
+                                        "search_count": {
+                                            "significance": {
+                                                "branch-a": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                },
+                                                "branch-b": {
+                                                    "overall": {"1": "positive"},
+                                                    "weekly": {},
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "branch-b": {
+                                "branch_data": {
+                                    "search_metrics": {
+                                        "search_count": {
+                                            "significance": {
+                                                "branch-a": {
+                                                    "overall": {"1": "positive"},
+                                                    "weekly": {},
+                                                },
+                                                "branch-b": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                },
+            }
+        }
+        self.experiment.save()
+        remaining_metrics = self.results_manager.get_remaining_metrics_metadata(
+            analysis_basis="enrollments", segment="all", reference_branch="branch-a"
+        )
+
+        self.assertEqual(
+            remaining_metrics[0].get("overall_change"),
+            "positive",
+        )
+
+    def test_get_default_metrics_with_exclusions(self):
         self.experiment.results_data = {
             "v3": {
                 "metadata": {


### PR DESCRIPTION
Because

- Metric group was hardcoded as `other_metrics` for all default metrics
- This caused default metrics that don't belong to that group to have their data missed and end up using the neutral fallback value

This commit

- Passes the correct metric group to `get_overall_changes` for default metrics

Fixes #14546 