### PR TITLE
style(nimbus): reduce size of extra info cards

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -206,6 +206,35 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         ),
     }
 
+    COMPLETE_EXPERIMENT_ERROR_MESSAGE = """Your experiment is complete, but there were
+    issues computing some results. Contact Experimenter support using the button below
+    for help resolving analysis errors."""
+
+    INCOMPLETE_EXPERIMENT_ERROR_MESSAGE = """Your experiment is still running &mdash;
+    some metrics aren't available yet. This usually affects early results but may
+    indicate a configuration issue; see error details on the right or Contact
+    Experimenter Support using the button below."""
+
+    INVALID_EXPOSURE_DATA_MESSAGE = """Some branches are missing exposure data while
+    others have them. Exposure-based analysis may be incomplete. You can still view
+    available results — try switching the analysis basis to "Exposures" to inspect what's
+    present, or contact Experimenter Support if you need help fixing the data."""
+
+    CONFIG_OVERRIDES_MESSAGE = """The results shown on this page are from an analysis ran
+    with at least one experiment override that affects only the analysis. The original
+    <b>experiment details and description on the Summary page will not reflect this.</b>
+    """
+
+    ENROLLMENT_PHASE_MESSAGE = """Enrollment is when participants can join your
+    experiment. You'll need to end it yourself once enough people have joined, or when
+    the time you set for enrollment has passed — it won't close automatically."""
+
+    OBSERVATION_PHASE_MESSAGE = """Your experiment is officially in progress, and early
+    numbers are starting to come in. These results are just for checking that
+    everything's running correctly — they aren't reliable for decisions until the
+    monitoring period is complete.
+    <a href="https://experimenter.info/workflow/monitoring">Learn more</a>"""
+
     class MetricAreaType:
         PRIMARY = {
             "label": "Primary Metric",

--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -331,3 +331,13 @@
     padding-left: 0.75rem !important;
   }
 }
