### PR TITLE
fix(nimbus): remove incorrect weekly dates from metric popout

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1367,17 +1367,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         return timeline_entries
 
-    def get_weekly_dates(self):
-        weekly_dates = []
-        if not self.is_rollout:
-            if self._enrollment_end_date:
-                date = self._enrollment_end_date
-                while (date + datetime.timedelta(days=6)) <= self.computed_end_date:
-                    weekly_dates.append((date, date + datetime.timedelta(days=6)))
-                    date += datetime.timedelta(days=7)
-
-        return weekly_dates
-
     def get_sorted_branches(self):
         return (
             [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1410,35 +1410,6 @@ class TestNimbusExperiment(TestCase):
             self.assertNotIn(ai_targeting_expr, experiment.targeting)
         validate_jexl_expr(experiment.targeting, experiment.application)
 
-    @parameterized.expand(
-        [
-            [
-                datetime.date(2025, 1, 1),
-                datetime.date(2025, 1, 30),
-                [
-                    (datetime.date(2025, 1, 1), datetime.date(2025, 1, 7)),
-                    (datetime.date(2025, 1, 8), datetime.date(2025, 1, 14)),
-                    (datetime.date(2025, 1, 15), datetime.date(2025, 1, 21)),
-                    (datetime.date(2025, 1, 22), datetime.date(2025, 1, 28)),
-                ],
-            ],
-            [
-                datetime.date(2025, 1, 1),
-                datetime.date(2025, 1, 8),
-                [(datetime.date(2025, 1, 1), datetime.date(2025, 1, 7))],
-            ],
-            [datetime.date(2025, 1, 1), datetime.date(2025, 1, 3), []],
-        ]
-    )
-    def test_get_weekly_dates_for_experiment(self, start_date, end_date, expected_dates):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
-            _enrollment_end_date=start_date,
-            _computed_end_date=end_date,
-        )
-
-        self.assertEqual(experiment.get_weekly_dates(), expected_dates)
-
     def test_start_date_returns_None_for_not_started_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -39,172 +39,371 @@ class TestExperimentResultsManager(TestCase):
         )
         self.results_manager = ExperimentResultsManager(self.experiment)
 
-    def test_get_weekly_metric_data(self):
-        self.experiment.results_data = {
-            "v3": {
-                "weekly": {
-                    "enrollments": {
-                        "all": {
-                            "branch-a": {
-                                "branch_data": {
-                                    "other_metrics": {
-                                        "urlbar_amazon_search_count": {
-                                            "absolute": {
-                                                "all": [
-                                                    {
-                                                        "lower": 140,
-                                                        "upper": 160,
-                                                        "point": 150,
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 130,
+                                                                "upper": 150,
+                                                                "point": 140,
+                                                                "window_index": "2",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
                                                     },
-                                                    {
-                                                        "lower": 130,
-                                                        "upper": 150,
-                                                        "point": 140,
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
                                                     },
-                                                    {
-                                                        "lower": 120,
-                                                        "upper": 140,
-                                                        "point": 130,
+                                                }
+                                            }
+                                        },
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 130,
+                                                                "upper": 150,
+                                                                "point": 140,
+                                                                "window_index": "2",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
                                                     },
-                                                ]
-                                            },
-                                            "relative_uplift": {
-                                                "branch-a": {"all": []},
-                                            },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": 10,
+                                                                    "upper": 20,
+                                                                    "point": 15,
+                                                                    "window_index": "1",
+                                                                },
+                                                                {
+                                                                    "lower": 5,
+                                                                    "upper": 15,
+                                                                    "point": 10,
+                                                                    "window_index": "2",
+                                                                },
+                                                                {
+                                                                    "lower": 0,
+                                                                    "upper": 10,
+                                                                    "point": 5,
+                                                                    "window_index": "3",
+                                                                },
+                                                            ]
+                                                        },
+                                                        "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
                                         }
-                                    }
-                                },
-                            },
-                            "branch-b": {
-                                "branch_data": {
-                                    "other_metrics": {
-                                        "urlbar_amazon_search_count": {
-                                            "absolute": {
-                                                "all": [
-                                                    {
-                                                        "lower": 140,
-                                                        "upper": 160,
-                                                        "point": 150,
-                                                    },
-                                                    {
-                                                        "lower": 130,
-                                                        "upper": 150,
-                                                        "point": 140,
-                                                    },
-                                                    {
-                                                        "lower": 120,
-                                                        "upper": 140,
-                                                        "point": 130,
-                                                    },
-                                                ]
-                                            },
-                                            "relative_uplift": {
-                                                "branch-a": {
-                                                    "all": [
-                                                        {
-                                                            "lower": 10,
-                                                            "upper": 20,
-                                                            "point": 15,
-                                                        },
-                                                        {
-                                                            "lower": 5,
-                                                            "upper": 15,
-                                                            "point": 10,
-                                                        },
-                                                        {
-                                                            "lower": 0,
-                                                            "upper": 10,
-                                                            "point": 5,
-                                                        },
-                                                    ]
-                                                },
-                                                "branch-b": {"all": []},
-                                            },
-                                        }
-                                    }
+                                    },
                                 }
