### PR TITLE
fix(nimbus): add FIREFOX_DESKTOP parametrize to advanced targeting test

### DIFF
--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from functools import cache
 from pathlib import Path
 
@@ -12,8 +13,9 @@ from nimbus.utils import helpers
 @pytest.fixture(scope="module")
 def base_experiment_slug():
     """Create one experiment per module that gets reused for all targeting tests."""
+    name = f"targeting-test-base-{uuid.uuid4().hex[:8]}"
     slug = helpers.create_basic_experiment(
-        "targeting-test-base",
+        name,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
     )
     return slug


### PR DESCRIPTION
Because

* The test_check_advanced_targeting function uses the driver fixture
  instead of selenium, which means it lacks the FIREFOX_DESKTOP
  parametrize ID that -k FIREFOX_DESKTOP filters on
* This caused all 215 advanced targeting tests to be silently
  deselected, leaving only 7 audience targeting tests running

This commit

* Adds @pytest.mark.parametrize so -k FIREFOX_DESKTOP matches

Fixes #14981