### PR TITLE
fix(nimbus): add pagination to YAML export endpoint

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -64,15 +64,50 @@
       "get": {
         "operationId": "listNimbusExperiments",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "text/yaml": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NimbusExperimentYaml"
+                  "type": "object",
+                  "required": [
+                    "count",
+                    "results"
+                  ],
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "example": 123
+                    },
+                    "next": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "uri",
+                      "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "uri",
+                      "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/NimbusExperimentYaml"
+                      }
+                    }
                   }
                 }
               }

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -76,15 +76,50 @@
       "get": {
         "operationId": "listNimbusExperiments",
         "description": "",
-        "parameters": [],
+        "parameters": [
+          {
+            "name": "page",
+            "required": false,
+            "in": "query",
+            "description": "A page number within the paginated result set.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {
               "text/yaml": {
                 "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/NimbusExperimentYaml"
+                  "type": "object",
+                  "required": [
+                    "count",
+                    "results"
+                  ],
+                  "properties": {
+                    "count": {
+                      "type": "integer",
+                      "example": 123
+                    },
+                    "next": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "uri",
+                      "example": "http://api.example.org/accounts/?page=4"
+                    },
+                    "previous": {
+                      "type": "string",
+                      "nullable": true,
+                      "format": "uri",
+                      "example": "http://api.example.org/accounts/?page=2"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/NimbusExperimentYaml"
+                      }
+                    }
                   }
                 }
               }

--- a/experimenter/experimenter/experiments/api/cache.py
+++ b/experimenter/experimenter/experiments/api/cache.py
@@ -29,8 +29,6 @@ def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_k
         qs = sorted(qs, key=sort_key, reverse=True)
     data = serializer_class(qs, many=True).data
     rendered = renderer.render(data)
-    if isinstance(rendered, str):
-        rendered = rendered.encode("utf-8")
     cache_key = get_api_cache_key(key_prefix)
     cache.set(cache_key, rendered, timeout=settings.API_CACHE_WARMING_TTL)
     logger.info("Warmed cache for %s (%d bytes)", key_prefix, len(rendered))

--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -1,5 +1,7 @@
 import yaml
+from django.db.models import F
 from rest_framework.generics import ListAPIView, UpdateAPIView
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.renderers import BaseRenderer
 from rest_framework_csv.renderers import CSVRenderer
 
@@ -57,12 +59,23 @@ class NimbusExperimentYamlRenderer(BaseRenderer):
         return obj
 
     def render(self, data, accepted_media_type=None, renderer_context=None):
-        if not data:
-            return ""
-        cleaned = [self._strip_empty(exp) for exp in data]
+        experiments = [self._strip_empty(exp) for exp in data["results"]]
+        output = {
+            **{k: v for k, v in data.items() if k != "results"},
+            "experiments": experiments,
+        }
         return yaml.dump(
-            cleaned, default_flow_style=False, allow_unicode=True, sort_keys=False
+            output,
+            default_flow_style=False,
+            allow_unicode=True,
+            sort_keys=False,
         )
+
+
+class YamlExportPagination(PageNumberPagination):
+    page_size = 100
+    page_size_query_param = None
+    max_page_size = 100
 
 
 class NimbusExperimentYamlListView(CachedListMixin, ListAPIView):
@@ -84,20 +97,11 @@ class NimbusExperimentYamlListView(CachedListMixin, ListAPIView):
             "excluded_experiments",
         )
         .filter(is_archived=False, status=NimbusExperiment.Status.COMPLETE)
+        .order_by(F("_start_date").desc(nulls_last=True), "-id")
     )
     serializer_class = NimbusExperimentYamlSerializer
     renderer_classes = (NimbusExperimentYamlRenderer,)
-    pagination_class = None
-
-    def get_queryset(self):
-        return sorted(
-            super().get_queryset(),
-            key=lambda experiment: (
-                (experiment.start_date and experiment.start_date.strftime("%Y-%m-%d"))
-                or ""
-            ),
-            reverse=True,
-        )
+    pagination_class = YamlExportPagination
 
 
 class FmlErrorsView(UpdateAPIView):

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -38,15 +38,6 @@ def _get_warm_cache_endpoints():
             },
         ),
         (
-            "v5:yaml",
-            v5_views.NimbusExperimentYamlListView.queryset,
-            v5_ser.NimbusExperimentYamlSerializer,
-            {
-                "renderer": v5_views.NimbusExperimentYamlRenderer(),
-                "sort_key": _start_date_sort_key,
-            },
-        ),
-        (
             "v6:experiments",
             v6_views.NimbusExperimentViewSet.queryset,
             v6_ser.NimbusExperimentSerializer,

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -128,22 +128,30 @@ class TestNimbusExperimentYamlListView(TestCase):
         super().setUp()
         cache.clear()
 
-    def _get_yaml(self):
+    def _get_yaml_response(self, page=None):
+        url = reverse("nimbus-experiments-yaml")
+        if page is not None:
+            url = f"{url}?page={page}"
         response = self.client.get(
-            reverse("nimbus-experiments-yaml"),
+            url,
             **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
         )
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response["Content-Type"], "text/yaml; charset=utf-8")
         return yaml.safe_load(response.content.decode("utf-8"))
 
