### PR TITLE
fix(nimbus): fix unhandled invalid metric data structure

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -270,11 +270,14 @@ class ExperimentResultsManager:
                 )
 
                 def check_valid_point(point):
-                    return any(value != 0 for value in point.values())
+                    return (
+                        point.get("lower") and point.get("upper") and point.get("point")
+                    )
 
-                if (not abs_point_data or not check_valid_point(abs_point_data)) and (
-                    not rel_point_data or not check_valid_point(rel_point_data)
-                ):
+                if (
+                    (not abs_point_data or not check_valid_point(abs_point_data))
+                    and metric_slug != NimbusConstants.DAILY_ACTIVE_USERS
+                ) or (not rel_point_data or not check_valid_point(rel_point_data)):
                     return False
         return True
 
@@ -401,7 +404,7 @@ class ExperimentResultsManager:
                             reference_branch,
                         ),
                         "has_data": self.metric_has_data(
-                            slug, group, analysis_basis, segment
+                            slug, group, analysis_basis, segment, reference_branch
                         ),
                     }
                 )
@@ -521,6 +524,7 @@ class ExperimentResultsManager:
                 if (
                     is_metric_notable(metric["slug"], metric["group"])
                     and metric not in metric_areas[NimbusUIConstants.NOTABLE_METRIC_AREA]
+                    and metric.get("has_data")
                 ):
                     metric_areas[NimbusUIConstants.NOTABLE_METRIC_AREA].append(metric)
 

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -31,7 +31,8 @@ class TestExperimentResultsManager(TestCase):
             primary_outcomes=[self.desktop_outcome_1.slug],
             secondary_outcomes=[],
         )
-        NimbusBranchFactory.create(
+        self.experiment.delete_branches()
+        self.experiment.reference_branch = NimbusBranchFactory.create(
             experiment=self.experiment, name="Branch A", slug="branch-a"
         )
         NimbusBranchFactory.create(
@@ -920,6 +921,102 @@ class TestExperimentResultsManager(TestCase):
                         "custom_metric": "Custom Metric Name",
                     }
                 },
+                "overall": {
+                    "enrollments": {
+                        "all": {
+                            "branch-a": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "retained": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 1.19,
+                                                        "upper": 1.74,
+                                                        "point": 1.62,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 1.19,
+                                                    "upper": 1.74,
+                                                    "point": 1.62,
+                                                },
+                                            },
+                                            "relative_uplift": {
+                                                "branch-a": {"all": [], "first": {}},
+                                                "branch-b": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -0.1,
+                                                            "upper": 0.42,
+                                                            "point": 0.2,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 1.19,
+                                                        "upper": 1.74,
+                                                        "point": 1.62,
+                                                    },
+                                                },
+                                            },
+                                            "significance": {
+                                                "branch-a": {"overall": {}},
+                                                "branch-b": {
+                                                    "overall": {"1": "negative"}
+                                                },
+                                            },
+                                        }
+                                    }
+                                }
+                            },
+                            "branch-b": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "retained": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "lower": 1.19,
+                                                        "upper": 1.74,
+                                                        "point": 1.62,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "lower": 1.19,
+                                                    "upper": 1.74,
+                                                    "point": 1.62,
+                                                },
+                                            },
+                                            "relative_uplift": {
+                                                "branch-a": {
+                                                    "all": [
+                                                        {
+                                                            "lower": -0.1,
+                                                            "upper": 0.42,
+                                                            "point": 0.2,
+                                                        }
+                                                    ],
+                                                    "first": {
+                                                        "lower": 1.19,
+                                                        "upper": 1.74,
+                                                        "point": 1.62,
+                                                    },
+                                                },
+                                                "branch-b": {"all": [], "first": {}},
+                                            },
+                                            "significance": {
+                                                "branch-a": {
+                                                    "overall": {"1": "positive"}
+                                                },
+                                                "branch-b": {"overall": {}},
+                                            },
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                },
             }
         }
         self.experiment.save()
@@ -927,7 +1024,13 @@ class TestExperimentResultsManager(TestCase):
         MetricAreas.clear_cache()
         metric_areas = self.results_manager.get_metric_areas(
             "enrollments", "all", "branch-a"
-        ).keys()
+        )
+
+        self.assertIn("Notable Changes", metric_areas)
+        self.assertIn(
+            "retained",
+            [metric["slug"] for metric in metric_areas["Notable Changes"]],
+        )
 
         self.assertIn("KPI Metrics", metric_areas)
         self.assertIn("Engagement", metric_areas)
@@ -968,7 +1071,7 @@ class TestExperimentResultsManager(TestCase):
 
         result = self.results_manager.get_branch_data("enrollments", "all")
 
-        self.assertEqual(len(result), 4)
+        self.assertEqual(len(result), 2)
 
         index_map = {item.get("slug"): i for i, item in enumerate(result)}
         first = result[index_map.get("branch-a")]
