### PR TITLE
feat(nimbus): add daily metrics to metric popout card

### DIFF
--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -306,7 +306,7 @@ class ResultsObjectModelBase(BaseModel):
                             significance
                         )
 
-                if window == AnalysisWindow.WEEKLY:
+                if window == AnalysisWindow.WEEKLY or window == AnalysisWindow.DAILY:
                     data_point.window_index = window_index
 
                 comparison_data = getattr(metric_data, branch_comparison)

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -206,21 +206,21 @@ class JetstreamTestData:
         DATA_POINT_F_COVARIATE,
     ):
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_B,
             SignificanceData(
                 daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
             ),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_F_COVARIATE,
+            DATA_POINT_A_COVARIATE,
             SignificanceData(
                 daily={"1": Significance.POSITIVE.value}, weekly={}, overall={}
             ),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_C,
             SignificanceData(
                 daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
             ),
@@ -258,21 +258,21 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E,
+            DATA_POINT_B,
             SignificanceData(
                 daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
             ),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_F,
+            DATA_POINT_A,
             SignificanceData(
                 daily={"1": Significance.POSITIVE.value}, weekly={}, overall={}
             ),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_C,
             SignificanceData(
                 daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
             ),
@@ -375,6 +375,7 @@ class JetstreamTestData:
                 )
 
                 data_point_daily = range_data.model_copy()
+                data_point_daily.window_index = "1"
                 formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
                     primary_metric
                 ] = cls.get_metric_data(data_point_daily)
@@ -426,6 +427,7 @@ class JetstreamTestData:
                 )
 
                 data_point_daily = range_data.model_copy()
+                data_point_daily.window_index = "1"
                 formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
                     primary_metric
                 ] = cls.get_metric_data(data_point_daily)
@@ -778,7 +780,7 @@ class JetstreamTestData:
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
                         "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "some_ratio": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "some_dau_impact": EMPTY_METRIC_DATA.model_dump(
@@ -806,17 +808,17 @@ class JetstreamTestData:
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
-                        "some_count": ABSOLUTE_METRIC_DATA_F_COVARIATE.model_dump(
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_A_COVARIATE.model_dump(
                             exclude_none=True
                         ),
-                        "some_ratio": ABSOLUTE_METRIC_DATA_F.model_dump(
+                        "some_ratio": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "some_dau_impact": ABSOLUTE_METRIC_DATA_F.model_dump(
+                        "some_dau_impact": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                        "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
                         "retained": (
@@ -1217,7 +1219,7 @@ class JetstreamTestData:
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
                         "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "retained": (
@@ -1240,11 +1242,11 @@ class JetstreamTestData:
                     },
                     Group.USAGE.value: {},
                     Group.OTHER.value: {
-                        "identity": ABSOLUTE_METRIC_DATA_F.model_dump(exclude_none=True),
-                        "some_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                        "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
+                        "some_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
+                        "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
                         "retained": (
@@ -1598,17 +1600,17 @@ class ZeroJetstreamTestData(JetstreamTestData):
         DATA_POINT_F_COVARIATE,
     ):
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_B,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_F,
+            DATA_POINT_A,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_C,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="control",
         )
@@ -1644,17 +1646,17 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E,
+            DATA_POINT_B,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_DAILY_POSITIVE_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_F,
+            DATA_POINT_A,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_C,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="variant",
         )
@@ -1746,6 +1748,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
                 )
 
                 data_point_daily = range_data.model_copy()
+                data_point_daily.window_index = "1"
                 formatted_daily_data[branch]["branch_data"][Group.OTHER.value][
                     primary_metric
                 ] = cls.get_metric_data(data_point_daily)

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -140,6 +140,7 @@ class TestExperimentResultsManager(TestCase):
                         }
                     }
                 },
+                "weekly",
                 {
                     "data": {
                         "branch-a": [
@@ -303,6 +304,7 @@ class TestExperimentResultsManager(TestCase):
                         }
                     }
                 },
