### PR TITLE
feat(nimbus): add telemetry enabled advanced targeting config

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4056,6 +4056,17 @@ VPN_EARLY_ACCESS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+TELEMETRY_ENABLED = NimbusTargetingConfig(
+    name="Telemetry Enabled",
+    slug="telemetry_enabled",
+    description="Users with telemetry (data reporting) enabled",
+    targeting="'datareporting.healthreport.uploadEnabled'|preferenceValue",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 
 class TargetingConstants:
     TARGETING_CONFIGS = {


### PR DESCRIPTION
## Summary

Because

* Rollouts may want to target only clients that have telemetry enabled
* There is no existing targeting config for the `datareporting.healthreport.uploadEnabled` preference

This commit

* Adds a new "Telemetry Enabled" `NimbusTargetingConfig` that checks `'datareporting.healthreport.uploadEnabled'|preferenceValue`

Fixes #14741