### PR TITLE
feat(nimbus): Pass channel id to add the reaction

### DIFF
--- a/experimenter/experimenter/slack/notification.py
+++ b/experimenter/experimenter/slack/notification.py
@@ -157,15 +157,17 @@ def send_experiment_launch_success_message(experiment_id, thread_ts):
 
     try:
         # Send threaded reply to the original launch request
-        client.chat_postMessage(
+        post_response = client.chat_postMessage(
             channel=channel,
             text=message,
             thread_ts=thread_ts,
         )
 
+        channel_id = post_response["channel"]
+
         # Add reaction emoji to original message
         client.reactions_add(
-            channel=channel,
+            channel=channel_id,
             name="white_check_mark",
             timestamp=thread_ts,
         )

--- a/experimenter/experimenter/slack/tests/test_notification.py
+++ b/experimenter/experimenter/slack/tests/test_notification.py
@@ -535,7 +535,7 @@ class TestSlackNotifications(TestCase):
     def test_send_experiment_launch_success_message(self, mock_webclient):
         mock_client = Mock()
         mock_webclient.return_value = mock_client
-        mock_client.chat_postMessage.return_value = {"ok": True}
+        mock_client.chat_postMessage.return_value = {"ok": True, "channel": "C123456"}
         mock_client.reactions_add.return_value = {"ok": True}
 
         thread_ts = "1234567890.123456"
@@ -554,9 +554,10 @@ class TestSlackNotifications(TestCase):
         self.assertIn(self.experiment.slug, call_args.kwargs["text"])
         self.assertEqual(call_args.kwargs["thread_ts"], thread_ts)
 
-        # Verify reaction emoji was added
+        # Verify reaction emoji was added with the correct channel ID
         mock_client.reactions_add.assert_called_once()
         reaction_call = mock_client.reactions_add.call_args
+        self.assertEqual(reaction_call.kwargs["channel"], "C123456")
         self.assertEqual(reaction_call.kwargs["name"], "white_check_mark")
         self.assertEqual(reaction_call.kwargs["timestamp"], thread_ts)
 


### PR DESCRIPTION
Because

- We want to add the emojis to the Slack message, and it requires passing the channel id

This commit

- Passes channel id instead of channel name to add the emoji to the request message

Fixes #14411 