### PR TITLE
fix(nimbus): handle missing image file in v7 branch screenshot serializer

### DIFF
--- a/experimenter/experimenter/experiments/api/v7/serializers.py
+++ b/experimenter/experimenter/experiments/api/v7/serializers.py
@@ -42,7 +42,7 @@ class NimbusBranchSerializer(serializers.ModelSerializer):
         return features
 
     def get_screenshots(self, obj):
-        return [s.image.url for s in obj.screenshots.all()]
+        return [s.image.url for s in obj.screenshots.all() if s.image and s.image.name]
 
 
 class NimbusExperimentSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Because

* The v7 `NimbusBranchSerializer.get_screenshots` method calls `s.image.url`
  for every screenshot without checking if the image field has an
  associated file
* When a `NimbusBranchScreenshot` record exists but has no file (e.g. due
  to storage issues or data inconsistency), this raises `ValueError`
* The v5 GraphQL types already guard against this with
  `if self.image and self.image.name`

This commit

* Adds a guard to filter out screenshots with no image file in the v7
  serializer's `get_screenshots` method, matching the v5 pattern
* Adds a test that creates a screenshot record with an empty image field
  and verifies the serializer skips it without raising `ValueError`

Fixes #14664