+
+.info-cards-container {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.info-cards-container > *:last-child:nth-child(odd) {
+  grid-column: 1 / -1;
+}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
@@ -49,12 +49,10 @@
   {% endif %}
   {% if experiment.is_enrolling %}
     <div class="bg-info-subtle p-4 mb-0 rounded-4 border border-1 border-secondary-subtle">
-      <div class="row align-items-stretch">
-        <div class="col-5 py-4 mt-0">
+      <div class="row g-2 align-items-center">
+        <div class="col-xxl-5">
           <h5>Enrollment in progress — don't forget to close it</h5>
-          <p class="text-muted mb-0">
-            Enrollment is when participants can join your experiment. You'll need to end it yourself once enough people have joined, or when the time you set for enrollment has passed — it won't close automatically.
-          </p>
+          <p class="text-muted mb-0">{{ NimbusUIConstants.ENROLLMENT_PHASE_MESSAGE }}</p>
           {% if experiment.should_show_end_enrollment %}
             <div class="mt-4">
               <form>
@@ -99,8 +97,8 @@
             </div>
           {% endif %}
         </div>
-        <div class="col">
-          <div class="card p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4 h-100 d-flex justify-content-center">
+        <div class="col-xxl">
+          <div class="p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4 border border-1 border-secondary-subtle">
             <h6>{{ experiment.enrollment_percent_completion }}% of enrollment complete</h6>
             <div class="progress mb-2 bg-secondary-subtle"
                  role="progressbar"
@@ -126,75 +124,72 @@
     </div>
   {% elif experiment.is_observation %}
     <div class="bg-primary-subtle p-4 mb-0 rounded-4 border border-1 border-secondary-subtle">
-      <div class="row align-items-center">
-        <div class="col-5 py-4 mt-0">
-          <h5>Observing — results still forming</h5>
-          <p class="text-muted mb-0">
-            Your experiment is officially in progress, and early numbers are starting to come in. These results are just for checking that everything's running correctly — they aren't reliable for decisions until the monitoring period is complete. <a href="https://experimenter.info/workflow/monitoring">
-            Learn more
-          </p>
-        </a>
-        <div class="mt-4">
-          <form>
-            {% csrf_token %}
-            {% if experiment.is_rollout_update_requested %}
-              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-update-rollout" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+      <div class="row g-2 align-items-center">
+        <div class="col-xxl-5">
+          <div class="py-4 mt-0">
+            <h5>Observing — results still forming</h5>
+            <p class="text-muted mb-0">{{ NimbusUIConstants.OBSERVATION_PHASE_MESSAGE|sanitize_html }}</p>
+          </div>
+          <div>
+            <form>
+              {% csrf_token %}
+              {% if experiment.is_rollout_update_requested %}
+                {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-update-rollout" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
 
-            {% elif experiment.is_enrollment_pause_requested %}
-              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-enrollment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+              {% elif experiment.is_enrollment_pause_requested %}
+                {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-enrollment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
 
-            {% elif experiment.is_end_experiment_requested %}
-              {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
+              {% elif experiment.is_end_experiment_requested %}
+                {% include "common/cancel_review_button.html" with cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment fragment="progress_card" replaced_element="#"|add:experiment.slug|add:"-progress-card" %}
 
-            {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
-              {% if experiment.should_show_end_experiment %}
-                <button type="button"
-                        hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
-                        hx-select="#{{ experiment.slug }}-progress-card"
-                        hx-target="#{{ experiment.slug }}-progress-card"
-                        hx-swap="outerHTML"
-                        id="end-experiment"
-                        class="btn btn-primary m-1 end_experiment_btn">
-                  End
-                  {% if experiment.is_rollout %}
-                    rollout
-                  {% else %}
-                    experiment
-                  {% endif %}
-                  early
-                </button>
+              {% elif experiment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
+                {% if experiment.should_show_end_experiment %}
+                  <button type="button"
+                          hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
+                          hx-select="#{{ experiment.slug }}-progress-card"
+                          hx-target="#{{ experiment.slug }}-progress-card"
+                          hx-swap="outerHTML"
+                          id="end-experiment"
+                          class="btn btn-primary m-1 end_experiment_btn">
+                    End
+                    {% if experiment.is_rollout %}
+                      rollout
+                    {% else %}
+                      experiment
+                    {% endif %}
+                    early
+                  </button>
+                {% endif %}
               {% endif %}
-            {% endif %}
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
-      <div class="col">
-        <div class="p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4 border border-1 border-secondary-subtle">
-          <h6>
-            {{ experiment.days_since_observation_start }}/{{ experiment.computed_observations_days }} expected days monitored
-          </h6>
-          <div class="progress mb-2 bg-secondary-subtle"
-               role="progressbar"
-               aria-label="{{ experiment.name }} enrollment progress"
-               aria-valuenow="{{ experiment.observation_percent_completion }}"
-               aria-valuemin="0"
-               aria-valuemax="100"
-               style="height: 10px">
-            <div class="progress-bar"
-                 style="width: {{ experiment.observation_percent_completion }}%"></div>
-          </div>
-          <div class="text-muted d-flex gap-2 align-items-center mb-1">
-            <i class="fa-solid fa-chart-line"></i>
-            <small>Results become reliable after experiment ends <span class="fst-italic">(expected on {{ experiment.proposed_end_date }})</span></small>
-          </div>
-          <div class="text-muted d-flex gap-2 align-items-center">
-            {% comment %} TODO(gh-13723): check if there are any metric errors and show them here {% endcomment %}
-            <i class="fa-solid fa-circle-check text-success"></i>
-            <small>Metrics reporting correctly</small>
+        <div class="col-xxl">
+          <div class="p-2 bg-body-secondary bg-opacity-50 py-5 px-4 rounded-4 border border-1 border-secondary-subtle">
+            <h6>
+              {{ experiment.days_since_observation_start }}/{{ experiment.computed_observations_days }} expected days monitored
+            </h6>
+            <div class="progress mb-2 bg-secondary-subtle"
+                 role="progressbar"
+                 aria-label="{{ experiment.name }} enrollment progress"
+                 aria-valuenow="{{ experiment.observation_percent_completion }}"
+                 aria-valuemin="0"
+                 aria-valuemax="100"
+                 style="height: 10px">
+              <div class="progress-bar"
+                   style="width: {{ experiment.observation_percent_completion }}%"></div>
+            </div>
+            <div class="text-muted d-flex gap-2 align-items-center mb-1">
+              <i class="fa-solid fa-chart-line"></i>
+              <small>Results become reliable after experiment ends <span class="fst-italic">(expected on {{ experiment.proposed_end_date }})</span></small>
+            </div>
+            <div class="text-muted d-flex gap-2 align-items-center">
+              <i class="fa-solid fa-circle-check text-success"></i>
+              <small>Metrics reporting correctly</small>
+            </div>
           </div>
         </div>
       </div>
     </div>
-  </div>
-{% endif %}
+  {% endif %}
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
@@ -1,185 +1,180 @@
 {% load nimbus_extras %}
 
 <div class="d-flex flex-column gap-3 mt-4" id="experiment-results-page">
-  {% if experiment.has_results_errors %}
-    <div class="alert p-4 py-3 mb-0 rounded-4 alert-warning" role="alert">
-      <div class="row align-items-center">
-        <div class="col-5 py-4 mt-0">
+  <div class="info-cards-container">
+    {% if experiment.has_results_errors %}
+      <div class="alert p-4 py-3 mb-0 rounded-4 alert-warning" role="alert">
+        <div class="row align-items-center">
+          <div class="col-xxl py-4 mt-0">
+            <div class="d-flex align-items-center mb-2 gap-2">
+              <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+              <h5 class="mb-0">Issues detected in a few metrics</h5>
+            </div>
+            <p class="text-muted">
+              {% if experiment.is_complete %}
+                {{ NimbusUIConstants.COMPLETE_EXPERIMENT_ERROR_MESSAGE }}
+              {% else %}
+                {{ NimbusUIConstants.INCOMPLETE_EXPERIMENT_ERROR_MESSAGE }}
+              {% endif %}
+            </p>
+            <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
+               target="_blank"
+               href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+          </div>
+          <div class="col-xxl">
+            <div class="bg-warning bg-opacity-25 px-4 py-3 rounded-4 h-100 d-flex flex-column justify-content-start text-body">
+              <p class="text-muted mb-2">Possible Issues</p>
+              <ul class="list-unstyled mb-0">
+                {% for error_group, error_list in experiment.results_data.v3.errors.items %}
+                  {% for error in error_list %}
+                    {% if forloop.last or error_group == "experiment" %}
+                      <li class="d-flex align-items-center gap-1 mb-2 text-muted">
+                        <i class="fa-solid fa-triangle-exclamation"></i>
+                        <small class="fw-bold">
+                          {% if error.metric %}
+                            {{ error.metric }} metric encountered issues. —
+                          {% else %}
+                            {{ error.exception_type|default:"Unknown error" }} —
+                          {% endif %}
+                        </small>
+                        <button class="btn btn-link p-0"
+                                data-bs-toggle="modal"
+                                data-bs-target="#{{ experiment.slug }}-error-{{ forloop.counter }}">
+                          <small>View details</small>
+                        </button>
+                      </li>
+                      <div class="modal fade"
+                           id="{{ experiment.slug }}-error-{{ forloop.counter }}"
+                           tabindex="-1"
+                           aria-labelledby="exampleModalLabel"
+                           aria-hidden="true">
+                        <div class="modal-dialog modal-dialog-centered modal-lg">
+                          <div class="modal-content">
+                            <div class="modal-header">
+                              <h5 class="modal-title">Error Details</h5>
+                              <button type="button"
+                                      class="btn-close"
+                                      data-bs-dismiss="modal"
+                                      aria-label="Close"></button>
+                            </div>
+                            <div class="modal-body">
+                              <dl class="row">
+                                <dt class="col-sm-4">Level</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.log_level }}
+                                </dd>
+                                <dt class="col-sm-4">Type</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.exception_type }}
+                                </dd>
+                                <dt class="col-sm-4">Timestamp</dt>
+                                <dd class="col-sm-8">
+                                  [{{ error.timestamp }}]
+                                </dd>
+                                <dt class="col-sm-4">Message</dt>
+                                <dd class="col-sm-8 text-break">
+                                  {{ error.message }}
+                                </dd>
+                                <dt class="col-sm-4">File</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.filename }}
+                                </dd>
+                                <dt class="col-sm-4">Function</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.func_name }}
+                                </dd>
+                                <dt class="col-sm-4">Metric</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.metric|default:"—" }}
+                                </dd>
+                                <dt class="col-sm-4">Segment</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.segment|default:"—" }}
+                                </dd>
+                                <dt class="col-sm-4">Analysis basis</dt>
+                                <dd class="col-sm-8">
+                                  {{ error.analysis_basis|default:"—" }}
+                                </dd>
+                                {% if error.exception %}
+                                  <details class="mt-3">
+                                    <summary class="small">View full exception</summary>
+                                    <code class="mt-2 mb-0 text-break">{{ error.exception }}</code>
+                                  </details>
+                                {% endif %}
+                              </dl>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    {% endif %}
+                  {% endfor %}
+                {% endfor %}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+    {% if experiment.has_exposures == invalid_exposure_status %}
+      <div class="alert p-4 mb-0 rounded-4 alert-warning" role="alert">
+        <div class="d-flex flex-column gap-2 align-items-start justify-content-center h-100">
           <div class="d-flex align-items-center mb-2 gap-2">
             <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-            <h5 class="mb-0">Issues detected in a few metrics</h5>
