### PR TITLE
fix(project): use factory.Sequence in UserFactory to prevent duplicate emails

### DIFF
--- a/experimenter/experimenter/openidc/tests/factories.py
+++ b/experimenter/experimenter/openidc/tests/factories.py
@@ -8,7 +8,7 @@ faker = Faker()
 class UserFactory(factory.django.DjangoModelFactory):
     first_name = factory.LazyAttribute(lambda o: faker.first_name())
     last_name = factory.LazyAttribute(lambda o: faker.last_name())
-    email = factory.LazyAttribute(lambda o: faker.company_email())
+    email = factory.Sequence(lambda n: f"user-{n}@example.com")
     username = factory.LazyAttribute(lambda o: o.email)
 
     class Meta:


### PR DESCRIPTION
fix(project): use factory.Sequence in UserFactory to prevent duplicate emails

Because

* UserFactory used `faker.company_email()` without uniqueness guarantees
* Each `NimbusExperimentFactory.create()` generates ~9+ User instances (owner, subscribers, changelog author)
* Tests creating multiple experiments (e.g. iterating all Lifecycles) frequently exhausted Faker's limited email pool, causing `IntegrityError` on the `auth_user_username_key` unique constraint

This commit

* Replaces `faker.company_email()` with `factory.Sequence` to guarantee unique email addresses across all factory invocations within a test run

Fixes #14635