### PR TITLE
chore(nimbus): remove show_analysis flag from results data

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -3,8 +3,8 @@ from collections import defaultdict
 from datetime import date, datetime, timedelta
 from itertools import chain
 from pathlib import Path
+from typing import Any
 
-from django.conf import settings
 from django.core.files.storage import storages
 from django.utils import timezone
 from mozilla_nimbus_schemas.jetstream import (
@@ -222,8 +222,7 @@ def get_experiment_data(experiment: NimbusExperiment):
     except RuntimeError as e:
         runtime_errors.append(str(e))
 
-    experiment_data = {
-        "show_analysis": settings.FEATURE_ANALYSIS,
+    experiment_data: dict[str, Any] = {
         "metadata": experiment_metadata,
     }
 

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.core.cache import cache
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.utils import timezone
 from mozilla_nimbus_schemas.jetstream import SampleSizes, SampleSizesFactory
 from parameterized import parameterized
@@ -25,7 +25,6 @@ from experimenter.outcomes import Outcomes
 
 
 @mock_valid_outcomes
-@override_settings(FEATURE_ANALYSIS=False)
 class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
     maxDiff = None
 
@@ -688,7 +687,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     "analysis_start_time": "2022-08-31T04:30:03+00:00",
                     "metrics": {},
                 },
-                "show_analysis": False,
                 "errors": ERRORS,
             },
         }
@@ -861,7 +859,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                 "weekly": {},
                 "overall": {},
                 "metadata": None,
-                "show_analysis": False,
             }
         }
 
@@ -880,7 +877,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                 "weekly": {},
                 "overall": {},
                 "metadata": None,
-                "show_analysis": False,
             }
         }
 
@@ -955,7 +951,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     },
                 },
                 "metadata": {},
-                "show_analysis": False,
                 "errors": ERRORS,
             },
         }
@@ -1091,7 +1086,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     "analysis_start_time": analysis_start_time,
                     "metrics": {},
                 },
-                "show_analysis": False,
                 "errors": {
                     "experiment": [
                         {
@@ -1223,7 +1217,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     },
                 },
                 "metadata": {},
-                "show_analysis": False,
                 "errors": ERRORS,
             },
         }
@@ -1605,7 +1598,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     },
                 },
                 "metadata": {},
-                "show_analysis": False,
                 "errors": {"experiment": []},
             },
         }
@@ -2995,7 +2987,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     }
                 },
                 "other_metrics": {"other_metrics": {"test": "Test"}},
-                "show_analysis": False,
             },
         }
 
@@ -3162,7 +3153,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     "v3": {
                         "metadata": None,
                         "overall": {},
-                        "show_analysis": False,
                         "daily": {},
                         "weekly": {},
                         "errors": {
@@ -3227,7 +3217,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             "v3": {
                 "metadata": None,
                 "overall": None,
-                "show_analysis": False,
                 "weekly": None,
             },
         }

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -485,9 +485,6 @@ SECURE_REFERRER_POLICY = config("SECURE_REFERRER_POLICY", default="origin")
 # Silenced ssl_redirect, sts, django primary key checks
 SILENCED_SYSTEM_CHECKS = ["security.W008", "security.W004", "models.W042"]
 
-# Feature Flags
-FEATURE_ANALYSIS = config("FEATURE_ANALYSIS", default=False, cast=bool)
-
 # Kinto settings
 KINTO_HOST = config("KINTO_HOST")
 KINTO_USER = config("KINTO_USER")

--- a/experimenter/experimenter/visualization/tests/api/test_views.py
+++ b/experimenter/experimenter/visualization/tests/api/test_views.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from django.urls import reverse
 from parameterized import parameterized
 
@@ -10,7 +10,6 @@ from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 
 
-@override_settings(FEATURE_ANALYSIS=False)
 class TestVisualizationView(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Because

- The `show_analysis` is no longer useful to keep around

This commit

- Removes `show_analysis` from the results data

Fixes #7375 