### PR TITLE
feat(nimbus): add results_data to YAML export serializer

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1469,6 +1469,10 @@
           "parent_experiment": {
             "type": "string",
             "readOnly": true
+          },
+          "results_data": {
+            "type": "object",
+            "nullable": true
           }
         },
         "required": [

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1481,6 +1481,10 @@
           "parent_experiment": {
             "type": "string",
             "readOnly": true
+          },
+          "results_data": {
+            "type": "object",
+            "nullable": true
           }
         },
         "required": [

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -329,6 +329,7 @@ class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
             "required_experiments",
             "excluded_experiments",
             "parent_experiment",
+            "results_data",
         ]
 
     def get_hypothesis(self, obj):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -255,6 +255,13 @@ class TestNimbusExperimentYamlListView(TestCase):
             risk_ai=True,
             qa_status=NimbusExperiment.QAStatus.GREEN,
             conclusion_recommendations=["RERUN", "GRADUATE"],
+            results_data={
+                "v3": {
+                    "overall": {
+                        "enrollments": {"all": {"percentage": 100.0, "population": 1000}}
+                    }
+                }
+            },
         )
         experiment.locales.add(locale)
         experiment.countries.add(country)
@@ -315,6 +322,12 @@ class TestNimbusExperimentYamlListView(TestCase):
         # Feature configs
         slugs = [fc["slug"] for fc in exp["feature_configs"]]
         self.assertIn("test-feature", slugs)
+
+        # Results data
+        self.assertEqual(
+            exp["results_data"]["v3"]["overall"]["enrollments"]["all"]["population"],
+            1000,
+        )
 
     def test_default_hypothesis_excluded(self):
         application = NimbusExperiment.Application.DESKTOP


### PR DESCRIPTION
feat(nimbus): add results_data to YAML export serializer

Because

* The YAML export endpoint is used by the chatbot assistant to understand
  experiment outcomes, but it was missing the results_data JSON field
* Completed experiments with analysis results (enrollments, exposures,
  errors across overall/weekly/daily windows) had no way to surface
  this data through the YAML export

This commit

* Adds results_data to NimbusExperimentYamlSerializer fields list
* Adds test coverage for results_data in the YAML export
* Regenerates API schema docs

Fixes #14929