+            <h5 class="mb-0">Exposure data misconfigured</h5>
           </div>
-          <p class="text-muted">
-            {% if experiment.is_complete %}
-              Your experiment is complete, but there were issues computing some results. Contact Experimenter support using the button below for help resolving analysis errors.
-            {% else %}
-              Your experiment is still running &mdash; some metrics aren't available yet. This usually affects early results but may indicate a configuration issue; see error details on the right or Contact Experimenter Support using the button below.
-            {% endif %}
-          </p>
+          <p class="text-muted">{{ NimbusUIConstants.INVALID_EXPOSURE_DATA_MESSAGE }}</p>
           <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
              target="_blank"
              href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
         </div>
-        <div class="col">
-          <div class="bg-warning bg-opacity-25 px-4 py-3 rounded-4 h-100 d-flex flex-column justify-content-start text-body">
-            <p class="text-muted mb-2">Possible Issues</p>
-            <ul class="list-unstyled mb-0">
-              {% for error_group, error_list in experiment.results_data.v3.errors.items %}
-                {% for error in error_list %}
-                  {% if forloop.last or error_group == "experiment" %}
-                    <li class="d-flex align-items-center gap-1 mb-2 text-muted">
-                      <i class="fa-solid fa-triangle-exclamation"></i>
-                      <small class="fw-bold">
-                        {% if error.metric %}
-                          {{ error.metric }} metric encountered issues. —
-                        {% else %}
-                          {{ error.exception_type|default:"Unknown error" }} —
-                        {% endif %}
-                      </small>
-                      <button class="btn btn-link p-0"
-                              data-bs-toggle="modal"
-                              data-bs-target="#{{ experiment.slug }}-error-{{ forloop.counter }}">
-                        <small>View details</small>
-                      </button>
-                    </li>
-                    <div class="modal fade"
-                         id="{{ experiment.slug }}-error-{{ forloop.counter }}"
-                         tabindex="-1"
-                         aria-labelledby="exampleModalLabel"
-                         aria-hidden="true">
-                      <div class="modal-dialog modal-dialog-centered modal-lg">
-                        <div class="modal-content">
-                          <div class="modal-header">
-                            <h5 class="modal-title">Error Details</h5>
-                            <button type="button"
-                                    class="btn-close"
-                                    data-bs-dismiss="modal"
-                                    aria-label="Close"></button>
-                          </div>
-                          <div class="modal-body">
-                            <dl class="row">
-                              <dt class="col-sm-4">Level</dt>
-                              <dd class="col-sm-8">
-                                {{ error.log_level }}
-                              </dd>
-                              <dt class="col-sm-4">Type</dt>
-                              <dd class="col-sm-8">
-                                {{ error.exception_type }}
-                              </dd>
-                              <dt class="col-sm-4">Timestamp</dt>
-                              <dd class="col-sm-8">
-                                [{{ error.timestamp }}]
-                              </dd>
-                              <dt class="col-sm-4">Message</dt>
-                              <dd class="col-sm-8 text-break">
-                                {{ error.message }}
-                              </dd>
-                              <dt class="col-sm-4">File</dt>
-                              <dd class="col-sm-8">
-                                {{ error.filename }}
-                              </dd>
-                              <dt class="col-sm-4">Function</dt>
-                              <dd class="col-sm-8">
-                                {{ error.func_name }}
-                              </dd>
-                              <dt class="col-sm-4">Metric</dt>
-                              <dd class="col-sm-8">
-                                {{ error.metric|default:"—" }}
-                              </dd>
-                              <dt class="col-sm-4">Segment</dt>
-                              <dd class="col-sm-8">
-                                {{ error.segment|default:"—" }}
-                              </dd>
-                              <dt class="col-sm-4">Analysis basis</dt>
-                              <dd class="col-sm-8">
-                                {{ error.analysis_basis|default:"—" }}
-                              </dd>
-                              {% if error.exception %}
-                                <details class="mt-3">
-                                  <summary class="small">View full exception</summary>
-                                  <code class="mt-2 mb-0 text-break">{{ error.exception }}</code>
-                                </details>
-                              {% endif %}
-                            </dl>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                  {% endif %}
-                {% endfor %}
-              {% endfor %}
-            </ul>
-          </div>
-        </div>
       </div>
