### PR TITLE
chore(nimbus): Add GHA workflow for Schema tests

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -42,6 +42,17 @@ runs:
       shell: bash
       run: docker push ${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
 
+    - name: Build schemas with cache
+      uses: docker/build-push-action@v6
+      with:
+        context: schemas/
+        file: schemas/Dockerfile
+        target: dev
+        tags: schemas:dev
+        load: true
+        cache-from: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }}
+        cache-to: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }},mode=max
+
     - name: Export build flags
       shell: bash
       env:
@@ -50,3 +61,5 @@ runs:
       run: |
         echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
         echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
+        echo 'SCHEMAS_BUILD_FLAGS=--load' >> "$GITHUB_ENV"
+        echo 'DOCKER_RUN_INTERACTIVE=' >> "$GITHUB_ENV"

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -1,0 +1,26 @@
+name: Schema Tests
+
+on:
+  pull_request:
+    paths:
+      - "schemas/**"
+      - ".github/workflows/check-schemas.yml"
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check:
+    name: "Check Schemas"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-cached-build
+        with:
+          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Run schemas tests and linting
+        run: make schemas_check


### PR DESCRIPTION
Because

* We are migrating CI from CircleCI to GitHub Actions (EXP-6320)
* The schemas check job needs to run on PRs that change `schemas/`

This commit

* Adds a GitHub Actions workflow that runs `make schemas_check` on PRs
* Triggers on changes to `schemas/` and the workflow file itself

fixes #14582