### PR TITLE
chore(project): remove test result reporting and fix parallel make check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,50 +50,7 @@ commands:
           name: Create Workspace
           command: |
             mkdir -p workspace/test-results
-            mkdir -p dashboard/test-results
 
-  upload-to-gcs:
-    parameters:
-      source:
-        type: string
-      destination:
-        type: string
-      extension:
-        type: enum
-        enum: ["xml", "json"]
-    steps:
-      - run:
-          name: Check branch and files
-          when: always
-          command: |
-            allowed_branches=("update_firefox_versions" "update-application-services")
-
-            for branch in "${allowed_branches[@]}"; do
-              if [[ "$CIRCLE_BRANCH" == "$branch" || "$CIRCLE_BRANCH" == gh-readonly-queue/$branch/* ]]; then
-                FILES=$(ls -1 << parameters.source >>/*.<< parameters.extension >> 2>/dev/null)
-                if [ -z "$FILES" ]; then
-                  echo "No << parameters.extension >> files found in << parameters.source >>/"
-                  circleci-agent step halt
-                fi
-                echo "Uploading..."
-                break
-              else
-                echo "Skipping artifact upload; not on an allowed or merge queue branch."
-                circleci-agent step halt
-              fi
-            done
-      - run:
-          name: Change gcloud folder permissions
-          command: sudo chown -R $USER /home/circleci/.config/gcloud/ || true
-      - gcp-cli/setup:
-          gcloud_service_key: ETE_GCLOUD_SERVICE_KEY
-          google_project_id: ETE_GOOGLE_PROJECT_ID
-      - run:
-          name: Upload << parameters.source >> << parameters.extension >> Files to GCS
-          when: always
-          command: |
-            FILES=$(ls -1 << parameters.source >>/*.<< parameters.extension >> 2>/dev/null)
-            gsutil cp -n $FILES << parameters.destination >>
   setup-github-bot:
     steps:
       - run:
@@ -134,36 +91,6 @@ jobs:
             cp .env.sample .env
             make check
 
-  check_experimenter_and_report:
-    machine:
-      image: ubuntu-2204:2024.11.1
-      docker_layer_caching: true
-    resource_class: large
-    working_directory: ~/experimenter
-    steps:
-      - checkout
-      - check_file_paths:
-          paths: "experimenter/|application-services/"
-      - create_test_result_workspace
-      - run:
-          name: Run coverage
-          no_output_timeout: 20m
-          command: |
-            cp .env.sample .env
-            make check_and_report || true
-      - store_test_results:
-          path: workspace/test-results/experimenter_tests.xml
-      - store_test_results:
-          path: workspace/test-results/junit.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/coverage
-          extension: json
-
   check_experimenter_aarch64:
     machine:
       image: ubuntu-2204:2024.11.1
@@ -190,21 +117,10 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "cirrus/|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check_and_report
-      - store_test_results:
-          path: workspace/test-results/cirrus_pytest.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/coverage
-          extension: json
+            make cirrus_check
 
   check_cirrus_aarch64:
     machine:
@@ -216,21 +132,10 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "cirrus/|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run Cirrus tests and linting
           command: |
-            make cirrus_check_and_report
-      - store_test_results:
-          path: workspace/test-results/cirrus_pytest.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/coverage
-          extension: json
+            make cirrus_check
 
   check_local_feature_manifests:
     machine:
@@ -281,20 +186,13 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_remote_settings_launch:
     machine:
@@ -310,20 +208,13 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_remote_settings_all:
     parallelism: 3
@@ -340,7 +231,6 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
@@ -351,15 +241,9 @@ jobs:
               1) export PYTEST_ARGS="$PYTEST_ARGS -m remote_settings_rollouts" ;;
               2) export PYTEST_ARGS="$PYTEST_ARGS -m remote_settings_live_updates" ;;
             esac
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_desktop_enrollment:
     machine:
@@ -375,21 +259,14 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
           no_output_timeout: 30m
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_desktop_release_targeting:
     machine:
@@ -406,20 +283,13 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_desktop_beta_targeting:
     machine:
@@ -436,20 +306,13 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_desktop_nightly_targeting:
     machine:
@@ -465,20 +328,13 @@ jobs:
       - checkout
       - check_file_paths:
           paths: "experimenter/experimenter/targeting|experimenter/experimenter/experiments|experimenter/tests/firefox_desktop_release_build.env|experimenter/tests/firefox_desktop_beta_build.env|application-services/"
-      - create_test_result_workspace
       - run:
           name: Run integration tests
           command: |
             cp .env.integration-tests .env
-            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS" integration_test_and_report
+            make refresh SKIP_DUMMY=1 PYTEST_SENTRY_DSN=$PYTEST_SENTRY_DSN CIRCLECI=$CIRCLECI up_prod_detached integration_test_nimbus_desktop PYTEST_ARGS="$PYTEST_ARGS"
       - store_artifacts:
           path: ~/experimenter/experimenter/tests/integration/test-reports/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_fenix_enrollment:
     executor:
@@ -517,12 +373,6 @@ jobs:
           cache-prefix: v1a
       - store_artifacts:
           path: workspace/test-results/report.htm
-      - store_test_results:
-          path: workspace/test-results/experimenter_fenix_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   integration_nimbus_ios_enrollment:
     macos:
@@ -585,12 +435,6 @@ jobs:
             poetry add pydantic==2.10.3
             poetry install
             poetry run pytest --junitxml=/Users/distiller/project/workspace/test-results/experimenter_ios_integration_tests.xml -k test_ios_integration.py --feature ios_enrollment
-            cp /Users/distiller/project/workspace/test-results/experimenter_ios_integration_tests.xml /Users/distiller/project/dashboard/test-results/${CIRCLE_BUILD_NUM}__$(date +"%s")__${CIRCLE_PROJECT_REPONAME}__build__integration__results.xml
-      - run:
-          name: Change python version for GCP CLI  # circleci/macos with xcode 16.2 has python 3.13 and gcp-cli doesn't support this yet.
-          command: |
-            pyenv install 3.12.5
-            pyenv global 3.12.5
       - run:
           name: Collect XCTest Results
           command: |
@@ -607,12 +451,6 @@ jobs:
           path: ~/project/xcodebuild.log
       - store_artifacts:
           path: ~/project/results.zip
-      - store_test_results:
-          path: /Users/distiller/project/workspace/test-results/experimenter_ios_integration_tests.xml
-      - upload-to-gcs:
-          source: dashboard/test-results
-          destination: gs://ecosystem-test-eng-metrics/experimenter/junit
-          extension: xml
 
   create_mobile_recipes:
     working_directory: ~/experimenter
@@ -931,14 +769,6 @@ workflows:
           name: Check Experimenter x86_64
       - check_experimenter_aarch64:
           name: Check Experimenter aarch64
-      - check_experimenter_and_report:
-          name: Check Experimenter and report
-          filters:
-            branches:
-              only:
-                - main
-                - update_firefox_versions
-                - update-application-services
       - check_cirrus_x86_64:
           name: Check Cirrus x86_64
       - check_cirrus_aarch64:

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ COMPOSE_CIRRUS = [[ -n $$CIRRUS ]] && echo "-f docker-compose-cirrus.yml"
 COMPOSE = docker compose -f docker-compose.yml $$(${COMPOSE_CIRRUS})
 COMPOSE_RUN = ${COMPOSE} run --rm
 COMPOSE_TEST = docker compose -f docker-compose-test.yml
-COMPOSE_TEST_RUN = ${COMPOSE_TEST} run --name experimenter_test
+COMPOSE_TEST_RUN = ${COMPOSE_TEST} run --rm
 COMPOSE_PROD = docker compose -f docker-compose-prod.yml $$(${COMPOSE_CIRRUS})
 COMPOSE_INTEGRATION = ${COMPOSE_PROD} -f docker-compose-integration-test.yml $$(${COMPOSE_CIRRUS})
-COMPOSE_INTEGRATION_RUN = ${COMPOSE_INTEGRATION} run --name experimenter_integration
+COMPOSE_INTEGRATION_RUN = ${COMPOSE_INTEGRATION} run --rm
 DOCKER_BUILD = docker buildx build
 PYTEST_BASE_URL ?= https://nginx/nimbus/
 
@@ -24,16 +24,6 @@ SCHEMAS_BUILD_FLAGS ?=
 # Interactive flags for docker run. Set to empty for non-TTY environments (CI).
 DOCKER_RUN_INTERACTIVE ?= -ti
 
-WORKFLOW := build
-EPOCH_TIME := $(shell date +"%s")
-TEST_RESULTS_DIR ?= $(if $(CIRCLECI),dashboard/test-results,.)
-TEST_FILE_PREFIX := $(if $(CIRCLECI),$(CIRCLE_BUILD_NUM)__$(EPOCH_TIME)__$(CIRCLE_PROJECT_REPONAME)__$(WORKFLOW)__)
-UNIT_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__results.xml
-UNIT_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
-UI_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)ui__coverage.json
-UI_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)ui__results.xml
-INTEGRATION_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml
-
 JOBS = 4
 PARALLEL = parallel --halt now,fail=1 --jobs ${JOBS} {} :::
 NOCOLOR= \033[0m
@@ -41,7 +31,6 @@ RED = \033[0;31m
 GREEN = \033[0;32m
 PAD = -------------------------------------------------\n
 COLOR_CHECK = && echo "${GREEN}${PAD}All Checks Passed\n${PAD}${NOCOLOR}" || (echo "${RED}${PAD}Some Checks Failed\n${PAD}${NOCOLOR}";exit 1)
-PYTHON_COVERAGE = pytest --cov --cov-report json:experimenter_coverage.json --cov-branch --junitxml=experimenter_tests.xml
 PYTHON_TEST = pytest --cov --cov-report term-missing
 PYTHON_TYPECHECK = pyright experimenter/
 PYTHON_CHECK_MIGRATIONS = python manage.py makemigrations --check --dry-run --noinput
@@ -167,21 +156,11 @@ kill: compose_stop compose_rm docker_prune  ## Stop, remove, and prune container
 	echo "All containers removed!"
 
 lint: build_test  ## Running linting on source code
-	-docker rm experimenter_test
 	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "$(RUFF_FORMAT_CHECK)" "$(RUFF_CHECK)" "$(DJLINT_CHECK)" "$(ESLINT_RESULTS)" "$(ESLINT_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_RESULTS)" "$(RESULTS_SCHEMA_CHECK)") ${COLOR_CHECK}'
 
 check: lint
 
-check_and_report: build_test  ## Only to be used on CI
-	-docker rm experimenter_test
-	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_COVERAGE)") ${COLOR_CHECK}' || true
-	docker cp experimenter_test:/experimenter/experimenter_coverage.json workspace/test-results
-	docker cp experimenter_test:/experimenter/experimenter_tests.xml workspace/test-results
-	cp workspace/test-results/experimenter_coverage.json $(UNIT_COVERAGE_JSON)
-	cp workspace/test-results/experimenter_tests.xml $(UNIT_JUNIT_XML)
-
 test: build_test  ## Run tests
-	-docker rm experimenter_test
 	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) python manage.py test --parallel'
 pytest: test
 
@@ -238,9 +217,6 @@ dependabot_approve:
 integration_shell:
 	$(COMPOSE_INTEGRATION_RUN) firefox bash
 
-integration_clean:
-	-docker rm experimenter_integration
-
 integration_sdk_shell: build_prod build_integration_test
 	$(COMPOSE_INTEGRATION_RUN) rust-sdk bash
 
@@ -267,7 +243,7 @@ integration_test_vnc: build_prod
 	$(COMPOSE_INTEGRATION) up -d firefox
 	$(COMPOSE_INTEGRATION) exec firefox bash
 
-integration_test_nimbus_desktop: build_prod integration_clean
+integration_test_nimbus_desktop: build_prod
 	MOZ_HEADLESS=1 $(COMPOSE_INTEGRATION_RUN) firefox sh -c "FIREFOX_CHANNEL=$(FIREFOX_CHANNEL) PYTEST_SENTRY_DSN=$(PYTEST_SENTRY_DSN) PYTEST_SENTRY_ALWAYS_REPORT=$(PYTEST_SENTRY_ALWAYS_REPORT) CIRCLECI=$(CIRCLECI) ./experimenter/tests/nimbus_integration_tests.sh"
 
 integration_test_nimbus_sdk: build_integration_test build_prod
@@ -276,11 +252,6 @@ integration_test_nimbus_sdk: build_integration_test build_prod
 integration_test_nimbus_fenix:
 	poetry -C experimenter/tests/integration/ -vvv install --no-root
 	poetry -C experimenter/tests/integration/ -vvv run pytest --html=workspace/test-results/report.htm --self-contained-html --reruns-delay 30 --driver Firefox experimenter/tests/integration/nimbus/android --junitxml=experimenter/tests/integration/test-reports/experimenter_fenix_integration_tests.xml -vvv
-	cp experimenter/tests/integration/test-reports/experimenter_fenix_integration_tests.xml $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml
-
-make integration_test_and_report:
-	docker cp experimenter_integration:/code/experimenter/tests/integration/test-reports/experimenter_integration_tests.xml workspace/test-results
-	cp workspace/test-results/experimenter_integration_tests.xml $(INTEGRATION_JUNIT_XML)
 
 # cirrus
 CIRRUS_ENABLE = export CIRRUS=1 &&
@@ -292,8 +263,6 @@ CIRRUS_PYTEST = pytest . --cov-config=.coveragerc --cov=cirrus --cov-branch --co
 CIRRUS_PYTHON_TYPECHECK = pyright -p .
 CIRRUS_PYTHON_TYPECHECK_CREATESTUB = pyright -p . --createstub cirrus
 CIRRUS_GENERATE_DOCS = python cirrus/generate_docs.py
-CIRRUS_COVERAGE_JSON := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)unit__coverage.json
-CIRRUS_JUNIT_XML := $(TEST_RESULTS_DIR)/$(TEST_FILE_PREFIX)integration__results.xml
 
 cirrus_build: build_megazords
 	$(CIRRUS_ENABLE) $(DOCKER_BUILD) --target deploy -f cirrus/server/Dockerfile -t cirrus:deploy --build-context=fml=experimenter/experimenter/features/manifests/ cirrus/server/
@@ -317,20 +286,12 @@ cirrus_down:
 	$(CIRRUS_ENABLE) $(COMPOSE) down cirrus
 
 cirrus_test: cirrus_build_test
-	-docker rm experimenter_test
 	$(CIRRUS_ENABLE) $(COMPOSE_TEST_RUN) cirrus sh -c '$(CIRRUS_PYTEST)'
 
 cirrus_check: cirrus_lint
 
-cirrus_lint: cirrus_build_test integration_clean
-	-docker rm experimenter_test
+cirrus_lint: cirrus_build_test
 	$(CIRRUS_ENABLE) $(COMPOSE_TEST_RUN) cirrus sh -c "$(CIRRUS_RUFF_FORMAT_CHECK) && $(CIRRUS_RUFF_CHECK) && $(CIRRUS_PYTHON_TYPECHECK) && $(CIRRUS_PYTEST) && $(CIRRUS_GENERATE_DOCS) --check"
-
-cirrus_check_and_report: cirrus_lint
-	docker cp experimenter_test:/cirrus/cirrus_pytest.xml workspace/test-results
-	docker cp experimenter_test:/cirrus/cirrus_coverage.json workspace/test-results
-	cp workspace/test-results/cirrus_pytest.xml $(CIRRUS_JUNIT_XML)
-	cp workspace/test-results/cirrus_coverage.json $(CIRRUS_COVERAGE_JSON)
 
 cirrus_code_format: cirrus_build
 	$(CIRRUS_ENABLE) $(COMPOSE_RUN) cirrus sh -c '$(CIRRUS_RUFF_FORMAT_FIX) && $(CIRRUS_RUFF_FIX)'

--- a/docker-compose-cirrus.yml
+++ b/docker-compose-cirrus.yml
@@ -19,7 +19,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - '3002:3002'
-    restart: always
     depends_on:
       - cirrus
     environment:
@@ -31,7 +30,6 @@ services:
       dockerfile: Dockerfile
     ports:
       - '8080:3000'
-    restart: always
     depends_on:
       - demo-app-server
     environment:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -44,7 +44,6 @@ services:
       - "443:443"
 
   db:
-    restart: always
     image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -14,7 +14,6 @@ services:
       - db
 
   db:
-    restart: always
     image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,6 @@ services:
       - "443:443"
 
   db:
-    restart: always
     image: postgres:14.8
     environment:
       POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
Because

* The Makefile hardcodes container names `experimenter_test` and
  `experimenter_integration` via `--name`, causing collisions when
  multiple worktrees run `make check` concurrently
* The `--name` flag was only needed for `docker cp` in the now-unused
  `check_and_report` / `cirrus_check_and_report` / `integration_test_and_report`
  CI targets that uploaded test results to GCS
* The `restart: always` policy on db and other services causes containers
  to linger and accumulate across reboots

This commit

* Removes `check_and_report`, `cirrus_check_and_report`, and
  `integration_test_and_report` Make targets and their CI jobs/steps
* Removes the GCS upload command and related CI infrastructure
* Switches `COMPOSE_TEST_RUN` and `COMPOSE_INTEGRATION_RUN` back to
  `--rm` since named containers are no longer needed
* Removes all `docker rm` / `docker cp` of named containers
* Removes `restart: always` from all compose files to prevent zombie
  containers
* Removes unused variables: `PYTHON_COVERAGE`, `TEST_RESULTS_DIR`,
  `TEST_FILE_PREFIX`, `*_JUNIT_XML`, `*_COVERAGE_JSON`

Fixes #14846