### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 150.0.20260303.170544 for desktop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -3989,6 +3989,20 @@ ACCEPTED_TOU_ON_OR_AFTER_DEC_9_2025_AND_FX_149_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_150_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx150 Mar-03 Trainhop",
+    slug="newtab-150-0309-trainhop",
+    description=(
+        "Desktop users having the New Tab 150.0.20260303.170544 train hop, "
+        "which includes users of Fx148"
+    ),
+    targeting="newtabAddonVersion|versionCompare('150.0.20260303.170544') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",


### PR DESCRIPTION
This commit will allow us to create experiments targeting users of the latest New Tab trainhop that will be released (2026-03-10) to Firefox 148 on the release channel.

Fixes https://github.com/mozilla/experimenter/issues/14812