### PR TITLE
chore(nimbus): collapse Fenix profiles into single representative app context

### DIFF
--- a/experimenter/tests/integration/nimbus/app_contexts.json
+++ b/experimenter/tests/integration/nimbus/app_contexts.json
@@ -1,119 +1,17 @@
 {
-  "query_result": {
-    "id": 15734423,
-    "query_hash": "85e731a13b18b6a67cb24eb9ab953842",
-    "query": "-- A query to generate Nimbus application contexts in JSON format for the\n-- purpose of testing client targeting.\n--\n-- The existing app contexts used by the Nimbus Rust SDK are shaped like this:\n--\n-- pub struct AppContext {\n--     pub app_name: String,\n--     pub app_id: String,\n--     pub channel: String,\n--     pub app_version: Option<String>,\n--     pub app_build: Option<String>,\n--     pub architecture: Option<String>,\n--     pub device_manufacturer: Option<String>,\n--     pub device_model: Option<String>,\n--     pub locale: Option<String>,\n--     pub os: Option<String>,\n--     pub os_version: Option<String>,\n--     pub android_sdk_version: Option<String>,\n--     pub debug_tag: Option<String>,\n--     pub installation_date: Option<i64>,\n--     #[serde(flatten)]\n--     pub custom_targeting_attributes: Option<HashMap<String, String>>,\n-- }\n\nWITH randomish_sample AS\n(\n    SELECT \n        \"fenix\" AS app_name,\n        \"org.mozilla.firefox\" AS app_id,\n        client_info.app_channel AS channel,\n        client_info.app_display_version AS app_version,\n        client_info.app_build AS app_build,\n        client_info.architecture AS architecture,\n        client_info.device_manufacturer AS device_manufacturer,\n        client_info.device_model AS device_model,\n        client_info.locale AS locale,\n        client_info.os AS os,\n        client_info.os_version AS os_version,\n        client_info.android_sdk_version AS android_sdk_version,\n        NULL AS debug_tag,\n        UNIX_SECONDS(PARSE_TIMESTAMP('%F%Ez', client_info.first_run_date)) AS installation_date,\n        NULL AS custom_targeting_attributes,\n        ROW_NUMBER() OVER(PARTITION BY client_info.locale) AS rowno,\n    FROM \n        org_mozilla_firefox.baseline\n    WHERE \n        DATE(submission_timestamp) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)\n        -- grabbing @ 100 samples here to ensure we get enough to LIMIT to 20 later\n        AND RAND() < 100/(SELECT COUNT(*) FROM org_mozilla_firefox.baseline WHERE DATE(submission_timestamp) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)) \n), app_contexts AS (\n    -- Stripping out the rowno, which is used to ensure we don't have duplicate locales\n    -- so that we can match the AppContext object schema\n    SELECT\n        app_name,\n        app_id,\n        channel,\n        app_version,\n        app_build,\n        architecture,\n        device_manufacturer,\n        device_model,\n        locale,\n        os,\n        os_version,\n        android_sdk_version,\n        debug_tag,\n        installation_date,\n        custom_targeting_attributes\n    FROM\n        randomish_sample\n    WHERE\n        rowno <= 1\n)\n\nSELECT \n    TO_JSON_STRING(t) AS app_context\nFROM \n    app_contexts AS t\nLIMIT\n    20",
-    "data": {
-      "columns": [
-        {
-          "name": "app_context",
-          "friendly_name": "app_context",
-          "type": "string"
-        }
-      ],
-      "rows": [
-        {
-          "app_context": {
-            "app_name": "fenix",
-            "app_id": "org.mozilla.firefox",
-            "channel": "release",
-            "app_version": "95.2.0",
-            "app_build": "2015851759",
-            "architecture": "armeabi-v7a",
-            "device_manufacturer": "HUAWEI",
-            "device_model": "MED-LX9",
-            "locale": "es-MX",
-            "language":"es",
-            "os": "Android",
-            "os_version": "10",
-            "android_sdk_version": "29",
-            "debug_tag": null,
-            "installation_date": 1641967200
-          }
-        },
-        {
-          "app_context": {
-            "app_name": "fenix",
-            "app_id": "org.mozilla.firefox",
-            "channel": "release",
-            "app_version": "100.1.2",
-            "app_build": "2015879543",
-            "architecture": "arm64-v8a",
-            "device_manufacturer": "asus",
-            "device_model": "ASUS_Z012DA",
-            "locale": "zh-TW",
-            "language":"zh",
-            "os": "Android",
-            "os_version": "8.0.0",
-            "android_sdk_version": "26",
-            "debug_tag": null,
-            "installation_date": 1597939200
-          }
-        },
-        {
-          "app_context": {
-            "app_name": "fenix",
-            "app_id": "org.mozilla.firefox",
-            "channel": "release",
-            "app_version": "100.1.2",
-            "app_build": "2015879543",
-            "architecture": "armeabi-v7a",
-            "device_manufacturer": "HUAWEI",
-            "device_model": "AMN-LX1",
-            "locale": "fr-FR",
-            "language":"fr",
-            "os": "Android",
-            "os_version": "9",
-            "android_sdk_version": "28",
-            "debug_tag": null,
-            "installation_date": 1650405600
-          }
-        },
-        {
-          "app_context": {
-            "app_name": "fenix",
-            "app_id": "org.mozilla.firefox",
-            "channel": "release",
-            "app_version": "100.2.0",
-            "app_build": "2015880367",
-            "architecture": "arm64-v8a",
-            "device_manufacturer": "samsung",
-            "device_model": "SM-A326B",
-            "locale": "en-GB",
-            "language":"en",
-            "os": "Android",
-            "os_version": "12",
-            "android_sdk_version": "31",
-            "debug_tag": null,
-            "installation_date": 1651602600
-          }
-        },
-        {
-          "app_context": {
-            "app_name": "fenix",
-            "app_id": "org.mozilla.firefox",
-            "channel": "release",
-            "app_version": "100.1.2",
-            "app_build": "2015879543",
-            "architecture": "arm64-v8a",
-            "device_manufacturer": "samsung",
-            "device_model": "SM-G998U",
-            "locale": "en-US ",
-            "language":"en",
-            "os": "Android",
-            "os_version": "12",
-            "android_sdk_version": "31",
-            "debug_tag": null,
-            "installation_date": 1612674000
-          }
-        }
-      ],
-      "metadata": {
-        "data_scanned": 123246204411
-      }
-    },
-    "data_source_id": 63,
-    "runtime": 7.98217,
-    "retrieved_at": "2022-05-24T22:03:07.953Z"
-  }
+  "app_name": "fenix",
+  "app_id": "org.mozilla.firefox",
+  "channel": "release",
+  "app_version": "100.2.0",
+  "app_build": "2015880367",
+  "architecture": "arm64-v8a",
+  "device_manufacturer": "samsung",
+  "device_model": "SM-A326B",
+  "locale": "en-US",
+  "language": "en",
+  "os": "Android",
+  "os_version": "12",
+  "android_sdk_version": "31",
+  "debug_tag": null,
+  "installation_date": 1651602600
 }

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -28,10 +28,10 @@ class MockMetricsHandler(nimbus_rust.MetricsHandler):
         pass
 
 
