### PR TITLE
perf(nimbus): reuse single experiment for advanced targeting tests

### DIFF
--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -9,6 +9,16 @@ from nimbus.pages.browser import Browser
 from nimbus.utils import helpers
 
 
+@pytest.fixture(scope="module")
+def base_experiment_slug():
+    """Create one experiment per module that gets reused for all targeting tests."""
+    slug = helpers.create_basic_experiment(
+        "targeting-test-base",
+        BaseExperimentApplications.FIREFOX_DESKTOP.value,
+    )
+    return slug
+
+
 @pytest.fixture(params=helpers.load_targeting_configs())
 def targeting_config_slug(request):
     return request.param
@@ -24,22 +34,21 @@ def targeting_script():
 
 @pytest.mark.run_targeting
 def test_check_advanced_targeting(
-    selenium,
+    driver,
+    base_experiment_slug,
     targeting_config_slug,
-    experiment_slug,
     targeting_script,
 ):
-    helpers.create_experiment(
-        experiment_slug,
-        BaseExperimentApplications.FIREFOX_DESKTOP.value,
-        targeting=targeting_config_slug,
+    helpers.update_experiment_audience(
+        base_experiment_slug,
+        {"targeting_config_slug": targeting_config_slug},
     )
-    experiment_data = helpers.load_experiment_data(experiment_slug)
+    experiment_data = helpers.load_experiment_data(base_experiment_slug)
     targeting = experiment_data["targeting"]
     recipe = experiment_data["recipe_json"]
 
     result = Browser.execute_async_script(
-        selenium,
+        driver,
         targeting,
         json.dumps({"experiment": recipe}),
         script=targeting_script,

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -334,6 +334,23 @@ def create_experiment(slug, app, data=None, targeting=None, is_rollout=False):
     )
 
 
+def update_experiment_audience(slug, audience_data):
+    """Update the audience form on an existing draft experiment.
+
+    Merges audience_data into the default desktop audience fields so Django
+    form validation passes even when only one field is being changed.
+    """
+    defaults = {
+        "targeting_config_slug": "",
+        "population_percent": "100",
+        "total_enrolled_clients": "55",
+        "firefox_min_version": "120.!",
+        "channels": ["nightly", "beta", "release"],
+    }
+    defaults.update(audience_data)
+    _post_form(f"/nimbus/{slug}/update_audience/", defaults)
+
+
 def end_experiment(slug):
     _post_form(f"/nimbus/{slug}/live-to-complete/")
     _post_form(f"/nimbus/{slug}/approve-end-experiment/")


### PR DESCRIPTION
Because

* Each of 215 test_check_advanced_targeting cases created a new
  experiment from scratch via 5-6 HTTP requests (~3.1s per test),
  totaling ~11 minutes of HTTP I/O for experiment creation alone
* The only field that varies between tests is targeting_config_slug

This commit

* Adds a module-scoped `base_experiment_slug` fixture that creates one
  experiment per xdist worker, reused across all advanced targeting
  test cases
* Each test now just updates the audience form (1 POST) and fetches
  the experiment data (1 GET) instead of full experiment creation
* Adds `update_experiment_audience` helper that merges overrides into
  default desktop audience fields
* Uses the `driver` fixture instead of `selenium` since targeting tests
  don't need per-test experiment lifecycle management

Fixes #14981