-                            },
+                            }
                         }
                     }
-                }
-            }
-        }
+                },
+                {
+                    "data": {
+                        "branch-a": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": 130,
+                                    "upper": 150,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                None,
+                            ),
+                        ],
+                        "branch-b": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                {
+                                    "avg_rel_change": 15,
+                                    "lower": 10,
+                                    "upper": 20,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": 130,
+                                    "upper": 150,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                {
+                                    "avg_rel_change": 10,
+                                    "lower": 5,
+                                    "upper": 15,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                {
+                                    "avg_rel_change": 5,
+                                    "lower": 0,
+                                    "upper": 10,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                            ),
+                        ],
+                    },
+                    "has_weekly_data": True,
+                },
+            ),
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        },
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "lower": 140,
+                                                                "upper": 160,
+                                                                "point": 150,
+                                                                "window_index": "1",
+                                                            },
+                                                            {
+                                                                "lower": 120,
+                                                                "upper": 140,
+                                                                "point": 130,
+                                                                "window_index": "3",
+                                                            },
+                                                        ]
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": 10,
+                                                                    "upper": 20,
+                                                                    "point": 15,
+                                                                    "window_index": "1",
+                                                                },
+                                                                {
+                                                                    "lower": 0,
+                                                                    "upper": 10,
+                                                                    "point": 5,
+                                                                    "window_index": "3",
+                                                                },
+                                                            ]
+                                                        },
+                                                        "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "data": {
+                        "branch-a": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": None,
+                                    "upper": None,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                None,
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                None,
+                            ),
+                        ],
+                        "branch-b": [
+                            (
+                                {
+                                    "lower": 140,
+                                    "upper": 160,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                                {
+                                    "avg_rel_change": 15,
+                                    "lower": 10,
+                                    "upper": 20,
+                                    "significance": "neutral",
+                                    "window_index": "1",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": None,
+                                    "upper": None,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                                {
+                                    "lower": None,
+                                    "upper": None,
+                                    "significance": "neutral",
+                                    "window_index": "2",
+                                },
+                            ),
+                            (
+                                {
+                                    "lower": 120,
+                                    "upper": 140,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                                {
+                                    "avg_rel_change": 5,
+                                    "lower": 0,
+                                    "upper": 10,
+                                    "significance": "neutral",
+                                    "window_index": "3",
+                                },
+                            ),
+                        ],
+                    },
+                    "has_weekly_data": True,
+                },
+            ),
+        ]
+    )
+    def test_get_weekly_metric_data(self, results_data, expected_weekly_data):
+        self.experiment.results_data = results_data
         self.experiment.save()
 
-        expected_weekly_data = {
-            "urlbar_amazon_search_count": {
-                "data": {
-                    "branch-a": [
-                        (
-                            {"lower": 140, "upper": 160, "significance": "neutral"},
-                            None,
-                        ),
-                        (
-                            {"lower": 130, "upper": 150, "significance": "neutral"},
-                            None,
-                        ),
-                        (
-                            {"lower": 120, "upper": 140, "significance": "neutral"},
-                            None,
-                        ),
-                    ],
-                    "branch-b": [
-                        (
-                            {"lower": 140, "upper": 160, "significance": "neutral"},
-                            {
-                                "avg_rel_change": 15,
-                                "lower": 10,
-                                "upper": 20,
-                                "significance": "neutral",
-                            },
-                        ),
-                        (
-                            {"lower": 130, "upper": 150, "significance": "neutral"},
-                            {
-                                "avg_rel_change": 10,
-                                "lower": 5,
-                                "upper": 15,
-                                "significance": "neutral",
-                            },
-                        ),
-                        (
-                            {"lower": 120, "upper": 140, "significance": "neutral"},
-                            {
-                                "avg_rel_change": 5,
-                                "lower": 0,
-                                "upper": 10,
-                                "significance": "neutral",
-                            },
-                        ),
-                    ],
-                },
-                "has_weekly_data": True,
-            },
-            "total_amazon_search_count": {
-                "data": {},
-                "has_weekly_data": False,
-            },
-            "retained": {
-                "data": {},
-                "has_weekly_data": False,
-            },
-            "active_in_last_3_days_legacy": {
-                "data": {},
-                "has_weekly_data": False,
-            },
-            "client_level_daily_active_users_v2": {
-                "data": {},
-                "has_weekly_data": False,
-            },
-            "search_count": {
-                "data": {},
-                "has_weekly_data": False,
-            },
-        }
-
         self.assertEqual(
-            self.results_manager.get_weekly_metric_data("enrollments", "all", "branch-a"),
+            self.results_manager.get_weekly_metric_data(
+                "enrollments", "all", "branch-a"
+            ).get("urlbar_amazon_search_count"),
             expected_weekly_data,
+        )
+        self.assertEqual(
+            self.results_manager.get_weekly_metric_data(
+                "enrollments", "all", "branch-a"
+            ).get("total_amazon_search_count"),
+            {
+                "data": {},
+                "has_weekly_data": False,
+            },
         )
 
     def test_get_metric_data_returns_correct_data(self):
