### PR TITLE
feat(nimbus): improve ui for metrics with missing data

### DIFF
--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -420,6 +420,7 @@ class TestExperimentResultsManager(TestCase):
                         "description": "Percentage of users who returned to Firefox two weeks later.",  # noqa E501
                         "display_type": "percentage",
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                     {
                         "group": "search_metrics",
@@ -427,6 +428,7 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "search_count",
                         "description": "Daily mean number of searches per user.",
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                     {
                         "group": "other_metrics",
@@ -434,6 +436,7 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "client_level_daily_active_users_v2",
                         "description": "Average number of client that sent a main ping per day.",  # noqa E501
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                 ],
             ),
@@ -447,6 +450,7 @@ class TestExperimentResultsManager(TestCase):
                         "description": "Percentage of users who returned to Firefox two weeks later.",  # noqa E501
                         "display_type": "percentage",
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                     {
                         "group": "search_metrics",
@@ -454,6 +458,7 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "search_count",
                         "description": "Daily mean number of searches per user.",
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                     {
                         "group": "other_metrics",
@@ -461,6 +466,7 @@ class TestExperimentResultsManager(TestCase):
                         "slug": "days_of_use",
                         "description": "Average number of days each client sent a main ping.",  # noqa E501
                         "overall_change": "neutral",
+                        "has_data": False,
                     },
                 ],
             ),
@@ -469,6 +475,7 @@ class TestExperimentResultsManager(TestCase):
     def test_get_kpi_metrics_returns_correct_metrics(
         self, kpi_slug, expected_kpi_metrics
     ):
+        self.maxDiff = None
         self.experiment.results_data = {
             "v3": {
                 "overall": {
@@ -840,6 +847,7 @@ class TestExperimentResultsManager(TestCase):
                 "description": "Average number of client that sent a main ping per day.",
                 "has_errors": True,
                 "overall_change": "neutral",
+                "has_data": False,
             },
             kpi_metrics,
         )
@@ -1404,6 +1412,278 @@ class TestExperimentResultsManager(TestCase):
                 "enrollments",
                 "all",
                 "branch-a",
+            ),
+            expected,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "urlbar_amazon_search_count",
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 140,
+                                                            "upper": 160,
+                                                            "point": 150,
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                True,
+            ),
+            (
+                "urlbar_amazon_search_count",
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 0,
+                                                            "upper": 0,
+                                                            "point": 0,
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                False,
+            ),
+            (
+                "client_level_daily_active_users_v2",
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "client_level_daily_active_users_v2": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"first": {}},
+                                                        "branch-b": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "client_level_daily_active_users_v2": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                        "branch-b": {"first": {}},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                True,
+            ),
+            (
+                "client_level_daily_active_users_v2",
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "client_level_daily_active_users_v2": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                        "branch-b": {
+                                                            "first": {
+                                                                "lower": 0,
+                                                                "upper": 0,
+                                                                "point": 0,
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "client_level_daily_active_users_v2": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": 0,
+                                                                "upper": 0,
+                                                                "point": 0,
+                                                            }
+                                                        },
+                                                        "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                False,
+            ),
+        ]
+    )
+    def test_metrics_have_data(self, metric_slug, results_data, expected):
+        self.experiment.results_data = results_data
+        self.experiment.delete_branches()
+
+        self.experiment.reference_branch = NimbusBranchFactory.create(
+            experiment=self.experiment, name="Branch A", slug="branch-a"
+        )
+        NimbusBranchFactory.create(
+            experiment=self.experiment, name="Branch B", slug="branch-b"
+        )
+        self.experiment.save()
+
+        self.assertEqual(
+            self.results_manager.metric_has_data(
+                metric_slug,
+                "other_metrics",
+                "enrollments",
+                "all",
+                reference_branch="branch-a",
+            ),
+            expected,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "overall": {},
+                        "daily": {},
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 140,
+                                                            "upper": 160,
+                                                            "point": 150,
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                True,
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {},
+                        "weekly": {},
+                        "daily": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 0.5,
+                                                            "upper": 1.5,
+                                                            "point": 1.0,
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                True,
+            ),
+        ]
+    )
+    def test_metrics_have_data_different_windows(self, results_data, expected):
+        self.experiment.results_data = results_data
+        self.experiment.delete_branches()
+
+        self.experiment.reference_branch = NimbusBranchFactory.create(
+            experiment=self.experiment, name="Branch A", slug="branch-a"
+        )
+        NimbusBranchFactory.create(
+            experiment=self.experiment, name="Branch B", slug="branch-b"
+        )
+        self.experiment.save()
+
+        self.assertEqual(
+            self.results_manager.metric_has_data(
+                "urlbar_amazon_search_count",
+                "other_metrics",
+                "enrollments",
+                "all",
+                reference_branch="branch-a",
             ),
             expected,
         )

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
@@ -4,8 +4,9 @@
   {% if slug == reference_branch %}
     <div class="p-3 bg-body-tertiary text-muted text-center d-flex align-items-center justify-content-center flex-wrap rounded-3"
          style="height: 100px">
