### PR TITLE
chore(project): update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-/cirrus/ @jaredlockhart @yashikakhurana @jeddai
-/experimenter/experimenter/ @jaredlockhart @yashikakhurana @freshstrangemusic
-/experimenter/jetstream @jaredlockhart @mikewilli
-/experimenter/manifesttool/ @jaredlockhart @freshstrangemusic
-/experimenter/tests @b4handjr
-/schemas/ @jaredlockhart @mikewilli @freshstrangemusic
+* @freshstrangemusic @jaredlockhart @mikewilli @yashikakhurana @relud


### PR DESCRIPTION
Becuase

* We haven't updated codeowners in a while

This commit

* Updates codeowners to the current team members
* Removes per package assignments since everybody's gotten comfortable reviewing every part of the project by now

fixes #14556

