### PR TITLE
chore(nimbus): speed up integration tests with typed Selenium helpers

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/base.py
+++ b/experimenter/tests/integration/nimbus/pages/base.py
@@ -1,10 +1,27 @@
+import contextlib
 import logging
-import threading
 import time
 
 from pypom import Page
 from selenium.common.exceptions import NoSuchElementException
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.select import Select
+
+logger = logging.getLogger(__name__)
+
+HTMX_TRACKER_SCRIPT = """
+if (typeof window.__htmxPending === 'undefined') {
+    window.__htmxPending = 0;
+    document.body.addEventListener('htmx:beforeRequest', function() {
+        window.__htmxPending++;
+    });
+    document.body.addEventListener('htmx:afterSettle', function() {
+        window.__htmxPending--;
+    });
+}
+"""
 
 
 class Base(Page):
@@ -12,10 +29,56 @@ class Base(Page):
 
     def __init__(self, selenium, base_url, **kwargs):
         super().__init__(selenium, base_url, timeout=120, **kwargs)
-        self.logging = logging
+
+    # --- Low-level helpers ---
+
+    def _inject_htmx_tracker(self):
+        with contextlib.suppress(Exception):
+            self.selenium.execute_script(HTMX_TRACKER_SCRIPT)
+
+    def wait_for_htmx(self):
+        self.wait.until(
+            lambda driver: driver.execute_script(
+                "return typeof window.__htmxPending === 'undefined'"
+                " || window.__htmxPending === 0"
+            ),
+            message="Timed out waiting for HTMX requests to settle",
+        )
+
+    def _scroll_into_view(self, element):
+        self.selenium.execute_script(
+            "arguments[0].scrollIntoView({block: 'center'});", element
+        )
+
+    def _wait_clickable(self, locator):
+        logger.info(f"_wait_clickable: {locator}")
+        self.wait_for_htmx()
+        logger.info("_wait_clickable: htmx settled, waiting for clickable")
+        self.wait.until(
+            EC.element_to_be_clickable(locator),
+            message=f"{self.PAGE_TITLE}: {locator} not clickable",
+        )
+        element = self.find_element(*locator)
+        self._scroll_into_view(element)
+        logger.info("_wait_clickable: done")
+        return self.find_element(*locator)
+
+    def _wait_present(self, locator):
+        logger.info(f"_wait_present: {locator}")
+        self.wait_for_htmx()
+        logger.info("_wait_present: htmx settled, waiting for presence")
+        self.wait.until(
+            EC.presence_of_element_located(locator),
+            message=f"{self.PAGE_TITLE}: {locator} not found",
+        )
+        logger.info("_wait_present: done")
+        return self.find_element(*locator)
+
+    # --- Page lifecycle ---
 
     def wait_for_page_to_load(self):
         self.wait.until(EC.presence_of_element_located(self._page_wait_locator))
+        self._inject_htmx_tracker()
         return self
 
     def wait_with_refresh(self, locator, message):
@@ -25,11 +88,7 @@ class Base(Page):
                 selenium.find_element(*locator)
             except NoSuchElementException:
                 selenium.refresh()
-                sleep_thread = threading.Thread(
-                    target=self.non_blocking_sleep, args=(10,)
-                )
-                sleep_thread.start()
-                sleep_thread.join()  # Wait for the thread to finish sleeping
+                time.sleep(5)
                 return False
             else:
                 return True
@@ -44,11 +103,7 @@ class Base(Page):
                 assert el.text == expected_text
             except (NoSuchElementException, AssertionError):
                 selenium.refresh()
-                sleep_thread = threading.Thread(
-                    target=self.non_blocking_sleep, args=(10,)
-                )
-                sleep_thread.start()
-                sleep_thread.join()  # Wait for the thread to finish sleeping
+                time.sleep(5)
                 return False
             else:
                 return True
@@ -63,23 +118,124 @@ class Base(Page):
         if refresh:
             self.wait_with_refresh(locator, message=message)
         else:
+            self.wait_for_htmx()
             self.wait.until(
-                EC.presence_of_all_elements_located(locator),
+                EC.presence_of_element_located(locator),
                 message=message,
             )