-    </div>
-  {% endif %}
-  {% if experiment.has_exposures == invalid_exposure_status %}
-    <div class="alert p-4 mb-0 rounded-4 alert-warning" role="alert">
-      <div class="d-flex flex-column gap-2 align-items-start">
-        <div class="d-flex align-items-center mb-2 gap-2">
-          <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-          <h5 class="mb-0">Exposure data misconfigured</h5>
-        </div>
-        <p class="text-muted">
-          Some branches are missing exposure data while others have them. Exposure-based
-          analysis may be incomplete. You can still view available results — try switching
-          the analysis basis to "Exposures" to inspect what's present, or contact Experimenter
-          Support if you need help fixing the data.
-        </p>
-        <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
-           target="_blank"
-           href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
-      </div>
-    </div>
-  {% endif %}
-  {% if experiment.is_enrolling or experiment.is_observation %}
-    {% include "nimbus_experiments/launch_controls_v2.html" %}
+    {% endif %}
+    {% if experiment.is_enrolling or experiment.is_observation %}
+      {% include "nimbus_experiments/launch_controls_v2.html" %}
 
-  {% endif %}
-  {% if experiment.results_data.v3.metadata.external_config %}
-    {% with external_config=experiment.results_data.v3.metadata.external_config %}
-      <div class="alert p-4 mb-0 rounded-4 alert-info" role="alert">
-        <div class="d-flex flex-column gap-2 align-items-start">
-          <div class="d-flex align-items-center mb-2 gap-2">
-            <i class="fa-solid fa-circle-exclamation fs-5"></i>
-            <h5 class="mb-0">Analysis has manual overrides in Jetstream</h5>
+    {% endif %}
+    {% if experiment.results_data.v3.metadata.external_config %}
+      {% with external_config=experiment.results_data.v3.metadata.external_config %}
+        <div class="alert p-4 mb-0 rounded-4 alert-info" role="alert">
+          <div class="d-flex flex-column gap-2 align-items-start justify-content-center h-100">
+            <div class="d-flex align-items-center mb-2 gap-2">
+              <i class="fa-solid fa-circle-exclamation fs-5"></i>
+              <h5 class="mb-0">Analysis has manual overrides in Jetstream</h5>
+            </div>
+            <p class="text-muted">{{ NimbusUIConstants.CONFIG_OVERRIDES_MESSAGE|sanitize_html }}</p>
+            <p class="mb-0">
+              Overrides (<a href={{ external_config.url }}>click here</a> to view the config file):
+            </p>
+            <ul>
+              {% if external_config.start_date %}
+                <li>
+                  Start date → <b>{{ external_config.start_date|parse_date|date:"M d, Y" }}</b>
+                </li>
+              {% endif %}
+              {% if external_config.end_date %}
+                <li>
+                  End date → <b>{{ external_config.end_date|parse_date|date:"M d, Y" }}</b>
+                </li>
+              {% endif %}
+              {% if external_config.enrollment_period %}
+                <li>
+                  Enrollment period → <b>{{ external_config.enrollment_period }}</b>
+                </li>
+              {% endif %}
+              {% if external_config.reference_branch %}
+                <li>
+                  Baseline branch → <b>{{ external_config.reference_branch }}</b>
+                </li>
+              {% endif %}
+            </ul>
+            <p class="mb-0">
+              If you have questions about this, please ask in <a target="_blank" href="{{ ask_experimenter_slack_link }}">#ask-experimenter</a>.
+            </p>
           </div>
