### PR TITLE
feat(nimbus): Update advanced targeting for FX_149_TRAINHOP_2_ACTIVATION_WINDOW

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -31,6 +31,7 @@ HAS_PIN = "!doesAppNeedPin"
 NEED_DEFAULT = "!isDefaultBrowser"
 PROFILE28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"
 PROFILELESSTHAN28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 < 28"
+PROFILELESSTHAN1HOUR = "(currentDate|date - profileAgeCreated|date) / 3600000 < 1"
 PROFILEMORETHAN7DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 > 7"
 NEW_PROFILE = "(currentDate|date - profileAgeCreated|date) / 3600000 <= 24"
 NEW_NON_SELECTABLE_PROFILE = f"({NEW_PROFILE}) && profileGroupProfileCount == 0"
@@ -4081,7 +4082,7 @@ FX_149_TRAINHOP_2_ACTIVATION_WINDOW = NimbusTargetingConfig(
         "which includes users of Fx148"
     ),
     targeting=(
-        f"isFirstStartup && os.isWindows && "
+        f"{PROFILELESSTHAN1HOUR} && os.isWindows && "
         f"{NEW_NON_SELECTABLE_PROFILE} && "
         f"{FX_149_TRAINHOP_2.targeting}"
     ),


### PR DESCRIPTION
Because

    Users aren't being enrolled with the existing targeting

This commit

    Updates the existing targeting to use profiles created within 1 hour instead of isFirstStartup

Fixes https://github.com/mozilla/experimenter/issues/14807