### PR TITLE
fix(project): add application-services/ to CircleCI path filters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/"
+          paths: "experimenter/|application-services/"
       - run:
           name: Run tests and linting
           command: |
@@ -280,7 +280,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/"
+          paths: "experimenter/experimenter/|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -309,7 +309,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/"
+          paths: "experimenter/experimenter/|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -339,7 +339,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/"
+          paths: "experimenter/experimenter/|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -374,7 +374,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env"
+          paths: "experimenter/experimenter/|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -405,7 +405,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -435,7 +435,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -464,7 +464,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
       - create_test_result_workspace
       - run:
           name: Run integration tests
@@ -490,7 +490,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_fenix_beta_build.env|experimenter/tests/firefox_fenix_release_build.env"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_fenix_beta_build.env|experimenter/tests/firefox_fenix_release_build.env|application-services/"
       - create_test_result_workspace
       - attach_workspace:
           at: /tmp/experimenter
@@ -541,7 +541,7 @@ jobs:
     steps:
       - checkout
       - check_file_paths:
-          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|<< parameters.file_path >>"
+          paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|<< parameters.file_path >>|application-services/"
       - create_test_result_workspace
       - macos/preboot-simulator:
           version: << parameters.ios_version >>


### PR DESCRIPTION
Because

* The `check_experimenter_aarch64` job was missing `application-services/` from its
  path filter, while the x86_64 counterpart had it
* All integration test jobs (desktop UI, remote settings, targeting, enrollment,
  fenix, iOS) were also missing `application-services/` from their path filters
* This caused these jobs to silently skip on `update-application-services` PRs,
  meaning SDK changes were not being tested by integration tests

This commit

* Adds `application-services/` to the `check_file_paths` parameter for
  `check_experimenter_aarch64` to match `check_experimenter_x86_64`
* Adds `application-services/` to all integration test jobs that were missing it

Fixes #14610