-def client_info_list():
+def load_app_context_data():
     path = Path(__file__).parent / "app_contexts.json"
     with path.open() as file:
-        return [r["app_context"] for r in json.load(file)["query_result"]["data"]["rows"]]
+        return json.load(file)
 
 
 @pytest.fixture(params=helpers.load_targeting_configs(app="MOBILE"))
@@ -71,14 +71,13 @@ def fixture_sdk_client():
 
 @pytest.mark.run_targeting
 @pytest.mark.parametrize("targeting", helpers.load_targeting_configs("MOBILE"))
-@pytest.mark.parametrize("context", client_info_list())
 def test_check_mobile_targeting(
     sdk_client,
     load_app_context,
-    context,
     targeting,
     experiment_slug,
 ):
+    context = load_app_context_data()
     # The context fixtures can only contain strings or null
     context["language"] = context["language"][:2]  # strip region
     # This context dictionary supports non string values


### PR DESCRIPTION
Because

* The mobile SDK targeting test parametrized over 5 sample Fenix device
  profiles, creating a 5x multiplier on the SDK targeting CI run
* The multiple profiles were originally added to verify against a broad
  set of samples, but the important thing is the syntactic validation of
  the JEXL itself, which the SDK does regardless of the particular
  targeting context

This commit

* Replaces the 5 Fenix profiles in `app_contexts.json` with a single
  representative profile covering all required fields
* Simplifies the JSON fixture from the old BigQuery query result format
  to a plain app context object
* Removes the `@pytest.mark.parametrize("context", client_info_list())`
  decorator from `test_check_mobile_targeting`

Fixes #14641