### PR TITLE
fix(project): allow CI workflows to run on fork PRs without GCP auth

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Cached Docker Build"
-description: "Authenticate to GAR, set up Buildx, and build megazords with registry cache"
+description: "Set up Buildx and build megazords, optionally with GAR registry cache"
 
 inputs:
   gar-cache:
@@ -9,19 +9,22 @@ inputs:
     description: "Architecture tag for cache (e.g. x86_64, aarch64)"
     default: "x86_64"
   gcp-project-number:
-    description: "GCP project number for workload identity"
-    required: true
+    description: "GCP project number for workload identity (empty to skip GAR caching)"
+    required: false
+    default: ""
 
 runs:
   using: composite
   steps:
     - name: Authenticate to Google Cloud
+      if: inputs.gcp-project-number != ''
       uses: google-github-actions/auth@v2
       with:
         workload_identity_provider: projects/${{ inputs.gcp-project-number }}/locations/global/workloadIdentityPools/github-actions/providers/github-actions
         service_account: artifact-writer@moz-fx-experimenter-prod-6cd5.iam.gserviceaccount.com
 
     - name: Login to Artifact Registry
+      if: inputs.gcp-project-number != ''
       shell: bash
       run: gcloud auth configure-docker us-docker.pkg.dev --quiet
 
@@ -29,6 +32,7 @@ runs:
       uses: docker/setup-buildx-action@v3
 
     - name: Build megazords with cache
+      if: inputs.gcp-project-number != ''
       shell: bash
       env:
         MEGAZORD_BUILD_FLAGS: >-
@@ -38,11 +42,20 @@ runs:
           -t ${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
       run: make build_megazords
 
+    - name: Build megazords
+      if: inputs.gcp-project-number == ''
+      shell: bash
+      env:
+        MEGAZORD_BUILD_FLAGS: --load
+      run: make build_megazords
+
     - name: Push megazords to registry
+      if: inputs.gcp-project-number != ''
       shell: bash
       run: docker push ${{ inputs.gar-cache }}/megazords:${{ inputs.arch }}
 
     - name: Build schemas with cache
+      if: inputs.gcp-project-number != ''
       uses: docker/build-push-action@v6
       with:
         context: schemas/
@@ -53,7 +66,18 @@ runs:
         cache-from: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }}
         cache-to: type=registry,ref=${{ inputs.gar-cache }}/schemas-cache:${{ inputs.arch }},mode=max
 
+    - name: Build schemas
+      if: inputs.gcp-project-number == ''
+      uses: docker/build-push-action@v6
+      with:
+        context: schemas/
+        file: schemas/Dockerfile
+        target: dev
+        tags: schemas:dev
+        load: true
+
     - name: Build cirrus with cache
+      if: inputs.gcp-project-number != ''
       uses: docker/build-push-action@v6
       with:
         context: cirrus/server/
@@ -67,15 +91,35 @@ runs:
         cache-from: type=registry,ref=${{ inputs.gar-cache }}/cirrus-cache:${{ inputs.arch }}
         cache-to: type=registry,ref=${{ inputs.gar-cache }}/cirrus-cache:${{ inputs.arch }},mode=max
 
+    - name: Build cirrus
+      if: inputs.gcp-project-number == ''
+      uses: docker/build-push-action@v6
+      with:
+        context: cirrus/server/
+        file: cirrus/server/Dockerfile
+        target: deploy
+        tags: cirrus:deploy
+        load: true
+        build-contexts: |
+          experimenter:megazords=docker-image://experimenter:megazords
+          fml=experimenter/experimenter/features/manifests/
+
     - name: Export build flags
       shell: bash
       env:
-        GAR_CACHE: ${{ inputs.gar-cache }}
+        GAR_CACHE: ${{ inputs.gcp-project-number != '' && inputs.gar-cache || '' }}
         ARCH: ${{ inputs.arch }}
       run: |
-        echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
-        echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
-        echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
-        echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --load" >> "$GITHUB_ENV"
+        if [ -n "$GAR_CACHE" ]; then
+          echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
+          echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/test-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/test-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
+          echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --cache-from type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH} --cache-to type=registry,ref=${GAR_CACHE}/dev-cache:${ARCH},mode=max --load" >> "$GITHUB_ENV"
+          echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://${GAR_CACHE}/megazords:${ARCH} --load" >> "$GITHUB_ENV"
+        else
+          echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
+          echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
+          echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
+          echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
+        fi
         echo 'SCHEMAS_BUILD_FLAGS=--load' >> "$GITHUB_ENV"
         echo 'DOCKER_RUN_INTERACTIVE=' >> "$GITHUB_ENV"

--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: ./.github/actions/setup-cached-build
         with:
           arch: ${{ matrix.arch }}
-          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          gcp-project-number: ${{ !github.event.pull_request.head.repo.fork && vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER || '' }}
 
       - name: Run Cirrus tests and linting
         run: |

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -39,7 +39,7 @@ jobs:
       - uses: ./.github/actions/setup-cached-build
         with:
           arch: ${{ matrix.arch }}
-          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          gcp-project-number: ${{ !github.event.pull_request.head.repo.fork && vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER || '' }}
 
       - name: Run tests and linting
         run: |

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-build
         with:
-          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          gcp-project-number: ${{ !github.event.pull_request.head.repo.fork && vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER || '' }}
 
       - name: Check local feature manifests
         run: |

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -20,7 +20,7 @@ jobs:
 
       - uses: ./.github/actions/setup-cached-build
         with:
-          gcp-project-number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          gcp-project-number: ${{ !github.event.pull_request.head.repo.fork && vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER || '' }}
 
       - name: Run schemas tests and linting
         run: make schemas_check


### PR DESCRIPTION
Because

* Fork PRs cannot obtain OIDC tokens from GitHub Actions, so the
  GCP authentication step in `setup-cached-build` fails immediately
  and tests never run (surfaced by #14986)
* The GCP auth is only needed for GAR registry caching, not for
  the actual test execution

This commit

* Makes `gcp-project-number` optional in the `setup-cached-build` action
* Adds `if` conditions to skip GCP auth, GAR login, registry cache,
  and image push steps when no project number is provided
* Falls back to plain local Docker builds for fork PRs (slower but
  functional)
* Updates all 4 check workflows to detect fork PRs and pass an
  empty project number via `github.event.pull_request.head.repo.fork`

Fixes #14989