### PR TITLE
fix(nimbus): fix indefinite page loading on new results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -82,12 +82,18 @@ const setupHTMXLoadingOverlay = () => {
     }
   });
 
-  document.addEventListener("htmx:afterRequest", function () {
+  const hideOverlay = () => {
     const loadingOverlay = document.querySelector("#htmx-loading-overlay");
     if (loadingOverlay) {
       loadingOverlay.style.opacity = "0";
       loadingOverlay.style.pointerEvents = "none";
     }
+  };
+
+  document.addEventListener("htmx:afterRequest", hideOverlay);
+
+  window.addEventListener("popstate", function () {
+    setTimeout(hideOverlay, 10);
   });
 };
 


### PR DESCRIPTION
Because

- After making a selection from the filter dropdowns on the new results page and going back, the loading overlay would be stuck over the page content

This commit

- Fixes the indefinite page loading 

Fixes #14625 