### PR TITLE
fix(nimbus): capture branch feature value changes in history changelog

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -829,8 +829,8 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     @transaction.atomic
     def save(self, *args, **kwargs):
-        experiment = super().save(*args, **kwargs)
         self.branches.save()
+        experiment = super().save(*args, **kwargs)
 
         if experiment.is_rollout:
             branches = experiment.branches.all()

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3226,6 +3226,18 @@ class TestNimbusBranchesForm(RequestFormTestCase):
 
         changelog = experiment.changes.get()
         self.assertIn("updated branches", changelog.message)
+        changelog_branches = changelog.experiment_data["branches"]
+        changelog_fv_values = [
+            fv["value"] for b in changelog_branches for fv in b["feature_values"]
+        ]
+        self.assertIn(
+            json.dumps({"control-feature1-key": "control-feature-1-value"}),
+            changelog_fv_values,
+        )
+        self.assertIn(
+            json.dumps({"treatment-feature-1-key": "treatment-feature-1-value"}),
+            changelog_fv_values,
+        )
 
     def test_branches_form_saves_added_feature_config(self):
         application = NimbusExperiment.Application.DESKTOP


### PR DESCRIPTION
Because

* `NimbusBranchesForm.save()` called `super().save()` which triggered `NimbusChangeLogFormMixin.save()` to generate the changelog snapshot before `self.branches.save()` ran, causing the changelog to capture stale feature values instead of the updated ones
* Feature value changes were invisible on the History page

This commit

* Bypasses the mixin's `save()` in `NimbusBranchesForm` to call `ModelForm.save()` directly, then generates the changelog after all branch and feature value saves are complete
* Adds a test that saves an experiment with initial feature values, updates the values, and asserts the changelog captures the change

Fixes #14998