### PR TITLE
fix(nimbus): fix contact experimenter button on metric cards' link

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-new-inner.html
@@ -305,9 +305,9 @@
                                           <i class="fa-solid fa-triangle-exclamation fs-5"></i>
                                           <p class="mb-0 fw-semibold">Metric unavailable</p>
                                           <p class="mb-0">Other metrics are unaffected.</p>
-                                          <button class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold">
-                                            Contact Experimenter Support
-                                          </button>
+                                          <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                             target="_blank"
+                                             href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
                                         </div>
                                       </div>
                                     {% else %}


### PR DESCRIPTION
Because

- The "Contact Experimenter Support" button on the error cards was not linking to anything

This commit

- Adds link to the experimenter slack channel to the error cards

Fixes #14632