### PR TITLE
feat(nimbus): add last computed results date to results page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -12,7 +12,15 @@
   </div>
   {% comment %} Overview {% endcomment %}
   <div class="px-5 pt-4 pb-5 shadow-sm rounded-4 bg-body border border-1">
-    <h4 class="mt-2">Overview</h4>
+    <div class="d-flex mt-2 align-items-center justify-content-between">
+      <h4 class="m-0">Overview</h4>
+      <div>
+        Results last calculated:
+        <span class="fw-bold">{{ experiment.results_data.v3.metadata.analysis_start_time|parse_date|date:"N j, Y g:i A"|default:"N/A" }}
+          {% if experiment.results_data.v3.metadata.analysis_start_time %}UTC{% endif %}
+        </span>
+      </div>
+    </div>
     <div id="{{ experiment.slug }}-results-overview">
       <div class="d-flex flex-column gap-4">
         <hr>

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -3,6 +3,7 @@ from datetime import date
 
 import humanize
 from django import template
+from django.utils.dateparse import parse_datetime
 from django.utils.safestring import mark_safe
 
 from experimenter.experiments.constants import NimbusConstants
@@ -351,3 +352,10 @@ def dict_get(d, key):
     if isinstance(d, dict):
         return d.get(key)
     return None
+
+
+@register.filter
+def parse_date(value):
+    if isinstance(value, str):
+        return parse_datetime(value)
+    return value

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -38,6 +38,7 @@ from experimenter.nimbus_ui.templatetags.nimbus_extras import (
     format_not_set,
     format_string,
     home_status_display,
+    parse_date,
     qa_icon_info,
     remove_underscores,
     render_channel_icons,
@@ -170,6 +171,28 @@ class FilterTests(TestCase):
         self.assertEqual(dict_get(sample_dict, "key2"), "value2")
         self.assertIsNone(dict_get(sample_dict, "key3"))
         self.assertIsNone(dict_get("not_a_dict", "key1"))
+
+    def test_parse_date_valid_datetime_string(self):
+        result = parse_date("2025-12-17 13:32:04.516902+00:00")
+        self.assertIsNotNone(result)
+        self.assertEqual(result.year, 2025)
+        self.assertEqual(result.month, 12)
+        self.assertEqual(result.day, 17)
+        self.assertEqual(result.hour, 13)
+        self.assertEqual(result.minute, 32)
+
+    def test_parse_date_none_returns_none(self):
+        self.assertIsNone(parse_date(None))
+
+    def test_parse_date_empty_string_returns_none(self):
+        self.assertIsNone(parse_date(""))
+
+    def test_parse_date_invalid_string_returns_none(self):
+        self.assertIsNone(parse_date("not-a-date"))
+
+    def test_parse_date_already_datetime_returns_as_is(self):
+        dt = datetime.datetime(2025, 1, 1, 12, 0, 0)
+        self.assertEqual(parse_date(dt), dt)
 
 
 class TestHomeFilters(AuthTestCase):


### PR DESCRIPTION
Because

- Several requests were made to include the last computed results date to the new results page ui

This commit

- Adds last computed results date to the new results page

Fixes #14666