### PR TITLE
feat(nimbus): enable results link for experiments with only daily results

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1680,7 +1680,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         # True if self.results_data has weekly or overall results
         if self.results_data and "v3" in self.results_data:
             results_data = self.results_data["v3"]
-            for window in ["overall", "weekly"]:
+            for window in ["overall", "weekly", "daily"]:
                 if results_data.get(window):
                     for base in ["enrollments", "exposures"]:
                         base_results = results_data[window].get(base, {}).get("all")

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3376,6 +3376,7 @@ class TestNimbusExperiment(TestCase):
         [
             ({"v3": {"overall": {"enrollments": {"all": {}}}}},),
             ({"v3": {"weekly": {"enrollments": {"all": {}}}}},),
+            ({"v3": {"daily": {"enrollments": {"all": {}}}}},),
         ]
     )
     def test_has_displayable_results_true(self, results_data):
@@ -3491,11 +3492,15 @@ class TestNimbusExperiment(TestCase):
             ({"v3": {}},),
             ({"v3": {"overall": {}}},),
             ({"v3": {"weekly": {}}},),
+            ({"v3": {"daily": {}}},),
             ({"v3": {"overall": {"enrollments": {}}}},),
             ({"v3": {"weekly": {"enrollments": {}}}},),
+            ({"v3": {"daily": {"enrollments": {}}}},),
             ({"v3": {"overall": {"enrollments": {"all": None}}}},),
             ({"v3": {"weekly": {"enrollments": {"all": None}}}},),
+            ({"v3": {"daily": {"enrollments": {"all": None}}}},),
             ({"v3": {"overall": None}},),
+            ({"v3": {"daily": None}},),
         ]
     )
     def test_has_displayable_results_false(self, results_data):


### PR DESCRIPTION
Because

- Experiments with only daily results data available should have the results link enabled

This commit

- Allows users to click on results if only daily results are ready

Fixes #14787 