### PR TITLE
fix(nimbus): fix misaligned cards and overflow with long branch names

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/branch_card.html
@@ -36,7 +36,7 @@
   {% endwith %}
   <div class="w-50">
     <span class="badge rounded text-body-secondary bg-body-secondary border border-secondary-subtle d-inline-flex flex-column w-100 align-items-start gap-2 fs-6">
-      <div>{{ branch.name }}</div>
+      <div class="text-truncate w-100 text-start" title="{{ branch.name }}">{{ branch.name }}</div>
       <div class="d-inline-flex gap-1 fw-normal">
         {{ branch.percentage|floatformat:"0g" }}%
         <span>&middot;</span>

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -25,18 +25,11 @@
             <div class="col">
               <p class="fw-bold text-center">Branches</p>
               {% for branch in branch_data %}
-                <div class="p-3 mb-3 d-flex justify-content-center text-start text-center"
+                <div class="p-3 mb-3 d-flex flex-column justify-content-center text-start text-center align-items-center"
                      style="height: 75px">
-                  <div class="d-flex flex-column align-items-center">
-                    <small class="text-muted mb-0">{{ branch.name }}</small>
-                    <p class="mb-0">
-                      {% if branch.slug == reference_branch %}
-                        Baseline
-                      {% else %}
-                        {{ branch.name }}
-                      {% endif %}
-                    </p>
-                  </div>
+                  {% if branch.slug == reference_branch %}<small class="text-muted">Baseline</small>{% endif %}
+                  <p class="mb-0 text-truncate w-100 text-center"
+                     title="{{ branch.name }}">{{ branch.name }}</p>
                 </div>
               {% endfor %}
             </div>
@@ -95,7 +88,8 @@
                     {% endif %}
                     {% for branch in branch_data %}
                       <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                        <p class="fs-5">{{ branch.name }}</p>
+                        <p class="fs-5 text-truncate w-100 text-center"
+                           title="{{ branch.name }}">{{ branch.name }}</p>
                         <div class="d-flex flex-column gap-3 w-100 h-100">
                           {% for weekly_data_point in weekly_metric_data.data|dict_get:branch.slug %}
                             {% if not weekly_data_point.0.lower and not weekly_data_point.1.lower %}
@@ -150,7 +144,8 @@
                     {% endif %}
                     {% for branch in branch_data %}
                       <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                        <p class="fs-5">{{ branch.name }}</p>
+                        <p class="fs-5 text-truncate w-100 text-center"
+                           title="{{ branch.name }}">{{ branch.name }}</p>
                         <div class="d-flex flex-column gap-3 w-100 h-100">
                           {% for daily_data_point in daily_metric_data.data|dict_get:branch.slug|slice:":7" %}
                             {% if not daily_data_point.0.lower and not daily_data_point.1.lower %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -327,7 +327,8 @@
                     <div class="row flex-row flex-nowrap overflow-auto mx-2 {% if branch_data|length > 4 %}mx-4{% endif %}">
                       {% for branch in branch_data %}
                         <div class="{% if branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                          <p class="fs-5">{{ branch.name }}</p>
+                          <p class="fs-5 text-truncate w-100 text-center"
+                             title="{{ branch.name }}">{{ branch.name }}</p>
                         </div>
                       {% endfor %}
                     </div>
@@ -342,7 +343,8 @@
                       {% endif %}
                       {% for branch in branch_data %}
                         <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 4 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                          <p class="fs-5">{{ branch.name }}</p>
+                          <p class="fs-5 text-truncate w-100 text-center"
+                             title="{{ branch.name }}">{{ branch.name }}</p>
                           <div class="d-flex flex-column gap-3 w-100">
                             {% for metric in metric_metadata %}
                               {% for curr_metric_slug, metric_branch_data in metric_data.items %}


### PR DESCRIPTION
Because

- The current results page ui was improperly handling branches with long names which caused some inconsistencies with the visual flow

This commit

- Fixes metric cards becoming misaligned when a branch had a longer name
- Fixes overflow in branch cards

Fixes #14563