### PR TITLE
feat(nimbus): add info box to results page showing parameters overriden by custom config

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
@@ -174,7 +174,7 @@
             {% endif %}
           </ul>
           <p class="mb-0">
-            If you have questions about this, please ask data science in <a target="_blank" href="{{ ask_experimenter_slack_link }}">#ask-experimenter</a>.
+            If you have questions about this, please ask in <a target="_blank" href="{{ ask_experimenter_slack_link }}">#ask-experimenter</a>.
           </p>
         </div>
       </div>


### PR DESCRIPTION
Because

- The new results page was missing the alert informing the user of manual overrides in Jetstream

This commit

- Adds an info box showing which parameters have had their values overridden by a custom config when applicable

Fixes #14788