### PR TITLE
Update targeting for 151 trainhop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4131,6 +4131,20 @@ FX_151_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_151_2_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx151 Mar-28 Trainhop",
+    slug="newtab-151-0328-trainhop",
+    description=(
+        "Desktop users having the New Tab 151.2.20260328.211913 train hop, "
+        "which includes users of Fx149"
+    ),
+    targeting="newtabAddonVersion|versionCompare('151.2.20260328.211913') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",
@@ -4303,11 +4317,11 @@ TOPSITES_1ROW_NON_EDITORIAL_FX151_TRAINHOP = NimbusTargetingConfig(
     slug="topsites-1row-non-editorial-fx151-trainhop",
     description=(
         "Desktop users in non-editorial content markets, with top sites rows set to 1, "
-        "having the New Tab 151.1.20260327.141953 train hop"
+        "having the New Tab 151.2.20260328.211913 train hop"
     ),
     targeting=(
         f"(region in {EDITORIAL_CONTENT_MARKETS}) != true"
-        f" && {FX_151_TRAINHOP.targeting}"
+        f" && {FX_151_2_TRAINHOP.targeting}"
         " && 'browser.newtabpage.activity-stream.topSitesRows'|preferenceValue == 1"
     ),
     desktop_telemetry="",


### PR DESCRIPTION
This is a follow-up on #15063 which added the initial Fx151 train-hop targeting.
This PR essentially updates the newtab trainhop version we recently had to cut. 
It updates the advanced targeting config for the New Tab train-hop from `151.1.20260327.141953` to `151.2.20260328.211913`. 

The new XPI was cut to fix a localization issue discovered after the previous build.