+    def _get_yaml(self, page=None):
+        parsed = self._get_yaml_response(page=page)
+        if isinstance(parsed, dict) and "experiments" in parsed:
+            return parsed["experiments"]
+        return parsed
+
     def test_returns_empty_for_no_complete_experiments(self):
-        response = self.client.get(
-            reverse("nimbus-experiments-yaml"),
-            **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.content.decode("utf-8"), "")
+        parsed = self._get_yaml_response()
+        self.assertEqual(parsed["count"], 0)
+        self.assertEqual(parsed["experiments"], [])
+        self.assertIsNone(parsed["next"])
+        self.assertIsNone(parsed["previous"])
 
     def test_sorted_by_start_date_descending(self):
         application = NimbusExperiment.Application.DESKTOP
@@ -374,6 +382,66 @@ class TestNimbusExperimentYamlListView(TestCase):
         data = self._get_yaml()
         exp = next(e for e in data if e["slug"] == experiment.slug)
         self.assertNotIn("targeting", exp)
+
+    def test_pagination_returns_metadata(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            feature_configs=[feature_config],
+        )
+
+        parsed = self._get_yaml_response()
+        self.assertEqual(parsed["count"], 1)
+        self.assertIsNone(parsed["next"])
+        self.assertIsNone(parsed["previous"])
+        self.assertEqual(len(parsed["experiments"]), 1)
+
+    @override_settings(
+        CACHES={
+            "default": {
+                "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            }
+        }
+    )
+    def test_pagination_multiple_pages(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        # Create 3 experiments; use page_size=2 via override
+        for i in range(3):
+            NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+                start_date=datetime.date(2020 + i, 1, 1),
+                application=application,
+                feature_configs=[feature_config],
+            )
+
+        with self.settings(YAML_EXPORT_PAGE_SIZE=2):
+            from experimenter.experiments.api.v5.views import YamlExportPagination
+
+            original_page_size = YamlExportPagination.page_size
+            YamlExportPagination.page_size = 2
+            try:
+                cache.clear()
+                page1 = self._get_yaml_response(page=1)
+                self.assertEqual(page1["count"], 3)
+                self.assertEqual(len(page1["experiments"]), 2)
+                self.assertIsNotNone(page1["next"])
+                self.assertIsNone(page1["previous"])
+
+                page2 = self._get_yaml_response(page=2)
+                self.assertEqual(page2["count"], 3)
+                self.assertEqual(len(page2["experiments"]), 1)
+                self.assertIsNone(page2["next"])
+                self.assertIsNotNone(page2["previous"])
+
+                # Ensure no overlap between pages
+                page1_slugs = {e["slug"] for e in page1["experiments"]}
+                page2_slugs = {e["slug"] for e in page2["experiments"]}
+                self.assertEqual(len(page1_slugs & page2_slugs), 0)
+            finally:
+                YamlExportPagination.page_size = original_page_size
 
 
 class TestFmlErrorsView(MockFmlErrorMixin, TestCase):

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -132,19 +132,6 @@ class TestWarmApiCaches(TestCase):
                 self.assertIn("slug", exp)
                 self.assertIn("branches", exp)
 
-    def test_warm_api_caches_v5_yaml_endpoint(self):
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
-            slug="complete-experiment",
-        )
-
-        warm_api_caches()
-
-        cached = cache.get(get_api_cache_key("v5:yaml"))
-        self.assertIsNotNone(cached)
-        content = cached.decode("utf-8") if isinstance(cached, bytes) else cached
-        self.assertIn("complete-experiment", content)
-
     def test_warm_api_caches_v5_csv_endpoint(self):
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,


### PR DESCRIPTION
Because

* The `/api/v5/yaml/` endpoint serializes all ~1000+ completed experiments
  into a single response which times out at 30s on production (502)
* The upstream proxy has a 30s connection timeout that cannot be changed
* Cache warming does not help because the response is too large to
  transfer within the timeout even when served from cache

This commit

* Adds `YamlExportPagination` (100 experiments per page) to the YAML view
* Updates the YAML renderer to handle paginated response shape with
  count, next, previous, and experiments fields
* Moves sorting from Python `sorted()` to ORM `.order_by()` which is
  required for DRF pagination to work correctly
* Removes YAML from cache warming since paginated pages are fast enough
  without pre-warming
* Updates tests for the new paginated response format and adds
  pagination-specific tests

Fixes #14844