+                "weekly",
                 {
                     "data": {
                         "branch-a": [
@@ -384,25 +386,207 @@ class TestExperimentResultsManager(TestCase):
                     "has_weekly_data": True,
                 },
             ),
+            (
+                {
+                    "v3": {
+                        "daily": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 130,
+                                                                "upper": 150,
+                                                                "point": 140,
+                                                                "window_index": "2",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        },
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 130,
+                                                                "upper": 150,
+                                                                "point": 140,
+                                                                "window_index": "2",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": 10,
+                                                                    "upper": 20,
+                                                                    "point": 15,
+                                                                    "window_index": "1",
+                                                                },
+                                                                {
+                                                                    "lower": 5,
+                                                                    "upper": 15,
+                                                                    "point": 10,
+                                                                    "window_index": "2",
+                                                                },
+                                                                {
+                                                                    "lower": 0,
+                                                                    "upper": 10,
+                                                                    "point": 5,
+                                                                    "window_index": "3",
+                                                                },
+                                                            ]
+                                                        },
+                                                        "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                "daily",
+                {
+                    "data": {
+                        "branch-a": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": 130,
+                                    "upper": 150,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                None,
+                            ),
+                        ],
+                        "branch-b": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                {
+                                    "avg_rel_change": 15,
+                                    "lower": 10,
+                                    "upper": 20,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": 130,
+                                    "upper": 150,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                {
+                                    "avg_rel_change": 10,
+                                    "lower": 5,
+                                    "upper": 15,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                {
+                                    "avg_rel_change": 5,
+                                    "lower": 0,
+                                    "upper": 10,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                            ),
+                        ],
+                    },
+                    "has_daily_data": True,
+                },
+            ),
         ]
     )
-    def test_get_weekly_metric_data(self, results_data, expected_weekly_data):
+    def test_get_weekly_metric_data(self, results_data, window, expected_data):
         self.experiment.results_data = results_data
         self.experiment.save()
 
         self.assertEqual(
-            self.results_manager.get_weekly_metric_data(
-                "enrollments", "all", "branch-a"
+            self.results_manager.build_window_metric_breakdown(
+                "enrollments", "all", "branch-a", window
             ).get("urlbar_amazon_search_count"),
-            expected_weekly_data,
+            expected_data,
         )
         self.assertEqual(
-            self.results_manager.get_weekly_metric_data(
-                "enrollments", "all", "branch-a"
+            self.results_manager.build_window_metric_breakdown(
+                "enrollments", "all", "branch-a", window
             ).get("total_amazon_search_count"),
             {
                 "data": {},
-                "has_weekly_data": False,
+                f"has_{window}_data": False,
             },
         )
 

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -80,12 +80,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 10.0,
                                                         "point": 12.0,
                                                         "upper": 13.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 10.0,
                                                     "point": 12.0,
                                                     "upper": 13.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -125,12 +127,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 10.0,
                                                         "point": 12.0,
                                                         "upper": 13.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 10.0,
                                                     "point": 12.0,
                                                     "upper": 13.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -175,12 +179,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 10.0,
                                                         "point": 12.0,
                                                         "upper": 13.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 10.0,
                                                     "point": 12.0,
                                                     "upper": 13.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -220,12 +226,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 10.0,
                                                         "point": 12.0,
                                                         "upper": 13.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 10.0,
                                                     "point": 12.0,
                                                     "upper": 13.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -1240,12 +1248,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 0.0,
                                                         "point": 0.0,
                                                         "upper": 0.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 0.0,
                                                     "point": 0.0,
                                                     "upper": 0.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -1285,12 +1295,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 0.0,
                                                         "point": 0.0,
                                                         "upper": 0.0,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 0.0,
                                                     "point": 0.0,
                                                     "upper": 0.0,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -1879,12 +1891,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 0.855,
                                                         "point": 0.856,
                                                         "upper": 0.8575,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 0.855,
                                                     "point": 0.856,
                                                     "upper": 0.8575,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -1895,12 +1909,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -10.2,
                                                             "point": -0.1,
                                                             "upper": -0.01,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -10.2,
                                                         "point": -0.1,
                                                         "upper": -0.01,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-b": {
@@ -1909,12 +1925,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -1.2,
                                                             "point": -1.1,
                                                             "upper": -1.01,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -1.2,
                                                         "point": -1.1,
                                                         "upper": -1.01,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                             },
@@ -1943,12 +1961,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -0.3,
                                                             "point": -0.2,
                                                             "upper": -0.1,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -0.3,
                                                         "point": -0.2,
                                                         "upper": -0.1,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-b": {
@@ -1957,12 +1977,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -2.2,
                                                             "point": -2.1,
                                                             "upper": -2.01,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -2.2,
                                                         "point": -2.1,
                                                         "upper": -2.01,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                             },
@@ -1983,12 +2005,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 0.857,
                                                         "point": 0.858,
                                                         "upper": 0.8596,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 0.857,
                                                     "point": 0.858,
                                                     "upper": 0.8596,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -1998,12 +2022,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -10.0,
                                                             "point": 0.1,
                                                             "upper": 10.2,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -10.0,
                                                         "point": 0.1,
                                                         "upper": 10.2,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-a": {"all": [], "first": {}},
@@ -2013,12 +2039,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": 2.5,
                                                             "point": 0.1,
                                                             "upper": 1.0,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": 2.5,
                                                         "point": 0.1,
                                                         "upper": 1.0,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                             },
@@ -2046,12 +2074,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": 0.1,
                                                             "point": 0.2,
                                                             "upper": 0.3,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": 0.1,
                                                         "point": 0.2,
                                                         "upper": 0.3,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-a": {"all": [], "first": {}},
