### PR TITLE
docs(project): remove bug bounty program reference from SECURITY.md

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,5 @@
 # Security Policy
 
-This code and its associated production web page are included in the Mozilla’s web and services [bug bounty program](https://www.mozilla.org/en-US/security/web-bug-bounty/). If you find a security vulnerability, please submit it via the process outlined in the program and [FAQ pages](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/). Further technical details about this application are available from the [Bug Bounty Onramp page](https://wiki.mozilla.org/Security/BugBountyOnramp/).
+If you find a security vulnerability, please submit it via the process outlined in the [FAQ pages](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/). Further technical details about this application are available from the [Bug Bounty Onramp page](https://wiki.mozilla.org/Security/BugBountyOnramp/).
 
 Please submit all security-related bugs through Bugzilla using the [web security bug form](https://bugzilla.mozilla.org/form.web.bounty). Never submit security-related bugs through a Github Issue or by email.


### PR DESCRIPTION
Because

* The SECURITY.md file incorrectly states that experimenter is part of
  Mozilla's web and services bug bounty program

This commit

* Removes the bug bounty program mention from .github/SECURITY.md
* Retains the vulnerability reporting instructions and Bugzilla submission guidance

Fixes #14949