@@ -2053,6 +2156,31 @@ class TestExperimentResultsManager(TestCase):
                         "overall": {
                             "enrollments": {
                                 "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 140,
+                                                            "upper": 160,
+                                                            "point": 150,
+                                                        },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"first": {}},
+                                                        "branch-b": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
                                     "branch-b": {
                                         "branch_data": {
                                             "other_metrics": {
@@ -2063,6 +2191,16 @@ class TestExperimentResultsManager(TestCase):
                                                             "upper": 160,
                                                             "point": 150,
                                                         },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                        "branch-b": {"first": {}},
                                                     },
                                                 }
                                             }
@@ -2082,6 +2220,25 @@ class TestExperimentResultsManager(TestCase):
                         "overall": {
                             "enrollments": {
                                 "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 0,
+                                                            "upper": 0,
+                                                            "point": 0,
+                                                        },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"first": {}},
+                                                        "branch-b": {"first": {}},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
                                     "branch-b": {
                                         "branch_data": {
                                             "other_metrics": {
@@ -2092,6 +2249,10 @@ class TestExperimentResultsManager(TestCase):
                                                             "upper": 0,
                                                             "point": 0,
                                                         },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"first": {}},
+                                                        "branch-b": {"first": {}},
                                                     },
                                                 }
                                             }
