### PR TITLE
fix(nimbus): add v5 YAML and CSV endpoints to API cache warming

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -3,6 +3,7 @@ from rest_framework.generics import ListAPIView, UpdateAPIView
 from rest_framework.renderers import BaseRenderer
 from rest_framework_csv.renderers import CSVRenderer
 
+from experimenter.experiments.api.cache import CachedListMixin
 from experimenter.experiments.api.v5.serializers import (
     FmlFeatureValueSerializer,
     NimbusExperimentCsvSerializer,
@@ -16,7 +17,9 @@ class NimbusExperimentCsvRenderer(CSVRenderer):
     labels = {field: field.replace("_", " ").title() for field in header}
 
 
-class NimbusExperimentCsvListView(ListAPIView):
+class NimbusExperimentCsvListView(CachedListMixin, ListAPIView):
+    cache_key_prefix = "v5:csv"
+    cache_content_type = "text/csv; charset=utf-8"
     queryset = (
         NimbusExperiment.objects.select_related("owner")
         .prefetch_related("feature_configs")
@@ -62,7 +65,9 @@ class NimbusExperimentYamlRenderer(BaseRenderer):
         )
 
 
-class NimbusExperimentYamlListView(ListAPIView):
+class NimbusExperimentYamlListView(CachedListMixin, ListAPIView):
+    cache_key_prefix = "v5:yaml"
+    cache_content_type = "text/yaml; charset=utf-8"
     queryset = (
         NimbusExperiment.objects.select_related("owner", "reference_branch", "parent")
         .prefetch_related(

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -8,12 +8,18 @@ logger = get_task_logger(__name__)
 metrics = markus.get_metrics("experiments.api_cache")
 
 
+def _start_date_sort_key(experiment):
+    return (experiment.start_date and experiment.start_date.strftime("%Y-%m-%d")) or ""
+
+
 def _get_warm_cache_endpoints():
-    """Return the list of (key_prefix, queryset, serializer_class) to warm.
+    """Return the list of (key_prefix, queryset, serializer_class, kwargs) to warm.
 
     Imports are deferred so the module can be loaded before Django is fully
     initialised (Celery auto-discovery).
     """
+    from experimenter.experiments.api.v5 import serializers as v5_ser
+    from experimenter.experiments.api.v5 import views as v5_views
     from experimenter.experiments.api.v6 import serializers as v6_ser
     from experimenter.experiments.api.v6 import views as v6_views
     from experimenter.experiments.api.v7 import serializers as v7_ser
@@ -23,34 +29,58 @@ def _get_warm_cache_endpoints():
 
     return [
         (
+            "v5:csv",
+            v5_views.NimbusExperimentCsvListView.queryset,
+            v5_ser.NimbusExperimentCsvSerializer,
+            {
+                "renderer": v5_views.NimbusExperimentCsvRenderer(),
+                "sort_key": _start_date_sort_key,
+            },
+        ),
+        (
+            "v5:yaml",
+            v5_views.NimbusExperimentYamlListView.queryset,
+            v5_ser.NimbusExperimentYamlSerializer,
+            {
+                "renderer": v5_views.NimbusExperimentYamlRenderer(),
+                "sort_key": _start_date_sort_key,
+            },
+        ),
+        (
             "v6:experiments",
             v6_views.NimbusExperimentViewSet.queryset,
             v6_ser.NimbusExperimentSerializer,
+            {},
         ),
         (
             "v6:draft-experiments",
             v6_views.NimbusExperimentDraftViewSet.queryset,
             v6_ser.NimbusExperimentSerializer,
+            {},
         ),
         (
             "v6:first-run",
             v6_views.NimbusExperimentFirstRunViewSet.queryset,
             v6_ser.NimbusExperimentSerializer,
+            {},
         ),
         (
             "v7:experiments",
             v7_views.NimbusExperimentViewSet.queryset,
             v7_ser.NimbusExperimentSerializer,
+            {},
         ),
         (
             "v8:experiments",
             v8_views.NimbusExperimentViewSet.queryset,
             v8_ser.NimbusExperimentSerializer,
+            {},
         ),
         (
             "v8:draft-experiments",
             v8_views.NimbusExperimentDraftViewSet.queryset,
             v8_ser.NimbusExperimentSerializer,
+            {},
         ),
     ]
 
@@ -62,8 +92,8 @@ def warm_api_caches():
     metrics.incr("warm_api_caches.started")
 
     try:
-        for key_prefix, queryset, serializer_class in _get_warm_cache_endpoints():
-            warm_api_cache(key_prefix, queryset, serializer_class)
+        for key_prefix, queryset, serializer_class, kwargs in _get_warm_cache_endpoints():
+            warm_api_cache(key_prefix, queryset, serializer_class, **kwargs)
             logger.info("Warmed %s", key_prefix)
 
         metrics.incr("warm_api_caches.completed")

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -3,7 +3,8 @@ import json
 
 import yaml
 from django.conf import settings
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 from django.urls import reverse
 
 from experimenter.base.models import Country, Language, Locale
@@ -20,7 +21,18 @@ from experimenter.experiments.tests.factories import (
 )
 
 
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+)
 class TestNimbusExperimentCsvListView(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
     def test_get_returns_csv_info_sorted_by_start_date(self):
         user_email = "user@example.com"
         application = NimbusExperiment.Application.DESKTOP
@@ -104,7 +116,18 @@ class TestNimbusExperimentCsvListView(TestCase):
         self.assertEqual(csv_data, expected_csv_data)
 
 
+@override_settings(
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        }
+    }
+)
 class TestNimbusExperimentYamlListView(TestCase):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+
     def _get_yaml(self):
         response = self.client.get(
             reverse("nimbus-experiments-yaml"),


### PR DESCRIPTION
Because

* The /api/v5/yaml/ and /api/v5/csv/ endpoints were not included in the
  Celery cache warming task, so every request hit the database, serialized
  all experiments, and rendered from scratch
* For the YAML endpoint this took >30 seconds, causing gunicorn worker
  timeouts and 502 errors in production
* The v6/v7/v8 JSON endpoints already used CachedListMixin and
  warm_api_cache() to serve instantly from Redis

This commit

* Generalizes warm_api_cache() to accept optional renderer and sort_key
  parameters, defaulting to JSONRenderer for backwards compatibility
* Generalizes CachedListMixin to use the view's own renderer and a
  configurable cache_content_type instead of hardcoding JSON
* Adds v5 YAML and CSV endpoints to _get_warm_cache_endpoints() with
  their respective renderers and start_date sort key
* Applies CachedListMixin to NimbusExperimentCsvListView and
  NimbusExperimentYamlListView so on-demand requests also cache

Fixes #14721