### PR TITLE
Add guidance notification GIF experiment targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1098,6 +1098,24 @@ WIN11_ONLY = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+GUIDANCE_NOTIFICATION_GIF_EXPERIMENT = NimbusTargetingConfig(
+    name="Guidance notification GIF experiment",
+    slug="guidance_notification_gif_experiment",
+    description=(
+        "Windows 11 users but not Windows 10 users: EN users on Fx146+ or users on Fx149+"
+    ),
+    targeting=(
+        "(os.isWindows && os.windowsVersion >= 10 && "
+        "os.windowsBuildNumber >= 22000) && "
+        "((localeLanguageCode == 'en' && version|versionCompare('146.!') >= 0) || "
+        "version|versionCompare('149.!') >= 0)"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIN10_VPN_PROMOTION_ELIGIBLE = NimbusTargetingConfig(
     name="Windows 10 users eligible for VPN promotion",
     slug="win10_vpn_promotion_eligible",


### PR DESCRIPTION
This is a bespoke advanced targeting config for an experiment. The experiment struggles to reach the required sample size, so we extended it relative to a previous iteration by including all locales instead of just EN. But the necessary strings only landed in 149. And if we excluded pre-149 versions, we'd be excluding EN users who could see the message. And we'd be shrinking the audience, counteracting the locale expansion. So we are including EN users on versions 146 and later PLUS all locales on versions 149 and later. That means this targeting config will have no use outside of this experiment, so we can remove it once the experiment is finished.