### PR TITLE
feat(nimbus): Add nimbus-devtools messaging integration

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
@@ -36,6 +36,7 @@ export const createReadonlyJsonEditor = (textarea, maxLines = null) => {
   });
 
   view.dom.style.border = "1px solid #ccc";
+  view.dom.style.minHeight = "3em";
 
   textarea.parentNode.insertBefore(view.dom, textarea);
   textarea.style.display = "none";

--- a/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/edit_branches.js
@@ -46,6 +46,7 @@ const setupCodemirror = (selector, textarea, extraExtensions) => {
   });
 
   view.dom.style.border = "1px solid #ccc";
+  view.dom.style.minHeight = "3em";
 
   textarea.parentNode.insertBefore(view.dom, textarea);
   textarea.style.display = "none";

--- a/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
@@ -2,11 +2,14 @@
   <div class="collapsed-json">
     <div class="position-relative">
       <textarea class="readonly-json">{{ json_content }}</textarea>
-      <button type="button"
-              class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-1 py-0 px-1 codemirror-copy-btn"
-              aria-label="Copy JSON">
-        <i class="fa-solid fa-copy"></i>
-      </button>
+      <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+        {% block json_controls_collapsed %}{% endblock %}
+        <button type="button"
+                class="btn btn-sm btn-outline-secondary ms-1 codemirror-copy-btn"
+                aria-label="Copy JSON">
+          <i class="fa-solid fa-copy"></i>
+        </button>
+      </div>
     </div>
     <button class="btn btn-outline-primary btn-sm mt-2 d-block show-btn d-none">
       <i class="fa-solid fa-plus"></i> Show more
@@ -14,12 +17,15 @@
   </div>
   <div class="expanded-json d-none">
     <div class="position-relative">
-      <textarea class="readonly-json">{{ json_content }}</textarea>
-      <button type="button"
-              class="btn btn-sm btn-outline-secondary position-absolute top-0 end-0 m-1 py-0 px-1 codemirror-copy-btn"
-              aria-label="Copy JSON">
-        <i class="fa-solid fa-copy"></i>
-      </button>
+      {% block json %}<textarea class="readonly-json">{{ json_content }}</textarea>{% endblock %}
+      <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+        {% block json_controls_expanded %}{% endblock %}
+        <button type="button"
+                class="btn btn-sm btn-outline-secondary ms-1 codemirror-copy-btn"
+                aria-label="Copy JSON">
+          <i class="fa-solid fa-copy"></i>
+        </button>
+      </div>
     </div>
     <button class="btn btn-outline-primary btn-sm mt-2 d-block hide-btn d-none">
       <i class="fa-solid fa-minus"></i> Show less

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -1,10 +1,11 @@
 {% extends "nimbus_experiments/experiment_base.html" %}
 
 {% load static %}
-{% load nimbus_extras %}
+{% load nimbus_extras nimbus_devtools %}
 
 {% block title %}{{ experiment.name }}{% endblock %}
 {% block main_content %}
