### PR TITLE
feat(nimbus): add back ingestion for daily metrics in experimenter

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -197,9 +197,9 @@ def get_other_metrics_names_and_map(
 
 def get_experiment_data(experiment: NimbusExperiment):
     recipe_slug = experiment.slug.replace("-", "_")
-    # we don't use DAILY results in Experimenter, so only get WEEKLY/OVERALL
-    windows = [AnalysisWindow.WEEKLY, AnalysisWindow.OVERALL]
+    windows = [AnalysisWindow.DAILY, AnalysisWindow.WEEKLY, AnalysisWindow.OVERALL]
     raw_data = {
+        AnalysisWindow.DAILY: {},
         AnalysisWindow.WEEKLY: {},
         AnalysisWindow.OVERALL: {},
     }
@@ -276,8 +276,9 @@ def get_experiment_data(experiment: NimbusExperiment):
 
                 if segment == Segment.ALL:
                     experiment_data["other_metrics"] = other_metrics
-            elif data and window == AnalysisWindow.WEEKLY:
-                # Create the output object (weekly data)
+            elif (data and window == AnalysisWindow.WEEKLY) or (
+                data and window == AnalysisWindow.DAILY
+            ):
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
@@ -314,7 +315,9 @@ def get_experiment_data(experiment: NimbusExperiment):
 
                 if segment == Segment.ALL:
                     experiment_data["other_metrics"].update(other_metrics)
-            elif data and window == AnalysisWindow.WEEKLY:
+            elif (data and window == AnalysisWindow.WEEKLY) or (
+                data and window == AnalysisWindow.DAILY
+            ):
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -189,6 +189,7 @@ class BranchComparisonData(BaseModel):
 class SignificanceData(BaseModel):
     overall: dict[str, Any] = Field(default_factory=dict)
     weekly: dict[str, Any] = Field(default_factory=dict)
+    daily: dict[str, Any] = Field(default_factory=dict)
 
 
 class MetricData(BaseModel):

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -205,6 +205,27 @@ class JetstreamTestData:
         DATA_POINT_A_COVARIATE,
         DATA_POINT_F_COVARIATE,
     ):
