### PR TITLE
fix(nimbus): exclude Preview status experiments from v8 API

### DIFF
--- a/experimenter/experimenter/experiments/api/v8/views.py
+++ b/experimenter/experimenter/experiments/api/v8/views.py
@@ -74,7 +74,12 @@ class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):
 
     queryset = (
         NimbusExperiment.objects.with_related()
-        .filter(status=NimbusExperiment.Status.DRAFT)
+        .filter(
+            status__in=[
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.PREVIEW,
+            ]
+        )
         .order_by("slug")
     )
 

--- a/experimenter/experimenter/experiments/tests/api/v8/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_views.py
@@ -265,7 +265,10 @@ class TestNimbusExperimentDraftViewSet(
                 slug=lifecycle.name,
             )
 
-            if experiment.status == NimbusExperiment.Status.DRAFT:
+            if experiment.status in [
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.PREVIEW,
+            ]:
                 draft_slugs.append(experiment.slug)
             else:
                 non_draft_slugs.append(experiment.slug)
@@ -287,7 +290,10 @@ class TestNimbusExperimentDraftViewSet(
                 slug=lifecycle.name,
             )
 
-            if experiment.status == NimbusExperiment.Status.DRAFT:
+            if experiment.status in [
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.PREVIEW,
+            ]:
                 expected_slugs.append(experiment.slug)
 
         response = self.client.get(reverse(self.LIST_VIEW))


### PR DESCRIPTION
Because

* Preview experiments are not intended to be served to clients and
  should be excluded from v8 like Draft experiments

This commit

* Adds `NimbusExperiment.Status.PREVIEW` to the exclude list in
  `NimbusExperimentViewSet` queryset
* Updates the test to expect Preview experiments to be excluded

Fixes #14823