+  {% devtools_metadata experiment %}
   <div id="PageSummary" class="mt-3">
     {% include "nimbus_experiments/invalid_pages_warning.html" %}
     {% include "nimbus_experiments/audience_overlap_warnings.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -38,7 +38,7 @@
               </th>
               <td colspan="3"
                   class="{% if forloop.last and not branch.screenshots.all.exists %}border-bottom-0{% endif %}">
-                {% include "common/readonly_json.html" with json_content=feature_value.value %}
+                {% include "nimbus_experiments/readonly_feature_value.html" with feature_id=feature_value.feature_config.slug json_content=feature_value.value %}
 
               </td>
             </tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -1,13 +1,14 @@
 {% extends "nimbus_experiments/experiment_base.html" %}
 
 {% load static %}
-{% load nimbus_extras %}
+{% load nimbus_devtools nimbus_extras %}
 {% load django_bootstrap5 %}
 {% load widget_tweaks %}
 {% load error_helpers %}
 
 {% block title %}{{ experiment.name }} - Branches{% endblock %}
 {% block main_content %}
+  {% devtools_metadata experiment %}
   <div class="position-relative">
     <!-- Full form overlay -->
     <div id="htmx-loading-overlay"
@@ -144,7 +145,19 @@
                             <div class="form-text">{{ NimbusUIConstants.COENROLLMENT_NOTE }}</div>
                           {% endif %}
                         </label>
-                        <div class="feature-value-editor">{{ branch_feature_values_form.value|add_error_class:"is-invalid" }}</div>
+                        <div class="feature-value-editor position-relative"
+                             data-nimbus-devtools-feature-editor
+                             data-feature-id="{{ branch_feature_values_form.instance.feature_config.slug }}">
+                          {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
+                          <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+                            <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
+                                    type="button"
+                                    title="Preview with about:messagepreview"
+                                    data-nimbus-devtools-try-preview-button>
+                              <span class="fa fa-eye"></span>
+                            </button>
+                          </div>
+                        </div>
                         {% for error in branch_feature_values_form.value.errors %}
                           <div class="invalid-feedback d-block">{{ error }}</div>
                         {% endfor %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_base.html
@@ -68,26 +68,38 @@
       </form>
     </div>
   </div>
-  <div id="slug-toast"
-       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto z-3"
-       role="alert"
-       aria-live="assertive"
-       aria-atomic="true">
-    <div class="toast-body">
-      <i class="fa-regular fa-circle-check"></i>
-      Slug copied to clipboard!
+  <div class="position-fixed top-0 end-0 m-3 w-auto z-3">
+    <div id="toasts-container" class="d-flex flex-column">
+      <div id="slug-toast"
+           class="toast hide text-bg-primary mb-1"
+           role="alert"
+           aria-live="assertive"
+           aria-atomic="true">
+        <div class="toast-body">
+          <i class="fa-regular fa-circle-check"></i>
+          Slug copied to clipboard!
+        </div>
+      </div>
+      <div id="json-copy-toast"
+           class="toast hide text-bg-primary mb-1"
+           role="alert"
+           aria-live="assertive"
+           aria-atomic="true">
+        <div class="toast-body">
+          <i class="fa-regular fa-circle-check"></i>
+          JSON copied to clipboard!
+        </div>
+      </div>
     </div>
   </div>
-  <div id="json-copy-toast"
-       class="toast hide text-bg-primary position-fixed top-0 end-0 m-3 w-auto z-3"
-       role="alert"
-       aria-live="assertive"
-       aria-atomic="true">
-    <div class="toast-body">
-      <i class="fa-regular fa-circle-check"></i>
-      JSON copied to clipboard!
+  <template id="template-toast">
+    <div class="toast hide text-bg-primary mb-1"
+         role="alert"
+         aria-live="assertive"
+         aria-atomic="true">
+      <div class="toast-body"></div>
     </div>
-  </div>
+  </template>
   <div class="modal fade"
        id="cloneModal"
        tabindex="-1"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
@@ -1,0 +1,33 @@
+{% extends "common/readonly_json.html" %}
+
+{% block json %}
+  <textarea class="readonly-json"
+            data-nimbus-devtools-feature-value
+            data-feature-id="{{ feature_id }}">{{ json_content }}</textarea>
+{% endblock %}
+{% block json_controls_collapsed %}
+  <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
+          type="button"
+          title="Preview with about:messagepreview"
+          data-nimbus-devtools-preview-button>
+    <span class="fa fa-eye"></span>
+  </button>
+  <div class="btn btn-sm btn-outline-danger ms-1 d-none"
+       type="button"
+       data-nimbus-devtools-cannot-preview-notice>
+    <span class="fa fa-eye"></span>
+  </div>
+{% endblock %}
+{% block json_controls_expanded %}
+  <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
+          type="button"
+          title="Preview with about:messagepreview"
+          data-nimbus-devtools-preview-button>
+    <span class="fa fa-eye"></span>
+  </button>
+  <div class="btn btn-sm btn-outline-danger ms-1 d-none"
+       type="button"
+       data-nimbus-devtools-cannot-preview-notice>
+    <span class="fa fa-eye"></span>
+  </div>
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
@@ -1,0 +1,17 @@
+from django import template
+from django.utils.html import json_script
+
+register = template.Library()
+
+
+@register.simple_tag
+def devtools_metadata(experiment):
+    """Embed metadata about a given experiment in a page for nimbus-devtools to
+    consume.
+    """
+    return json_script(
+        {
+            "application": experiment.application,
+        },
+        element_id="nimbus-devtools-experiment-metadata",
+    )


### PR DESCRIPTION
Because:

- nimbus-devtools is going to be integrating into experimenter;
- nimbus-devtools needs metadata about the experiment and page layout to support one-click message previews and force-enrollment; and
- our buttons on CodeMirror editors are slightly off and can render outside the editor if it is only a single line high

this commit:

- embeds metadata into experiment summary and branch edit pages; and
- fixes up some styling inconsistencies with the button overlays on our CodeMirror editors.

Fixes #14849