### PR TITLE
fix(nimbus): update doc links to match reorganized experimenter-docs site

### DIFF
--- a/docs/adrs/0012-exposure-events-and-coenrolling-features.md
+++ b/docs/adrs/0012-exposure-events-and-coenrolling-features.md
@@ -20,7 +20,7 @@ This ADR is deciding what to do— in the case of messaging— about the attribu
 
 ### Current status: no coenrollments
 
-Currently, for [experimenting with mobile `messaging`](https://experimenter.info/mobile-messaging/#experimenting-with-messages), the message sender (the user) must identify which message or messages are under experiment, then the system works out the experiment. For example, the feature JSON for annotating a message as being under experiment is:
+Currently, for [experimenting with mobile `messaging`](https://experimenter.info/messaging/desktop/mobile-messaging#experimenting-with-messages), the message sender (the user) must identify which message or messages are under experiment, then the system works out the experiment. For example, the feature JSON for annotating a message as being under experiment is:
 
 ```json
 {
@@ -36,7 +36,7 @@ This works because:
 1. the key `message-under-experiment` comes from exactly zero or one experiments
 2. if the message being displayed is named as being under experiment, then the feature is in an experiment, and the system can deduce _which_ experiment.
 
-The [`is-control` message property](https://experimenter.info/mobile-messaging/#control-messages) is used to label messages that are control messages.
+The [`is-control` message property](https://experimenter.info/messaging/desktop/mobile-messaging#control-messages) is used to label messages that are control messages.
 
 ```json
 {
@@ -138,5 +138,5 @@ When the message is displayed, the `experiment` property is the experiment slug;
 
 ## Links
 
-* [Experimenting with mobile messaging](https://experimenter.info/mobile-messaging/#experimenting-with-messages)
+* [Experimenting with mobile messaging](https://experimenter.info/messaging/desktop/mobile-messaging#experimenting-with-messages)
 * [EXP-3602 Support for coenrollment features](https://mozilla-hub.atlassian.net/browse/EXP-3602) epic

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1160,9 +1160,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
 
 EXTERNAL_URLS = {
-    "SIGNOFF_QA": "https://experimenter.info/qa-sign-off",
-    "TRAINING_AND_PLANNING_DOC": "https://experimenter.info/for-product",
-    "PREVIEW_LAUNCH_DOC": "https://experimenter.info/previewing-experiments",
+    "SIGNOFF_QA": "https://experimenter.info/workflow/risk-mitigation#qa-sign-off",
+    "TRAINING_AND_PLANNING_DOC": "https://experimenter.info/getting-started/for-experiment-owners",
+    "PREVIEW_LAUNCH_DOC": "https://experimenter.info/platform-guides/desktop/preview",
 }
 
 

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -28,7 +28,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
 
     RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
-    REVIEW_URL = "https://experimenter.info/access"
+    REVIEW_URL = "https://experimenter.info/getting-started/for-reviewers"
 
     EXCLUDING_EXPERIMENTS_WARNING = """The following experiments are being excluded by
     your experiment and may reduce the eligible population for your experiment which
@@ -57,9 +57,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     behaviour.  Running an experiment on multiple channels can create misleading or
     inaccurate results.  It is recommended to run experiments only on a single channel."""
 
-    AUDIENCE_OVERLAP_WARNING = "https://experimenter.info/faq/warnings/#audience-overlap"
+    AUDIENCE_OVERLAP_WARNING = (
+        "https://experimenter.info/advanced/warnings#audience-overlap"
+    )
     ROLLOUT_BUCKET_WARNING = (
-        "https://experimenter.info/faq/warnings/#rollout-bucketing-warning"
+        "https://experimenter.info/advanced/warnings#rollout-bucketing-warning"
     )
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created
@@ -96,16 +98,16 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "welcome_learn_more_url": "https://experimenter.info/workflow/overview/"
     }
     AUDIENCE_PAGE_LINKS = {
-        "custom_audiences_url": "https://experimenter.info/workflow/implementing/custom-audiences#how-to-add-a-new-custom-audience",
+        "custom_audiences_url": "https://experimenter.info/advanced/custom-audiences#how-to-add-new-advanced-targeting",
         "targeting_criteria_request_url": "https://github.com/mozilla/experimenter/issues/new?template=targeting_request_template.yml&title=Targeting%20criteria%20request",
-        "sticky_targeting_url": "https://experimenter.info/workflow/implementing/custom-audiences#sticky-targeting",
+        "sticky_targeting_url": "https://experimenter.info/advanced/custom-audiences#sticky-targeting",
         "experimentation_office_hours_url": "https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/6849684/Experimentation+Office+Hours",
     }
     OVERVIEW_PAGE_LINKS = {
         "risk_link": "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthishavehighrisktothebrand?",
         "message_consult_link": "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation",
-        "revenue_risk_link": "https://experimenter.info/vp-sign-off",
-        "partner_related_risk_link": "https://experimenter.info/legal-sign-off",
+        "revenue_risk_link": "https://experimenter.info/workflow/risk-mitigation#vp-sign-off",
+        "partner_related_risk_link": "https://experimenter.info/workflow/risk-mitigation#legal-sign-off",
     }
     METRICS_PAGE_LINKS = {
         "metrics_hub_url": "https://mozilla.github.io/metric-hub/metrics/firefox_desktop/",
@@ -124,7 +126,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "my_deliveries": """
             Shows all deliveries (experiments, rollouts, etc) that you are the owner of,
             subscribed to or where you are a collaborator.
-            <a href="https://experimenter.info/for-product">Learn</a> how to get started.
+            <a href="https://experimenter.info/getting-started/for-experiment-owners">Learn</a>
+            how to get started.
         """,
     }
     SIDEBAR_COMMON_LINKS = {
@@ -148,7 +151,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     OTHER_METRICS_AREA = "Other Metrics"
     NOTABLE_METRIC_AREA = "Notable Changes"
     FEATURE_PAGE_LINKS = {
-        "feature_learn_more_url": "https://experimenter.info/for-product#track-your-feature-health",
+        "feature_learn_more_url": "https://experimenter.info/getting-started/for-experiment-owners",
         "deliveries_table_tooltip": """This shows all Nimbus experiments, rollouts, Labs
         experiences, etc. associated with your selected feature.""",
     }

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
@@ -43,7 +43,7 @@
               {% endif %}
             {% endif %}
             {% if experiment.signoff_recommendations.qa_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
-            <span class="ms-1">Please file a QA request. <a href="https://experimenter.info/qa-sign-off">Learn More</a></span>
+            <span class="ms-1">Please file a QA request. <a href="https://experimenter.info/workflow/risk-mitigation#qa-sign-off">Learn More</a></span>
           </td>
         </tr>
         <tr>
@@ -59,7 +59,7 @@
               {% endif %}
             {% endif %}
             {% if experiment.signoff_recommendations.vp_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
-            <span class="ms-1">Please email your VP. <a href="https://experimenter.info/vp-sign-off">Learn More</a></span>
+            <span class="ms-1">Please email your VP. <a href="https://experimenter.info/workflow/risk-mitigation#vp-sign-off">Learn More</a></span>
           </td>
         </tr>
         <tr>
@@ -77,7 +77,7 @@
             {% if experiment.signoff_recommendations.legal_signoff %}
               <span class="text-success ms-1">Recommended:</span>
             {% endif %}
-            <span class="ms-1">Please email legal. <a href="https://experimenter.info/legal-sign-off">Learn More</a></span>
+            <span class="ms-1">Please email legal. <a href="https://experimenter.info/workflow/risk-mitigation#legal-sign-off">Learn More</a></span>
           </td>
         </tr>
       </tbody>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -34,7 +34,8 @@
             <div class="col">
               <label for="id_feature_configs" class="form-label">
                 You must select at least one feature configuration for your experiment.
-                <a target="_blank" href="https://experimenter.info/feature-definition/">Learn more</a>
+                <a target="_blank"
+                   href="https://experimenter.info/technical-reference/feature-definition">Learn more</a>
               </label>
               {{ form.feature_configs }}
               {% for error in validation_errors.feature_configs %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
@@ -45,8 +46,7 @@
               <div class="form-check">
                 {{ form.is_rollout }}
                 <label class="form-check-label" for="id_is_rollout">This is a rollout (single branch)</label>
-                <a target="_blank"
-                   href="https://experimenter.info/deep-dives/experimenter/rollouts">Learn more</a>
+                <a target="_blank" href="https://experimenter.info/advanced/rollouts">Learn more</a>
               </div>
               {% for error in validation_errors.is_rollout %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_metrics.html
@@ -30,7 +30,7 @@
           <div class="row">
             <div class="col">
               <p>
-                Every experiment analysis automatically includes how your experiment has impacted Retention, Search Count, and Ad Click metrics. Get more information on <a href="https://experimenter.info/deep-dives/jetstream/metrics/">Core Firefox Metrics</a>.
+                Every experiment analysis automatically includes how your experiment has impacted Retention, Search Count, and Ad Click metrics. Get more information on <a href="https://experimenter.info/data-analysis/jetstream/metrics">Core Firefox Metrics</a>.
               </p>
             </div>
           </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
@@ -130,7 +130,7 @@
         <div class="col-5 py-4 mt-0">
           <h5>Observing — results still forming</h5>
           <p class="text-muted mb-0">
-            Your experiment is officially in progress, and early numbers are starting to come in. These results are just for checking that everything's running correctly — they aren't reliable for decisions until the monitoring period is complete. <a href="https://experimenter.info/observing">
+            Your experiment is officially in progress, and early numbers are starting to come in. These results are just for checking that everything's running correctly — they aren't reliable for decisions until the monitoring period is complete. <a href="https://experimenter.info/workflow/monitoring">
             Learn more
           </p>
         </a>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
@@ -147,7 +147,7 @@
          data-bs-toggle="tooltip"
          data-bs-html="true"
          data-bs-delay='{"hide":1000}'
-         title="Select the <strong>analysis basis</strong> whose results you want to see. See <a href='https://experimenter.info/jetstream/configuration/#defining-exposure-signals'>defining exposure signals</a> in the docs for more info."></i>
+         title="Select the <strong>analysis basis</strong> whose results you want to see. See <a href='https://experimenter.info/data-analysis/jetstream/configuration#defining-exposure-signals'>defining exposure signals</a> in the docs for more info."></i>
       <select name="analysis_basis"
               class="form-select bg-secondary-subtle"
               aria-label="Analysis Basis">
@@ -182,7 +182,7 @@
          data-bs-toggle="tooltip"
          data-bs-html="true"
          data-bs-delay='{"hide":1000}'
-         title="Select the <strong>analysis segment</strong> whose results you want to see. See <a href='https://experimenter.info/jetstream/configuration/#defining-segments'>defining segments</a> in the docs for more info."></i>
+         title="Select the <strong>analysis segment</strong> whose results you want to see. See <a href='https://experimenter.info/data-analysis/jetstream/configuration#defining-segments'>defining segments</a> in the docs for more info."></i>
       <select name="segment"
               class="form-select bg-secondary-subtle"
               aria-label="Segment">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
@@ -41,7 +41,7 @@
               {% endif %}
             {% endif %}
             {% if experiment.signoff_recommendations.qa_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
-            <span class="ms-1">Please file a QA request. <a href="https://experimenter.info/qa-sign-off">Learn More</a></span>
+            <span class="ms-1">Please file a QA request. <a href="https://experimenter.info/workflow/risk-mitigation#qa-sign-off">Learn More</a></span>
           </td>
         </tr>
         <tr>
@@ -57,7 +57,7 @@
               {% endif %}
             {% endif %}
             {% if experiment.signoff_recommendations.vp_signoff %}<span class="text-success ms-1">Recommended:</span>{% endif %}
-            <span class="ms-1">Please email your VP. <a href="https://experimenter.info/vp-sign-off">Learn More</a></span>
+            <span class="ms-1">Please email your VP. <a href="https://experimenter.info/workflow/risk-mitigation#vp-sign-off">Learn More</a></span>
           </td>
         </tr>
         <tr>
@@ -75,7 +75,7 @@
             {% if experiment.signoff_recommendations.legal_signoff %}
               <span class="text-success ms-1">Recommended:</span>
             {% endif %}
-            <span class="ms-1">Please email legal. <a href="https://experimenter.info/legal-sign-off">Learn More</a></span>
+            <span class="ms-1">Please email legal. <a href="https://experimenter.info/workflow/risk-mitigation#legal-sign-off">Learn More</a></span>
           </td>
         </tr>
       </tbody>

--- a/experimenter/experimenter/outcomes/README.md
+++ b/experimenter/experimenter/outcomes/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-[Outcomes](https://experimenter.info/jetstream/outcomes) define automated analyses that can be applied to Nimbus experiments. They are stored in the [metric-hub repo](https://github.com/mozilla/metric-hub/tree/main/jetstream/outcomes) as [TOML](https://github.com/toml-lang/toml) files and are consumed by Experimenter as a [Git Submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
+[Outcomes](https://experimenter.info/data-analysis/jetstream/outcomes) define automated analyses that can be applied to Nimbus experiments. They are stored in the [metric-hub repo](https://github.com/mozilla/metric-hub/tree/main/jetstream/outcomes) as [TOML](https://github.com/toml-lang/toml) files and are consumed by Experimenter as a [Git Submodule](https://git-scm.com/book/en/v2/Git-Tools-Submodules).
 
 ## Building and Deploying
 

--- a/experimenter/experimenter/results/src/components/PageResults/index.tsx
+++ b/experimenter/experimenter/results/src/components/PageResults/index.tsx
@@ -235,11 +235,11 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
       ? (Object.keys(analysis?.overall || {}).sort() as AnalysisBases[])
       : (Object.keys(analysis?.weekly || {}).sort() as AnalysisBases[]);
   const analysisBasisHelpMarkdown =
-    "Select the **analysis basis** whose results you want to see. See [defining exposure signals](https://experimenter.info/jetstream/configuration/#defining-exposure-signals) in the docs for more info.";
+    "Select the **analysis basis** whose results you want to see. See [defining exposure signals](https://experimenter.info/data-analysis/jetstream/configuration#defining-exposure-signals) in the docs for more info.";
 
   const allSegments = Object.keys(analysis?.overall?.enrollments || {}).sort();
   const segmentHelpMarkdown =
-    "Select the **analysis segment** whose results you want to see. See [defining segments](https://experimenter.info/jetstream/configuration/#defining-segments) in the docs for more info.";
+    "Select the **analysis segment** whose results you want to see. See [defining segments](https://experimenter.info/data-analysis/jetstream/configuration#defining-segments) in the docs for more info.";
 
   const filterErrors = (
     errors: AnalysisError[],
@@ -323,7 +323,8 @@ const PageResults: React.FunctionComponent<RouteComponentProps> = () => {
     );
   };
 
-  const exposureEventsInfoUrl = "https://experimenter.info/missing-exposure";
+  const exposureEventsInfoUrl =
+    "https://experimenter.info/data-analysis/data-topics/missing_exposures";
 
   return (
     <ResultsContext.Provider value={resultsContextValue}>

--- a/experimenter/experimenter/results/src/lib/constants.ts
+++ b/experimenter/experimenter/results/src/lib/constants.ts
@@ -38,38 +38,45 @@ export const SERVER_ERRORS = {
 };
 
 export const EXTERNAL_URLS = {
-  TRAINING_AND_PLANNING_DOC: "https://experimenter.info/for-product",
+  TRAINING_AND_PLANNING_DOC:
+    "https://experimenter.info/getting-started/for-experiment-owners",
   NIMBUS_MANA_DOC: "https://mana.mozilla.org/wiki/display/FJT/Nimbus",
   WORKFLOW_MANA_DOC:
-    "https://experimenter.info/data-scientists/#sample-size-recommendations",
-  BRANCHES_EXPERIMENTER_DOC: "https://experimenter.info/feature-definition/",
+    "https://experimenter.info/getting-started/for-data-scientists#sample-size-recommendations",
+  BRANCHES_EXPERIMENTER_DOC:
+    "https://experimenter.info/technical-reference/feature-definition",
   METRICS_EXPERIMENTER_DOC:
-    "https://experimenter.info/deep-dives/jetstream/metrics",
+    "https://experimenter.info/data-analysis/jetstream/metrics",
   // EXP-866 TBD URL
-  PREVIEW_LAUNCH_DOC: "https://experimenter.info/previewing-experiments",
-  RISK_BRAND: "https://experimenter.info/comms-sign-off",
+  PREVIEW_LAUNCH_DOC:
+    "https://experimenter.info/platform-guides/desktop/preview",
+  RISK_BRAND:
+    "https://experimenter.info/workflow/risk-mitigation#comms--messaging-sign-off",
   RISK_MESSAGE:
     "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation",
-  RISK_PARTNER: "https://experimenter.info/legal-sign-off",
-  RISK_REVENUE: "https://experimenter.info/vp-sign-off",
-  SIGNOFF_QA: "https://experimenter.info/qa-sign-off",
-  SIGNOFF_VP: "https://experimenter.info/vp-sign-off",
-  SIGNOFF_LEGAL: "https://experimenter.info/legal-sign-off",
-  REVIEW_PRIVILIGES: "https://experimenter.info/access",
+  RISK_PARTNER:
+    "https://experimenter.info/workflow/risk-mitigation#legal-sign-off",
+  RISK_REVENUE:
+    "https://experimenter.info/workflow/risk-mitigation#vp-sign-off",
+  SIGNOFF_QA: "https://experimenter.info/workflow/risk-mitigation#qa-sign-off",
+  SIGNOFF_VP: "https://experimenter.info/workflow/risk-mitigation#vp-sign-off",
+  SIGNOFF_LEGAL:
+    "https://experimenter.info/workflow/risk-mitigation#legal-sign-off",
+  REVIEW_PRIVILIGES: "https://experimenter.info/getting-started/for-reviewers",
   ROLLOUT_SETPREF_REENROLL_EXPLANATION:
-    "https://experimenter.info/faq/warnings#rollouts-and-setpref-interaction-desktop",
+    "https://experimenter.info/advanced/warnings#rollouts-and-setpref-interaction-desktop",
   EXPERIMENTER_DOCUMENTATION: "https://experimenter.info",
   ASK_EXPERIMENTER_SLACK: "https://slack.com/app_redirect?channel=CF94YGE03",
   FEEDBACK: "https://bit.ly/38dgkqR",
   GITHUB_TICKET: "https://github.com/mozilla/experimenter/issues/new",
   LAUNCH_DOCUMENTATION:
-    "https://experimenter.info/access#onboarding-for-new-reviewers-l3",
+    "https://experimenter.info/getting-started/for-reviewers#onboarding-for-new-reviewers-l3",
   BUCKET_WARNING_EXPLANATION:
-    "https://experimenter.info/faq/warnings#rollout-bucketing-warning",
+    "https://experimenter.info/advanced/warnings#rollout-bucketing-warning",
   AUDIENCE_OVERLAP_WARNING:
-    "https://experimenter.info/faq/warnings/#audience-overlap",
+    "https://experimenter.info/advanced/warnings#audience-overlap",
   CUSTOM_AUDIENCES_EXPLANATION:
-    "https://experimenter.info/workflow/implementing/custom-audiences",
+    "https://experimenter.info/advanced/custom-audiences",
   WHAT_TRAIN_IS_IT: "https://whattrainisitnow.com",
   QA_PI_DOC:
     "https://mozilla-hub.atlassian.net/jira/software/c/projects/QA/boards/261",


### PR DESCRIPTION
Because

* The experimenter-docs site was reorganized in Jan-Feb 2026
* Many URLs in the codebase pointed to old paths that no longer exist
* Sign-off pages moved to /workflow/risk-mitigation
* Jetstream docs moved under /data-analysis/jetstream/
* Custom audiences moved to /advanced/custom-audiences
* Warnings moved from /faq/warnings to /advanced/warnings

This commit

* Updates all experimenter.info URLs across 12 files to their new paths
* Covers Python constants, TypeScript constants, HTML templates, and docs

Fixes #14643