### PR TITLE
fix(nimbus): remove hard-coded prevent_pref_conflicts for rollouts

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -799,9 +799,6 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
         self.was_labs_opt_in = self.instance.is_firefox_labs_opt_in
 
-        if self.instance.is_rollout:
-            self.fields["prevent_pref_conflicts"].disabled = True
-
     @property
     def errors(self):
         errors = super().errors
@@ -823,9 +820,6 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             cleaned_data["firefox_labs_description_links"] = "null"
             cleaned_data["firefox_labs_group"] = ""
             cleaned_data["requires_restart"] = False
-
-        if cleaned_data["is_rollout"]:
-            cleaned_data["prevent_pref_conflicts"] = True
 
         return cleaned_data
 

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -80,9 +80,6 @@
                 <label class="form-check-label" for="id_prevent_pref_conflicts">
                   Prevent enrollment if users have changed any prefs set by this experiment
                 </label>
-                {% if form.prevent_pref_conflicts.field.disabled %}
-                  <div class="form-text">This option is required for rollouts to prevent re-enrollment after pref changes.</div>
-                {% endif %}
               </div>
               {% for error in validation_errors.prevent_pref_conflicts %}
                 <div class="form-text text-danger">{{ error }}</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3766,58 +3766,6 @@ class TestNimbusBranchesForm(RequestFormTestCase):
         self.assertTrue(experiment.is_rollout)
         self.assertFalse(experiment.is_firefox_labs_opt_in)
 
-    def test_rollout_forces_prevent_pref_conflicts_true(self):
-        application = NimbusExperiment.Application.DESKTOP
-        feature_config = NimbusFeatureConfigFactory.create(application=application)
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=application,
-            feature_configs=[feature_config],
-            is_rollout=True,
-            prevent_pref_conflicts=False,
-        )
-        experiment.branches.all().delete()
-        experiment.changes.all().delete()
-        reference_branch = NimbusBranchFactory.create(experiment=experiment, ratio=1)
-        experiment.reference_branch = reference_branch
-        experiment.save()
-
-        form = NimbusBranchesForm(
-            instance=experiment,
-            data={
-                "feature_configs": [feature_config.id],
-                "equal_branch_ratio": False,
-                "is_rollout": True,
-                "is_firefox_labs_opt_in": False,
-                "branches-TOTAL_FORMS": "1",
-                "branches-INITIAL_FORMS": "1",
-                "branches-MIN_NUM_FORMS": "0",
-                "branches-MAX_NUM_FORMS": "1000",
-                "branches-0-id": reference_branch.id,
-                "branches-0-name": "Control",
-                "branches-0-description": "Control Description",
-                "branches-0-ratio": 1,
-                "branches-0-feature-value-TOTAL_FORMS": "1",
-                "branches-0-feature-value-INITIAL_FORMS": "1",
-                "branches-0-feature-value-MIN_NUM_FORMS": "0",
-                "branches-0-feature-value-MAX_NUM_FORMS": "1000",
-                "branches-0-feature-value-0-id": (
-                    reference_branch.feature_values.first().id
-                ),
-                "branches-0-feature-value-0-value": "{}",
-                "branches-0-screenshots-TOTAL_FORMS": "0",
-                "branches-0-screenshots-INITIAL_FORMS": "0",
-                "branches-0-screenshots-MIN_NUM_FORMS": "0",
-                "branches-0-screenshots-MAX_NUM_FORMS": "1000",
-            },
-            request=self.request,
-        )
-        self.assertTrue(form.is_valid(), form.errors)
-        experiment = form.save()
-        self.assertTrue(experiment.is_rollout)
-        self.assertTrue(experiment.prevent_pref_conflicts)
-        self.assertTrue(form.fields["prevent_pref_conflicts"].disabled)
-
     def test_can_save_with_empty_value(self):
         application = NimbusExperiment.Application.DESKTOP
         feature_config1 = NimbusFeatureConfigFactory.create(application=application)


### PR DESCRIPTION
Because

* The Nimbus client now tracks different unenrollment reasons, so rollout unenrollment no longer causes immediate re-enrollment that would clobber user pref settings
* The forced `prevent_pref_conflicts=True` for rollouts is no longer needed

This commit

* Removes the code in `NimbusBranchesForm` that disabled the `prevent_pref_conflicts` checkbox for rollouts
* Removes the code that forced `prevent_pref_conflicts=True` when `is_rollout=True` in form cleaning
* Removes the template text explaining the checkbox is required for rollouts
* Removes the test asserting the forcing behavior

Fixes #14767