### PR TITLE
feat(nimbus): disable slack notification toggle for complete experiments

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -45,10 +45,12 @@
             class="d-flex align-items-center">
         {% csrf_token %}
         <input type="hidden" name="enable_review_slack_notifications" value="false">
-        <div class="form-check form-switch d-flex align-items-center">
+        <div class="form-check form-switch d-flex align-items-center"
+             {% if experiment.is_complete %}data-bs-toggle="tooltip" data-bs-placement="left" title="Disabled because experiment is complete"{% endif %}>
           <label for="slack-notifications-toggle"
                  class="form-check-label text-secondary small me-2 mb-0"
-                 style="cursor: pointer">
+                 style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %};
+                        {% if experiment.is_complete %}opacity: 0.5{% endif %}">
             <i class="fa-solid fa-bell me-1"></i>
             <span>Enable review Slack notifications</span>
           </label>
@@ -57,10 +59,11 @@
                  name="enable_review_slack_notifications"
                  value="true"
                  {% if experiment.enable_review_slack_notifications %}checked{% endif %}
+                 {% if experiment.is_complete %}disabled{% endif %}
                  onchange="this.form.submit()"
                  class="form-check-input m-0"
                  role="switch"
-                 style="cursor: pointer">
+                 style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %}">
         </div>
       </form>
     </div>


### PR DESCRIPTION
Becuase

* Once an experiment completes there will be no more slack review notifications
* We should disable the toggle for it once an experiment completes
* We could hide it entirely but perhaps it's a better UI pattern to leave it in place and disable it with a tooltip explaining why

This commit

* Disables the slack review notification toggle for complete experiments
* Adds an explanatory tooltip

fixes #14548