@@ -320,7 +519,14 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertEqual(
             data_a.get("urlbar_amazon_search_count").get("branch-a").get("absolute"),
-            [{"lower": 1.49, "upper": 1.74, "significance": "neutral"}],
+            [
+                {
+                    "lower": 1.49,
+                    "upper": 1.74,
+                    "significance": "neutral",
+                    "window_index": None,
+                }
+            ],
         )
         self.assertEqual(
             data_a.get("urlbar_amazon_search_count").get("branch-a").get("relative"),
@@ -330,13 +536,21 @@ class TestExperimentResultsManager(TestCase):
                     "upper": 0.15,
                     "significance": "neutral",
                     "avg_rel_change": 0.02,
+                    "window_index": None,
                 }
             ],
         )
 
         self.assertEqual(
             data_b.get("urlbar_amazon_search_count").get("branch-b").get("absolute"),
-            [{"lower": 1.24, "upper": 1.63, "significance": "positive"}],
+            [
+                {
+                    "lower": 1.24,
+                    "upper": 1.63,
+                    "significance": "positive",
+                    "window_index": None,
+                }
+            ],
         )
 
     @mock_valid_metrics

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -75,12 +75,15 @@
                 <div class="col-2">
                   <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
                   {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
-                    {% for week in experiment.get_weekly_dates %}
-                      <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
-                           style="height: 100px">
-                        <small class="text-muted">Week {{ forloop.counter }}</small>
-                        <p class="mb-0">{{ week.0|date:"M j" }} - {{ week.1|date:"M j" }}</p>
-                      </div>
+                    {% for branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
+                      {% if forloop.first %}
+                        {% for week in branch_weekly_metric_data %}
+                          <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                               style="height: 100px">
+                            <small class="text-muted">Week {{ forloop.counter }}</small>
+                          </div>
+                        {% endfor %}
+                      {% endif %}
                     {% endfor %}
                   {% endwith %}
                 </div>
@@ -93,14 +96,28 @@
                     {% for branch in branch_data %}
                       <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
                         <p class="fs-5">{{ branch.name }}</p>
-                        <div class="d-flex flex-column gap-3 w-100">
-                          {% for curr_branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
-                            {% if curr_branch_slug == branch.slug %}
-                              {% for weekly_data_point in branch_weekly_metric_data %}
-                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
+                        <div class="d-flex flex-column gap-3 w-100 h-100">
+                          {% for weekly_data_point in weekly_metric_data.data|dict_get:branch.slug %}
+                            {% if not weekly_data_point.0.lower and not weekly_data_point.1.lower %}
+                              <div class="d-flex align-items-center" style="height: 100px;">
+                                <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                  <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                  <p class="mb-0 fw-semibold">Week unavailable</p>
+                                  <p class="mb-0">Other weeks may not be affected.</p>
+                                  <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                     target="_blank"
+                                     href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+                                </div>
+                              </div>
+                            {% else %}
+                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
 
-                              {% endfor %}
                             {% endif %}
+                          {% empty %}
+                            {% comment %} DAU edge case: reference branch lacks both absolute and relative weekly data, so render a standalone baseline column. {% endcomment %}
+                            <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
+                              <div>Baseline</div>
+                            </div>
                           {% endfor %}
                         </div>
                       </div>


### PR DESCRIPTION
Because

- The weekly date ranges shown in the metric popout were incorrect

This commit

- Removes the date ranges from the popout
- Fixes missing data block under reference branch for DAU in popout 
- Display error card if metric is missing a weekly data block

Fixes #14699