### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 149

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3882,6 +3882,32 @@ FX_149_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+ACCEPTED_TOU_ON_OR_AFTER_DEC_9_2025_AND_FX_149_TRAINHOP = NimbusTargetingConfig(
+    name="TOU accepted after Dec 9 2025, non-Linux, Fx149 trainhop",
+    slug="tou_accepted_and_fx149_trainhop",
+    description=(
+        "Users who have accepted TOU on or after Dec 9 2025, are not on Linux, "
+        "and have the New Tab 149.1.20260121.51415 train hop"
+    ),
+    targeting=f"""
+    (
+        (
+            !os.isLinux
+            &&
+            {HAS_TOU_ACCEPTED_DATE}
+            &&
+            ({TOU_ACCEPTED_DATE}  >= {DEC_9_2025})
+        )
+        &&
+        newtabAddonVersion|versionCompare('149.1.20260121.51415') >= 0
+    )
+    """,
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",


### PR DESCRIPTION
This commit will allow us to create experiments targeting users of the latest New Tab trainhop that will be released (2026-02-09), users that have accepted v4 or higher of the terms of use and are on mac or windows.

Fixes mozilla#14614

