### PR TITLE
fix(nimbus): check daily window in has_exposures for live experiments

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1718,7 +1718,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         if self.results_data and "v3" in self.results_data:
             results_data = self.results_data["v3"]
-            for window in ["overall", "weekly"]:
+            for window in ["overall", "weekly", "daily"]:
                 if results_data.get(window):
                     exposures_branch_data = (
                         results_data[window].get("exposures", {}).get("all", {})

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3467,6 +3467,51 @@ class TestNimbusExperiment(TestCase):
             experiment.has_exposures, NimbusUIConstants.ExposuresStatus.NO_EXPOSURES
         )
 
+    def test_has_exposures_daily_only(self):
+        results_data = {
+            "v3": {
+                "daily": {
+                    "exposures": {
+                        "all": {
+                            "control": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 120,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            "treatment": {
+                                "branch_data": {
+                                    "other_metrics": {
+                                        "identity": {
+                                            "absolute": {
+                                                "first": {
+                                                    "point": 120,
+                                                },
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            }
+        }
+        experiment = NimbusExperimentFactory.create()
+        experiment.results_data = results_data
+        experiment.save()
+
+        self.assertEqual(
+            experiment.has_exposures, NimbusUIConstants.ExposuresStatus.VALID
+        )
+
     def test_has_exposures_missing_data(self):
         results_data = {
             "v3": {


### PR DESCRIPTION
Because

* The `has_exposures` property only checked `overall` and `weekly` result
  windows for exposure data
* For live experiments that haven't completed a full analysis week,
  Jetstream only produces daily results
* This caused the exposure basis dropdown on the results page to be disabled
  even though exposure-basis data was being computed and ingested by Jetstream

This commit

* Adds `daily` to the window list checked by `has_exposures`
* Adds a test for the daily-only exposure data case

Fixes #14976