### PR TITLE
feat(nimbus): add YAML export endpoint for completed experiments

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -60,6 +60,31 @@
         ]
       }
     },
+    "/api/v5/yaml/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/yaml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperimentYaml"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v6/experiments/": {
       "get": {
         "operationId": "listNimbusExperiments",
@@ -1185,6 +1210,235 @@
           "experiment_name",
           "experiment_summary",
           "rollout"
+        ]
+      },
+      "NimbusExperimentYaml": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[-a-zA-Z0-9_]+$"
+          },
+          "status": {
+            "enum": [
+              "Draft",
+              "Preview",
+              "Live",
+              "Complete"
+            ],
+            "type": "string"
+          },
+          "public_description": {
+            "type": "string"
+          },
+          "hypothesis": {
+            "type": "string",
+            "readOnly": true
+          },
+          "is_rollout": {
+            "type": "boolean"
+          },
+          "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "application_display": {
+            "type": "string",
+            "readOnly": true
+          },
+          "channels": {
+            "type": "string",
+            "readOnly": true
+          },
+          "feature_configs": {
+            "type": "string",
+            "readOnly": true
+          },
+          "branches": {
+            "type": "string",
+            "readOnly": true
+          },
+          "targeting": {
+            "type": "string",
+            "readOnly": true
+          },
+          "firefox_min_version": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "firefox_max_version": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "population_percent": {
+            "type": "string",
+            "format": "decimal",
+            "multipleOf": 0.0001,
+            "maximum": 1000,
+            "minimum": -1000
+          },
+          "is_sticky": {
+            "type": "boolean"
+          },
+          "is_first_run": {
+            "type": "boolean"
+          },
+          "locales": {
+            "type": "string",
+            "readOnly": true
+          },
+          "countries": {
+            "type": "string",
+            "readOnly": true
+          },
+          "languages": {
+            "type": "string",
+            "readOnly": true
+          },
+          "projects": {
+            "type": "string",
+            "readOnly": true
+          },
+          "proposed_duration": {
+            "type": "integer",
+            "maximum": 1000,
+            "minimum": 0
+          },
+          "proposed_enrollment": {
+            "type": "integer",
+            "maximum": 1000,
+            "minimum": 0
+          },
+          "total_enrolled_clients": {
+            "type": "integer",
+            "maximum": 2147483647,
+            "minimum": 0
+          },
+          "_start_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "_enrollment_end_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "_end_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "published_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "primary_outcomes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "secondary_outcomes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "risk_flags": {
+            "type": "string",
+            "readOnly": true
+          },
+          "documentation_links": {
+            "type": "string",
+            "readOnly": true
+          },
+          "qa_status": {
+            "type": "string",
+            "readOnly": true
+          },
+          "qa_comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_firefox_labs_opt_in": {
+            "type": "boolean"
+          },
+          "firefox_labs_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "firefox_labs_description": {
+            "type": "string",
+            "nullable": true
+          },
+          "conclusion_recommendation_labels": {
+            "type": "string",
+            "readOnly": true
+          },
+          "takeaways_summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_metric_gain": {
+            "type": "boolean"
+          },
+          "takeaways_gain_amount": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_qbr_learning": {
+            "type": "boolean"
+          },
+          "project_impact": {
+            "enum": [
+              "HIGH",
+              "MODERATE",
+              "TARGETED"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "next_steps": {
+            "type": "string",
+            "nullable": true
+          },
+          "experiment_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "tags": {
+            "type": "string",
+            "readOnly": true
+          },
+          "required_experiments": {
+            "type": "string",
+            "readOnly": true
+          },
+          "excluded_experiments": {
+            "type": "string",
+            "readOnly": true
+          },
+          "parent_experiment": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "name",
+          "slug"
         ]
       },
       "NimbusExperiment": {

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -72,6 +72,31 @@
         ]
       }
     },