@@ -2115,6 +2276,7 @@ class TestExperimentResultsManager(TestCase):
                                         "branch_data": {
                                             "other_metrics": {
                                                 "client_level_daily_active_users_v2": {
+                                                    "absolute": {"first": {}},
                                                     "relative_uplift": {
                                                         "branch-a": {"first": {}},
                                                         "branch-b": {
@@ -2133,6 +2295,7 @@ class TestExperimentResultsManager(TestCase):
                                         "branch_data": {
                                             "other_metrics": {
                                                 "client_level_daily_active_users_v2": {
+                                                    "absolute": {"first": {}},
                                                     "relative_uplift": {
                                                         "branch-a": {
                                                             "first": {
@@ -2165,6 +2328,7 @@ class TestExperimentResultsManager(TestCase):
                                         "branch_data": {
                                             "other_metrics": {
                                                 "client_level_daily_active_users_v2": {
+                                                    "absolute": {"first": {}},
                                                     "relative_uplift": {
                                                         "branch-a": {"all": []},
                                                         "branch-b": {
@@ -2183,6 +2347,7 @@ class TestExperimentResultsManager(TestCase):
                                         "branch_data": {
                                             "other_metrics": {
                                                 "client_level_daily_active_users_v2": {
+                                                    "absolute": {"first": {}},
                                                     "relative_uplift": {
                                                         "branch-a": {
                                                             "first": {
@@ -2192,6 +2357,64 @@ class TestExperimentResultsManager(TestCase):
                                                             }
                                                         },
                                                         "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                False,
+            ),
+            (
+                "urlbar_amazon_search_count",
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "all": [
+                                                            {
+                                                                "window_index": "1",
+                                                            }
+                                                        ],
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                        "branch-b": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "client_level_daily_active_users_v2": {
+                                                    "relative_uplift": {
+                                                        "absolute": {
+                                                            "all": [
+                                                                {
+                                                                    "window_index": "1",
+                                                                }
+                                                            ],
+                                                        },
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                        "branch-b": {"first": {}},
                                                     },
                                                 }
                                             }
@@ -2239,6 +2462,31 @@ class TestExperimentResultsManager(TestCase):
                         "weekly": {
                             "enrollments": {
                                 "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 140,
+                                                            "upper": 160,
+                                                            "point": 150,
+                                                        },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {},
+                                                        "branch-b": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
                                     "branch-b": {
                                         "branch_data": {
                                             "other_metrics": {
@@ -2249,6 +2497,16 @@ class TestExperimentResultsManager(TestCase):
                                                             "upper": 160,
                                                             "point": 150,
                                                         },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                        "branch-b": {},
                                                     },
                                                 }
                                             }
@@ -2269,6 +2527,31 @@ class TestExperimentResultsManager(TestCase):
                         "daily": {
                             "enrollments": {
                                 "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "urlbar_amazon_search_count": {
+                                                    "absolute": {
+                                                        "first": {
+                                                            "lower": 0.5,
+                                                            "upper": 1.5,
+                                                            "point": 1.0,
+                                                        },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {},
+                                                        "branch-b": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
                                     "branch-b": {
                                         "branch_data": {
                                             "other_metrics": {
@@ -2279,6 +2562,16 @@ class TestExperimentResultsManager(TestCase):
                                                             "upper": 1.5,
                                                             "point": 1.0,
                                                         },
+                                                    },
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "first": {
+                                                                "lower": -0.12,
+                                                                "upper": 0.15,
+                                                                "point": 0.02,
+                                                            }
+                                                        },
+                                                        "branch-b": {},
                                                     },
                                                 }
                                             }

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3337,13 +3337,14 @@ class TestResultsView(AuthTestCase):
             primary_outcomes=[desktop_outcome_1.slug],
             secondary_outcomes=[],
         )
-        branch_a = NimbusBranchFactory.create(
+        experiment.delete_branches()
+        experiment.reference_branch = NimbusBranchFactory.create(
             experiment=experiment, name="Branch A", slug="branch-a"
         )
-        branch_b = NimbusBranchFactory.create(
+        NimbusBranchFactory.create(
             experiment=experiment, name="Branch B", slug="branch-b"
         )
-        branch_c = NimbusBranchFactory.create(
+        NimbusBranchFactory.create(
             experiment=experiment, name="Branch C", slug="branch-c"
         )
 
@@ -3356,8 +3357,22 @@ class TestResultsView(AuthTestCase):
                                 "branch_data": {
                                     "other_metrics": {
                                         "urlbar_amazon_search_count": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "point": 100,
+                                                        "lower": 90,
+                                                        "upper": 110,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "point": 100,
+                                                    "lower": 90,
+                                                    "upper": 110,
+                                                },
+                                            },
                                             "relative_uplift": {
-                                                "branch-a": {"all": []},
+                                                "branch-a": {"first": {}},
                                                 "branch-b": {
                                                     "all": [
                                                         {
@@ -3365,7 +3380,12 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 0.15,
                                                             "point": 0.02,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.12,
+                                                        "upper": 0.15,
+                                                        "point": 0.02,
+                                                    },
                                                 },
                                                 "branch-c": {
                                                     "all": [
@@ -3374,7 +3394,12 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 0.2,
                                                             "point": 0.03,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.1,
+                                                        "upper": 0.2,
+                                                        "point": 0.03,
+                                                    },
                                                 },
                                             },
                                         }
@@ -3385,6 +3410,20 @@ class TestResultsView(AuthTestCase):
                                 "branch_data": {
                                     "other_metrics": {
                                         "urlbar_amazon_search_count": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "point": 100,
+                                                        "lower": 80,
+                                                        "upper": 120,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "point": 100,
+                                                    "lower": 80,
+                                                    "upper": 120,
+                                                },
+                                            },
                                             "relative_uplift": {
                                                 "branch-a": {
                                                     "all": [
@@ -3393,9 +3432,14 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 2,
                                                             "point": 1.5,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": 1,
+                                                        "upper": 2,
+                                                        "point": 1.5,
+                                                    },
                                                 },
-                                                "branch-b": {"all": []},
+                                                "branch-b": {"first": {}},
                                                 "branch-c": {
                                                     "all": [
                                                         {
@@ -3403,9 +3447,14 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 0.45,
                                                             "point": 0.1,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.25,
+                                                        "upper": 0.45,
+                                                        "point": 0.1,
+                                                    },
                                                 },
-                                            }
+                                            },
                                         }
                                     }
                                 }
@@ -3414,6 +3463,20 @@ class TestResultsView(AuthTestCase):
                                 "branch_data": {
                                     "other_metrics": {
                                         "urlbar_amazon_search_count": {
+                                            "absolute": {
+                                                "all": [
+                                                    {
+                                                        "point": 100,
+                                                        "lower": 80,
+                                                        "upper": 120,
+                                                    }
+                                                ],
+                                                "first": {
+                                                    "point": 100,
+                                                    "lower": 80,
+                                                    "upper": 120,
+                                                },
+                                            },
                                             "relative_uplift": {
                                                 "branch-a": {
                                                     "all": [
@@ -3422,7 +3485,12 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 20,
                                                             "point": 15,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": 10,
+                                                        "upper": 20,
+                                                        "point": 15,
+                                                    },
                                                 },
                                                 "branch-b": {
                                                     "all": [
@@ -3431,9 +3499,14 @@ class TestResultsView(AuthTestCase):
                                                             "upper": 0.45,
                                                             "point": 0.1,
                                                         }
-                                                    ]
+                                                    ],
+                                                    "first": {
+                                                        "lower": -0.25,
+                                                        "upper": 0.45,
+                                                        "point": 0.1,
+                                                    },
                                                 },
-                                                "branch-c": {"all": []},
+                                                "branch-c": {"all": [], "first": {}},
                                             },
                                         }
                                     }
@@ -3445,9 +3518,6 @@ class TestResultsView(AuthTestCase):
             }
         }
 
-        branch_a.save()
-        branch_b.save()
-        branch_c.save()
         experiment.save()
 
         response = self.client.get(

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -816,6 +816,9 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
 
             # Prepare relative metric changes for UI rendering
             for metric_metadata in metadata:
+                if not metric_metadata.get("has_data"):
+                    continue
+
                 data = (
                     metric_data.get("data", {})
                     .get(displayed_window, {})


### PR DESCRIPTION
Because

- Some experiments were producing invalid metrics with data of the form `{"window_index": "1"}` missing values for `lower`, `upper` and `point`
- The previous validation logic considered a metric valid if any field was present, which allowed these incomplete data points to pass through.

This commit

- Updates the `metric_has_data` validation logic to properly mark metrics with incomplete data as erroneous

Fixes #14675 