@@ -2061,12 +2091,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": 3.141592653589793,
                                                             "point": 0.1111111111111111,
                                                             "upper": 0.2222222222222222,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": 3.141592653589793,
                                                         "point": 0.1111111111111111,
                                                         "upper": 0.2222222222222222,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                             },
@@ -2087,12 +2119,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                         "lower": 0.856,
                                                         "point": 0.857,
                                                         "upper": 0.8589,
+                                                        "window_index": "1",
                                                     }
                                                 ],
                                                 "first": {
                                                     "lower": 0.856,
                                                     "point": 0.857,
                                                     "upper": 0.8589,
+                                                    "window_index": "1",
                                                 },
                                             },
                                             "difference": {
@@ -2102,12 +2136,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": 1.0,
                                                             "point": 0.0,
                                                             "upper": 0.5,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": 1.0,
                                                         "point": 0.0,
                                                         "upper": 0.5,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-a": {
@@ -2116,12 +2152,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -0.9,
                                                             "point": -0.8,
                                                             "upper": -0.5,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -0.9,
                                                         "point": -0.8,
                                                         "upper": -0.5,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-b": {"all": [], "first": {}},
@@ -2150,12 +2188,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": 2.2,
                                                             "point": 0.1,
                                                             "upper": 0.02,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": 2.2,
                                                         "point": 0.1,
                                                         "upper": 0.02,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-a": {
@@ -2164,12 +2204,14 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                                                             "lower": -0.2,
                                                             "point": -0.1,
                                                             "upper": -0.01,
+                                                            "window_index": "1",
                                                         }
                                                     ],
                                                     "first": {
                                                         "lower": -0.2,
                                                         "point": -0.1,
                                                         "upper": -0.01,
+                                                        "window_index": "1",
                                                     },
                                                 },
                                                 "treatment-b": {"all": [], "first": {}},

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -128,6 +128,60 @@
             </div>
           {% endif %}
         {% endwith %}
+        {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
+          {% if daily_metric_data.has_daily_data %}
+            <div class="border border-1 rounded py-4 px-5 rounded-4">
+              <h2 class="fs-6 fw-bold">Daily breakdown</h2>
+              <div class="d-flex mt-3">
+                <div class="col-2">
+                  <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+                  {% for i in '0123456'|make_list %}
+                    <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                         style="height: 100px">
+                      <small class="text-muted">Day {{ forloop.counter }}</small>
+                    </div>
+                  {% endfor %}
+                </div>
+                <div class="col position-relative w-25">
+                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
+                    {% if branch_data|length > 3 %}
+                      <div class="branch-fade branch-fade-left"></div>
+                      <div class="branch-fade branch-fade-right"></div>
+                    {% endif %}
+                    {% for branch in branch_data %}
+                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                        <p class="fs-5">{{ branch.name }}</p>
+                        <div class="d-flex flex-column gap-3 w-100 h-100">
+                          {% for daily_data_point in daily_metric_data.data|dict_get:branch.slug|slice:":7" %}
+                            {% if not daily_data_point.0.lower and not daily_data_point.1.lower %}
+                              <div class="d-flex align-items-center" style="height: 100px;">
+                                <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                  <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                  <p class="mb-0 fw-semibold">Day unavailable</p>
+                                  <p class="mb-0">Other days may not be affected.</p>
+                                  <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                     target="_blank"
+                                     href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+                                </div>
+                              </div>
+                            {% else %}
+                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=daily_data_point.0.lower absolute_upper=daily_data_point.0.upper significance=daily_data_point.1.significance percentage=daily_data_point.1.avg_rel_change %}
+
+                            {% endif %}
+                          {% empty %}
+                            <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
+                              <div>Baseline</div>
+                            </div>
+                          {% endfor %}
+                        </div>
+                      </div>
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+        {% endwith %}
       </div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -864,8 +864,11 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
                     )
 
         context["relative_metric_changes"] = relative_metric_changes
-        context["all_weekly_metric_data"] = results_manager.get_weekly_metric_data(
-            analysis_basis, selected_segment, selected_reference_branch
+        context["all_weekly_metric_data"] = results_manager.build_window_metric_breakdown(
+            analysis_basis, selected_segment, selected_reference_branch, "weekly"
+        )
+        context["all_daily_metric_data"] = results_manager.build_window_metric_breakdown(
+            analysis_basis, selected_segment, selected_reference_branch, "daily"
         )
 
         return context


### PR DESCRIPTION
Because

- Daily metrics are now included in the results data object but are not being displayed anywhere

This commit

- Shows daily metric data when its available in the metric popout cards
- Adds missing `window_index` field to daily metrics

Fixes #14691 