### PR TITLE
fix(project): clean up test containers after make check and make test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,11 +133,13 @@ compose_stop:
 	$(CIRRUS_ENABLE) $(COMPOSE) kill || true
 	$(COMPOSE_INTEGRATION) kill || true
 	$(COMPOSE_PROD) kill || true
+	$(COMPOSE_TEST) kill || true
 
 compose_rm:
 	$(COMPOSE) rm -f -v || true
 	$(COMPOSE_INTEGRATION) rm -f -v || true
 	$(COMPOSE_PROD) rm -f -v || true
+	$(COMPOSE_TEST) rm -f -v || true
 
 docker_prune:
 	docker container prune -f
@@ -156,12 +158,18 @@ kill: compose_stop compose_rm docker_prune  ## Stop, remove, and prune container
 	echo "All containers removed!"
 
 lint: build_test  ## Running linting on source code
-	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "$(RUFF_FORMAT_CHECK)" "$(RUFF_CHECK)" "$(DJLINT_CHECK)" "$(ESLINT_RESULTS)" "$(ESLINT_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_RESULTS)" "$(RESULTS_SCHEMA_CHECK)") ${COLOR_CHECK}'
+	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) (${PARALLEL} "$(PYTHON_CHECK_MIGRATIONS)" "$(CHECK_DOCS)" "$(RUFF_FORMAT_CHECK)" "$(RUFF_CHECK)" "$(DJLINT_CHECK)" "$(ESLINT_RESULTS)" "$(ESLINT_NIMBUS_UI)" "$(PYTHON_TYPECHECK)" "$(PYTHON_TEST)" "$(JS_TEST_RESULTS)" "$(RESULTS_SCHEMA_CHECK)") ${COLOR_CHECK}'; \
+	status=$$?; \
+	$(COMPOSE_TEST) down; \
+	exit $$status
 
 check: lint
 
 test: build_test  ## Run tests
-	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) python manage.py test --parallel'
+	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) python manage.py test --parallel'; \
+	status=$$?; \
+	$(COMPOSE_TEST) down; \
+	exit $$status
 pytest: test
 
 start: build_dev cirrus_build  ## Start containers


### PR DESCRIPTION
Because

* `docker compose run --rm` only removes the named service container,
  not dependency containers started via `depends_on`
* The db and cirrus containers from docker-compose-test.yml were left
  running indefinitely after `make check` / `make test` finished
* `make kill` also missed test containers since `compose_stop` and
  `compose_rm` did not reference `COMPOSE_TEST`

This commit

* Adds `docker compose down` after lint and test targets to stop and
  remove all test containers (db, cirrus) when the command finishes
* Captures the exit status so a lint/test failure still propagates
* Adds `COMPOSE_TEST` to `compose_stop` and `compose_rm` so `make kill`
  also cleans up any straggling test containers

Fixes #14983