### PR TITLE
bug(nimbus): Remove overflow-hidden class from all cards

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_branch.html
@@ -14,7 +14,7 @@
               data-bs-target="#promoteToRolloutModal-{{ branch.slug }}">Promote to Rollout</button>
     {% endif %}
   </div>
-  <div class="card-body p-0 overflow-hidden rounded-bottom">
+  <div class="card-body p-0 rounded-bottom">
     <table class="table table-striped mb-0">
       <tbody>
         <tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_base.html
@@ -10,7 +10,7 @@
         </h4>
       {% endblock %}
     </div>
-    <div class="card-body p-0 overflow-hidden rounded-bottom">
+    <div class="card-body p-0 rounded-bottom">
       {% block card_body %}{% endblock %}
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_qa.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_qa.html
@@ -21,8 +21,7 @@
               hx-target="#qa-status-form-container"
               hx-swap="outerHTML">Edit</button>
     </div>
-    <div class="card-body p-0 overflow-hidden rounded-bottom"
-         id="qa-status-form-container">
+    <div class="card-body p-0 rounded-bottom" id="qa-status-form-container">
       {% include "nimbus_experiments/qa_container_content.html" %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_signoff.html
@@ -27,7 +27,7 @@
          hx-swap="outerHTML">Edit</a>
     {% endif %}
   </div>
-  <div class="card-body p-0 overflow-hidden">
+  <div class="card-body p-0">
     <table class="table table-striped mb-0">
       <tbody>
         <tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/qa_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/qa_card.html
@@ -19,7 +19,7 @@
               hx-target="#qa-status-form-container"
               hx-swap="outerHTML">Edit</button>
     </div>
-    <div class="card-body p-0 overflow-hidden" id="qa-status-form-container">
+    <div class="card-body p-0" id="qa-status-form-container">
       {% include "nimbus_experiments/qa_container_content.html" %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/signoff_card.html
@@ -25,7 +25,7 @@
          hx-swap="outerHTML">Edit</a>
     {% endif %}
   </div>
-  <div class="card-body p-0 overflow-hidden">
+  <div class="card-body p-0">
     <table class="table table-striped mb-0">
       <tbody>
         <tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/takeaways_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/takeaways_card.html
@@ -19,7 +19,7 @@
             hx-swap="outerHTML"
             data-testid="edit-takeaways">Edit</button>
   </div>
-  <div class="card-body p-0 overflow-hidden">
+  <div class="card-body p-0">
     <table class="table table-striped mb-0">
       <tbody>
         <tr>


### PR DESCRIPTION
Because:

- we have existing dropdowns inside these cards;
- we are adding more for nimbus-devtools integration; and
- `overflow: hidden` seems to be an otherwise unnecessary style on these cards that just breaks dropdowns

this commit:

- removes all the `overflow-hidden` classes on cards.

Fixes #14879