### PR TITLE
fix(nimbus): skip cloning screenshots with no associated image file

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2360,6 +2360,9 @@ class NimbusBranchScreenshot(models.Model):
             self.image.storage.delete(old_image_name)
 
     def clone(self, to_branch):
+        if not self.image:
+            return None
+
         image_copy = ContentFile(self.image.read())
         image_copy.name = self.image.name
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5590,6 +5590,24 @@ class TestNimbusBranchScreenshot(TestCase):
             self.screenshot.delete()
             mock_delete.assert_called_with(expected_filename)
 
+    def test_clone_screenshot_with_missing_image_skips(self):
+        self.screenshot.save()
+        # Simulate a screenshot record whose image field has no file associated
+        # (e.g., file was removed from storage or field was cleared)
+        NimbusBranchScreenshot.objects.filter(id=self.screenshot.id).update(image="")
+        self.screenshot.refresh_from_db()
+
+        target_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        target_branch = target_experiment.branches.first()
+        initial_count = target_branch.screenshots.count()
+
+        # Should not raise ValueError — just skip the broken screenshot
+        result = self.screenshot.clone(target_branch)
+        self.assertIsNone(result)
+        self.assertEqual(target_branch.screenshots.count(), initial_count)
+
 
 class NimbusFeatureConfigTests(TestCase):
     def test_schemas_between_versions(self):


### PR DESCRIPTION
Because

* Cloning an experiment with a branch screenshot whose image file is
  missing from storage raises `ValueError: The 'image' attribute has no file associated with it.`, crashing the clone operation
* This was reported via Sentry ([EXPERIMENTER-PROD-197](https://mozilla.sentry.io/issues/7333590977/))

This commit

* Adds a guard in `NimbusBranchScreenshot.clone()` to return `None` when
  the image field has no file associated, skipping the broken screenshot
* Adds a test that reproduces the `ValueError` from the Sentry report

Fixes #14911