### PR TITLE
fix(project): add results node_modules volume to experimenter service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - /experimenter/experimenter/glean/generated/
       - /experimenter/experimenter/legacy/legacy-ui/core/.cache/
       - /experimenter/experimenter/legacy/legacy-ui/core/node_modules/
+      - /experimenter/experimenter/results/node_modules/
       - /experimenter/experimenter/nimbus_ui/static/node_modules/
       - /experimenter/experimenter/served/
       - /experimenter/node_modules/


### PR DESCRIPTION
Because

* The experimenter Docker service was missing an anonymous volume for
  results/node_modules, causing ESLint to fall back to root node_modules
  with incompatible package versions (eslint-config-prettier v9 instead
  of v7, @typescript-eslint/eslint-plugin v2 instead of v4)
* The yarn-results service already had this volume, but the main
  experimenter service (used by make code_format) did not

This commit

* Adds /experimenter/experimenter/results/node_modules/ as an anonymous
  volume to the experimenter service in docker-compose.yml, matching
  the yarn-results service

Fixes #14639