### PR TITLE
fix(nimbus): fix failing jetstream ingestion for complete experiments missing weekly data

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -267,11 +267,15 @@ def get_experiment_data(experiment: NimbusExperiment):
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
                 data.append_retention_data(
-                    raw_data[AnalysisWindow.WEEKLY][AnalysisBasis.ENROLLMENTS][segment]
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
                 )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
-                    raw_data[AnalysisWindow.DAILY][AnalysisBasis.ENROLLMENTS][segment]
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
                 )
                 # Create the output object (overall data)
                 ResultsObjectModel = create_results_object_model(data)
@@ -310,11 +314,15 @@ def get_experiment_data(experiment: NimbusExperiment):
                 # Append some values onto Jetstream data
                 data.append_population_percentages()
                 data.append_retention_data(
-                    raw_data[AnalysisWindow.WEEKLY][AnalysisBasis.EXPOSURES][segment]
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
                 )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
-                    raw_data[AnalysisWindow.DAILY][AnalysisBasis.EXPOSURES][segment]
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
                 )
 
                 ResultsObjectModel = create_results_object_model(data)

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -984,6 +984,67 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
 
     @parameterized.expand(
         [
+            (NimbusExperimentFactory.Lifecycles.CREATED,),
+            (NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,),
+        ]
+    )
+    def test_complete_results_data_missing_weekly(self, lifecycle):
+        primary_outcomes = ["default-browser"]
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            primary_outcomes=primary_outcomes,
+        )
+
+        def mock_jetstream_data_by_window(_, window):
+            if window == AnalysisWindow.DAILY:
+                return [
+                    {
+                        "metric": "identity",
+                        "statistic": "count",
+                        "branch": "control",
+                        "point": 10,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "1",
+                    },
+                    {
+                        "metric": "identity",
+                        "statistic": "count",
+                        "branch": "control",
+                        "point": 20,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "2",
+                    },
+                ]
+            elif window == AnalysisWindow.WEEKLY:
+                return []  # Simulate missing weekly data
+            elif window == AnalysisWindow.OVERALL:
+                return [
+                    {
+                        "metric": "identity",
+                        "statistic": "count",
+                        "branch": "control",
+                        "point": 40,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "1",
+                    }
+                ]
+            return []
+
+        with (
+            patch("experimenter.jetstream.client.get_data") as mock_get_data,
+            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
+            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
+        ):
+            mock_get_data.side_effect = mock_jetstream_data_by_window
+            mock_get_metadata.return_value = None
+            mock_get_errors.return_value = None
+            tasks.fetch_experiment_data(experiment.id)
+
+    @parameterized.expand(
+        [
             (None, "2022-08-31T04:32:03"),
             ("", "2022-08-31 04:32:03+04:00"),
             ("2022-08-31T04:30:03+00:00", "2022-08-31T04:32:03+00:00"),


### PR DESCRIPTION
Because

- Jetstream data ingestion previously operated on the assumption that if overall data was present then weekly data would be as well
- This caused errors when attempting to access elements in dictionaries under the weekly window with square brackets

This commit

- Changes dictionary access methods to `.get(key)` instead of `[key]` in `get_experiment_data`

Fixes #14877 