### PR TITLE
style(nimbus): replace 'to' with hyphen in absolute value display

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
@@ -10,7 +10,7 @@
           <span class="mb-0 me-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower|to_percentage }}">({{ absolute_lower|to_percentage:1 }}</span>
-          to
+          -
           <span class="mb-0 ms-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_upper|to_percentage }}">{{ absolute_upper|to_percentage:1 }})</span>
@@ -18,7 +18,7 @@
           <span class="mb-0 me-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower }}">({{ absolute_lower|floatformat:2 }}</span>
-          to
+          -
           <span class="mb-0 ms-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_upper }}">{{ absolute_upper|floatformat:2 }})</span>
@@ -47,7 +47,7 @@
               <span class="mb-0 me-1"
                     data-bs-toggle="tooltip"
                     data-bs-title="{{ absolute_lower|to_percentage }}">({{ absolute_lower|to_percentage:1 }}</span>
-              to
+              -
               <span class="mb-0 ms-1"
                     data-bs-toggle="tooltip"
                     data-bs-title="{{ absolute_upper|to_percentage }}">{{ absolute_upper|to_percentage:1 }})</span>
@@ -55,7 +55,7 @@
               <span class="mb-0 me-1"
                     data-bs-toggle="tooltip"
                     data-bs-title="{{ absolute_lower }}">({{ absolute_lower|floatformat:2 }}</span>
-              to
+              -
               <p class="mb-0 ms-1"
                  data-bs-toggle="tooltip"
                  data-bs-title="{{ absolute_upper }}">

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout_card.html
@@ -14,7 +14,7 @@
           <span class="mb-0 me-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower|to_percentage }}">{{ absolute_lower|to_percentage:1 }}</span>
-          to
+          -
           <p class="mb-0 ms-1"
              data-bs-toggle="tooltip"
              data-bs-title="{{ absolute_upper|to_percentage }}">
@@ -24,7 +24,7 @@
           <span class="mb-0 me-1"
                 data-bs-toggle="tooltip"
                 data-bs-title="{{ absolute_lower }}">{{ absolute_lower|floatformat:2 }}</span>
-          to
+          -
           <p class="mb-0 ms-1"
              data-bs-toggle="tooltip"
              data-bs-title="{{ absolute_upper }}">


### PR DESCRIPTION
Because

- Some users found interpreting absolute value bounds confusing and were mistakenly believing them to indicate `(baseline to treatment)` change as opposed to `(lower to upper)`

This commit

- Changes absolute value display from `(lower to upper)` to `(lower - upper)`

Fixes #14698