### PR TITLE
feat(nimbus): Update advanced targeting for VPN Early Access.

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4039,14 +4039,8 @@ AI_TAB_GROUPING_ENABLED = NimbusTargetingConfig(
 VPN_EARLY_ACCESS = NimbusTargetingConfig(
     name="VPN Early Access",
     slug="vpn_early_access",
-    description=(
-        "Users who have FxA enabled, "
-        "and do not have enterprise policies set"
-    ),
-    targeting=(
-        "isFxAEnabled && "
-        f"{NO_ENTERPRISE.targeting}"
-    ),
+    description=("Users who have FxA enabled, and do not have enterprise policies set"),
+    targeting=(f"isFxAEnabled && {NO_ENTERPRISE.targeting}"),
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,


### PR DESCRIPTION
Because

- We want to be able to target users that are eligible for VPN early access.

This commit

- Narrows the VPN Early Access advanced targeting to just users with FxA enabled and not using enterprise policies.
