### PR TITLE
feat(nimbus): Ingest 3 day retention data

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -933,7 +933,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             "group": "other_metrics",
             "friendly_name": "3-Day Retention",
             "slug": RETENTION_3_DAYS,
-            "description": "Users who returned in first 3 days.",
+            "description": "Users who returned to Firefox within 3 days after enrollment.",  # noqa
             "display_type": "percentage",
         },
         {

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -270,7 +270,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                     raw_data[AnalysisWindow.WEEKLY][AnalysisBasis.ENROLLMENTS][segment]
                 )
                 # Append 3-day retention from daily data
-                data.append_days_3_retention(
+                data.append_retention_3_days(
                     raw_data[AnalysisWindow.DAILY][AnalysisBasis.ENROLLMENTS][segment]
                 )
                 # Create the output object (overall data)
@@ -313,7 +313,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                     raw_data[AnalysisWindow.WEEKLY][AnalysisBasis.EXPOSURES][segment]
                 )
                 # Append 3-day retention from daily data
-                data.append_days_3_retention(
+                data.append_retention_3_days(
                     raw_data[AnalysisWindow.DAILY][AnalysisBasis.EXPOSURES][segment]
                 )
 

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -164,7 +164,7 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
 
         self.extend(retention_data)
 
-    def append_days_3_retention(self, daily_data):
+    def append_retention_3_days(self, daily_data):
         # Extract the 3-day retention data (window index 4)
         # without falling back to earlier windows
         retention_data = self.get_retention_by_window(

--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -219,13 +219,12 @@ class ExperimentResultsManager:
                 if branch.slug == reference_branch:
                     continue
 
-                branch_group_data = (
+                metric_data = (
                     window_results.get(branch.slug, {})
                     .get("branch_data", {})
                     .get(group, {})
+                    .get(metric_slug, {})
                 )
-
-                metric_data = branch_group_data.get(metric_slug, {})
 
                 abs_point_data = metric_data.get("absolute", {}).get("first", {})
                 rel_point_data = (

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -46,7 +46,7 @@ class TestJetstreamData(TestCase):
         self.assertIn(expected_control, data)
         self.assertIn(expected_variant, data)
 
-    def test_append_days_3_retention_extracts_data(self):
+    def test_append_retention_3_days_extracts_data(self):
         retention = JetstreamDataPoint(
             metric=Metric.RETENTION_3_DAYS,
             statistic=Statistic.BINOMIAL,
@@ -57,6 +57,6 @@ class TestJetstreamData(TestCase):
         )
 
         data = JetstreamData([])
-        data.append_days_3_retention([retention])
+        data.append_retention_3_days([retention])
 
         self.assertIn(retention, data)

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -433,7 +433,7 @@ class TestExperimentResultsManager(TestCase):
                         "group": "other_metrics",
                         "friendly_name": "3-Day Retention",
                         "slug": "active_in_last_3_days_legacy",
-                        "description": "Users who returned in first 3 days.",
+                        "description": "Users who returned to Firefox within 3 days after enrollment.",  # noqa
                         "display_type": "percentage",
                         "overall_change": MetricSignificance.NEUTRAL,
                         "has_data": False,
@@ -472,7 +472,7 @@ class TestExperimentResultsManager(TestCase):
                         "group": "other_metrics",
                         "friendly_name": "3-Day Retention",
                         "slug": "active_in_last_3_days_legacy",
-                        "description": "Users who returned in first 3 days.",
+                        "description": "Users who returned to Firefox within 3 days after enrollment.",  # noqa
                         "display_type": "percentage",
                         "overall_change": MetricSignificance.NEUTRAL,
                         "has_data": False,


### PR DESCRIPTION
Because

- Add 3-day retention data to the Results page so experiment teams can see how many users returned to Firefox within 3 days of enrollment.

This commit

- Added code to extract 3-day retention data from Jetstream
- Updated metric configuration files to include the new metric

Fixes #14694 