### PR TITLE
docs(project): replace SECURITY.md with updated contact info

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,5 +1,3 @@
 # Security Policy
 
-If you find a security vulnerability, please submit it via the process outlined in the [FAQ pages](https://www.mozilla.org/en-US/security/bug-bounty/faq-webapp/). Further technical details about this application are available from the [Bug Bounty Onramp page](https://wiki.mozilla.org/Security/BugBountyOnramp/).
-
-Please submit all security-related bugs through Bugzilla using the [web security bug form](https://bugzilla.mozilla.org/form.web.bounty). Never submit security-related bugs through a Github Issue or by email.
+If you find a security vulnerability, please inform us by contacting us at security@mozilla.org or by submitting a Github advisory using the form https://github.com/mozilla/experimenter/security/advisories/new


### PR DESCRIPTION
Because

* The security policy still contained outdated Bugzilla and bug bounty
  references after the initial cleanup in #14949

This commit

* Replaces the entire SECURITY.md content with updated instructions
  directing reporters to security@mozilla.org and the GitHub security
  advisory form

Fixes #14960