### PR TITLE
feat(nimbus): show percentage bounds on hover instead of high precision for relative metric values

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_card.html
@@ -33,13 +33,15 @@
         {% if sig == "positive" %}
           <span class="fw-semibold"
                 data-bs-toggle="tooltip"
-                data-bs-title="{{ percentage|to_percentage }}">{{ percentage|to_percentage:1 }} increase</span>
+                data-bs-title="Range: {{ lower_percent|to_percentage:2 }} to {{ upper_percent|to_percentage:2 }}">{{ percentage|to_percentage:1 }} average increase</span>
         {% elif sig == "negative" %}
           <span class="fw-semibold"
                 data-bs-toggle="tooltip"
-                data-bs-title="{{ percentage|to_percentage }}">{{ percentage|to_percentage:1 }} decrease</span>
+                data-bs-title="Range: {{ lower_percent|to_percentage:2 }} to {{ upper_percent|to_percentage:2 }}">{{ percentage|to_percentage:1 }} average decrease</span>
         {% else %}
-          <span class="fw-semibold">No notable change</span>
+          <span class="fw-semibold"
+                data-bs-toggle="tooltip"
+                data-bs-title="Range: {{ lower_percent|to_percentage:2 }} to {{ upper_percent|to_percentage:2 }}">No notable change</span>
         {% endif %}
         <span class="mb-0 d-flex">
           {% if absolute_lower %}

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -110,7 +110,7 @@
                                 </div>
                               </div>
                             {% else %}
-                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change %}
+                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change lower_percent=weekly_data_point.1.lower upper_percent=weekly_data_point.1.upper %}
 
                             {% endif %}
                           {% empty %}
@@ -165,7 +165,7 @@
                                 </div>
                               </div>
                             {% else %}
-                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=daily_data_point.0.lower absolute_upper=daily_data_point.0.upper significance=daily_data_point.1.significance percentage=daily_data_point.1.avg_rel_change %}
+                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=daily_data_point.0.lower absolute_upper=daily_data_point.0.upper significance=daily_data_point.1.significance percentage=daily_data_point.1.avg_rel_change lower_percent=daily_data_point.1.lower upper_percent=daily_data_point.1.upper %}
 
                             {% endif %}
                           {% empty %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -329,7 +329,7 @@
                                       {% if curr_branch_slug == branch.slug %}
                                         {% with abs_last=branch_metric_data.absolute|last %}
                                           {% with rel_last=branch_metric_data.relative|last %}
-                                            {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=abs_last.lower absolute_upper=abs_last.upper significance=rel_last.significance percentage=rel_last.avg_rel_change display_type=metric.display_type %}
+                                            {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=abs_last.lower absolute_upper=abs_last.upper significance=rel_last.significance percentage=rel_last.avg_rel_change lower_percent=rel_last.lower upper_percent=rel_last.upper display_type=metric.display_type %}
 
                                           {% endwith %}
                                         {% endwith %}


### PR DESCRIPTION
Because

- Hovering over the relative percent values would show a tooltip with the full precision value
- It is not very useful to display the full value and we would instead benefit from showing just the percent value range

This commit

- Updates the tooltip to show relative percent range value

Fixes #14756 