### PR TITLE
feat(nimbus): warm readonly API list caches in background via Celery

### DIFF
--- a/experimenter/experimenter/experiments/api/cache.py
+++ b/experimenter/experimenter/experiments/api/cache.py
@@ -1,0 +1,51 @@
+import hashlib
+import logging
+from urllib.parse import urlencode
+
+from django.conf import settings
+from django.core.cache import cache
+from django.http import HttpResponse
+from rest_framework.renderers import JSONRenderer
+
+logger = logging.getLogger(__name__)
+
+
+def get_api_cache_key(view_name, query_params=None):
+    """Build a deterministic cache key from the view name and query parameters."""
+    if query_params:
+        params = sorted(query_params.lists())
+        param_str = urlencode(params, doseq=True)
+        param_hash = hashlib.md5(param_str.encode()).hexdigest()
+        return f"nimbus:api:{view_name}:{param_hash}"
+    return f"nimbus:api:{view_name}"
+
+
+def warm_api_cache(key_prefix, queryset, serializer_class):
+    """Query the DB, serialize, and store the rendered JSON in the cache."""
+    data = serializer_class(queryset.all(), many=True).data
+    rendered = JSONRenderer().render(data)
+    cache_key = get_api_cache_key(key_prefix)
+    cache.set(cache_key, rendered, timeout=settings.API_CACHE_WARMING_TTL)
+    logger.info("Warmed cache for %s (%d bytes)", key_prefix, len(rendered))
+
+
+class CachedListMixin:
+    """Mixin that serves list responses from an application-level Redis cache.
+
+    Set ``cache_key_prefix`` on each viewset (e.g. "v6:experiments").
+    The Celery task ``warm_api_caches`` pre-populates the cache for unfiltered
+    requests.  Filtered requests are cached on first hit.
+    """
+
+    cache_key_prefix = ""
+
+    def list(self, request, *args, **kwargs):
+        cache_key = get_api_cache_key(self.cache_key_prefix, request.query_params)
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return HttpResponse(cached, content_type="application/json")
+
+        response = super().list(request, *args, **kwargs)
+        rendered = JSONRenderer().render(response.data)
+        cache.set(cache_key, rendered, timeout=settings.API_CACHE_WARMING_TTL)
+        return response

--- a/experimenter/experimenter/experiments/api/v6/views.py
+++ b/experimenter/experimenter/experiments/api/v6/views.py
@@ -1,10 +1,8 @@
-from django.conf import settings
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from django_filters import FilterSet, filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 
+from experimenter.experiments.api.cache import CachedListMixin
 from experimenter.experiments.api.v6.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
 
