### PR TITLE
feat(nimbus): Support previewing translated messages with devtools

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/readonly_json.html
@@ -2,7 +2,7 @@
   <div class="collapsed-json">
     <div class="position-relative">
       <textarea class="readonly-json">{{ json_content }}</textarea>
-      <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+      <div class="position-absolute top-0 end-0 m-1 py-1 px-1 d-flex">
         {% block json_controls_collapsed %}{% endblock %}
         <button type="button"
                 class="btn btn-sm btn-outline-secondary ms-1 codemirror-copy-btn"
@@ -18,7 +18,7 @@
   <div class="expanded-json d-none">
     <div class="position-relative">
       {% block json %}<textarea class="readonly-json">{{ json_content }}</textarea>{% endblock %}
-      <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+      <div class="position-absolute top-0 end-0 m-1 py-1 px-1 d-flex">
         {% block json_controls_expanded %}{% endblock %}
         <button type="button"
                 class="btn btn-sm btn-outline-secondary ms-1 codemirror-copy-btn"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -156,6 +156,17 @@
                                     data-nimbus-devtools-try-preview-button>
                               <span class="fa fa-eye"></span>
                             </button>
+                            <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
+                              <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
+                                      type="button"
+                                      title="Preview with about:messagepreview"
+                                      data-bs-toggle="dropdown"
+                                      aria-expanded="false">
+                                <span class="fa fa-eye"></span>
+                              </button>
+                              <ul class="dropdown-menu">
+                              </ul>
+                            </div>
                           </div>
                         </div>
                         {% for error in branch_feature_values_form.value.errors %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
@@ -17,6 +17,17 @@
        data-nimbus-devtools-cannot-preview-notice>
     <span class="fa fa-eye"></span>
   </div>
+  <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
+    <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
+            type="button"
+            title="Preview with about:messagepreview"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
+      <span class="fa fa-eye"></span>
+    </button>
+    <ul class="dropdown-menu">
+    </ul>
+  </div>
 {% endblock %}
 {% block json_controls_expanded %}
   <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
@@ -29,5 +40,17 @@
        type="button"
        data-nimbus-devtools-cannot-preview-notice>
     <span class="fa fa-eye"></span>
+  </div>
+  <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
+    <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
+            id="{{ feature_id }}-expanded-try-preview-dropdown"
+            type="button"
+            title="Preview with about:messagepreview"
+            data-bs-toggle="dropdown"
+            aria-expanded="false">
+      <span class="fa fa-eye"></span>
+    </button>
+    <ul class="dropdown-menu">
+    </ul>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
@@ -12,6 +12,8 @@ def devtools_metadata(experiment):
     return json_script(
         {
             "application": experiment.application,
+            "isLocalized": experiment.is_localized,
+            "localizations": experiment.localizations,
         },
         element_id="nimbus-devtools-experiment-metadata",
     )


### PR DESCRIPTION
Because:

- messages support localization; and
- it will be very useful to be able to preview each message in each locale

this commit:

- adds the necessary metadata and DOM elements to enable nimbus-devtools to preview localized messages.

Fixes #14909