### PR TITLE
fix(nimbus): fix experiments with only weekly data not displaying results

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -58,8 +58,9 @@ class ExperimentResultsManager:
         reference_branch,
         outcome_group,
         outcome_slug,
+        window="overall",
     ):
-        overall_results = self.get_window_results(analysis_basis, segment, "overall")
+        overall_results = self.get_window_results(analysis_basis, segment, window)
         max_value = 0
 
         for branch in self.experiment.get_sorted_branches():
@@ -287,6 +288,7 @@ class ExperimentResultsManager:
                 analysis_basis,
                 segment,
                 reference_branch,
+                window=window,
             )
 
             kpi["has_data"] = self.metric_has_data(
@@ -390,6 +392,7 @@ class ExperimentResultsManager:
                         analysis_basis,
                         segment,
                         reference_branch,
+                        window=window,
                     ),
                     "has_data": self.metric_has_data(
                         metric.slug,
@@ -520,23 +523,32 @@ class ExperimentResultsManager:
         )
 
     def get_overall_change(
-        self, group, metric_slug, analysis_basis, segment, reference_branch
+        self,
+        group,
+        metric_slug,
+        analysis_basis,
+        segment,
+        reference_branch,
+        window="overall",
     ):
-        branch_results = self.get_window_results(analysis_basis, segment, "overall")
+        branch_results = self.get_window_results(analysis_basis, segment, window)
         overall_change = MetricSignificance.NEUTRAL
 
         for branch_slug, branch_data in branch_results.items():
             if branch_slug == reference_branch:
                 continue
 
-            metric_significance = (
+            metric_significance_list = (
                 branch_data.get("branch_data", {})
                 .get(group, {})
                 .get(metric_slug, {})
                 .get("significance", {})
                 .get(reference_branch, {})
-                .get("overall", {})
-                .get("1", MetricSignificance.NEUTRAL)
+                .get(window, {})
+            )
+
+            metric_significance = metric_significance_list.get(
+                str(len(metric_significance_list.keys())), MetricSignificance.NEUTRAL
             )
 
             significances = {metric_significance, overall_change}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -202,7 +202,7 @@
   </div>
   {% comment %} Metrics {% endcomment %}
   {% for area, metric_data_metadata in metric_area_data.items %}
-    {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data.overall %}
+    {% with metric_metadata=metric_data_metadata.metrics metric_data=metric_data_metadata.data|dict_get:displayed_window %}
       {% if metric_data or area == NimbusUIConstants.NOTABLE_METRIC_AREA %}
         <div class="accordion-item p-3 px-4 shadow-sm rounded-4 border border-1">
           <button class="{% if metric_data %}accordion-button{% else %}border-0 py-3 px-4{% endif %} bg-transparent shadow-none text-body d-flex {% if not area == NimbusUIConstants.NOTABLE_METRIC_AREA %}collapsed{% endif %}"
@@ -319,8 +319,12 @@
                                   {% else %}
                                     {% for curr_branch_slug, branch_metric_data in metric_branch_data.items %}
                                       {% if curr_branch_slug == branch.slug %}
-                                        {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=branch_metric_data.absolute.0.lower absolute_upper=branch_metric_data.absolute.0.upper significance=branch_metric_data.relative.0.significance percentage=branch_metric_data.relative.0.avg_rel_change display_type=metric.display_type %}
+                                        {% with abs_last=branch_metric_data.absolute|last %}
+                                          {% with rel_last=branch_metric_data.relative|last %}
+                                            {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=abs_last.lower absolute_upper=abs_last.upper significance=rel_last.significance percentage=rel_last.avg_rel_change display_type=metric.display_type %}
 
+                                          {% endwith %}
+                                        {% endwith %}
                                       {% endif %}
                                     {% endfor %}
                                   {% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3529,6 +3529,180 @@ class TestResultsView(AuthTestCase):
         self.assertIn("primary_outcome_links", response.context["experiment_context"])
         self.assertIn("secondary_outcome_links", response.context["experiment_context"])
 
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                        "weekly": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                        "daily": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+                "overall",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {},
+                        "weekly": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                        "daily": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+                "weekly",
+            ),
+            (
+                {
+                    "v3": {
+                        "overall": {},
+                        "weekly": {},
+                        "daily": {
+                            "exposures": {"all": {}},
+                            "enrollments": {
+                                "all": {
+                                    "control": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "point": 210,
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        },
+                    }
+                },
+                "daily",
+            ),
+        ]
+    )
+    def test_correct_experiment_displayed_window(self, results_data, expected_window):
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        experiment.results_data = results_data
+        experiment.save()
+
+        response = self.client.get(
+            reverse("nimbus-ui-results", kwargs={"slug": experiment.slug}),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["displayed_window"], expected_window)
+
 
 @mock_valid_outcomes
 class TestOldResultsView(AuthTestCase):


### PR DESCRIPTION
Because

- Many of the functions used to parse the results data were defaulting to "overall" as no value for the analysis window was being provided
- This meant that in-progress experiments that were missing overall data but still contained relevant weekly data were not having the correct data displayed

This commit

- Refactored several functions that previously handled only overall data so they now also support weekly data processing

Fixes #14654