### PR TITLE
fix(nimbus): replace |safe template filter with nh3 HTML sanitization

### DIFF
--- a/experimenter/experimenter/legacy/legacy-ui/templates/base.html
+++ b/experimenter/experimenter/legacy/legacy-ui/templates/base.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load nimbus_extras %}
 
 <!DOCTYPE html>
 <html lang="en">
@@ -120,7 +121,7 @@
           {% for message in request.user.notifications.get_unread %}
           <p>
             <span class="fas fa-info-circle"></span>
-            {{ message|safe }}
+            {{ message|sanitize_html }}
           </p>
           {% endfor %}
         </div>

--- a/experimenter/experimenter/legacy/legacy-ui/templates/experiments/detail_base.html
+++ b/experimenter/experimenter/legacy/legacy-ui/templates/experiments/detail_base.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% load static %}
+{% load nimbus_extras %}
 
 {% block header_content %}
   <h3>
@@ -187,7 +188,7 @@
                                     {% endfor %}
                                 </td>
                                 {% else %}
-                                  <th scope="row">{{value.display_name|safe}}</th>
+                                  <th scope="row">{{value.display_name|sanitize_html}}</th>
                                   <td>{{value.old_value|linebreaks}}</td>
                                   <td>{{value.new_value|linebreaks}}</td>
                                 {% endif %}

--- a/experimenter/experimenter/legacy/legacy-ui/templates/experiments/emails/new_change_email.html
+++ b/experimenter/experimenter/legacy/legacy-ui/templates/experiments/emails/new_change_email.html
@@ -1,3 +1,4 @@
+{% load nimbus_extras %}
 {% autoescape off %}
 
 <style>
@@ -52,7 +53,7 @@
         {% endfor %} {% endfor %}
       </td>
       {% else %}
-      <th scope="row">{{value.display_name|safe}}</th>
+      <th scope="row">{{value.display_name|sanitize_html}}</th>
       <td>{{value.old_value|linebreaks}}</td>
       <td>{{value.new_value|linebreaks}}</td>
       {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/changelog/overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/changelog/overview.html
@@ -55,11 +55,11 @@
                       <div class="row">
                         <div class="col border-end">
                           <h6>Old Value</h6>
-                          <pre style="white-space: pre-wrap;">{{ change.old_value|safe }}</pre>
+                          <pre style="white-space: pre-wrap;">{{ change.old_value|sanitize_html }}</pre>
                         </div>
                         <div class="col">
                           <h6>New Value</h6>
-                          <pre style="white-space: pre-wrap;">{{ change.new_value|safe }}</pre>
+                          <pre style="white-space: pre-wrap;">{{ change.new_value|sanitize_html }}</pre>
                         </div>
                       </div>
                     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -121,7 +121,7 @@
               <div class="col">
                 <h5>Key takeaways</h5>
                 {% if experiment.takeaways_summary %}
-                  <div>{{ experiment.takeaways_summary|safe }}</div>
+                  <div>{{ experiment.takeaways_summary|sanitize_html }}</div>
                 {% else %}
                   <p class="text-muted">
                     {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.key_takeaways }}
@@ -132,7 +132,7 @@
                 <div>
                   <h5>Next steps</h5>
                   {% if experiment.next_steps %}
-                    <div>{{ experiment.next_steps|safe }}</div>
+                    <div>{{ experiment.next_steps|sanitize_html }}</div>
                   {% else %}
                     <p class="text-muted">
                       {{ experiment.key_takeaways|default:NimbusUIConstants.OVERVIEW_REFLECTION_PROMPTS.next_steps }}

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -2,6 +2,7 @@ import json
 from datetime import date
 
 import humanize
+import nh3
 from django import template
 from django.utils.dateparse import parse_datetime
 from django.utils.safestring import mark_safe
@@ -367,3 +368,10 @@ def render_markdown(value):
     if not value:
         return ""
     return mark_safe(markdown(value))
+
+
+@register.filter
+def sanitize_html(value):
+    if not value:
+        return ""
+    return mark_safe(nh3.clean(str(value)))

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -43,6 +43,7 @@ from experimenter.nimbus_ui.templatetags.nimbus_extras import (
     remove_underscores,
     render_channel_icons,
     render_markdown,
+    sanitize_html,
     short_number,
     status_icon_info,
     to_percentage,
@@ -207,6 +208,32 @@ class FilterTests(TestCase):
     )
     def test_render_markdown(self, markdown_text, expected_html):
         self.assertEqual(render_markdown(markdown_text), expected_html)
+
+    @parameterized.expand(
+        [
+            (
+                "<p>Hello <strong>world</strong></p>",
+                "<p>Hello <strong>world</strong></p>",
+            ),
+            (
+                '<script>alert("xss")</script><p>Safe content</p>',
+                "<p>Safe content</p>",
+            ),
+            (
+                '<a href="javascript:alert(1)">click</a>',
+                '<a rel="noopener noreferrer">click</a>',
+            ),
+            (
+                '<p onclick="alert(1)">text</p>',
+                "<p>text</p>",
+            ),
+            ("", ""),
+            (None, ""),
+            ("Plain text", "Plain text"),
+        ]
+    )
+    def test_sanitize_html(self, input_html, expected_output):
+        self.assertEqual(sanitize_html(input_html), expected_output)
 
 
 class TestHomeFilters(AuthTestCase):

--- a/experimenter/poetry.lock
+++ b/experimenter/poetry.lock
@@ -1994,6 +1994,42 @@ pydantic = ">=2,<3"
 typing-extensions = ">=4.0.1"
 
 [[package]]
