### PR TITLE
fix(project): hoist eslint-config-react-app to root for results workspace

### DIFF
--- a/experimenter/package.json
+++ b/experimenter/package.json
@@ -8,7 +8,8 @@
     "experimenter/results"
   ],
   "devDependencies": {
-    "@types/react-select": "^5.0.1"
+    "@types/react-select": "^5.0.1",
+    "eslint-config-react-app": "^6.0.0"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",


### PR DESCRIPTION
Because

* `make code_format` fails on main because ESLint cannot find the
  `react-app` config to extend from in the results workspace
* Yarn v1 workspace hoisting fails to install `eslint-config-react-app@6.0.0`
  in any accessible `node_modules` path despite it being listed in
  `results/package.json` devDependencies and `yarn.lock`
* The only installed copy (5.2.1) is nested inside
  `react-scripts/node_modules/` which ESLint cannot resolve

This commit

* Add `eslint-config-react-app@^6.0.0` to root `package.json`
  devDependencies so Yarn hoists it to root `node_modules` where
  ESLint can find it

Fixes #14629