### PR TITLE
fix(nimbus): add missing SlackEmojiMockMixin to cancel form test classes

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -1858,7 +1858,7 @@ class TestApproveEndExperimentForm(
         )
 
 
-class TestCancelEndEnrollmentForm(RequestFormTestCase):
+class TestCancelEndEnrollmentForm(SlackEmojiMockMixin, RequestFormTestCase):
     def test_valid_transition(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
@@ -1950,7 +1950,7 @@ class TestCancelEndEnrollmentForm(RequestFormTestCase):
         self.assertIn("Cancelled end enrollment request.", changelog.message)
 
 
-class TestCancelEndExperimentForm(RequestFormTestCase):
+class TestCancelEndExperimentForm(SlackEmojiMockMixin, RequestFormTestCase):
     def test_valid_transition(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,


### PR DESCRIPTION
Because

* `TestCancelEndEnrollmentForm` and `TestCancelEndExperimentForm` call
  `form.save()` which triggers `add_emoji_to_message_async.delay()` via
  `CancelRequestMixin`, but these test classes were not mocking the
  Celery task
* This caused the tests to attempt a real Redis connection via the
  Celery broker, failing with `OperationalError` in environments
  without Redis

This commit

* Adds `SlackEmojiMockMixin` to `TestCancelEndEnrollmentForm` and
  `TestCancelEndExperimentForm`, matching the pattern already used by
  `TestApproveEndEnrollmentForm`, `TestApproveEndExperimentForm`, and
  `TestCancelUpdateRolloutForm`

Fixes #14938