### PR TITLE
fix(nimbus): reinitialize CodeMirror editors after branch page save

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
@@ -14,6 +14,9 @@ import {
 import { setupReadonlyJsonEditors } from "./codemirror_utils.js";
 import $ from "jquery";
 
+const BRANCHES_FORM_ID = "branches-form";
+const CONTENT_WITH_SIDEBAR_ID = "content-with-sidebar";
+
 const setupCodemirror = (selector, textarea, extraExtensions) => {
   if (!textarea) {
     console.warn(`No textarea found for selector: ${selector}`);
@@ -107,7 +110,7 @@ const setupCodeMirrorLocalizations = () => {
 };
 
 const setupSchemaToggleButtons = () => {
-  const form = document.getElementById("branches-form");
+  const form = document.getElementById(BRANCHES_FORM_ID);
   if (!form || form.dataset.schemaToggleSetup) return;
   form.dataset.schemaToggleSetup = "true";
 
@@ -141,7 +144,10 @@ $(() => {
   observeThemeChanges(updateAllViewThemes);
 
   document.body.addEventListener("htmx:afterSwap", function (event) {
-    if (event.detail.target.id === "branches-form") {
+    if (
+      event.detail.target.id === BRANCHES_FORM_ID ||
+      event.detail.target.id === CONTENT_WITH_SIDEBAR_ID
+    ) {
       initializeAllEditors();
     }
   });


### PR DESCRIPTION
Because

* In #14299 (8200d145) the branch form's htmx target was changed from
  `#branches-form` to `#content-with-sidebar` so the sidebar's missing
  details section would update on save
* The `htmx:afterSwap` handler in `edit_branches.js` only checked for the
  `branches-form` target, so it never fired after a form save
* This caused CodeMirror feature value editors to vanish after saving
  because they were not reinitialized in the swapped DOM

This commit

* Adds `content-with-sidebar` as an additional target ID check in the
  `htmx:afterSwap` handler so editors reinitialize after form saves
* Extracts both target IDs into constants for clarity

Fixes #14860