+    "/api/v5/yaml/": {
+      "get": {
+        "operationId": "listNimbusExperiments",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "text/yaml": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/NimbusExperimentYaml"
+                  }
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v6/experiments/": {
       "get": {
         "operationId": "listNimbusExperiments",
@@ -1197,6 +1222,235 @@
           "experiment_name",
           "experiment_summary",
           "rollout"
+        ]
+      },
+      "NimbusExperimentYaml": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "slug": {
+            "type": "string",
+            "maxLength": 80,
+            "pattern": "^[-a-zA-Z0-9_]+$"
+          },
+          "status": {
+            "enum": [
+              "Draft",
+              "Preview",
+              "Live",
+              "Complete"
+            ],
+            "type": "string"
+          },
+          "public_description": {
+            "type": "string"
+          },
+          "hypothesis": {
+            "type": "string",
+            "readOnly": true
+          },
+          "is_rollout": {
+            "type": "boolean"
+          },
+          "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "application_display": {
+            "type": "string",
+            "readOnly": true
+          },
+          "channels": {
+            "type": "string",
+            "readOnly": true
+          },
+          "feature_configs": {
+            "type": "string",
+            "readOnly": true
+          },
+          "branches": {
+            "type": "string",
+            "readOnly": true
+          },
+          "targeting": {
+            "type": "string",
+            "readOnly": true
+          },
+          "firefox_min_version": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "firefox_max_version": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "population_percent": {
+            "type": "string",
+            "format": "decimal",
+            "multipleOf": 0.0001,
+            "maximum": 1000,
+            "minimum": -1000
+          },
+          "is_sticky": {
+            "type": "boolean"
+          },
+          "is_first_run": {
+            "type": "boolean"
+          },
+          "locales": {
+            "type": "string",
+            "readOnly": true
+          },
+          "countries": {
+            "type": "string",
+            "readOnly": true
+          },
+          "languages": {
+            "type": "string",
+            "readOnly": true
+          },
+          "projects": {
+            "type": "string",
+            "readOnly": true
+          },
+          "proposed_duration": {
+            "type": "integer",
+            "maximum": 1000,
+            "minimum": 0
+          },
+          "proposed_enrollment": {
+            "type": "integer",
+            "maximum": 1000,
+            "minimum": 0
+          },
+          "total_enrolled_clients": {
+            "type": "integer",
+            "maximum": 2147483647,
+            "minimum": 0
+          },
+          "_start_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "_enrollment_end_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "_end_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "published_date": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "primary_outcomes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "secondary_outcomes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "risk_flags": {
+            "type": "string",
+            "readOnly": true
+          },
+          "documentation_links": {
+            "type": "string",
+            "readOnly": true
+          },
+          "qa_status": {
+            "type": "string",
+            "readOnly": true
+          },
+          "qa_comment": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_firefox_labs_opt_in": {
+            "type": "boolean"
+          },
+          "firefox_labs_title": {
+            "type": "string",
+            "nullable": true
+          },
+          "firefox_labs_description": {
+            "type": "string",
+            "nullable": true
+          },
+          "conclusion_recommendation_labels": {
+            "type": "string",
+            "readOnly": true
+          },
+          "takeaways_summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_metric_gain": {
+            "type": "boolean"
+          },
+          "takeaways_gain_amount": {
+            "type": "string",
+            "nullable": true
+          },
+          "takeaways_qbr_learning": {
+            "type": "boolean"
+          },
+          "project_impact": {
+            "enum": [
+              "HIGH",
+              "MODERATE",
+              "TARGETED"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "next_steps": {
+            "type": "string",
+            "nullable": true
+          },
+          "experiment_url": {
+            "type": "string",
+            "readOnly": true
+          },
+          "tags": {
+            "type": "string",
+            "readOnly": true
+          },
+          "required_experiments": {
+            "type": "string",
+            "readOnly": true
+          },
+          "excluded_experiments": {
+            "type": "string",
+            "readOnly": true
+          },
+          "parent_experiment": {
+            "type": "string",
+            "readOnly": true
+          }
+        },
+        "required": [
+          "name",
+          "slug"
         ]
       },
       "NimbusExperiment": {

--- a/experimenter/experimenter/experiments/api/v5/urls.py
+++ b/experimenter/experimenter/experiments/api/v5/urls.py
@@ -5,6 +5,7 @@ from graphene_file_upload.django import FileUploadGraphQLView
 from experimenter.experiments.api.v5.views import (
     FmlErrorsView,
     NimbusExperimentCsvListView,
+    NimbusExperimentYamlListView,
 )
 
 urlpatterns = [
@@ -17,6 +18,11 @@ urlpatterns = [
         r"^csv/$",
         NimbusExperimentCsvListView.as_view(),
         name="nimbus-experiments-csv",
+    ),
+    re_path(
+        r"^yaml/$",
+        NimbusExperimentYamlListView.as_view(),
+        name="nimbus-experiments-yaml",
     ),
     path(r"fml-errors/<slug:slug>/", FmlErrorsView.as_view(), name="nimbus-fml-errors"),
 ]

--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -1,9 +1,12 @@
+import yaml
 from rest_framework.generics import ListAPIView, UpdateAPIView
+from rest_framework.renderers import BaseRenderer
 from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.api.v5.serializers import (
     FmlFeatureValueSerializer,
     NimbusExperimentCsvSerializer,
+    NimbusExperimentYamlSerializer,
 )
 from experimenter.experiments.models import NimbusExperiment
 
@@ -21,6 +24,65 @@ class NimbusExperimentCsvListView(ListAPIView):
     )
     serializer_class = NimbusExperimentCsvSerializer
     renderer_classes = (NimbusExperimentCsvRenderer,)
