### PR TITLE
feat(nimbus): add exposure ratio info to results page

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -22,20 +22,36 @@ class ExperimentResultsManager:
         self.experiment = experiment
 
     def get_branch_data(self, analysis_basis, selected_segment, window="overall"):
-        window_results = self.get_window_results(analysis_basis, selected_segment, window)
+        enrollment_results = self.get_window_results(
+            "enrollments", selected_segment, window
+        )
+        exposure_results = self.get_window_results("exposures", selected_segment, window)
 
         branch_data = []
 
         for branch in self.experiment.get_sorted_branches():
             slug = branch.slug
-            participant_metrics = (
-                window_results.get(slug, {})
+            enrolled_client_metrics = (
+                enrollment_results.get(slug, {})
                 .get("branch_data", {})
                 .get("other_metrics", {})
                 .get("identity", {})
             )
-            num_participants = (
-                participant_metrics.get("absolute", {}).get("first", {}).get("point", 0)
+            exposed_client_metrics = (
+                exposure_results.get(slug, {})
+                .get("branch_data", {})
+                .get("other_metrics", {})
+                .get("identity", {})
+            )
+            num_enrolled_clients = (
+                enrolled_client_metrics.get("absolute", {})
+                .get("first", {})
+                .get("point", 0)
+            )
+            num_exposed_clients = (
+                exposed_client_metrics.get("absolute", {})
+                .get("first", {})
+                .get("point", 0)
             )
 
             branch_data.append(
@@ -44,8 +60,10 @@ class ExperimentResultsManager:
                     "name": branch.name,
                     "screenshots": branch.screenshots.all,
                     "description": branch.description,
-                    "percentage": participant_metrics.get("percent"),
-                    "num_participants": num_participants,
+                    "percentage": enrolled_client_metrics.get("percent"),
+                    "num_enrolled_clients": num_enrolled_clients,
+                    "num_exposed_clients": num_exposed_clients,
+                    "exposure_rate": self.exposure_rate(selected_segment, slug),
                 },
             )
 
@@ -637,3 +655,58 @@ class ExperimentResultsManager:
                 overall_change = MetricSignificance.NEGATIVE
 
         return overall_change
+
+    def exposure_rate(self, segment, branch_slug=None):
+        for window in ["overall", "weekly", "daily"]:
+            enrollments_data = self.get_window_results("enrollments", segment, window)
+            exposures_data = self.get_window_results("exposures", segment, window)
+
+            if not enrollments_data or not exposures_data:
+                continue
+
+            if branch_slug:
+                enrollments_client_count = (
+                    enrollments_data.get(branch_slug, {})
+                    .get("branch_data", {})
+                    .get("other_metrics", {})
+                    .get("identity", {})
+                    .get("absolute", {})
+                    .get("first", {})
+                    .get("point", 0)
+                )
+                exposures_client_count = (
+                    exposures_data.get(branch_slug, {})
+                    .get("branch_data", {})
+                    .get("other_metrics", {})
+                    .get("identity", {})
+                    .get("absolute", {})
+                    .get("first", {})
+                    .get("point", 0)
+                )
+            else:
+                # If branch_slug is not provided, calculate the overall exposure rate
+                # across all branches for the segment
+                enrollments_client_count = 0
+                exposures_client_count = 0
+                for branch_data in enrollments_data.values():
+                    enrollments_client_count += (
+                        branch_data.get("branch_data", {})
+                        .get("other_metrics", {})
+                        .get("identity", {})
+                        .get("absolute", {})
+                        .get("first", {})
+                        .get("point", 0)
+                    )
+                for branch_data in exposures_data.values():
+                    exposures_client_count += (
+                        branch_data.get("branch_data", {})
+                        .get("other_metrics", {})
+                        .get("identity", {})
+                        .get("absolute", {})
+                        .get("first", {})
+                        .get("point", 0)
+                    )
+
+            if enrollments_client_count:
+                return exposures_client_count / enrollments_client_count
+            return 0

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -953,14 +953,38 @@ class TestExperimentResultsManager(TestCase):
                                 "branch_data": {
                                     "other_metrics": {
                                         "identity": {
-                                            "absolute": {"first": {"point": 75}},
-                                            "percent": 88,
+                                            "absolute": {"first": {"point": 0}},
+                                            "percent": 0,
                                         }
                                     }
                                 }
                             },
                         }
-                    }
+                    },
+                    "exposures": {
+                        "all": {
+                            "branch-a": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {"first": {"point": 75}},
+                                            "percent": 12,
+                                        }
+                                    }
+                                }
+                            },
+                            "branch-b": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {"first": {"point": 0}},
+                                            "percent": 0,
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    },
                 }
             }
         }
@@ -978,13 +1002,17 @@ class TestExperimentResultsManager(TestCase):
         self.assertEqual(first["slug"], "branch-a")
         self.assertEqual(first["name"], "Branch A")
         self.assertEqual(first["percentage"], 12)
-        self.assertEqual(first["num_participants"], 150)
+        self.assertEqual(first["num_enrolled_clients"], 150)
+        self.assertEqual(first["num_exposed_clients"], 75)
+        self.assertEqual(first["exposure_rate"], 0.5)
 
         # Validate second branch
         self.assertEqual(second["slug"], "branch-b")
         self.assertEqual(second["name"], "Branch B")
