### PR TITLE
feat(nimbus) Add advanced targeting for 151 trainhop, content markets and 1 row shortcut experiments

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4202,9 +4202,7 @@ EDITORIAL_CONTENT_MARKETS = (
 EDITORIAL_CONTENT_AVAILABLE_MARKETS = NimbusTargetingConfig(
     name="New Tab Editorial Content Available Markets",
     slug="newtab-editorial-content-markets",
-    description=(
-        "Users in markets where Firefox New Tab Editorial Content is available"
-    ),
+    description=("Users in markets where Firefox New Tab Editorial Content is available"),
     targeting=f"region in {EDITORIAL_CONTENT_MARKETS}",
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
This commit adds new targeting for:
- 151 trainhop
- 1 row shortcuts
- markets with and without editorial content

Fixes #15006