### PR TITLE
feat(nimbus): add more info link to missing exposures error card

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -218,7 +218,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     INVALID_EXPOSURE_DATA_MESSAGE = """Some branches are missing exposure data while
     others have them. Exposure-based analysis may be incomplete. You can still view
     available results — try switching the analysis basis to "Exposures" to inspect what's
-    present, or contact Experimenter Support if you need help fixing the data."""
+    present, or contact Experimenter Support if you need help fixing the data.
+    <a href="https://experimenter.info/data-analysis/data-topics/missing_exposures/">
+    Learn more</a>"""
 
     CONFIG_OVERRIDES_MESSAGE = """The results shown on this page are from an analysis ran
     with at least one experiment override that affects only the analysis. The original

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
@@ -122,7 +122,7 @@
             <i class="fa-solid fa-triangle-exclamation fs-5"></i>
             <h5 class="mb-0">Exposure data misconfigured</h5>
           </div>
-          <p class="text-muted">{{ NimbusUIConstants.INVALID_EXPOSURE_DATA_MESSAGE }}</p>
+          <p class="text-muted">{{ NimbusUIConstants.INVALID_EXPOSURE_DATA_MESSAGE|sanitize_html }}</p>
           <a class="btn btn-secondary bg-secondary-subtle bg-opacity-25 border-0 text-body fw-semibold"
              target="_blank"
              href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>


### PR DESCRIPTION
Because

- We need to add a “Learn more” link for exposure misconfiguration needed to point users to the relevant documentation

This commit

- Adds a “Learn more” URL in the exposure misconfiguration alert

Fixes #15049