### PR TITLE
fix(nimbus): catch FmlError when FmlClient fails to parse a manifest

### DIFF
--- a/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/manifests/nimbus_fml_loader.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from typing import Optional
 
 from django.conf import settings
-from nimbus_megazord.fml import FmlClient
+from nimbus_megazord.fml import FmlClient, FmlError
 
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusFeatureVersion
@@ -55,10 +55,16 @@ class NimbusFmlLoader:
         """
         file_path = self.file_path(version)
         if file_path is not None:
-            return FmlClient(
-                str(file_path),
-                self.channel,
-            )
+            try:
+                return FmlClient(
+                    str(file_path),
+                    self.channel,
+                )
+            except FmlError:
+                logger.exception(
+                    f"Nimbus FML Loader: FmlClient failed to parse manifest: {file_path}"
+                )
+                return None
         else:
             logger.error("Nimbus FML Loader: Failed to get FmlClient.")
             return None

--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -2,7 +2,7 @@ import json
 from unittest.mock import patch
 
 from django.test import TestCase
-from nimbus_megazord.fml import FmlClient
+from nimbus_megazord.fml import FmlClient, FmlError
 
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
@@ -210,3 +210,36 @@ class TestNimbusFmlLoader(TestCase):
             self.assertEqual(loader.application, None)
             self.assertEqual(result, [])
             self.assertIn("Nimbus FML Loader: Invalid application", log.output[0])
+
+    @patch(
+        "nimbus_megazord.fml.FmlClient.__init__",
+        side_effect=FmlError("gecko-pref and default are mutually exclusive"),
+    )
+    @mock_fml_features
+    def test_fml_client_returns_none_when_manifest_fails_to_parse(self, _mock_client):
+        loader = self.create_loader()
+        with self.assertLogs(level="ERROR") as log:
+            result = loader.fml_client()
+            self.assertIsNone(result)
+            self.assertIn(
+                "Nimbus FML Loader: FmlClient failed to parse manifest",
+                log.output[0],
+            )
+
+    @patch(
+        "nimbus_megazord.fml.FmlClient.__init__",
+        side_effect=FmlError("gecko-pref and default are mutually exclusive"),
+    )
+    @mock_fml_features
+    def test_get_fml_errors_returns_empty_when_manifest_fails_to_parse(
+        self, _mock_client
+    ):
+        loader = self.create_loader()
+        test_blob = json.dumps({"enabled": True})
+        with self.assertLogs(level="ERROR") as log:
+            result = loader.get_fml_errors(test_blob, "cookie-banners")
+            self.assertEqual(result, [])
+            self.assertIn(
+                "Nimbus FML Loader: FmlClient failed to parse manifest",
+                log.output[0],
+            )


### PR DESCRIPTION
Because

* The `FmlClient` constructor can raise `FmlError.ValidationError` when a feature manifest has validation errors (e.g., a variable with both `gecko-pref` and `default`, which are now mutually exclusive as of the latest application-services build)
* `NimbusFmlLoader.fml_client()` did not catch this exception, so it propagated up and caused a 500 error on any page that calls `get_invalid_fields_errors()` (including the audience page during experiment creation)
* This was discovered via failing Fenix integration tests on PR #15002 (application-services version bump) — all `FIREFOX_FENIX` UI tests failed with `TimeoutException` because the audience page returned a 500

This commit

* Wraps the `FmlClient()` constructor in a `try/except FmlError` so invalid manifests are logged and skipped rather than crashing the page
* Adds unit tests for the graceful degradation in both `fml_client()` and `get_fml_errors()`

Fixes #15018