+name = "nh3"
+version = "0.2.22"
+description = "Python binding to Ammonia HTML sanitizer Rust crate"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "nh3-0.2.22-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:4743c9132e2ccf2109af88ce16074c5a7068df85be8f7b9840dbe683e50b9461"},
+    {file = "nh3-0.2.22-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca015dbd477e20a29bee8660a966523c677da0c34dfeb474c6acb64462fbfc15"},
+    {file = "nh3-0.2.22-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9d10f4c195f3b84a8127417ec940e1393062a3e2f05d405270dde7846854e22c"},
+    {file = "nh3-0.2.22-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9bbeb3d253c1026a46e7b23bc2698fe1f00641b5a7bdad8e4c8937daaa1f2b51"},
+    {file = "nh3-0.2.22-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:b71ea8e987923e2976a99e4bb17e39cc186c93a330712075650e6143cb2fa89b"},
+    {file = "nh3-0.2.22-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:56b328457370401aaf2039a5039d7f587e72b2c08bc95dfe807ad96ae98e83e4"},
+    {file = "nh3-0.2.22-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:e9762845ee47372df425b52ec4a133e994dbbedf95ad61eea4bfe6cb4d1401b4"},
+    {file = "nh3-0.2.22-cp313-cp313t-win32.whl", hash = "sha256:c61fbfe4131ceff1c83ed0663c39aebb72bd26c6b22157b14da0b43287ea15ed"},
+    {file = "nh3-0.2.22-cp313-cp313t-win_amd64.whl", hash = "sha256:4f47991a9819f644918aebc2a93d175562c7c0c2ec41cbc525fbdbf676793c03"},
+    {file = "nh3-0.2.22-cp313-cp313t-win_arm64.whl", hash = "sha256:29baf3c22d6e9d26325128600355baeddb52eecd6206780621f84537ad4db966"},
+    {file = "nh3-0.2.22-cp38-abi3-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:2a6e33de39218eded7187aaf05aea71884b1b8002d50d080a95df734d3ad3a44"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cb91663dcf139da2009d452aad23094e01579c45a6101b2a0b0c28181b8c496f"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f45f8a2347da8c9682f9b015cf9d492fdb8440cfb7bd523cceda1a705fd5a4bd"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f94ed44f433e2f8799f5285000f799e9f3ca66559328e40066c0f96c4fbad346"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:74039dfd41107bbb298fe814c4be5c39d66124855ff549d216e4947a69d3d9a1"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:60e1d4429762745a5a346277dc3378aade0e24632f75077f0da3bfc29bf385fd"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e9e93c67d1ec8db6d96e323832bd267cdfe94bdb8cc6adc88cbc0908ff59329"},
+    {file = "nh3-0.2.22-cp38-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7f186eea285ebf941fbaaecd1cd445e9506552a15435140ca73ca029334715da"},
+    {file = "nh3-0.2.22-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:87e532f885937c460ccbdc1b5ea03b0e420de8ef12dd5857621706298857b9aa"},
+    {file = "nh3-0.2.22-cp38-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fee209eb0d93830908e4f6fc549c08766def701f5681de2779637a00d48f288f"},
+    {file = "nh3-0.2.22-cp38-abi3-musllinux_1_2_i686.whl", hash = "sha256:10e8d0a833431860620f7f1434792607ca12cdfda81450a2678b8d69642eda69"},
+    {file = "nh3-0.2.22-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:adbb35826fad998f88f68b969e3936dff53b70052c9e6e951ef9e49db9590611"},
+    {file = "nh3-0.2.22-cp38-abi3-win32.whl", hash = "sha256:bcac2a186791c422ce55522cae332c8fa2135795b7b510e2475cb95a44f7b0ce"},
+    {file = "nh3-0.2.22-cp38-abi3-win_amd64.whl", hash = "sha256:a78a13f5bf5901f5de50580a74058a10734d3e836144cb090f0304ec5deb3df7"},
+    {file = "nh3-0.2.22-cp38-abi3-win_arm64.whl", hash = "sha256:602ad5229c81a287c8632ea1bf2d6b3654b3e208b57b0bcab5beec93ff91866f"},
+    {file = "nh3-0.2.22.tar.gz", hash = "sha256:dbfaa924ba226331c75896a64fe161a0cbd21172e4da687b2a69b5101db2c3e9"},
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.7.0"
 description = "Node.js virtual environment builder"
@@ -3803,4 +3839,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "507aae7a2b6fed6f268b0bd23f940ff4d96e3e17281f7d67e9b552d1197622e8"
+content-hash = "ec4a396e6868bbd696429098a706d5a6dc1138be3c7fda29190db4216a91b54e"

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -81,6 +81,7 @@ humanize = "^4.15.0"
 deepdiff = "^8.6.1"
 django-summernote = "^0.8.20.0"
 markdown = "^3.10.2"
+nh3 = "^0.2"
 
 [tool.poetry.dev-dependencies]
 rope = "^0.23.0"


### PR DESCRIPTION
Because

* Django's `|safe` filter renders HTML without any sanitization, which could allow XSS if untrusted content is stored in fields like `takeaways_summary`, `next_steps`, or changelog values
* These fields use the Summernote WYSIWYG editor which stores raw HTML, so we need to render markup but strip dangerous elements like script tags, `javascript:` URLs, and event handlers

This commit

* Adds `nh3` (Rust-based HTML sanitizer) as a dependency
* Creates a `|sanitize_html` template filter that uses `nh3.clean()` to strip scripts and event handlers while preserving safe formatting
* Replaces all 7 uses of `|safe` across 5 template files with `|sanitize_html`
* Adds tests covering script tags, `javascript:` URLs, event handlers, empty input, and plain text

Fixes #14919