### PR TITLE
feat(nimbus): add focus styles to metric popout buttons

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -275,7 +275,7 @@
             <div class="dropdown results-table-actions"
                  data-experiment-slug="{{ experiment.slug }}"
                  data-controlling-area="{{ area|slugify }}">
-              <a class="btn border-0"
+              <a class="btn border-0 focus-ring focus-ring-primary"
                  href="#"
                  role="button"
                  data-bs-toggle="dropdown"
@@ -315,7 +315,7 @@
                 <div class="col-2">
                   <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
                   {% for metric in metric_metadata %}
-                    <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle                   {% if metric.has_data %}nav-link-hover{% else %}bg-body-tertiary{% endif %}  text-break"
+                    <button class="btn border-3 p-3 {% if forloop.last %}mb-4{% endif %} align-items-center mb-3 d-flex rounded-4 w-100 text-start position-relative border-light-subtle focus-ring focus-ring-primary {% if metric.has_data %}nav-link-hover{% else %}bg-body-tertiary{% endif %} text-break"
                             type="button"
                             data-bs-toggle="modal"
                             data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"


### PR DESCRIPTION
Because

- Keyboard focus indicators were not visible on key interactive controls in the results UI

This commit

- Adds Bootstrap focus ring classes to the metric buttons

Fixes #14624