### PR TITLE
chore(cirrus): Add GHA workflow for Cirrus lint and tests

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -53,6 +53,20 @@ runs:
         cache-from: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }}
         cache-to: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }},mode=max
 
+    - name: Build cirrus with cache
+      uses: docker/build-push-action@v6
+      with:
+        context: cirrus/server/
+        file: cirrus/server/Dockerfile
+        target: deploy
+        tags: cirrus:deploy
+        load: true
+        build-contexts: |
+          experimenter:megazords=docker-image://${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
+          fml=experimenter/experimenter/features/manifests/
+        cache-from: type=registry,ref=${{ inputs.gar-cache }}/cirrus-cache:${{ inputs.arch }}
+        cache-to: type=registry,ref=${{ inputs.gar-cache }}/cirrus-cache:${{ inputs.arch }},mode=max
+
     - name: Export build flags
       shell: bash
       env:
@@ -62,5 +76,6 @@ runs:
         echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
         echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
         echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
+        echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --load" >> "$GITHUB_ENV"
         echo 'SCHEMAS_BUILD_FLAGS=--load' >> "$GITHUB_ENV"
         echo 'DOCKER_RUN_INTERACTIVE=' >> "$GITHUB_ENV"

--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -1,0 +1,45 @@
+name: Cirrus Check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "cirrus/**"
+      - "application-services/**"
+      - ".github/workflows/check-cirrus.yml"
+  pull_request:
+    paths:
+      - "cirrus/**"
+      - "application-services/**"
+      - ".github/workflows/check-cirrus.yml"
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            runner: ubuntu-24.04
+          - arch: aarch64
+            runner: ubuntu-24.04-arm
+    name: "${{ matrix.arch }}"
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: ./.github/actions/setup-cached-build
+        with:
+          arch: ${{ matrix.arch }}
+          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+
+      - name: Run Cirrus tests and linting
+        run: |
+          cp .env.sample .env
+          make cirrus_check

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ DOCKER_BUILD = docker buildx build
 MEGAZORD_BUILD_FLAGS ?=
 EXPERIMENTER_BUILD_FLAGS ?=
 DEV_BUILD_FLAGS ?=
+CIRRUS_BUILD_FLAGS ?=
 SCHEMAS_BUILD_FLAGS ?=
 
 # Interactive flags for docker run. Set to empty for non-TTY environments (CI).
@@ -286,7 +287,7 @@ cirrus_build_dev: build_megazords
 	$(CIRRUS_ENABLE) $(DOCKER_BUILD) --target dev -f cirrus/server/Dockerfile -t cirrus:dev --build-context=fml=experimenter/experimenter/features/manifests/ cirrus/server/
 
 cirrus_build_test: build_megazords
-	$(CIRRUS_ENABLE) $(COMPOSE_TEST) build cirrus
+	$(CIRRUS_ENABLE) $(DOCKER_BUILD) $(CIRRUS_BUILD_FLAGS) --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy --build-context fml=experimenter/experimenter/features/manifests/ cirrus/server/
 
 cirrus_bash: cirrus_build_dev
 	docker run --rm -ti -v ./cirrus/server:/cirrus -v /cirrus/cirrus/glean cirrus:dev bash

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -20,10 +20,6 @@ services:
       POSTGRES_PASSWORD: postgres
 
   cirrus:
+    image: cirrus:deploy
     env_file: .env.test
-    build:
-      additional_contexts:
-        - fml=experimenter/experimenter/features/manifests/
-      context: cirrus/server/
-      dockerfile: Dockerfile
     working_dir: /cirrus


### PR DESCRIPTION
Because

* We are migrating CI from CircleCI to GitHub Actions (EXP-6320)
* The Cirrus check jobs need to run on PRs and pushes to main

This commit

* Adds a GitHub Actions workflow that runs `make cirrus_check` on both x86_64 and aarch64 architectures
* Converts `cirrus_build_test` from `docker compose build` to `docker buildx build` for consistent caching with `CIRRUS_BUILD_FLAGS`
* Adds cirrus pre-build with registry cache to the `setup-cached-build` composite action
* Adds `image: cirrus:dev` to `docker-compose-test.yml` so compose uses the pre-built image
* Triggers on changes to `cirrus/`, `application-services/`, and the workflow file itself

Fixes #14579