-          <p class="text-muted">
-            The results shown on this page are from an analysis ran with at least one experiment override that affects only the analysis. The original <b>experiment details and description on the Summary page will not reflect this.</b>
-          </p>
-          <p class="mb-0">
-            Overrides (<a href={{ external_config.url }}>click here</a> to view the config file):
-          </p>
-          <ul>
-            {% if external_config.start_date %}
-              <li>
-                Start date → <b>{{ external_config.start_date|parse_date|date:"M d, Y" }}</b>
-              </li>
-            {% endif %}
-            {% if external_config.end_date %}
-              <li>
-                End date → <b>{{ external_config.end_date|parse_date|date:"M d, Y" }}</b>
-              </li>
-            {% endif %}
-            {% if external_config.enrollment_period %}
-              <li>
-                Enrollment period → <b>{{ external_config.enrollment_period }}</b>
-              </li>
-            {% endif %}
-            {% if external_config.reference_branch %}
-              <li>
-                Baseline branch → <b>{{ external_config.reference_branch }}</b>
-              </li>
-            {% endif %}
-          </ul>
-          <p class="mb-0">
-            If you have questions about this, please ask in <a target="_blank" href="{{ ask_experimenter_slack_link }}">#ask-experimenter</a>.
-          </p>
         </div>
-      </div>
-    {% endwith %}
-  {% endif %}
+      {% endwith %}
+    {% endif %}
+  </div>
   <form hx-get="{{ request.path }}"
         hx-push-url="true"
         hx-trigger="change"


### PR DESCRIPTION
Because

- The error, observation and overridden config cards are taking up a lot more space than they need to be

This commit

- Reorganizes them so they are side by side in a grid layout and take up less vertical space

Fixes #14894 