### PR TITLE
feat(nimbus): Send results available notification

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -813,6 +813,10 @@ class NimbusConstants:
         EXPERIMENT_LAUNCHED = "experiment_launched", "Experiment Launched"
         ENROLLMENT_HEALTHY = "enrollment_healthy", "Enrollment Healthy"
 
+    class AnalysisWindow(models.TextChoices):
+        WEEKLY = "weekly", "Weekly"
+        OVERALL = "overall", "Overall"
+
     class FirefoxLabsGroups(models.TextChoices):
         CUSTOMIZE_BROWSING = "experimental-features-group-customize-browsing"
         WEBPAGE_DISPLAY = "experimental-features-group-webpage-display"

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1703,6 +1703,21 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         return False
 
+    def has_results_for_window(self, window):
+        if not self.results_data or "v3" not in self.results_data:
+            return False
+
+        window_data = self.results_data["v3"].get(window)
+        if not window_data:
+            return False
+
+        for base in ["enrollments", "exposures"]:
+            base_results = window_data.get(base, {}).get("all")
+            if base_results is not None and len(base_results) > 0:
+                return True
+
+        return False
+
     @property
     def has_exposures(self):
         # Returns the enum corresponding to exposures state:


### PR DESCRIPTION
Because

- We want to notify users on slack when the weekly and overall results are available for the experiments

This commit

- Check whether the results are available, and if available, send the notification
- Also makes sure to send the alert once per window such as overall and weekly

Fixes #14409 