+        DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(
+                daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_F_COVARIATE,
+            SignificanceData(
+                daily={"1": Significance.POSITIVE.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(
+                daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="control",
+        )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
             DATA_POINT_B,
             SignificanceData(weekly={"1": Significance.NEUTRAL.value}, overall={}),
@@ -235,6 +256,27 @@ class JetstreamTestData:
             SignificanceData(weekly={}, overall={"1": Significance.NEGATIVE.value}),
             is_retention=True,
             comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_E,
+            SignificanceData(
+                daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="variant",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_F,
+            SignificanceData(
+                daily={"1": Significance.POSITIVE.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="variant",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(
+                daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
+            ),
+            comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
             DATA_POINT_B,
@@ -269,6 +311,12 @@ class JetstreamTestData:
         )
 
         return (
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT,
             DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL,
@@ -296,6 +344,7 @@ class JetstreamTestData:
     def add_outcome_data(
         cls,
         data,
+        formatted_daily_data,
         overall_data,
         weekly_data,
         primary_outcome,
@@ -310,6 +359,8 @@ class JetstreamTestData:
                     overall_data[branch]["branch_data"][Group.OTHER.value] = {}
                 if Group.OTHER not in weekly_data[branch]["branch_data"]:
                     weekly_data[branch]["branch_data"][Group.OTHER.value] = {}
+                if Group.OTHER not in formatted_daily_data[branch]["branch_data"]:
+                    formatted_daily_data[branch]["branch_data"][Group.OTHER.value] = {}
 
                 data_point_overall = range_data.model_copy()
                 data_point_overall.count = 48.0
@@ -322,6 +373,11 @@ class JetstreamTestData:
                 weekly_data[branch]["branch_data"][Group.OTHER.value][primary_metric] = (
                     cls.get_metric_data(data_point_weekly)
                 )
+
+                data_point_daily = range_data.model_copy()
+                formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
+                    primary_metric
+                ] = cls.get_metric_data(data_point_daily)
 
                 data.append(
                     JetstreamDataPoint(
@@ -339,6 +395,7 @@ class JetstreamTestData:
     def add_outcome_data_mean(
         cls,
         data,
+        formatted_daily_data,
         overall_data,
         weekly_data,
         primary_outcome,
@@ -353,6 +410,8 @@ class JetstreamTestData:
                     overall_data[branch]["branch_data"][Group.OTHER.value] = {}
                 if Group.OTHER not in weekly_data[branch]["branch_data"]:
                     weekly_data[branch]["branch_data"][Group.OTHER.value] = {}
+                if Group.OTHER not in formatted_daily_data[branch]["branch_data"]:
+                    formatted_daily_data[branch]["branch_data"][Group.OTHER.value] = {}
 
                 data_point_overall = range_data.model_copy()
                 data_point_overall.count = 0.0
@@ -365,6 +424,11 @@ class JetstreamTestData:
                 weekly_data[branch]["branch_data"][Group.OTHER.value][primary_metric] = (
                     cls.get_metric_data(data_point_weekly)
                 )
+
+                data_point_daily = range_data.model_copy()
+                formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
+                    primary_metric
+                ] = cls.get_metric_data(data_point_daily)
 
                 data.append(
                     JetstreamDataPoint(
@@ -382,6 +446,7 @@ class JetstreamTestData:
     def add_all_outcome_data(
         cls,
         data,
+        formatted_daily_data,
         overall_data,
         weekly_data,
         primary_outcomes,
@@ -390,13 +455,16 @@ class JetstreamTestData:
         for primary_outcome in primary_outcomes:
             cls.add_outcome_data(
                 data,
+                formatted_daily_data,
                 overall_data,
                 weekly_data,
                 primary_outcome,
                 analysis_basis,
             )
+
             cls.add_outcome_data_mean(
                 data,
+                formatted_daily_data,
                 overall_data,
                 weekly_data,
                 primary_outcome,
@@ -662,6 +730,12 @@ class JetstreamTestData:
         ) = cls.get_data_points()
 
         (
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT,
             DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL,
@@ -694,6 +768,67 @@ class JetstreamTestData:
             relative_uplift=PairwiseBranchComparisonData(),
             significance=PairwiseSignificanceData(),
         )
+
+        FORMATTED_DAILY_DATA = {
+            "control": {
+                "is_control": True,
+                "branch_data": {
+                    Group.SEARCH.value: {
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                    },
+                    Group.USAGE.value: {},
+                    Group.OTHER.value: {
+                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "some_dau_impact": EMPTY_METRIC_DATA.model_dump(
+                            exclude_none=True
+                        ),
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                    },
+                },
+            },
+            "variant": {
+                "is_control": False,
+                "branch_data": {
+                    Group.SEARCH.value: {
+                        "search_count": (
+                            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                    },
+                    Group.USAGE.value: {},
+                    Group.OTHER.value: {
+                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_F_COVARIATE.model_dump(
+                            exclude_none=True
+                        ),
+                        "some_ratio": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "some_dau_impact": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                        "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                    },
+                },
+            },
+        }
 
         WEEKLY_DATA = {
             "control": {
@@ -905,6 +1040,7 @@ class JetstreamTestData:
 
         cls.add_all_outcome_data(
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             OVERALL_DATA,
             WEEKLY_DATA,
             primary_outcomes,
@@ -912,6 +1048,7 @@ class JetstreamTestData:
         )
         cls.add_all_outcome_data(
             DAILY_EXPOSURES_DATA,
+            FORMATTED_DAILY_DATA,
             OVERALL_DATA,
             WEEKLY_DATA,
             primary_outcomes,
@@ -920,6 +1057,7 @@ class JetstreamTestData:
 
         return (
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
             ERRORS,
@@ -1031,6 +1169,12 @@ class JetstreamTestData:
         ) = cls.get_data_points()
 
         (
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT,
             DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL,
@@ -1063,6 +1207,108 @@ class JetstreamTestData:
             relative_uplift=PairwiseBranchComparisonData(),
             significance=PairwiseSignificanceData(),
         )
+
+        FORMATTED_DAILY_BASE = {
+            "control": {
+                "is_control": True,
+                "branch_data": {
+                    Group.SEARCH.value: {
+                        "search_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                    },
+                    Group.USAGE.value: {},
+                    Group.OTHER.value: {
+                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                    },
+                },
+            },
+            "variant": {
+                "is_control": False,
+                "branch_data": {
+                    Group.SEARCH.value: {
+                        "search_count": (
+                            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                    },
+                    Group.USAGE.value: {},
+                    Group.OTHER.value: {
+                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                            exclude_none=True
+                        ),
+                        "retained": (
+                            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL.model_dump(
+                                exclude_none=True
+                            )
+                        ),
+                    },
+                },
+            },
+        }
+
+        FORMATTED_DAILY_EXPOSURES_DATA = deepcopy(FORMATTED_DAILY_BASE)
+        del FORMATTED_DAILY_EXPOSURES_DATA["control"]["branch_data"][Group.OTHER][
+            "retained"
+        ]
+        del FORMATTED_DAILY_EXPOSURES_DATA["variant"]["branch_data"][Group.OTHER][
+            "retained"
+        ]
+        del FORMATTED_DAILY_EXPOSURES_DATA["control"]["branch_data"][Group.SEARCH][
+            "search_count"
+        ]
+        del FORMATTED_DAILY_EXPOSURES_DATA["variant"]["branch_data"][Group.SEARCH][
+            "search_count"
+        ]
+
+        FORMATTED_DAILY_SEGMENT_DATA = deepcopy(FORMATTED_DAILY_EXPOSURES_DATA)
+        del FORMATTED_DAILY_SEGMENT_DATA["control"]["branch_data"][Group.OTHER][
+            "another_count"
+        ]
+        del FORMATTED_DAILY_SEGMENT_DATA["variant"]["branch_data"][Group.OTHER][
+            "another_count"
+        ]
+        del FORMATTED_DAILY_SEGMENT_DATA["control"]["branch_data"][Group.OTHER][
+            "some_count"
+        ]
+        del FORMATTED_DAILY_SEGMENT_DATA["variant"]["branch_data"][Group.OTHER][
+            "some_count"
+        ]
+
+        FORMATTED_DAILY_ENROLLMENTS_DATA = deepcopy(FORMATTED_DAILY_BASE)
+        del FORMATTED_DAILY_ENROLLMENTS_DATA["control"]["branch_data"][Group.OTHER][
+            "another_count"
+        ]
+        del FORMATTED_DAILY_ENROLLMENTS_DATA["variant"]["branch_data"][Group.OTHER][
+            "another_count"
+        ]
+        del FORMATTED_DAILY_ENROLLMENTS_DATA["control"]["branch_data"][Group.OTHER][
+            "some_count"
+        ]
+        del FORMATTED_DAILY_ENROLLMENTS_DATA["variant"]["branch_data"][Group.OTHER][
+            "some_count"
+        ]
+
+        FORMATTED_DAILY_DATA = {
+            "enrollments": {
+                "all": FORMATTED_DAILY_ENROLLMENTS_DATA,
+                "some_segment": FORMATTED_DAILY_SEGMENT_DATA,
+            },
+            "exposures": {
+                "all": FORMATTED_DAILY_EXPOSURES_DATA,
+                "some_segment": FORMATTED_DAILY_SEGMENT_DATA,
+            },
+        }
 
         WEEKLY_BASE = {
             "control": {
@@ -1238,6 +1484,7 @@ class JetstreamTestData:
 
         cls.add_all_outcome_data(
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             OVERALL_DATA,
             WEEKLY_DATA,
             primary_outcomes,
@@ -1245,6 +1492,7 @@ class JetstreamTestData:
         )
         cls.add_all_outcome_data(
             DAILY_EXPOSURES_DATA,
+            FORMATTED_DAILY_DATA,
             OVERALL_DATA,
             WEEKLY_DATA,
             primary_outcomes,
@@ -1253,6 +1501,7 @@ class JetstreamTestData:
 
         return (
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
             ERRORS,
@@ -1348,6 +1597,21 @@ class ZeroJetstreamTestData(JetstreamTestData):
         DATA_POINT_A_COVARIATE,
         DATA_POINT_F_COVARIATE,
     ):
+        DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_F,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="control",
+        )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
             DATA_POINT_B,
             SignificanceData(weekly={}, overall={}),
@@ -1378,6 +1642,21 @@ class ZeroJetstreamTestData(JetstreamTestData):
             SignificanceData(weekly={}, overall={}),
             is_retention=True,
             comparison_to_branch="control",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_E,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="variant",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_F,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="variant",
+        )
+        DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT = cls.get_difference_metric_data(
+            DATA_POINT_D,
+            SignificanceData(daily={}, weekly={}, overall={}),
+            comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
             DATA_POINT_B,
@@ -1412,6 +1691,12 @@ class ZeroJetstreamTestData(JetstreamTestData):
         )
 
         return (
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT,
+            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_CONTROL,
             DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT,
             DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_CONTROL,
@@ -1430,6 +1715,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
     def add_outcome_data(
         cls,
         data,
+        formatted_daily_data,
         overall_data,
         weekly_data,
         primary_outcome,
@@ -1444,6 +1730,8 @@ class ZeroJetstreamTestData(JetstreamTestData):
                     overall_data[branch]["branch_data"][Group.OTHER.value] = {}
                 if Group.OTHER not in weekly_data[branch]["branch_data"]:
                     weekly_data[branch]["branch_data"][Group.OTHER.value] = {}
+                if Group.OTHER not in formatted_daily_data[branch]["branch_data"]:
+                    formatted_daily_data[branch]["branch_data"][Group.OTHER.value] = {}
 
                 data_point_overall = range_data.model_copy()
                 data_point_overall.count = 0.0
@@ -1456,6 +1744,11 @@ class ZeroJetstreamTestData(JetstreamTestData):
                 weekly_data[branch]["branch_data"][Group.OTHER.value][primary_metric] = (
                     cls.get_metric_data(data_point_weekly)
                 )
+
+                data_point_daily = range_data.model_copy()
+                formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
+                    primary_metric
+                ] = cls.get_metric_data(data_point_daily)
 
                 data.append(
                     JetstreamDataPoint(

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -55,6 +55,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         (
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
             ERRORS,
@@ -65,6 +66,198 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         FULL_DATA = {
             "v3": {
+                "daily": {
+                    "enrollments": {
+                        "all": FORMATTED_DAILY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                    "exposures": {
+                        "all": FORMATTED_DAILY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 10.0,
+                                                        "point": 12.0,
+                                                        "upper": 13.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 10.0,
+                                                    "point": 12.0,
+                                                    "upper": 13.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
                 "weekly": {
                     "enrollments": {
                         "all": WEEKLY_DATA,
@@ -101,10 +294,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -146,10 +341,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -196,10 +393,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -241,10 +440,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -291,10 +492,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 50.0,
@@ -335,10 +538,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 50.0,
@@ -384,10 +589,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 50.0,
@@ -428,10 +635,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 50.0,
@@ -711,6 +920,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         (
             _,
+            _,
             WEEKLY_DATA,
             OVERALL_DATA,
             ERRORS,
@@ -782,6 +992,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             _,
             _,
             _,
+            _,
             ERRORS,
             _,
             _,
@@ -790,6 +1001,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         FULL_DATA = {
             "v3": {
+                "daily": {},
                 "weekly": {},
                 "overall": {},
                 "metadata": {
@@ -917,6 +1129,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         (
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
             ERRORS,
@@ -931,6 +1144,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         FULL_DATA = {
             "v3": {
+                "daily": FORMATTED_DAILY_DATA,
                 "weekly": WEEKLY_DATA,
                 "overall": OVERALL_DATA,
                 "other_metrics": {
@@ -1001,6 +1215,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         (
             DAILY_DATA,
+            FORMATTED_DAILY_DATA,
             WEEKLY_DATA,
             OVERALL_DATA,
             _,
@@ -1011,6 +1226,103 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         FULL_DATA = {
             "v3": {
+                "daily": {
+                    "enrollments": {
+                        "all": FORMATTED_DAILY_DATA,
+                        "some_segment": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": True,
+                            },
+                            "variant": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.0,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.0,
+                                                    "point": 0.0,
+                                                    "upper": 0.0,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "variant": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                                "variant": {
+                                                    "overall": {},
+                                                    "weekly": {},
+                                                    "daily": {},
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "search_metrics": {},
+                                    "usage_metrics": {},
+                                },
+                                "is_control": False,
+                            },
+                        },
+                    },
+                },
                 "weekly": {
                     "enrollments": {
                         "all": WEEKLY_DATA,
@@ -1047,10 +1359,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -1092,10 +1406,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -1142,10 +1458,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 0.0,
@@ -1186,10 +1504,12 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "variant": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                             "percent": 0.0,
@@ -1271,6 +1591,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         (
             DAILY_DATA,
+            _,
             _,
             _,
             _,
@@ -1544,6 +1865,324 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
         FULL_DATA = {
             "v3": {
+                "daily": {
+                    "enrollments": {
+                        "all": {
+                            "control": {
+                                "is_control": True,
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "test": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.855,
+                                                        "point": 0.856,
+                                                        "upper": 0.8575,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.855,
+                                                    "point": 0.856,
+                                                    "upper": 0.8575,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {"all": [], "first": {}},
+                                                "treatment-a": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -10.2,
+                                                            "point": -0.1,
+                                                            "upper": -0.01,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -10.2,
+                                                        "point": -0.1,
+                                                        "upper": -0.01,
+                                                    },
+                                                },
+                                                "treatment-b": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -1.2,
+                                                            "point": -1.1,
+                                                            "upper": -1.01,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -1.2,
+                                                        "point": -1.1,
+                                                        "upper": -1.01,
+                                                    },
+                                                },
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "daily": {},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-a": {
+                                                    "daily": {"1": "negative"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-b": {
+                                                    "daily": {"1": "negative"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                            },
+                                            "relative_uplift": {
+                                                "control": {"all": [], "first": {}},
+                                                "treatment-a": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -0.3,
+                                                            "point": -0.2,
+                                                            "upper": -0.1,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.3,
+                                                        "point": -0.2,
+                                                        "upper": -0.1,
+                                                    },
+                                                },
+                                                "treatment-b": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -2.2,
+                                                            "point": -2.1,
+                                                            "upper": -2.01,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -2.2,
+                                                        "point": -2.1,
+                                                        "upper": -2.01,
+                                                    },
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "usage_metrics": {},
+                                    "search_metrics": {},
+                                },
+                            },
+                            "treatment-a": {
+                                "is_control": False,
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "test": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.857,
+                                                        "point": 0.858,
+                                                        "upper": 0.8596,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.857,
+                                                    "point": 0.858,
+                                                    "upper": 0.8596,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -10.0,
+                                                            "point": 0.1,
+                                                            "upper": 10.2,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -10.0,
+                                                        "point": 0.1,
+                                                        "upper": 10.2,
+                                                    },
+                                                },
+                                                "treatment-a": {"all": [], "first": {}},
+                                                "treatment-b": {
+                                                    "all": [
+                                                        {
+                                                            "lower": 2.5,
+                                                            "point": 0.1,
+                                                            "upper": 1.0,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 2.5,
+                                                        "point": 0.1,
+                                                        "upper": 1.0,
+                                                    },
+                                                },
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "daily": {"1": "neutral"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-a": {
+                                                    "daily": {},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-b": {
+                                                    "daily": {"1": "positive"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                            },
+                                            "relative_uplift": {
+                                                "control": {
+                                                    "all": [
+                                                        {
+                                                            "lower": 0.1,
+                                                            "point": 0.2,
+                                                            "upper": 0.3,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 0.1,
+                                                        "point": 0.2,
+                                                        "upper": 0.3,
+                                                    },
+                                                },
+                                                "treatment-a": {"all": [], "first": {}},
+                                                "treatment-b": {
+                                                    "all": [
+                                                        {
+                                                            "lower": 3.141592653589793,
+                                                            "point": 0.1111111111111111,
+                                                            "upper": 0.2222222222222222,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 3.141592653589793,
+                                                        "point": 0.1111111111111111,
+                                                        "upper": 0.2222222222222222,
+                                                    },
+                                                },
+                                            },
+                                        }
+                                    },
+                                    "usage_metrics": {},
+                                    "search_metrics": {},
+                                },
+                            },
+                            "treatment-b": {
+                                "is_control": False,
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "test": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 0.856,
+                                                        "point": 0.857,
+                                                        "upper": 0.8589,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 0.856,
+                                                    "point": 0.857,
+                                                    "upper": 0.8589,
+                                                },
+                                            },
+                                            "difference": {
+                                                "control": {
+                                                    "all": [
+                                                        {
+                                                            "lower": 1.0,
+                                                            "point": 0.0,
+                                                            "upper": 0.5,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 1.0,
+                                                        "point": 0.0,
+                                                        "upper": 0.5,
+                                                    },
+                                                },
+                                                "treatment-a": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -0.9,
+                                                            "point": -0.8,
+                                                            "upper": -0.5,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.9,
+                                                        "point": -0.8,
+                                                        "upper": -0.5,
+                                                    },
+                                                },
+                                                "treatment-b": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "control": {
+                                                    "daily": {"1": "positive"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-a": {
+                                                    "daily": {"1": "negative"},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                                "treatment-b": {
+                                                    "daily": {},
+                                                    "weekly": {},
+                                                    "overall": {},
+                                                },
+                                            },
+                                            "relative_uplift": {
+                                                "control": {
+                                                    "all": [
+                                                        {
+                                                            "lower": 2.2,
+                                                            "point": 0.1,
+                                                            "upper": 0.02,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 2.2,
+                                                        "point": 0.1,
+                                                        "upper": 0.02,
+                                                    },
+                                                },
+                                                "treatment-a": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -0.2,
+                                                            "point": -0.1,
+                                                            "upper": -0.01,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.2,
+                                                        "point": -0.1,
+                                                        "upper": -0.01,
+                                                    },
+                                                },
+                                                "treatment-b": {"all": [], "first": {}},
+                                            },
+                                        }
+                                    },
+                                    "usage_metrics": {},
+                                    "search_metrics": {},
+                                },
+                            },
+                        }
+                    }
+                },
                 "weekly": {
                     "enrollments": {
                         "all": {
@@ -1647,14 +2286,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "treatment-a": {
                                                     "overall": {},
                                                     "weekly": {"1": "negative"},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {},
                                                     "weekly": {"1": "negative"},
+                                                    "daily": {},
                                                 },
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -1764,14 +2406,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {"1": "neutral"},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {},
                                                     "weekly": {"1": "positive"},
+                                                    "daily": {},
                                                 },
                                                 "treatment-a": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -1881,14 +2526,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {"1": "positive"},
+                                                    "daily": {},
                                                 },
                                                 "treatment-a": {
                                                     "overall": {},
                                                     "weekly": {"1": "negative"},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -1994,14 +2642,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "treatment-a": {
                                                     "overall": {"1": "negative"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {"1": "negative"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "control": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -2101,14 +2752,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {"1": "neutral"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {"1": "positive"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "treatment-a": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -2208,14 +2862,17 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                 "control": {
                                                     "overall": {"1": "positive"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "treatment-a": {
                                                     "overall": {"1": "negative"},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                                 "treatment-b": {
                                                     "overall": {},
                                                     "weekly": {},
+                                                    "daily": {},
                                                 },
                                             },
                                         }
@@ -2341,6 +2998,24 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     "filename": "experimenter/jetstream/client.py",
                     "func_name": "load_data_from_gcs",
                     "log_level": "WARNING",
+                    "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_daily.json",  # noqa: E501
+                    "metric": None,
+                    "segment": None,
+                    "statistic": None,
+                    "timestamp": now.isoformat(timespec="milliseconds").removesuffix(
+                        "+00:00"
+                    )
+                    + "Z",
+                },
+                {
+                    "analysis_basis": None,
+                    "source": None,
+                    "exception": None,
+                    "exception_type": None,
+                    "experiment": experiment.slug,
+                    "filename": "experimenter/jetstream/client.py",
+                    "func_name": "load_data_from_gcs",
+                    "log_level": "WARNING",
                     "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_weekly.json",  # noqa: E501
                     "metric": None,
                     "segment": None,
@@ -2385,6 +3060,7 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                         "metadata": None,
                         "overall": {},
                         "show_analysis": False,
+                        "daily": {},
                         "weekly": {},
                         "errors": {
                             "experiment": experiment_errors,


### PR DESCRIPTION
Because

- Daily metrics are returning for certain guardrail metrics
- They're already being exported by Jetstream but need to be ingested into the results data objects

This commit

- Adds the daily results data back into the results data object

Fixes #14568 