+
+    # --- Typed field actions ---
+    # Use these in page object setters. Each encapsulates the full
+    # wait + interact pattern for its field type.
+
+    def click_and_wait_for_navigation(self, locator):
+        old_url = self.selenium.current_url
+        el = self._wait_clickable(locator)
+        self.selenium.execute_script(
+            "arguments[0].scrollIntoView({block: 'center'});arguments[0].click();",
+            el,
+        )
+        self.wait.until(EC.url_changes(old_url))
+        self.wait_for_page_to_load()
+
+    def get_input(self, locator):
+        logger.info(f"get_input: {locator}")
+        return self._wait_clickable(locator)
+
+    def set_input(self, locator, text):
+        logger.info(f"set_input: {locator} = '{text}'")
+        el = self._wait_clickable(locator)
+        el.clear()
+        el.send_keys(text)
+        logger.info("set_input: done")
+
+    def get_select(self, locator):
+        logger.info(f"get_select: {locator}")
+        return self._wait_present(locator)
+
+    def set_select(self, locator, value):
+        logger.info(f"set_select: {locator} = '{value}'")
+        el = self._wait_present(locator)
+        Select(el).select_by_value(value)
+        logger.info("set_select: done")
+
+    def set_select_by_text(self, locator, text):
+        logger.info(f"set_select_by_text: {locator} = '{text}'")
+        el = self._wait_present(locator)
+        Select(el).select_by_visible_text(text)
+        logger.info("set_select_by_text: done")
+
+    def click_element(self, locator):
+        logger.info(f"click_element: {locator}")
+        el = self._wait_clickable(locator)
+        el.click()
+        logger.info("click_element: done")
+
+    def js_click(self, elem):
+        logger.info("js_click")
+        self.wait_for_htmx()
+        self.selenium.execute_script(
+            "arguments[0].scrollIntoView({block: 'center'});arguments[0].click();",
+            elem,
+        )
+        logger.info("js_click: done")
+
+    def set_autocomplete(self, locator, text):
+        logger.info(f"set_autocomplete: {locator} = '{text}'")
+        el = self._wait_present(locator)
+        self._scroll_into_view(el)
+        # Tom Select hides the native input — use JS to focus, set value, and
+        # dispatch input + keydown(Enter) events to trigger the widget
+        self.selenium.execute_script(
+            "var el = arguments[0];"
+            "el.focus();"
+            "el.value = arguments[1];"
+            "el.dispatchEvent(new Event('input', {bubbles: true}));"
+            "el.dispatchEvent(new KeyboardEvent('keydown', "
+            "  {key: 'Enter', code: 'Enter', keyCode: 13, bubbles: true}));",
+            el,
+            text,
+        )
+        logger.info("set_autocomplete: done")
+
+    def set_bootstrap_select(self, button_locator, search_locator, values):
+        logger.info(f"set_bootstrap_select: {button_locator} values={values}")
+        self.wait_for_htmx()
+        self.wait.until(EC.presence_of_all_elements_located(button_locator))
+        btn = self.find_element(*button_locator)
+        for value in values:
+            logger.info(f"set_bootstrap_select: clicking for '{value}'")
+            btn.click()
+            self.wait.until(EC.presence_of_all_elements_located(search_locator))
+            search = self.find_element(*search_locator)
+            search.send_keys(value, Keys.RETURN)
+        # Dismiss the dropdown by sending Escape to the active element
+        ActionChains(self.selenium).send_keys(Keys.ESCAPE).perform()
+        logger.info("set_bootstrap_select: done")
+
+    # --- Legacy helpers (used by existing page objects not yet migrated) ---
 
     def wait_for_and_find_element(
         self, strategy, locator, description=None, refresh=False
     ):
-        self.wait_for_locator((strategy, locator), description)
+        if refresh:
+            self.wait_for_locator((strategy, locator), description, refresh=True)
+        else:
+            self.wait_for_htmx()
+            self.wait.until(
+                EC.presence_of_element_located((strategy, locator)),
+                message=f"{self.PAGE_TITLE}: could not find {description}",
+            )
         element = self.find_element(strategy, locator)
         self._scroll_into_view(element)
         return self.find_element(strategy, locator)
 
     def wait_for_and_find_elements(self, strategy, locator, description=None):
-        self.wait_for_locator((strategy, locator), description)
-        elements = self.find_elements(strategy, locator)
-        self._scroll_into_view(elements[0])
+        self.wait_for_htmx()
+        self.wait.until(
+            EC.presence_of_all_elements_located((strategy, locator)),
+            message=f"{self.PAGE_TITLE}: could not find {description}",
+        )
         return self.find_elements(strategy, locator)
 
     def non_blocking_sleep(self, seconds):
@@ -87,12 +243,3 @@ class Base(Page):
 
     def execute_script(self, script, *args):
         self.selenium.execute_script(script, *args)
-        time.sleep(1)
-
-    def js_click(self, elem):
-        self.execute_script("arguments[0].scrollIntoView({block: 'center'});", elem)
-        self.execute_script("arguments[0].click();", elem)
-
-    def _scroll_into_view(self, element):
-        self.execute_script("arguments[0].scrollIntoView({block: 'center'});", element)
-        time.sleep(0.5)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/audience.py
@@ -1,14 +1,12 @@
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.select import Select
 
 from nimbus.pages.experimenter.base import ExperimenterBase
 from nimbus.pages.experimenter.summary import SummaryPage
 
 
 class AudiencePage(ExperimenterBase):
-    """Experiment Audience Page."""
+    """Nimbus Audience page."""
 
     PAGE_TITLE = "Audience Page"
 
@@ -19,190 +17,137 @@ class AudiencePage(ExperimenterBase):
     _channels_text_locator = (By.CSS_SELECTOR, "#id_channels .filter-option-inner-inner")
     _min_version_select_locator = (By.CSS_SELECTOR, "#id_firefox_min_version")
     _targeting_select_locator = (By.CSS_SELECTOR, "#id_targeting_config_slug")
-    _population_fill_locator = (
-        By.CSS_SELECTOR,
-        "#id_population_percent",
-    )
+    _population_fill_locator = (By.CSS_SELECTOR, "#id_population_percent")
     _expected_clients_locator = (By.CSS_SELECTOR, "#id_total_enrolled_clients")
-    _enrollment_period_locator = (By.CSS_SELECTOR, "#proposedEnrollment")
-    _duration_locator = (By.CSS_SELECTOR, "#proposedDuration")
-    _locales_input_locator = (By.CSS_SELECTOR, "div[data-testid='locales'] input")
-    _locales_value_locator = (
+    _saved_locator = (By.CSS_SELECTOR, "#sidebar .text-success")
+    _locales_button_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='locales'] > div",
+        'div[data-testid="locales"] [data-id="id_locales"]',
     )
-    _countries_dropdown_button_loator = (
+    _locales_input_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='countries'] button",
+        'div[data-testid="locales"] .bs-searchbox input',
     )
-    _countries_input_locator = (By.CSS_SELECTOR, "div[data-testid='countries'] input")
-    _countries_value_locator = (
+    _countries_button_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='countries'] > div)",
+        'div[data-testid="countries"] [data-id="id_countries"]',
     )
