### PR TITLE
bug(nimbus): Keep the about:studies preview link with DevTools installed

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -192,39 +192,35 @@
         {% endif %}
       </div>
       {% if experiment.is_desktop %}
-        <div class="alert alert-light border my-3">
-          <div data-nimbus-devtools-preview-url-pane>
-            <h5 class="mb-2">Preview URL</h5>
-            <p class="mb-1">
-              <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
+        <div class="alert alert-light border my-3"
+             data-nimbus-devtools-opt-in-pane>
+          <h5 class="mb-2">Opt-In for Testing</h5>
+          <label for="branch-selector" class="form-label mt-2">Select Branch</label>
+          <select id="branch-selector"
+                  class="form-select mb-3"
+                  onchange="updatePreviewURL()"
+                  data-nimbus-devtools-force-enroll-branch-selector>
+            {% for branch in experiment.branches.all %}
+              <option value="{{ branch.slug }}"
+                      {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
+            {% endfor %}
+          </select>
+          <div class="d-none" data-nimbus-devtools-required>
+            <p>
+              Because you have <em>Nimbus Developer Tools</em> installed, you can opt-in with one click:
             </p>
-            <label for="branch-selector" class="form-label mt-2">Select Branch</label>
-            <select id="branch-selector"
-                    class="form-select mb-3"
-                    onchange="updatePreviewURL()">
-              {% for branch in experiment.branches.all %}
-                <option value="{{ branch.slug }}"
-                        {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
-              {% endfor %}
-            </select>
-            <button class="btn btn-sm" type="button">
-              <code id="preview-url" class="d-block text-danger user-select-all">
-                about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
-              </code>
-            </button>
-          </div>
-          <div class="d-none" data-nimbus-devtools-opt-in-pane>
-            <h5 class="mb-2">Opt-In for Testing</h5>
-            <select class="form-select mb-3" name="branch">
-              {% for branch in experiment.branches.all %}
-                <option value="{{ branch.slug }}"
-                        {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
-              {% endfor %}
-            </select>
-            <button class="btn btn-primary"
+            <button class="btn btn-primary mb-3"
                     type="button"
-                    data-nimbus-devtools-enroll-button>Enroll</button>
+                    data-nimbus-devtools-enroll-button>Force Enroll</button>
           </div>
+          <p class="mb-1">
+            <strong> Click the <code>about:studies</code> link below to copy</strong> then paste it in your browser. Ensure you enable <code>nimbus.debug</code> in <code>about:config</code> first.
+          </p>
+          <button class="btn btn-sm" type="button">
+            <code id="preview-url" class="d-block text-danger user-select-all">
+              about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview
+            </code>
+          </button>
         </div>
       {% endif %}
       <!-- Review Mode Controls -->


### PR DESCRIPTION
Because:

- people will still want to use the about:studies link to share opt-in URLs

this commit:

- updates the opt-in UI to be more integrated when devtools is installed, instead of showing two different UIs.

Fixes #14971