### PR TITLE
bug(nimbus): Prevent JEXL errors from breaking the summary page

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1151,6 +1151,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_CANNOT_PAUSE_INVALID = "Cannot end enrollment at this time"
 
+    ERROR_CANNOT_PARSE_TARGETING = "Cannot parse targeting expression"
+
     # Slack action constants
     SLACK_ACTION_LAUNCH_REQUEST = "launch_request"
     SLACK_ACTION_UPDATE_REQUEST = "update_request"

--- a/experimenter/experimenter/experiments/tests/test_jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_utils.py
@@ -165,3 +165,6 @@ e"""
         result = format_jexl("a || b || c")
         expected = "a ||\nb ||\nc"
         self.assertEqual(result, expected)
+
+    def test_invalid_operator(self):
+        self.assertEqual(format_jexl(")))))"), ")))))")


### PR DESCRIPTION
Because:

- some experiments in the prod database have invalid targeting cached on their published_dto; and
- we try to pretty-print these invalid expressions and raise an Exception

this commit:

- adds a try/except around the pretty-printing to fall back to the plain expression and report the error to sentry; and
- adds a validation to ensure that the entire expression parses before launch

Fixes #14727