+      <span class="fw-medium w-100">Baseline</span>
       {% if absolute_lower %}
-        {% if display_type == "percentage" %}
+        {% if absolute_lower and display_type == "percentage" %}
           <span class="mb-0 me-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower|to_percentage }}">({{ absolute_lower|to_percentage:1 }}</span>
@@ -18,14 +19,10 @@
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower }}">({{ absolute_lower|floatformat:2 }}</span>
           to
-          <p class="mb-0 ms-1"
-             data-bs-toggle="tooltip"
-             data-bs-title="{{ absolute_upper }}">
-            {{ absolute_upper|floatformat:2 }})
-          </span>
+          <span class="mb-0 ms-1"
+                data-bs-toggle="tooltip"
+                data-bs-title="{{ absolute_upper }}">{{ absolute_upper|floatformat:2 }})</span>
         {% endif %}
-      {% else %}
-        Baseline
       {% endif %}
     </div>
   {% else %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -234,9 +234,9 @@
                     <div>
                       <small class="text-muted">{{ metric.friendly_name }}</small>
                       <small>
-                        <i class="fa-solid ms-1 me-2 {% if metric.overall_change == 'positive' %}fa-up-long text-success{% elif metric.overall_change == 'negative' %}fa-down-long text-danger{% elif metric.overall_change == 'mixed' %}fa-up-down text-warning{% elif metric.overall_change == 'neutral' %}fa-left-long text-muted{% else %}fa-triangle-exclamation text-warning{% endif %}"
+                        <i class="fa-solid ms-1 me-2 {% if metric.has_errors or not metric.has_data %}fa-triangle-exclamation text-warning{% elif metric.overall_change == 'positive' %}fa-up-long text-success{% elif metric.overall_change == 'negative' %}fa-down-long text-danger{% elif metric.overall_change == 'mixed' %}fa-up-down text-warning{% elif metric.overall_change == 'neutral' %}fa-left-long text-muted{% endif %}"
                            data-bs-toggle="tooltip"
-                           title="{% if metric.overall_change == 'positive' %}Positive changes{% elif metric.overall_change == 'negative' %}Negative changes{% elif metric.overall_change == 'mixed' %}Mixed changes{% elif metric.overall_change == 'neutral' %}No notable change{% endif %}">
+                           title="{% if metric.has_errors or not metric.has_data %}No data available{% elif metric.overall_change == 'positive' %}Positive changes{% elif metric.overall_change == 'negative' %}Negative changes{% elif metric.overall_change == 'mixed' %}Mixed changes{% elif metric.overall_change == 'neutral' %}No notable change{% endif %}">
                         </i>
                       </small>
                       {% if not forloop.last %}<span class="text-muted">&middot;</span>{% endif %}
@@ -253,12 +253,15 @@
                 <div class="col-2">
                   <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
                   {% for metric in metric_metadata %}
-                    <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle nav-link-hover "
+                    <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle                   {% if metric.has_data %}nav-link-hover{% else %}bg-body-tertiary{% endif %}  text-break"
                             type="button"
                             data-bs-toggle="modal"
                             data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
-                            style="height: 100px">
-                      <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
+                            style="height: 100px;
+                                   {% if not metric.has_data %}cursor: default;{% endif %}">
+                      {% if metric.has_data %}
+                        <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
+                      {% endif %}
                       <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
                     </button>
                     {% for curr_metric_slug, metric_data in metric_data.items %}
@@ -298,13 +301,13 @@
                             {% for metric in metric_metadata %}
                               {% for curr_metric_slug, metric_branch_data in metric_data.items %}
                                 {% if curr_metric_slug == metric.slug %}
-                                  {% if metric.has_errors %}
+                                  {% if metric.has_errors or not metric.has_data %}
                                     {% if forloop.parentloop.parentloop.first %}
                                       <div class="d-flex align-items-center" style="height: 100px;">
                                         <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
                                           <i class="fa-solid fa-triangle-exclamation fs-5"></i>
                                           <p class="mb-0 fw-semibold">Metric unavailable</p>
-                                          <p class="mb-0">Other metrics are unaffected.</p>
+                                          <p class="mb-0">Other metrics may not be affected.</p>
                                           <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
                                              target="_blank"
                                              href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>


### PR DESCRIPTION
Because

- It is unclear when a metric is missing data

This commit

- Adds error text when a metric is missing data
- Updates metric tooltip in header to show error icon if the metric is unavailable
- Disable the popout view for unavailable metrics

Fixes #14501