+
+    def get_queryset(self):
+        return sorted(
+            super().get_queryset(),
+            key=lambda experiment: (
+                (experiment.start_date and experiment.start_date.strftime("%Y-%m-%d"))
+                or ""
+            ),
+            reverse=True,
+        )
+
+
+class NimbusExperimentYamlRenderer(BaseRenderer):
+    media_type = "text/yaml"
+    format = "yaml"
+    charset = "utf-8"
+
+    @staticmethod
+    def _strip_empty(obj):
+        if isinstance(obj, dict):
+            return {
+                k: NimbusExperimentYamlRenderer._strip_empty(v)
+                for k, v in obj.items()
+                if v is not None and v != "" and v != [] and v != {}
+            }
+        if isinstance(obj, list):
+            return [NimbusExperimentYamlRenderer._strip_empty(i) for i in obj]
+        return obj
+
+    def render(self, data, accepted_media_type=None, renderer_context=None):
+        if not data:
+            return ""
+        cleaned = [self._strip_empty(exp) for exp in data]
+        return yaml.dump(
+            cleaned, default_flow_style=False, allow_unicode=True, sort_keys=False
+        )
+
+
+class NimbusExperimentYamlListView(ListAPIView):
+    queryset = (
+        NimbusExperiment.objects.select_related("owner", "reference_branch", "parent")
+        .prefetch_related(
+            "feature_configs",
+            "branches",
+            "branches__feature_values__feature_config",
+            "documentation_links",
+            "projects",
+            "locales",
+            "countries",
+            "languages",
+            "tags",
+            "required_experiments",
+            "excluded_experiments",
+        )
+        .filter(is_archived=False, status=NimbusExperiment.Status.COMPLETE)
+    )
+    serializer_class = NimbusExperimentYamlSerializer
+    renderer_classes = (NimbusExperimentYamlRenderer,)
+    pagination_class = None
 
     def get_queryset(self):
         return sorted(

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -1,13 +1,15 @@
 import datetime
 import json
 
+import yaml
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
 
+from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
 from experimenter.experiments.api.v5.views import NimbusExperimentCsvRenderer
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import NimbusExperiment, Tag
 from experimenter.experiments.tests.api.v5.test_serializers.mixins import (
     MockFmlErrorMixin,
 )
@@ -100,6 +102,255 @@ class TestNimbusExperimentCsvListView(TestCase):
             renderer_context={"header": NimbusExperimentCsvSerializer.Meta.fields},
         )
         self.assertEqual(csv_data, expected_csv_data)
