### PR TITLE
fix(nimbus): sync is_paused from Remote Settings on rollback in handle_waiting_experiments

### DIFF
--- a/docs/experimenter/README.md
+++ b/docs/experimenter/README.md
@@ -1097,11 +1097,11 @@ A live experiment that is published in Remote Settings has passed its planned en
 
     Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the collection in <br/> to-sign with no record of the rejection
 
-
-    rect rgb(204,255,255) 
+    rect rgb(204,255,255)
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> is_paused: False <br/> + changelog
-    end 
+        Note over Experimenter Worker: Worker syncs is_paused from <br/> RS record's isEnrollmentPaused
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> is_paused: {sync from RS record} <br/> + changelog
+    end
 ```
 
 ### End Enrollment (Approve/Timeout)

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -91,7 +91,7 @@ def nimbus_check_kinto_push_queue_by_collection(collection):
     handle_launching_experiments(applications, records, collection)
     handle_updating_experiments(applications, records, collection)
     handle_ending_experiments(applications, records, collection)
-    handle_waiting_experiments(applications, collection)
+    handle_waiting_experiments(applications, records, collection)
 
     if queued_launch_experiment := next(
         NimbusExperiment.objects.launch_queue(applications, collection), None
@@ -290,13 +290,17 @@ def handle_ending_experiments(applications, records, collection):
             logger.info(f"{experiment.slug} ended")
 
 
-def handle_waiting_experiments(applications, collection):
+def handle_waiting_experiments(applications, records, collection):
     for experiment in NimbusExperiment.objects.waiting(applications, collection):
         with transaction.atomic():
             experiment.status_next = None
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
             if experiment.status == experiment.Status.DRAFT:
                 experiment.published_date = None
+
+            kinto_record = records.get(experiment.slug, {})
+            experiment.is_paused = kinto_record.get("isEnrollmentPaused", False)
+
             experiment.save()
 
             generate_nimbus_changelog(

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -979,6 +979,94 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertIsNone(waiting_experiment.computed_end_date)
 
     @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_waiting_pausing_experiment_with_rs_record_not_paused_resets_is_paused(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        """When a pause publish fails and RS record has isEnrollmentPaused=false,
+        is_paused syncs to False. Uses published_dto=None so
+        handle_updating_experiments skips the experiment (it checks
+        published_dto first) and handle_waiting_experiments catches it."""
+        feature_config = create_desktop_feature(feature_slug)
+        waiting_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PAUSING_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            published_dto=None,
+            feature_configs=[feature_config],
+        )
+        self.assertTrue(waiting_experiment.is_paused)
+
+        # RS record exists but isEnrollmentPaused is false (pause never landed)
+        self.mock_kinto_client.get_records.return_value = [
+            {
+                "id": waiting_experiment.slug,
+                "last_modified": "0",
+                "isEnrollmentPaused": False,
+            }
+        ]
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(waiting_experiment)
+
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_changed(
+            waiting_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+                "message": NimbusChangeLog.Messages.REJECTED_FROM_KINTO,
+            },
+        )
+        self.assertIsNone(waiting_experiment.status_next)
+        self.assertFalse(waiting_experiment.is_paused)
+
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
+    def test_check_waiting_ending_experiment_with_rs_record_paused_preserves_is_paused(
+        self, feature_slug, target_collection, alternate_collection
+    ):
+        """When an end-experiment publish fails but RS record has
+        isEnrollmentPaused=true, is_paused syncs to True (preserving
+        the previously published pause)."""
+        feature_config = create_desktop_feature(feature_slug)
+        waiting_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        self.assertTrue(waiting_experiment.is_paused)
+
+        # RS record still has isEnrollmentPaused=true from a previous pause
+        self.mock_kinto_client.get_records.return_value = [
+            {
+                "id": waiting_experiment.slug,
+                "last_modified": "0",
+                "isEnrollmentPaused": True,
+            }
+        ]
+        self.setup_kinto_no_pending_review()
+
+        self._assert_check_collection_unchanged(alternate_collection)
+        self._assert_experiment_status_unchanged(waiting_experiment)
+
+        self._assert_check_collection_unchanged(target_collection)
+        self._assert_experiment_status_changed(
+            waiting_experiment,
+            old_status=NimbusExperiment.Status.LIVE,
+            new_status=NimbusExperiment.Status.LIVE,
+            old_publish_status=NimbusExperiment.PublishStatus.WAITING,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            filter_kwargs={
+                "changed_by__email": settings.KINTO_DEFAULT_CHANGELOG_USER,
+                "message": NimbusChangeLog.Messages.REJECTED_FROM_KINTO,
+            },
+        )
+        self.assertIsNone(waiting_experiment.status_next)
+        self.assertTrue(waiting_experiment.is_paused)
+
+    @parameterized.expand(PREFFLIPS_PARAMETERIZED_CASES)
     def test_launching_experiment_live_when_record_is_in_main(
         self, feature_slug, target_collection, alternate_collection
     ):


### PR DESCRIPTION
Because

* When a kinto publish for "end enrollment" fails via the catch-all
  `handle_waiting_experiments` path (manual rollback, missing rejection),
  `is_paused` was left as `True` even though kinto never accepted the change
* This left the experiment stuck showing both "End Enrollment" and
  "End Experiment" buttons, with "End Enrollment" producing an error
* The root cause is that `handle_waiting_experiments` reset `publish_status`
  and `status_next` but did not sync `is_paused` with the actual RS state

This commit

* Passes kinto main records to `handle_waiting_experiments`
* Syncs `is_paused` from the RS record's `isEnrollmentPaused` field on
  rollback, defaulting to `False` if the record doesn't exist
* Updates the End Enrollment (Approve/Reject+Manual Rollback) mermaid
  diagram to document the `is_paused` sync behavior
* Adds tests for pause rollback (`is_paused` resets to `False`) and
  end-experiment rollback (`is_paused` preserved as `True` from RS)

Fixes #14864