@@ -38,6 +36,7 @@ class NimbusDraftExperimentFilterSet(BaseExperimentFilterSet):
 
 
 class NimbusExperimentViewSet(
+    CachedListMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
@@ -51,14 +50,12 @@ class NimbusExperimentViewSet(
     serializer_class = NimbusExperimentSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = NimbusExperimentFilterSet
-
-    @method_decorator(cache_page(settings.API_CACHE_DURATION))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+    cache_key_prefix = "v6:experiments"
 
 
 class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):
     filterset_class = NimbusDraftExperimentFilterSet
+    cache_key_prefix = "v6:draft-experiments"
 
     queryset = (
         NimbusExperiment.objects.with_related()
@@ -69,6 +66,7 @@ class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):
 
 class NimbusExperimentFirstRunViewSet(NimbusExperimentViewSet):
     filterset_class = BaseExperimentFilterSet
+    cache_key_prefix = "v6:first-run"
 
     queryset = (
         NimbusExperiment.objects.with_related()

--- a/experimenter/experimenter/experiments/api/v7/views.py
+++ b/experimenter/experimenter/experiments/api/v7/views.py
@@ -1,10 +1,8 @@
-from django.conf import settings
-from django.utils.decorators import method_decorator
-from django.views.decorators.cache import cache_page
 from django_filters import FilterSet, filters
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
 
+from experimenter.experiments.api.cache import CachedListMixin
 from experimenter.experiments.api.v7.serializers import NimbusExperimentSerializer
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureConfig
 
@@ -32,6 +30,7 @@ class NimbusExperimentFilterSet(FilterSet):
 
 
 class NimbusExperimentViewSet(
+    CachedListMixin,
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
@@ -45,7 +44,4 @@ class NimbusExperimentViewSet(
     serializer_class = NimbusExperimentSerializer
     filter_backends = [DjangoFilterBackend]
     filterset_class = NimbusExperimentFilterSet
-
-    @method_decorator(cache_page(settings.API_CACHE_DURATION))
-    def dispatch(self, request, *args, **kwargs):
-        return super().dispatch(request, *args, **kwargs)
+    cache_key_prefix = "v7:experiments"

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -1,0 +1,74 @@
+import markus
+from celery.utils.log import get_task_logger
+
+from experimenter.celery import app
+from experimenter.experiments.api.cache import warm_api_cache
+
+logger = get_task_logger(__name__)
+metrics = markus.get_metrics("experiments.api_cache")
+
+
+def _get_warm_cache_endpoints():
+    """Return the list of (key_prefix, queryset, serializer_class) to warm.
+
+    Imports are deferred so the module can be loaded before Django is fully
+    initialised (Celery auto-discovery).
+    """
+    from experimenter.experiments.api.v6 import serializers as v6_ser
+    from experimenter.experiments.api.v6 import views as v6_views
+    from experimenter.experiments.api.v7 import serializers as v7_ser
+    from experimenter.experiments.api.v7 import views as v7_views
+    from experimenter.experiments.api.v8 import serializers as v8_ser
+    from experimenter.experiments.api.v8 import views as v8_views
+
+    return [
+        (
+            "v6:experiments",
+            v6_views.NimbusExperimentViewSet.queryset,
+            v6_ser.NimbusExperimentSerializer,
+        ),
+        (
+            "v6:draft-experiments",
+            v6_views.NimbusExperimentDraftViewSet.queryset,
+            v6_ser.NimbusExperimentSerializer,
+        ),
+        (
+            "v6:first-run",
+            v6_views.NimbusExperimentFirstRunViewSet.queryset,
+            v6_ser.NimbusExperimentSerializer,
+        ),
+        (
+            "v7:experiments",
+            v7_views.NimbusExperimentViewSet.queryset,
+            v7_ser.NimbusExperimentSerializer,
+        ),
+        (
+            "v8:experiments",
+            v8_views.NimbusExperimentViewSet.queryset,
+            v8_ser.NimbusExperimentSerializer,
+        ),
+        (
+            "v8:draft-experiments",
+            v8_views.NimbusExperimentDraftViewSet.queryset,
+            v8_ser.NimbusExperimentSerializer,
+        ),
+    ]
+
+
+@app.task
+@metrics.timer_decorator("warm_api_caches")
+def warm_api_caches():
+    """Pre-populate the API list cache so requests are always served instantly."""
+    metrics.incr("warm_api_caches.started")
+
+    try:
+        for key_prefix, queryset, serializer_class in _get_warm_cache_endpoints():
+            warm_api_cache(key_prefix, queryset, serializer_class)
+            logger.info("Warmed %s", key_prefix)
+
+        metrics.incr("warm_api_caches.completed")
+
+    except Exception as e:
+        metrics.incr("warm_api_caches.failed")
+        logger.exception("warm_api_caches failed: %s", e)
+        raise

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -1,0 +1,144 @@
+import json
+from unittest import mock
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from experimenter.experiments.api.cache import get_api_cache_key
+from experimenter.experiments.tasks import _get_warm_cache_endpoints, warm_api_caches
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+
+
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+)
+class TestWarmApiCaches(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
+    def test_warm_api_caches_populates_cache_for_all_endpoints(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="live-experiment",
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+        )
+
+        warm_api_caches()
+
+        for key_prefix, _, _ in _get_warm_cache_endpoints():
+            cache_key = get_api_cache_key(key_prefix)
+            cached = cache.get(cache_key)
+            self.assertIsNotNone(cached, f"Cache for {key_prefix} should be populated")
+            data = json.loads(cached)
+            self.assertIsInstance(data, list)
+
+    def test_warm_api_caches_contains_correct_experiments(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="live-experiment",
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+        )
+
+        warm_api_caches()
+
+        # v6:experiments should contain the live experiment but not the draft
+        v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
+        v6_slugs = [exp["slug"] for exp in v6_data]
+        self.assertIn("live-experiment", v6_slugs)
+        self.assertNotIn("draft-experiment", v6_slugs)
+
+        # v6:draft-experiments should contain the draft but not the live
+        v6_draft_data = json.loads(cache.get(get_api_cache_key("v6:draft-experiments")))
+        v6_draft_slugs = [exp["slug"] for exp in v6_draft_data]
+        self.assertIn("draft-experiment", v6_draft_slugs)
+        self.assertNotIn("live-experiment", v6_draft_slugs)
+
+    def test_warm_api_caches_updates_stale_cache(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="experiment-1",
+        )
+
+        warm_api_caches()
+
+        v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
+        self.assertEqual(len([e for e in v6_data if e["slug"] == "experiment-1"]), 1)
+
+        # Add another experiment and re-warm
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="experiment-2",
+        )
+
+        warm_api_caches()
+
+        v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
+        slugs = [exp["slug"] for exp in v6_data]
+        self.assertIn("experiment-1", slugs)
+        self.assertIn("experiment-2", slugs)
+
+    def test_warm_api_caches_empty_db(self):
+        warm_api_caches()
+
+        for key_prefix, _, _ in _get_warm_cache_endpoints():
+            cache_key = get_api_cache_key(key_prefix)
+            cached = cache.get(cache_key)
+            self.assertIsNotNone(cached)
+            data = json.loads(cached)
+            self.assertEqual(data, [])
+
+    def test_warm_api_caches_first_run_endpoint(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="first-run-exp",
+            is_first_run=True,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="not-first-run-exp",
+            is_first_run=False,
+        )
+
+        warm_api_caches()
+
+        first_run_data = json.loads(cache.get(get_api_cache_key("v6:first-run")))
+        slugs = [exp["slug"] for exp in first_run_data]
+        self.assertIn("first-run-exp", slugs)
+        self.assertNotIn("not-first-run-exp", slugs)
+
+    def test_all_api_versions_produce_valid_json(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="test-experiment",
+        )
+
+        warm_api_caches()
+
+        for key_prefix, _, _ in _get_warm_cache_endpoints():
+            cache_key = get_api_cache_key(key_prefix)
+            cached = cache.get(cache_key)
+            data = json.loads(cached)
+            for exp in data:
+                self.assertIn("slug", exp)
+                self.assertIn("branches", exp)
+
+    def test_warm_api_caches_raises_on_error(self):
+        with (
+            mock.patch(
+                "experimenter.experiments.tasks.warm_api_cache",
+                side_effect=Exception("serialization failed"),
+            ),
+            self.assertRaises(Exception),
+        ):
+            warm_api_caches()

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -389,6 +389,7 @@ CACHES = {
     },
 }
 API_CACHE_DURATION = 60 * 60
+API_CACHE_WARMING_TTL = 60 * 60 * 24
 SIZING_DATA_KEY = "population_sizing"
 
 # Celery
@@ -423,6 +424,10 @@ CELERY_BEAT_SCHEDULE = {
     "check_experiment_alerts": {
         "task": "experimenter.slack.tasks.check_experiment_alerts",
         "schedule": crontab(minute=0, hour=18),
+    },
+    "warm_api_caches": {
+        "task": "experimenter.experiments.tasks.warm_api_caches",
+        "schedule": config("API_CACHE_WARMING_INTERVAL", default=3600, cast=int),
     },
 }
 


### PR DESCRIPTION
Because

* The v6/v7/v8 readonly API list endpoints dump all experiments without
  pagination, and the first request after cache expiry hangs while the
  full DB query and serialization completes
* The existing `cache_page` decorator only caches HTTP responses on demand,
  so there is always a cold-cache penalty after TTL expiry

This commit

* Replaces `cache_page` with a `CachedListMixin` that serves list responses
  from an application-level Redis cache
* Adds a `warm_api_caches` Celery periodic task (every 1 hour) that
  pre-populates the cache for all 6 unfiltered list endpoints
* Sets cache TTL to 24 hours so the Celery task always refreshes before
  expiry, ensuring callers never hit a cold cache
* Filtered requests are cached on first hit with the same long TTL

Fixes #14668