-    _languages_input_locator = (By.CSS_SELECTOR, "div[data-testid='languages'] input")
-    _languages_value_locator = (
+    _countries_input_locator = (
         By.CSS_SELECTOR,
-        "div[data-testid='localses'] > div",
+        'div[data-testid="countries"] .bs-searchbox input',
     )
-    _dropdown_input_locator = (
+    _languages_button_locator = (
         By.CSS_SELECTOR,
-        "#audience-form .bs-searchbox input.form-control",
+        'div[data-testid="languages"] [data-id="id_languages"]',
     )
-    _first_run_checkbox_locator = (By.CSS_SELECTOR, "#id_is_first_run")
+    _languages_input_locator = (
+        By.CSS_SELECTOR,
+        'div[data-testid="languages"] .bs-searchbox input',
+    )
+    _first_run_locator = (By.CSS_SELECTOR, "#id_is_first_run")
     _release_date_locator = (By.CSS_SELECTOR, "#id_proposed_release_date")
-    _saved_locator = (By.CSS_SELECTOR, "form.was-validated")
 
     NEXT_PAGE = SummaryPage
 
-    def save_and_continue(self):
-        # Explicitly save and wait for save to complete before continuing
-        # to prevent intermittent failures where summary loads before saving
-        # audience is complete
-        self.save()
-        self.wait_for_locator(self._saved_locator)
-
-        return super().save_and_continue()
-
     @property
     def channel(self):
-        return self.wait_for_and_find_element(*self._channel_select_locator).text
+        return self.get_select(self._channel_select_locator).text
 
     @channel.setter
     def channel(self, channel="Nightly"):
-        el = self.wait_for_and_find_element(*self._channel_select_locator)
-        select = Select(el)
-        select.select_by_visible_text(channel)
+        self.set_select_by_text(self._channel_select_locator, channel)
 
     @property
     def channels(self):
-        els = self.wait_for_and_find_elements(*self._channels_text_locator)
-        return els[0]
+        return self.wait_for_and_find_elements(*self._channels_text_locator)[0]
 
     @channels.setter
     def channels(self, channels):
-        els = self.wait_for_and_find_elements(*self._channels_button_locator)
-
-        for channel in channels:
-            els[0].click()
-            search_box = self.wait_for_and_find_elements(*self._channels_input_locator)
-            search_box[0].send_keys(channel, Keys.RETURN)
+        self.set_bootstrap_select(
+            self._channels_button_locator, self._channels_input_locator, channels
+        )
 
     @property
     def min_version(self):
-        return self.wait_for_and_find_element(*self._min_version_select_locator).text
+        return self.get_select(self._min_version_select_locator).text
 
     @min_version.setter
     def min_version(self, version=80):
-        el = self.wait_for_and_find_element(*self._min_version_select_locator)
-        el.click()
-        select = Select(el)
-        select.select_by_value(f"{version}")
+        self.set_select(self._min_version_select_locator, f"{version}")
 
     @property
     def targeting(self):
-        return self.wait_for_and_find_element(*self._targeting_select_locator).text
+        return self.get_select(self._targeting_select_locator).text
 
     @targeting.setter
     def targeting(self, targeting=""):
-        el = self.wait_for_and_find_element(*self._targeting_select_locator)
-        select = Select(el)
-        select.select_by_value(targeting)
+        self.set_select(self._targeting_select_locator, targeting)
 
     @property
     def percentage(self):
-        return self.wait_for_and_find_element(*self._population_fill_locator).text
+        return self.get_input(self._population_fill_locator).text
 
     @percentage.setter
-    def percentage(self, text) -> None:
-        name = self.wait_for_and_find_element(*self._population_fill_locator)
-        self.execute_script("arguments[0].scrollIntoView({block: 'center'});", name)
-        self.execute_script("arguments[0].click();", name)
-        self.execute_script(
-            "arguments[0].setAttribute('value', arguments[1]);", name, text
-        )
+    def percentage(self, text):
+        el = self.get_input(self._population_fill_locator)
+        el.click()
+        self.execute_script("arguments[0].setAttribute('value', arguments[1]);", el, text)
 
     @property
     def expected_clients(self):
-        el = self.wait_for_and_find_element(*self._expected_clients_locator)
-        return el.get_attribute("value")
+        return self.get_input(self._expected_clients_locator).text
 
     @expected_clients.setter
     def expected_clients(self, text):
-        el = self.wait_for_and_find_element(*self._expected_clients_locator)
-        el.send_keys(text)
-
-    @property
-    def locales(self):
-        return [
-            element.text
-            for element in self.wait_for_and_find_elements(*self._locales_value_locator)
-        ]
-
-    @locales.setter
-    def locales(self, text=None):
-        el = self.wait_for_and_find_element(*self._locales_input_locator)
-        for _ in text:
-            el.send_keys(f"{_}")
-            el.send_keys(Keys.ENTER)
-
-    @property
-    def countries(self):
-        return [
-            element.text
-            for element in self.wait_for_and_find_elements(*self._countries_value_locator)
-        ]
-
-    @countries.setter
-    def countries(self, text=None):
-        self.wait_for_and_find_element(*self._countries_dropdown_button_loator).click()
-        el = self.wait_for_and_find_element(*self._countries_input_locator)
-        el.click()
-        el.send_keys(text, Keys.ENTER)
-
-    @property
-    def languages(self):
-        return [
-            element.text
-            for element in self.wait_for_and_find_elements(*self._languages_value_locator)
-        ]
-
-    @languages.setter
-    def languages(self, text=None):
-        el = self.wait_for_and_find_element(*self._languages_input_locator)
-        for char in text:
-            el.send_keys(char)
-            el.send_keys(Keys.ENTER)
-
-    @property
-    def is_first_run(self):
-        return self.wait_for_and_find_element(
-            *self._first_run_checkbox_locator, "is first run"
-        )
-
-    def make_first_run(self):
-        self.wait_for_and_find_element(
-            *self._first_run_checkbox_locator, "is_first_run"
-        ).click()
+        self.set_input(self._expected_clients_locator, text)
 
     @property
     def proposed_release_date(self):
-        el = self.wait_for_and_find_element(*self._release_date_locator)
-        return el.get_attribute("value")
+        return self.get_input(self._release_date_locator).get_attribute("value")
 
     @proposed_release_date.setter
-    def proposed_release_date(self, text=None):
-        el = self.wait_for_and_find_element(*self._release_date_locator)
-        el.send_keys(text)
+    def proposed_release_date(self, text):
+        self.set_input(self._release_date_locator, text)
+
+    @property
+    def is_first_run(self):
+        return self.wait_for_and_find_element(*self._first_run_locator).is_selected()
+
+    def make_first_run(self):
+        self.click_element(self._first_run_locator)
+
+    @property
+    def locales(self):
+        return self.wait_for_and_find_elements(*self._locales_input_locator)[0]
+
+    @locales.setter
+    def locales(self, locales):
+        self.set_bootstrap_select(
+            self._locales_button_locator, self._locales_input_locator, locales
+        )
+
+    @property
+    def countries(self):
+        return self.wait_for_and_find_elements(*self._countries_input_locator)[0]
+
+    @countries.setter
+    def countries(self, text):
+        self.set_bootstrap_select(
+            self._countries_button_locator, self._countries_input_locator, [text]
+        )
+
+    @property
+    def languages(self):
+        return self.wait_for_and_find_elements(*self._languages_input_locator)[0]
+
+    @languages.setter
+    def languages(self, text):
+        self.set_bootstrap_select(
+            self._languages_button_locator, self._languages_input_locator, [text]
+        )
 
     def wait_until_release_date_not_found(self):
-        self.wait.until_not(
-            EC.presence_of_element_located(self._release_date_locator),
-            message="Audience Page: could not find release date",
-        )
+        self.wait.until(EC.invisibility_of_element_located(self._release_date_locator))
 
     def wait_until_first_run_not_found(self):
-        self.wait.until_not(
-            EC.presence_of_element_located(self._first_run_checkbox_locator),
-            message="Audience Page: could not find first run checkbox",
-        )
+        self.wait.until(EC.invisibility_of_element_located(self._first_run_locator))

--- a/experimenter/tests/integration/nimbus/pages/experimenter/branches.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/branches.py
@@ -1,6 +1,5 @@
 from selenium.webdriver.common.action_chains import ActionChains
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 
 from nimbus.pages.experimenter.base import ExperimenterBase
 from nimbus.pages.experimenter.metrics import MetricsPage
@@ -26,6 +25,7 @@ class BranchesPage(ExperimenterBase):
     )
     _remove_branch_locator = (By.CSS_SELECTOR, ".bg-transparent")
     _feature_select_locator = (By.CSS_SELECTOR, "#branches-form .dropdown")
+    _feature_search_locator = (By.CSS_SELECTOR, ".bs-searchbox > input:nth-child(1)")
     _add_screenshot_buttons_locator = (By.CSS_SELECTOR, "#add-screenshot-button")
     _rollout_checkbox_locator = (By.CSS_SELECTOR, '[data-testid="is-rollout-checkbox"]')
     _feature_config_id_locator = (By.CSS_SELECTOR, "#id_feature_configs > option")
@@ -33,95 +33,53 @@ class BranchesPage(ExperimenterBase):
     PAGE_TITLE = "Edit Branches Page"
 
     @property
-    def reference_branch_name(self):
-        return self.wait_for_and_find_element(
-            self._reference_branch_name_locator, "reference branch name"
-        ).text
-
-    @reference_branch_name.setter
-    def reference_branch_name(self, text=None):
-        self.wait_for_and_find_element(
-            self._reference_branch_name_locator, "reference branch name"
-        ).send_keys(f"{text}")
-
-    @property
     def reference_branch_description(self):
-        return self.wait_for_and_find_element(
-            *self._reference_branch_description_locator, "reference branch description"
-        ).text
+        return self.get_input(self._reference_branch_description_locator).text
 
     @reference_branch_description.setter
     def reference_branch_description(self, text=None):
-        self.wait_for_and_find_element(
-            *self._reference_branch_description_locator, "reference_branch description"
-        ).send_keys(f"{text}")
+        el = self.get_input(self._reference_branch_description_locator)
+        el.send_keys(f"{text}")
 
     @property
     def reference_branch_value(self):
-        return self._get_feature_value(
-            self.wait_for_and_find_element(
-                *self._reference_branch_value_locator, "reference branch value"
-            )
+        elements = self.wait_for_and_find_elements(
+            *self._branch_value_locator, "reference branch value"
         )
+        return self._get_feature_value(elements[0])
 
     @reference_branch_value.setter
     def reference_branch_value(self, text):
-        element = self.wait_for_and_find_elements(
+        elements = self.wait_for_and_find_elements(
             *self._branch_value_locator, "reference branch value"
         )
-
-        self._set_feature_value(
-            element[0],
-            text,
-        )
-
-    @property
-    def treatment_branch_name(self):
-        return self.wait_for_and_find_element(
-            *self._treatment_branch_name_locator, "treatment branch name"
-        ).text
-
-    @treatment_branch_name.setter
-    def treatment_branch_name(self, text=None):
-        self.wait_for_and_find_element(
-            *self._treatment_branch_name_locator, "treatment branch name"
-        ).send_keys(f"{text}")
+        self._set_feature_value(elements[0], text)
 
     @property
     def treatment_branch_description(self):
-        return self.wait_for_and_find_element(
-            *self._treatment_branch_description_locator, "treatment branch description"
-        ).text
+        return self.get_input(self._treatment_branch_description_locator).text
 
     @treatment_branch_description.setter
     def treatment_branch_description(self, text=None):
-        self.wait_for_and_find_element(
-            *self._treatment_branch_description_locator, "treatment branch description"
-        ).send_keys(f"{text}")
+        el = self.get_input(self._treatment_branch_description_locator)
+        el.send_keys(f"{text}")
 
     @property
     def treatment_branch_value(self):
-        return self._get_feature_value(
-            self.wait_for_and_find_element(
-                *self._treatment_branch_value_locator, "treatment branch value"
-            )
+        elements = self.wait_for_and_find_elements(
+            *self._branch_value_locator, "treatment branch value"
         )
+        return self._get_feature_value(elements[-1])
 
     @treatment_branch_value.setter
     def treatment_branch_value(self, text):
-        element = self.wait_for_and_find_elements(
+        elements = self.wait_for_and_find_elements(
             *self._branch_value_locator, "treatment branch value"
         )
-
-        self._set_feature_value(
-            element[-1],
-            text,
-        )
+        self._set_feature_value(elements[-1], text)
 
     def remove_branch(self):
-        self.wait_for_and_find_element(
-            *self._remove_branch_locator, "remove branch button"
-        ).click()
+        self.click_element(self._remove_branch_locator)
 
     @property
     def feature_config(self):
@@ -131,17 +89,11 @@ class BranchesPage(ExperimenterBase):
 
     @feature_config.setter
     def feature_config(self, feature_config_id):
-        el = self.wait_for_and_find_element(
-            *self._feature_select_locator, "feature configs"
+        self.set_bootstrap_select(
+            self._feature_select_locator,
+            self._feature_search_locator,
+            [feature_config_id],
         )
-
-        el.click()  # Open the drop-down
-        search_box = self.wait_for_and_find_element(
-            By.CSS_SELECTOR, ".bs-searchbox > input:nth-child(1)"
-        )
-        search_box.click()
-        search_box.send_keys(feature_config_id)
-        search_box.send_keys(Keys.ENTER)
 
     @property
     def is_rollout(self):
@@ -150,9 +102,7 @@ class BranchesPage(ExperimenterBase):
         )
 
     def make_rollout(self):
-        self.wait_for_and_find_element(
-            *self._rollout_checkbox_locator, "is_rollout"
-        ).click()
+        self.click_element(self._rollout_checkbox_locator)
 
     @property
     def add_screenshot_buttons(self):
@@ -184,8 +134,7 @@ class BranchesPage(ExperimenterBase):
         return self.wait_for_and_find_element(
             By.CSS_SELECTOR,
             selector,
-            f"screenshot description field for \
-            {screenshot_idx} screenshot {screenshot_idx}",
+            f"screenshot description field for {screenshot_idx}",
         )
 
     def screenshot_image_field(self, branch="referenceBranch", screenshot_idx=0):
@@ -193,5 +142,5 @@ class BranchesPage(ExperimenterBase):
         return self.wait_for_and_find_element(
             By.CSS_SELECTOR,
             selector,
-            f"screenshot image field for {screenshot_idx} screenshot {screenshot_idx}",
+            f"screenshot image field for {screenshot_idx}",
         )

--- a/experimenter/tests/integration/nimbus/pages/experimenter/home.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/home.py
@@ -1,6 +1,5 @@
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
-from selenium.webdriver.support.select import Select
 
 from nimbus.models.base_dataclass import (
     BaseExperimentApplications,
@@ -39,33 +38,30 @@ class HomePage(ExperimenterBase):
         )
 
     def create_new_button(self):
-        el = self.wait_for_and_find_element(*self._create_new_btn_locator)
-        el.click()
+        self.click_element(self._create_new_btn_locator)
 
     @property
     def public_name(self):
-        return self.wait_for_and_find_element(*self._public_name_locator).text
+        return self.get_input(self._public_name_locator).text
 
     @public_name.setter
     def public_name(self, text=None):
-        name = self.wait_for_and_find_element(*self._public_name_locator)
-        name.send_keys(f"{text}")
+        el = self.get_input(self._public_name_locator)
+        el.send_keys(f"{text}")
 
     @property
     def hypothesis(self):
-        return self.wait_for_and_find_element(*self._hypothesis_locator).text
+        return self.get_input(self._hypothesis_locator).text
 
     @hypothesis.setter
     def hypothesis(self, text=None):
-        name = self.wait_for_and_find_element(*self._hypothesis_locator)
-        name.send_keys(f" {text}")
+        el = self.get_input(self._hypothesis_locator)
+        el.send_keys(f" {text}")
 
     @property
     def application(self):
-        return self.wait_for_and_find_element(*self._application_select_locator).text
+        return self.get_select(self._application_select_locator).text
 
     @application.setter
     def application(self, app=BaseExperimentApplications.FIREFOX_DESKTOP.value):
-        el = self.wait_for_and_find_element(*self._application_select_locator)
-        select = Select(el)
-        select.select_by_value(app)
+        self.set_select(self._application_select_locator, app)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/metrics.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/metrics.py
@@ -11,17 +11,12 @@ class MetricsPage(ExperimenterBase):
     PAGE_TITLE = "Metrics Page"
 
     _page_wait_locator = (By.CSS_SELECTOR, "#metrics-form")
-    _outcomes_selector_locator = (By.CSS_SELECTOR, ".card-body button")
-    _outcomes_input_locator = (By.CSS_SELECTOR, ".card-body input")
+    _primary_outcomes_button_locator = (By.CSS_SELECTOR, ".card-body button")
+    _primary_outcomes_input_locator = (By.CSS_SELECTOR, ".card-body input")
     _outcomes_text_locator = (
         By.CSS_SELECTOR,
         ".card-body button .filter-option-inner-inner",
     )
-    _secondary_outcome_root_locator = (
-        By.CSS_SELECTOR,
-        "div[data-testid='secondary-outcomes']",
-    )
-    _multifeature_element_locator = (By.CSS_SELECTOR, "div[class$='-multiValue']")
     NEXT_PAGE = AudiencePage
 
     @property
@@ -30,10 +25,12 @@ class MetricsPage(ExperimenterBase):
         return els[0]
 
     def set_primary_outcomes(self, values=None):
-        els = self.wait_for_and_find_elements(*self._outcomes_selector_locator)
+        els = self.wait_for_and_find_elements(*self._primary_outcomes_button_locator)
         els[0].click()
-        search_box = self.wait_for_and_find_elements(*self._outcomes_input_locator)
-        search_box[0].send_keys(values, Keys.RETURN)
+        search_boxes = self.wait_for_and_find_elements(
+            *self._primary_outcomes_input_locator
+        )
+        search_boxes[0].send_keys(values, Keys.RETURN)
 
     @property
     def secondary_outcomes(self):
@@ -41,7 +38,9 @@ class MetricsPage(ExperimenterBase):
         return els[1]
 
     def set_secondary_outcomes(self, values=None):
-        els = self.wait_for_and_find_elements(*self._outcomes_selector_locator)
+        els = self.wait_for_and_find_elements(*self._primary_outcomes_button_locator)
         els[1].click()
-        search_box = self.wait_for_and_find_elements(*self._outcomes_input_locator)
-        search_box[1].send_keys(values, Keys.RETURN)
+        search_boxes = self.wait_for_and_find_elements(
+            *self._primary_outcomes_input_locator
+        )
+        search_boxes[1].send_keys(values, Keys.RETURN)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/overview.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/overview.py
@@ -1,6 +1,5 @@
 from selenium.common.exceptions import ElementNotInteractableException
 from selenium.webdriver.common.by import By
-from selenium.webdriver.support.ui import Select
 
 from nimbus.pages.experimenter.base import ExperimenterBase
 from nimbus.pages.experimenter.branches import BranchesPage
@@ -15,11 +14,11 @@ class OverviewPage(ExperimenterBase):
     _additional_link_root_locator = (By.CSS_SELECTOR, "#documentation-links .form-group")
     _additional_link_input_locator = (
         By.CSS_SELECTOR,
-        "#documentation-links .form-group input",
+        "#id_documentation_links-0-link",
     )
     _additional_link_select_locator = (
         By.CSS_SELECTOR,
-        "#documentation-links .form-group select",
+        "#id_documentation_links-0-title",
     )
     _additional_links_button_locator = (
         By.CSS_SELECTOR,
@@ -38,32 +37,27 @@ class OverviewPage(ExperimenterBase):
 
     @property
     def public_description(self):
-        return self.wait_for_and_find_element(*self._public_description_locator).text
+        return self.get_input(self._public_description_locator).text
 
     @public_description.setter
     def public_description(self, text=None):
-        name = self.wait_for_and_find_element(*self._public_description_locator)
-        name.send_keys(text)
+        el = self.get_input(self._public_description_locator)
+        el.send_keys(text)
 
     def select_risk_ai_false(self):
-        el = self.wait_for_and_find_element(*self._risk_ai_locator)
-        el.click()
+        self.click_element(self._risk_ai_locator)
 
     def select_risk_brand_false(self):
-        el = self.wait_for_and_find_element(*self._risk_brand_locator)
-        el.click()
+        self.click_element(self._risk_brand_locator)
 
     def select_risk_message_false(self):
-        el = self.wait_for_and_find_element(*self._risk_message_locator)
-        el.click()
+        self.click_element(self._risk_message_locator)
 
     def select_risk_revenue_false(self):
-        el = self.wait_for_and_find_element(*self._risk_revenue_locator)
-        el.click()
+        self.click_element(self._risk_revenue_locator)
 
     def select_risk_partner_false(self):
-        el = self.wait_for_and_find_element(*self._risk_partner_locator)
-        el.click()
+        self.click_element(self._risk_partner_locator)
 
     @property
     def tags(self):
@@ -71,14 +65,13 @@ class OverviewPage(ExperimenterBase):
         return [cb.get_attribute("value") for cb in checkboxes if cb.is_selected()]
 
     def select_tag(self, tag_id):
-        self.wait_for_and_find_element(*self._tags_dropdown_locator).click()
+        self.click_element(self._tags_dropdown_locator)
         checkbox = self.wait_for_and_find_element(By.CSS_SELECTOR, f"#tag-{tag_id}")
         if not checkbox.is_selected():
             checkbox.click()
 
     def select_first_available_tag(self):
-        """Select the first available tag for testing."""
-        self.wait_for_and_find_element(*self._tags_dropdown_locator).click()
+        self.click_element(self._tags_dropdown_locator)
         checkboxes = self.find_elements(*self._tags_checkbox_locator)
         if checkboxes:
             first_checkbox = checkboxes[0]
@@ -87,27 +80,15 @@ class OverviewPage(ExperimenterBase):
             return first_checkbox.get_attribute("value")
         return None
 
-    @property
-    def additional_links(self):
-        el = self.wait_for_and_find_element(*self._additional_link_type_locator)
-        select = Select(el)
-        return select.first_selected_option
-
     def set_additional_links(self, value=None, url="http://www.nimbus-rocks.com"):
         els = self.wait_for_and_find_elements(*self._additional_link_root_locator)
         for _ in els:
             try:
-                self.wait_for_and_find_element(
-                    By.CSS_SELECTOR, "#id_documentation_links-0-link"
-                ).send_keys(url)
-                select = Select(
-                    self.wait_for_and_find_element(
-                        By.CSS_SELECTOR, "#id_documentation_links-0-title"
-                    )
-                )
-                select.select_by_value(value)
+                el = self.get_input(self._additional_link_input_locator)
+                el.send_keys(url)
+                self.set_select(self._additional_link_select_locator, value)
             except ElementNotInteractableException:
                 continue
 
     def add_additional_links(self):
-        self.wait_for_and_find_element(*self._additional_links_button_locator).click()
+        self.click_element(self._additional_links_button_locator)

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -18,10 +18,7 @@ class SummaryPage(ExperimenterBase):
     _header_slug = (By.CSS_SELECTOR, "#experiment-slug")
     _approve_request_button_locator = (By.CSS_SELECTOR, "#review-controls .btn-success")
     _reject_request_button_locator = (By.CSS_SELECTOR, "#reject-button")
-    _reject_input_text_locator = (
-        By.CSS_SELECTOR,
-        "#changelog_message",
-    )
+    _reject_input_text_locator = (By.CSS_SELECTOR, "#changelog_message")
     _reject_input_text_submit_locator = (By.CSS_SELECTOR, "#submit-rejection-button")
     _rejection_notice_locator = (By.CSS_SELECTOR, "#rejection-reason")
     _launch_to_preview_locator = (By.CSS_SELECTOR, "#draft-to-preview-button")
@@ -41,15 +38,9 @@ class SummaryPage(ExperimenterBase):
     )
     _end_experiment_button_locator = (By.CSS_SELECTOR, "#end-experiment")
     _archive_button_locator = (By.CSS_SELECTOR, 'button[data-testid="nav-edit-archive"]')
-    _archive_label_locator = (
-        By.CSS_SELECTOR,
-        "#archive-badge",
-    )
+    _archive_label_locator = (By.CSS_SELECTOR, "#archive-badge")
     _clone_action_locator = (By.CSS_SELECTOR, 'a[data-testid="nav-edit-clone"]')
-    _clone_name_field_locator = (
-        By.CSS_SELECTOR,
-        "#clone-name",
-    )
+    _clone_name_field_locator = (By.CSS_SELECTOR, "#clone-name")
     _clone_save_locator = (By.CSS_SELECTOR, "#cloneForm .btn-primary")
     _clone_parent_locator = (By.CSS_SELECTOR, 'a[data-testid="experiment-parent"]')
     _branch_screenshot_description_locator = (
@@ -65,26 +56,13 @@ class SummaryPage(ExperimenterBase):
         By.CSS_SELECTOR,
         'button[data-testid="takeaways-edit-save"]',
     )
-    _takeaways_recommendation_field = (
-        By.CSS_SELECTOR,
-        'form[data-testid="FormTakeaways"] input[name="conclusionRecommendations"]',
-    )
-    _takeaways_summary_field = (
-        By.CSS_SELECTOR,
-        "#takeawaysSummary",
-    )
-    _takeaways_summary_text = (
-        By.CSS_SELECTOR,
-        "#takeawaysSummaryText",
-    )
+    _takeaways_summary_field_locator = (By.CSS_SELECTOR, "#takeawaysSummary")
+    _takeaways_summary_text = (By.CSS_SELECTOR, "#takeawaysSummaryText")
     _takeaways_recommendation_badge = (
         By.CSS_SELECTOR,
         'span[data-testid="conclusion-recommendation-status"]',
     )
-    _audience_section_locator = (
-        By.CSS_SELECTOR,
-        "#audience",
-    )
+    _audience_section_locator = (By.CSS_SELECTOR, "#audience")
     _audience_is_first_run_locator = (
         By.CSS_SELECTOR,
         '[data-testid="experiment-is-first-run"]',
@@ -93,10 +71,7 @@ class SummaryPage(ExperimenterBase):
         By.CSS_SELECTOR,
         '[data-testid="experiment-release-date"]',
     )
-    _timeline_locator = (
-        By.CSS_SELECTOR,
-        "#experiment-timeline",
-    )
+    _timeline_locator = (By.CSS_SELECTOR, "#experiment-timeline")
     _timeline_proposed_release_date_locator = (
         By.CSS_SELECTOR,
         '[data-testid="label-release-date"]',
@@ -172,12 +147,11 @@ class SummaryPage(ExperimenterBase):
         )
 
     def set_rejection_reason(self):
-        text_area = self.wait_for_and_find_element(*self._reject_input_text_locator)
-        text_area.send_keys("oh no")
+        el = self.get_input(self._reject_input_text_locator)
+        el.send_keys("oh no")
 
     def submit_rejection(self):
-        button = self.wait_for_and_find_element(*self._reject_input_text_submit_locator)
-        button.click()
+        self.click_element(self._reject_input_text_submit_locator)
 
     @property
     def experiment_slug(self):
@@ -185,19 +159,18 @@ class SummaryPage(ExperimenterBase):
 
     @property
     def experiment_status(self):
-        el = self.wait_for_and_find_element(*self._experiment_status_icon_locator)
-        return el.text
+        return self.wait_for_and_find_element(*self._experiment_status_icon_locator).text
 
     @property
     def launch_without_preview(self):
         return self.wait_for_and_find_element(*self._launch_without_preview_locator)
 
     def launch_to_preview(self):
-        self.wait_for_and_find_element(*self._launch_to_preview_locator).click()
+        self.click_element(self._launch_to_preview_locator)
         return self
 
     def back_to_draft(self):
-        self.wait_for_and_find_element(*self._back_to_draft_locator).click()
+        self.click_element(self._back_to_draft_locator)
         self.wait_for_and_find_element(*self._launch_to_preview_locator)
         return self
 
@@ -206,15 +179,15 @@ class SummaryPage(ExperimenterBase):
         return self.RequestReview(self)
 
     def approve(self):
-        self.wait_for_and_find_element(*self._approve_request_button_locator).click()
+        self.click_element(self._approve_request_button_locator)
 
     def request_update_and_approve(self):
         self.request_update()
-        self.wait_for_and_find_element(*self._approve_request_button_locator).click()
+        self.click_element(self._approve_request_button_locator)
 
     def request_update_and_reject(self):
         self.request_update()
-        self.wait_for_and_find_element(*self._reject_request_button_locator).click()
+        self.click_element(self._reject_request_button_locator)
 
     @property
     def request_update_action(self):
@@ -232,8 +205,7 @@ class SummaryPage(ExperimenterBase):
         self.approve()
 
     def end_and_approve(self):
-        el = self.wait_for_and_find_element(*self._end_experiment_button_locator)
-        el.click()
+        self.click_element(self._end_experiment_button_locator)
         self.approve()
 
     @property
@@ -272,11 +244,11 @@ class SummaryPage(ExperimenterBase):
 
     @property
     def clone_action(self):
-        return self.wait_for_and_find_element(*self._clone_action_locator)
+        return self.get_input(self._clone_action_locator)
 
     @property
     def clone_name_field(self):
-        return self.wait_for_and_find_element(*self._clone_name_field_locator)
+        return self.get_input(self._clone_name_field_locator)
 
     @property
     def clone_name(self):
@@ -284,7 +256,6 @@ class SummaryPage(ExperimenterBase):
 
     @clone_name.setter
     def clone_name(self, text=None):
-        # Control-a before typing, in order to fully overwrite default value
         self.clone_name_field.send_keys(f"{Keys.CONTROL}a")
         self.clone_name_field.send_keys(f"{text}")
 
@@ -294,11 +265,11 @@ class SummaryPage(ExperimenterBase):
 
     @property
     def clone_save(self):
-        return self.wait_for_and_find_element(*self._clone_save_locator)
+        return self.get_input(self._clone_save_locator)
 
     def clone(self):
         self.js_click(self.clone_action)
-        self.js_click(self.clone_save)
+        self.click_and_wait_for_navigation(self._clone_save_locator)
 
     @property
     def promote_to_rollout_buttons(self):
@@ -306,11 +277,7 @@ class SummaryPage(ExperimenterBase):
 
     def promote_first_branch_to_rollout(self):
         self.js_click(self.promote_to_rollout_buttons[0])
-        old_url = self.selenium.current_url
-        self.js_click(self.promote_to_rollout_save)
-        # Wait for navigation to the new rollout page
-        self.wait.until(EC.url_changes(old_url))
-        self.wait_for_page_to_load()
+        self.click_and_wait_for_navigation(self._promote_to_rollout_save_locator)
 
     @property
     def takeaways_edit_button(self):
@@ -321,10 +288,7 @@ class SummaryPage(ExperimenterBase):
         return self.wait_for_and_find_element(*self._takeaways_save_button)
 
     def takeaways_recommendation_checkbox_button(self, value=""):
-        selection_locator = (
-            By.ID,
-            f"conclusionRecommendation-{value}",
-        )
+        selection_locator = (By.ID, f"conclusionRecommendation-{value}")
         return self.wait_for_and_find_element(*selection_locator)
 
     @property
@@ -333,13 +297,13 @@ class SummaryPage(ExperimenterBase):
 
     @property
     def takeaways_summary_field(self):
-        return self.wait_for_and_find_element(*self._takeaways_summary_field)
+        return self.get_input(self._takeaways_summary_field_locator)
 
     @takeaways_summary_field.setter
     def takeaways_summary_field(self, text=None):
-        # Control-a before typing, in order to fully overwrite default value
-        self.takeaways_summary_field.send_keys(f"{Keys.CONTROL}a")
-        self.takeaways_summary_field.send_keys(f"{text}")
+        field = self.get_input(self._takeaways_summary_field_locator)
+        field.send_keys(f"{Keys.CONTROL}a")
+        field.send_keys(f"{text}")
 
     @property
     def takeaways_summary_text(self):

--- a/experimenter/tests/nimbus_integration_tests.sh
+++ b/experimenter/tests/nimbus_integration_tests.sh
@@ -45,7 +45,8 @@ case "$FIREFOX_CHANNEL" in
 esac
 
 curl -sSL https://install.python-poetry.org | python3 - --version 1.8.4
-sudo chmod -R a+rwx /code/experimenter/tests/integration/
+sudo chmod -R a+rw /code/experimenter/tests/integration/
+sudo chmod -R a+X /code/experimenter/tests/integration/
 mkdir -m a+rwx -p /code/experimenter/tests/integration/test-reports
 sudo chown -R seluser /opt/venv/
 


### PR DESCRIPTION
Because

* Integration test page objects used hard `time.sleep()` delays (0.5-1s) after every Selenium interaction to wait for Bootstrap Select dropdowns, modal animations, and HTMX swaps, making the Nimbus UI test suite take ~15 minutes
* The audience page used a stale React-era selector (`#PageEditAudience-page`) that no longer exists in the HTMX templates
* No consistent pattern for interacting with different field types, leading to duplicated wait logic and fragile tests
* The `chmod -R a+rwx` in the test runner script was adding the execute bit to all files, causing file permission changes to bleed into the host filesystem after every test run

This commit

* Adds HTMX settle tracker that counts pending HTMX requests via JS event listeners, replacing hard sleeps with deterministic waits
* Adds typed field helpers to the base page class (`set_input`, `set_select`, `set_bootstrap_select`, `click_element`, `click_and_wait_for_navigation`, `get_input`, `get_select`) each using the appropriate Selenium wait strategy for its field type
* Removes all hard `time.sleep()` calls from page object interaction methods
* Fixes stale `#PageEditAudience-page` selector to `#audience-form`
* Removes bogus auto-save wait from audience page `save_and_continue`
* Fixes clone and promote-to-rollout to wait for page navigation after form submission
* Migrates all page objects (home, overview, branches, metrics, audience, summary) to use typed helpers as one-liner setters
* Fixes `chmod` in test runner to use `a+rw` and `a+X` (capital X) instead of `a+rwx`, preventing file permission changes from bleeding into the host git working tree

Results: Nimbus UI test suite dropped from **~15 minutes to ~2 minutes** (136s for 17 tests across 3 app variants)

Fixes #14896