+
+
+class TestNimbusExperimentYamlListView(TestCase):
+    def _get_yaml(self):
+        response = self.client.get(
+            reverse("nimbus-experiments-yaml"),
+            **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/yaml; charset=utf-8")
+        return yaml.safe_load(response.content.decode("utf-8"))
+
+    def test_returns_empty_for_no_complete_experiments(self):
+        response = self.client.get(
+            reverse("nimbus-experiments-yaml"),
+            **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode("utf-8"), "")
+
+    def test_sorted_by_start_date_descending(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            start_date=datetime.date(2022, 5, 1),
+            name="Experiment Alpha",
+            application=application,
+            feature_configs=[feature_config],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            start_date=datetime.date(2020, 5, 1),
+            name="Experiment Beta",
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        data = self._get_yaml()
+        self.assertEqual(len(data), 2)
+        self.assertEqual(data[0]["name"], "Experiment Alpha")
+        self.assertEqual(data[1]["name"], "Experiment Beta")
+
+    def test_excludes_archived_and_non_complete(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            name="Complete Experiment",
+            application=application,
+            feature_configs=[feature_config],
+        )
+        NimbusExperimentFactory.create(
+            name="Archived Experiment",
+            application=application,
+            feature_configs=[feature_config],
+            is_archived=True,
+            status=NimbusExperiment.Status.COMPLETE,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            name="Live Experiment",
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        data = self._get_yaml()
+        names = [exp["name"] for exp in data]
+        self.assertIn("Complete Experiment", names)
+        self.assertNotIn("Archived Experiment", names)
+        self.assertNotIn("Live Experiment", names)
+
+    def test_yaml_contains_all_fields(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=application,
+            name="Test Feature",
+            slug="test-feature",
+        )
+
+        parent = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            name="Parent Experiment",
+            slug="parent-experiment",
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        required_exp = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            name="Required Experiment",
+            slug="required-experiment",
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        excluded_exp = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            name="Excluded Experiment",
+            slug="excluded-experiment",
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        locale = Locale.objects.create(code="en-US", name="English (US)")
+        country = Country.objects.create(code="US", name="United States")
+        language = Language.objects.create(code="en", name="English")
+        tag = Tag.objects.create(name="test-tag")
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            start_date=datetime.date(2022, 1, 1),
+            name="Full Experiment",
+            slug="full-experiment",
+            public_description="A test experiment.",
+            hypothesis="Testing improves quality.",
+            application=application,
+            feature_configs=[feature_config],
+            parent=parent,
+            risk_ai=True,
+            qa_status=NimbusExperiment.QAStatus.GREEN,
+            conclusion_recommendations=["RERUN", "GRADUATE"],
+        )
+        experiment.locales.add(locale)
+        experiment.countries.add(country)
+        experiment.languages.add(language)
+        experiment.tags.add(tag)
+        experiment.required_experiments.add(required_exp)
+        experiment.excluded_experiments.add(excluded_exp)
+        experiment.save()
+
+        data = self._get_yaml()
+        exp = next(e for e in data if e["slug"] == "full-experiment")
+
+        # Basic fields
+        self.assertEqual(exp["name"], "Full Experiment")
+        self.assertEqual(exp["status"], "Complete")
+        self.assertEqual(exp["application_display"], "Firefox Desktop")
+        self.assertIn("full-experiment", exp["experiment_url"])
+
+        # Parent
+        self.assertEqual(
+            exp["parent_experiment"], "Parent Experiment (parent-experiment)"
+        )
+
+        # Hypothesis (not default)
+        self.assertEqual(exp["hypothesis"], "Testing improves quality.")
+
+        # QA status (not NOT_SET)
+        self.assertEqual(exp["qa_status"], NimbusExperiment.QAStatus.GREEN)
+
+        # Locales/countries/languages
+        self.assertEqual(exp["locales"]["codes"], ["en-US"])
+        self.assertEqual(exp["countries"]["codes"], ["US"])
+        self.assertEqual(exp["languages"]["codes"], ["en"])
+
+        # Channels (desktop uses channels array)
+        self.assertIsInstance(exp["channels"], list)
+
+        # Tags
+        self.assertIn("test-tag", exp["tags"])
+
+        # Required/excluded experiments
+        self.assertIn(
+            "Required Experiment (required-experiment)",
+            exp["required_experiments"],
+        )
+        self.assertIn(
+            "Excluded Experiment (excluded-experiment)",
+            exp["excluded_experiments"],
+        )
+
+        # Risk flags (risk_ai=True)
+        self.assertIn("AI", exp["risk_flags"])
+
+        # Conclusion recommendations
+        self.assertIn("Rerun", exp["conclusion_recommendation_labels"])
+        self.assertIn("Graduate", exp["conclusion_recommendation_labels"])
+
+        # Feature configs
+        slugs = [fc["slug"] for fc in exp["feature_configs"]]
+        self.assertIn("test-feature", slugs)
+
+    def test_default_hypothesis_excluded(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            hypothesis=NimbusExperiment.HYPOTHESIS_DEFAULT,
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        data = self._get_yaml()
+        self.assertNotIn("hypothesis", data[0])
+
+    def test_not_set_qa_status_excluded(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            qa_status=NimbusExperiment.QAStatus.NOT_SET,
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        data = self._get_yaml()
+        self.assertNotIn("qa_status", data[0])
+
+    def test_mobile_single_channel_fallback(self):
+        application = NimbusExperiment.Application.FENIX
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_configs=[feature_config],
+        )
+
+        data = self._get_yaml()
+        self.assertEqual(data[0]["channels"], [NimbusExperiment.Channel.RELEASE])
+
+    def test_targeting_slug_fallback(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            feature_configs=[feature_config],
+            targeting_config_slug="removed-targeting",
+        )
+
+        data = self._get_yaml()
+        exp = next(e for e in data if e["slug"] == experiment.slug)
+        self.assertEqual(exp["targeting"]["name"], "removed-targeting")
+
+    def test_no_targeting_slug(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            feature_configs=[feature_config],
+            targeting_config_slug="",
+        )
+
+        data = self._get_yaml()
+        exp = next(e for e in data if e["slug"] == experiment.slug)
+        self.assertNotIn("targeting", exp)
 
 
 class TestFmlErrorsView(MockFmlErrorMixin, TestCase):

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -91,6 +91,15 @@
             </a>
           </li>
           <li>
+            <a href="{% url "nimbus-experiments-yaml" %}"
+               class="dropdown-item link-primary"
+               target="_blank"
+               rel="noreferrer">
+              <i class="fa-solid fa-file-lines me-2"></i>
+              YAML Export
+            </a>
+          </li>
+          <li>
             <a id="legacy_page_link"
                href="/legacy/"
                class="dropdown-item link-primary"


### PR DESCRIPTION
Because

* The Nimbus chatbot assistant (EXP-4985) needs experiment data as a
  knowledge file to answer questions about past experiments
* ChatGPT was tested with YAML and was able to read the data effectively

This commit

* Adds NimbusExperimentYamlSerializer with 40+ fields covering identity,
  timeline, audience, branches, outcomes, risk, QA, Firefox Labs, and
  takeaways
* Adds NimbusExperimentYamlRenderer using yaml.dump with empty-value
  stripping
* Adds /api/v5/yaml/ endpoint returning completed, non-archived
  experiments sorted by start date descending
* Adds "YAML Export" link in the navbar Links dropdown
* Adds 8 tests with 100% coverage

Fixes #14655