### PR TITLE
fix(nimbus): pass create_form context to NimbusFeaturesView

### DIFF
--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -4241,6 +4241,7 @@ class TestNimbusFeaturesView(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "nimbus_experiments/features.html")
+        self.assertIn("create_form", response.context)
 
     def test_features_view_dropdown_loads_correct_default(self):
         response = self.client.get(reverse("nimbus-ui-features"))

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -1118,6 +1118,8 @@ class NimbusFeaturesView(TemplateView):
             "feature_changes_non_sortable_headers": feature_changes_non_sortable_headers,
         }
 
+        context["create_form"] = NimbusExperimentCreateForm()
+
         # Add subscribers form if a feature is selected
         if selected_feature_config:
             context["subscribers_form"] = FeatureSubscribersForm(


### PR DESCRIPTION
Because

* The "Create Experiment" button on the features page (`/nimbus/features/`)
  opens an empty modal because the shared header template expects a
  `create_form` in the context, but `NimbusFeaturesView` does not provide one

This commit

* Adds `create_form = NimbusExperimentCreateForm()` to the features view
  context, matching the pattern used by `NimbusExperimentsHomeView` and
  `NimbusExperimentDetailView`
* Adds a test assertion to verify the `create_form` is in the context

Fixes #14979