### PR TITLE
chore(project): add DOCKER_USER override for dev containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,9 +73,6 @@ target/
 .envrc
 .psql_history
 
-# Local Docker Compose overrides (e.g., user: for Linux/WSL2 file permissions)
-docker-compose.override.yml
-
 # VS Code
 **/.vscode/*
 **/.devcontainer/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   experimenter:
     image: experimenter:dev
     env_file: .env
+    user: "${EXPERIMENTER_DOCKER_USER:-root}"
     stdin_open: true
     tty: true
     depends_on:
@@ -30,6 +31,7 @@ services:
   yarn-nimbus_ui:
     image: experimenter:dev
     env_file: .env
+    user: "${EXPERIMENTER_DOCKER_USER:-root}"
     stdin_open: true
     tty: true
     volumes:
@@ -49,6 +51,7 @@ services:
   worker:
     image: experimenter:dev
     env_file: .env
+    user: "${EXPERIMENTER_DOCKER_USER:-root}"
     depends_on:
       - db
       - redis
@@ -61,6 +64,7 @@ services:
   beat:
     image: experimenter:dev
     env_file: .env
+    user: "${EXPERIMENTER_DOCKER_USER:-root}"
     depends_on:
       - db
       - redis


### PR DESCRIPTION
Because

* Dev containers run as root, which works on macOS (Docker Desktop handles UID translation) but causes file permission issues on Linux and Windows/WSL2 where bind-mounted files end up owned by root
* Developers on those platforms need a way to match container UID/GID to their host user

This commit

* Adds `user: "${EXPERIMENTER_DOCKER_USER:-root}"` to dev services in `docker-compose.yml` (experimenter, yarn-nimbus_ui, worker, beat)
* Defaults to `root`, preserving current behavior for macOS developers and CI
* Linux/WSL2 developers set `EXPERIMENTER_DOCKER_USER=1000:1000` in their `.env` (replace with actual `$(id -u):$(id -g)`)

Fixes #14962