### PR TITLE
chore(nimbus): Add new MetricsHandler methods

### DIFF
--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -15,6 +15,12 @@ class MockMetricsHandler(nimbus_rust.MetricsHandler):
     def __init__(self, *args, **kwargs):
         pass
 
+    def record_database_load(self, *args, **kwargs):
+        pass
+
+    def record_database_migration(self, *args, **kwargs):
+        pass
+
     def record_enrollment_statuses(self, *args, **kwargs):
         pass
 
@@ -25,6 +31,9 @@ class MockMetricsHandler(nimbus_rust.MetricsHandler):
         pass
 
     def record_malformed_feature_config(self, *args, **kwargs):
+        pass
+
+    def submit_targeting_context(self, *args, **kwargs):
         pass
 
 

--- a/experimenter/tests/tools/sdk_eval_check.py
+++ b/experimenter/tests/tools/sdk_eval_check.py
@@ -9,6 +9,12 @@ class MockMetricsHandler(nimbus.MetricsHandler):
     def __init__(self, *args, **kwargs):
         pass
 
+    def record_database_load(self, *args, **kwargs):
+        pass
+
+    def record_database_migration(self, *args, **kwargs):
+        pass
+
     def record_enrollment_statuses(self, *args, **kwargs):
         pass
 
@@ -19,6 +25,9 @@ class MockMetricsHandler(nimbus.MetricsHandler):
         pass
 
     def record_malformed_feature_config(self, *args, **kwargs):
+        pass
+
+    def submit_targeting_context(self, *args, **kwargs):
         pass
 
 


### PR DESCRIPTION
Because:

- Nimbus SDK is adding new MetricsHandler methods

this commit:

- adds these new methods

Fixes #14765