-        self.assertEqual(second["percentage"], 88)
-        self.assertEqual(second["num_participants"], 75)
+        self.assertEqual(second["percentage"], 0)
+        self.assertEqual(second["num_enrolled_clients"], 0)
+        self.assertEqual(second["num_exposed_clients"], 0)
+        self.assertEqual(second["exposure_rate"], 0)
 
     @parameterized.expand(
         [
@@ -2343,3 +2371,109 @@ class TestExperimentResultsManager(TestCase):
         # Verify base KPI metrics are still present
         self.assertIn("retained", slugs)
         self.assertIn("search_count", slugs)
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 150}},
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 80}},
+                                                    "percent": 88,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                            "exposures": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 75}},
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 20}},
+                                                    "percent": 88,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        }
+                    }
+                },
+                (75 + 20) / (150 + 80),
+            ),
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 0}},
+                                                    "percent": 12,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                            "exposures": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "identity": {
+                                                    "absolute": {"first": {"point": 0}},
+                                                    "percent": 0,
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            },
+                        }
+                    }
+                },
+                0,
+            ),
+        ]
+    )
+    def test_get_overall_exposure_rate(self, results_data, expected_exposure_rate):
+        self.experiment.results_data = results_data
+        self.experiment.save()
+
+        self.assertAlmostEqual(
+            self.results_manager.exposure_rate("all"), expected_exposure_rate
+        )

--- a/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
@@ -38,12 +38,30 @@
     <span class="badge rounded text-body-secondary bg-body-secondary border border-secondary-subtle d-inline-flex flex-column w-100 align-items-start gap-2 fs-6">
       <div>{{ branch.name }}</div>
       <div class="d-inline-flex gap-1 fw-normal">
-        {{ branch.percentage|floatformat:"0g" }}%
-        <span>&middot;</span>
+        {% if branch.percentage %}
+          {{ branch.percentage|floatformat:"0g" }}%
+          <span>&middot;</span>
+        {% endif %}
+        {% if experiment.has_exposures == valid_exposure_status or experiment.has_exposures == invalid_exposure_status %}
+          <span class="mb-0"
+                data-bs-toggle="tooltip"
+                data-bs-title="{{ branch.num_exposed_clients }}">{{ branch.num_exposed_clients|short_number }}</span>
+          /
+        {% endif %}
         <span class="mb-0"
               data-bs-toggle="tooltip"
-              data-bs-title="{{ branch.num_participants }}">{{ branch.num_participants|short_number }}</span>users
+              data-bs-title="{{ branch.num_enrolled_clients }}">{{ branch.num_enrolled_clients|short_number }}</span>users
       </div>
+      {% if experiment.has_exposures == valid_exposure_status or experiment.has_exposures == invalid_exposure_status %}
+        <div class="d-inline-flex gap-1 fw-normal text-secondary">
+          <small>Exposure Rate: {{ branch.exposure_rate|to_percentage:1 }}
+            <i class="fa-regular fa-circle-question ps-1"
+               data-bs-toggle="tooltip"
+               data-bs-html="true"
+               data-bs-delay='{"hide":1000}'
+               data-bs-title="Percentage of the enrolled population that was exposed to this branch's treatment (also shown above as exposed/enrolled). <a href='https://experimenter.info/data-analysis/data-topics/sizing/#commentary-on-exposure-rates' target='_blank'>Learn more.</a>"></i></small>
+        </div>
+      {% endif %}
     </span>
     <p class="mt-2 text-muted">{{ branch.description|truncatechars:100 }}</p>
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -101,6 +101,17 @@
         </div>
         <hr>
         <div>
+          <h5 class="mb-3">Branches</h5>
+          {% if experiment.has_exposures == valid_exposure_status or experiment.has_exposures == invalid_exposure_status %}
+            <p class="text-muted">
+              Overall Exposure Rate: <strong>{{ overall_exposure_rate|to_percentage:2 }}</strong>
+              <i class="fa-regular fa-circle-question ps-1"
+                 data-bs-toggle="tooltip"
+                 data-bs-html="true"
+                 data-bs-delay='{"hide":1000}'
+                 data-bs-title="Percentage of the total enrolled population that was exposed to the experimental treatment (or would have been exposed, for control branches). <a href='https://experimenter.info/data-analysis/data-topics/sizing/#commentary-on-exposure-rates' target='_blank'>Learn more.</a>"></i>
+            </p>
+          {% endif %}
           <div class="row row-cols-2 row-cols-xxl-3 g-4">
             {% for branch in branch_data %}
               <div class="col">

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -771,6 +771,7 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
         )
         context["selected_analysis_basis"] = analysis_basis
 
+        context["valid_exposure_status"] = NimbusUIConstants.ExposuresStatus.VALID
         context["invalid_exposure_status"] = NimbusUIConstants.ExposuresStatus.INVALID
 
         displayed_window = "overall"
@@ -810,6 +811,8 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
         context["ask_experimenter_slack_link"] = settings.ASK_EXPERIMENTER_SLACK_LINK
 
         relative_metric_changes = {}
+
+        context["overall_exposure_rate"] = results_manager.exposure_rate(selected_segment)
 
         for metric_data in all_metrics.values():
             metadata = metric_data.get("metrics", {})


### PR DESCRIPTION
Because

- Exposure rate is a useful piece of information that we could include in the new results page

This commit

- Adds overall and individual branch exposure ratios to the results page ui

Fixes #14830 