### PR TITLE
chore(nimbus): Add GHA workflow for Check Local Feature Manifests

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -61,5 +61,6 @@ runs:
       run: |
         echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
         echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
+        echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
         echo 'SCHEMAS_BUILD_FLAGS=--load' >> "$GITHUB_ENV"
         echo 'DOCKER_RUN_INTERACTIVE=' >> "$GITHUB_ENV"

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -1,0 +1,37 @@
+name: Feature Manifest Tests
+
+on:
+  pull_request:
+    paths:
+      - "experimenter/experimenter/features/manifests/**"
+      - "experimenter/manifesttool/**"
+      - "application-services/**"
+      - ".github/workflows/check-feature-manifests.yml"
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check:
+    name: "Check Local Feature Manifests"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-cached-build
+        with:
+          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Check local feature manifests
+        run: |
+          cp .env.sample .env
+          make feature_manifests FETCH_ARGS="--local-apps"
+          if ! git diff --quiet experimenter/experimenter/features/manifests/; then
+            echo 'Please commit generated updates to local feature manifests:'
+            echo
+            echo '    make feature_manifests FETCH_ARGS="--local-apps"'
+            echo
+            exit 1
+          fi

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ DOCKER_BUILD = docker buildx build
 # Extra flags for docker buildx build, per target. Override to add caching, --load, etc.
 MEGAZORD_BUILD_FLAGS ?=
 EXPERIMENTER_BUILD_FLAGS ?=
+DEV_BUILD_FLAGS ?=
 SCHEMAS_BUILD_FLAGS ?=
 
 # Interactive flags for docker run. Set to empty for non-TTY environments (CI).
@@ -128,7 +129,7 @@ update_application_services: build_megazords
 		/application-services/update-application-services.sh
 
 build_dev: ssl build_megazords
-	$(DOCKER_BUILD) --target dev -f experimenter/Dockerfile -t experimenter:dev experimenter/
+	$(DOCKER_BUILD) $(DEV_BUILD_FLAGS) --target dev -f experimenter/Dockerfile -t experimenter:dev experimenter/
 
 build_integration_test: ssl build_megazords
 	$(DOCKER_BUILD) -f experimenter/tests/integration/Dockerfile -t experimenter:integration-tests experimenter/


### PR DESCRIPTION
Because

* We are migrating CI from CircleCI to GitHub Actions (EXP-6320)
* The feature manifests check verifies generated manifests are up to date

This commit

* Adds a GitHub Actions workflow that runs `make feature_manifests FETCH_ARGS="--local-apps"` and checks for uncommitted changes
* Adds `DEV_BUILD_FLAGS` override point to the Makefile for the `experimenter:dev` image build
* Updates the composite action to export `DEV_BUILD_FLAGS` with registry cache

Fixes #14580