### PR TITLE
bug(nimbus): Don't leak CodeMirror editors

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/theme_utils.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/theme_utils.js
@@ -12,7 +12,7 @@ export const getThemeExtensions = () => (isDarkMode() ? [oneDark] : []);
 const viewRegistry = new Set();
 
 export const registerView = (view) => {
-  viewRegistry.add(view);
+  viewRegistry.add(new WeakRef(view));
 };
 
 export const updateViewTheme = (view) => {
@@ -22,7 +22,22 @@ export const updateViewTheme = (view) => {
 };
 
 export const updateAllViewThemes = () => {
-  viewRegistry.forEach(updateViewTheme);
+  const toRemove = [];
+
+  for (const ref of viewRegistry) {
+    const view = ref.deref();
+
+    if (typeof view === "undefined") {
+      toRemove.push(ref);
+      continue;
+    }
+
+    updateViewTheme(view);
+  }
+
+  for (const ref of toRemove) {
+    viewRegistry.delete(ref);
+  }
 };
 
 export const observeThemeChanges = (callback) => {


### PR DESCRIPTION
Because:

- we were storing all our CodeMirror editor views in a set so we can iterate over them in response to theme changes;
- this creates a strong reference, preventing the editors from being garbage collected

this commit:

- wraps each editor view in a WeakRef, which will allow them to be garbage collected.

Fixes #14861