### PR TITLE
chore(nimbus): Add GHA workflow for Experimenter lint and tests

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -1,0 +1,52 @@
+name: "Setup Cached Docker Build"
+description: "Authenticate to GAR, set up Buildx, and build megazords with registry cache"
+
+inputs:
+  gar-cache:
+    description: "GAR cache path prefix"
+    default: "us-docker.pkg.dev/moz-fx-experimenter-prod-6cd5/experimenter-prod/cache"
+  arch:
+    description: "Architecture tag for cache (e.g. x86_64, aarch64)"
+    default: "x86_64"
+  gcp-project-number:
+    description: "GCP project number for workload identity"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: projects/${{ inputs.gcp-project-number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
+        service_account: artifact-writer@moz-fx-experimenter-prod-6cd5.iam.gserviceaccount.com
+
+    - name: Login to Artifact Registry
+      shell: bash
+      run: gcloud auth configure-docker us-docker.pkg.dev --quiet
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build megazords with cache
+      shell: bash
+      env:
+        MEGAZORD_BUILD_FLAGS: >-
+          --cache-from type=registry,ref=${{ inputs.gar-cache }}/megazords-cache:${{ inputs.arch }}
+          --cache-to type=registry,ref=${{ inputs.gar-cache }}/megazords-cache:${{ inputs.arch }},mode=max
+          --load
+          -t ${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
+      run: make build_megazords
+
+    - name: Push megazords to registry
+      shell: bash
+      run: docker push ${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
+
+    - name: Export build flags
+      shell: bash
+      env:
+        GAR_CACHE: ${{ inputs.gar-cache }}
+        ARCH: ${{ inputs.arch }}
+      run: |
+        echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
+        echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -1,0 +1,47 @@
+name: Experimenter Tests
+
+on:
+  push:
+    branches:
+      - main
+      - update_firefox_versions
+      - update-application-services
+    paths:
+      - "experimenter/**"
+      - "application-services/**"
+      - ".github/workflows/check-experimenter.yml"
+  pull_request:
+    paths:
+      - "experimenter/**"
+      - "application-services/**"
+      - ".github/workflows/check-experimenter.yml"
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    name: "${{ matrix.arch }}"
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-cached-build
+        with:
+          arch: ${{ matrix.arch }}
+          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Run tests and linting
+        run: |
+          cp .env.sample .env
+          make check

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,10 @@ COMPOSE_INTEGRATION = ${COMPOSE_PROD} -f docker-compose-integration-test.yml $$(
 COMPOSE_INTEGRATION_RUN = ${COMPOSE_INTEGRATION} run --name experimenter_integration
 DOCKER_BUILD = docker buildx build
 
+# Extra flags for docker buildx build, per target. Override to add caching, --load, etc.
+MEGAZORD_BUILD_FLAGS ?=
+EXPERIMENTER_BUILD_FLAGS ?=
+
 WORKFLOW := build
 EPOCH_TIME := $(shell date +"%s")
 TEST_RESULTS_DIR ?= $(if $(CIRCLECI),dashboard/test-results,.)
@@ -111,7 +115,7 @@ compose_build:  ## Build containers
 	$(COMPOSE) build
 
 build_megazords:
-	$(DOCKER_BUILD) -f application-services/Dockerfile -t experimenter:megazords application-services/
+	$(DOCKER_BUILD) $(MEGAZORD_BUILD_FLAGS) -f application-services/Dockerfile -t experimenter:megazords application-services/
 
 update_application_services: build_megazords
 	docker run \
@@ -126,7 +130,7 @@ build_integration_test: ssl build_megazords
 	$(DOCKER_BUILD) -f experimenter/tests/integration/Dockerfile -t experimenter:integration-tests experimenter/
 
 build_test: ssl build_megazords
-	$(DOCKER_BUILD) --target test -f experimenter/Dockerfile -t experimenter:test experimenter/
+	$(DOCKER_BUILD) $(EXPERIMENTER_BUILD_FLAGS) --target test -f experimenter/Dockerfile -t experimenter:test experimenter/
 
 build_ui: ssl
 	$(DOCKER_BUILD) --target ui -f experimenter/Dockerfile -t experimenter:ui experimenter/


### PR DESCRIPTION
Because

* We are migrating CI from CircleCI to GitHub Actions (EXP-6320)
* The Experimenter check jobs (`make check`) need to run on PRs and pushes
* Docker layer caching is needed to keep build times reasonable

This commit

* Adds a GitHub Actions workflow (`.github/workflows/check-experimenter.yml`) that runs `make check` on both x86_64 and aarch64 architectures
* Adds a reusable composite action (`.github/actions/setup-cached-build/action.yml`) that handles GCP workload identity auth, Docker Buildx setup, and registry-backed layer caching via Google Artifact Registry
* Adds `MEGAZORD_BUILD_FLAGS` and `EXPERIMENTER_BUILD_FLAGS` override points to the Makefile so CI can inject cache and build-context flags without duplicating build commands
* Triggers on changes to `experimenter/`, `application-services/`, and the workflow file itself
* Runs on PRs, pushes to main/update branches, and merge queue

fixes #14578