### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 149.2.20260220.204414 for desktop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4101,6 +4101,7 @@ FX_149_TRAINHOP_2_ACTIVATION_WINDOW = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+
 class TargetingConstants:
     TARGETING_CONFIGS = {
         targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs


### PR DESCRIPTION
This also includes a variant of this advanced targeting specifically for the activation window experiment (new non-selectable first-run Windows profiles).

Fixes #14750.