### PR TITLE
feat(nimbus): create targeting context fields parser

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -85,6 +85,7 @@ class ApplicationConfig:
     is_web: bool
     preview_collection: str
     kinto_collections_by_feature_id: Optional[dict[str, str]] = field(default=None)
+    targeting_context_file_name: Optional[str] = field(default=None)
 
     def get_kinto_collection_for_experiment(self, experiment: NimbusExperiment) -> str:
         if self.kinto_collections_by_feature_id is not None:
@@ -163,6 +164,7 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
         DESKTOP_NEWTAB_ADDON_SLUG: settings.KINTO_COLLECTION_NIMBUS_SECURE,
     },
     preview_collection=settings.KINTO_COLLECTION_NIMBUS_PREVIEW,
+    targeting_context_file_name="TargetingContextRecorder.sys.mjs",
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(
@@ -178,6 +180,7 @@ APPLICATION_CONFIG_FENIX = ApplicationConfig(
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     is_web=False,
     preview_collection=settings.KINTO_COLLECTION_NIMBUS_PREVIEW,
+    targeting_context_file_name="RecordedNimbusContext.kt",
 )
 
 APPLICATION_CONFIG_IOS = ApplicationConfig(
@@ -193,6 +196,7 @@ APPLICATION_CONFIG_IOS = ApplicationConfig(
     randomization_unit=BucketRandomizationUnit.NIMBUS,
     is_web=False,
     preview_collection=settings.KINTO_COLLECTION_NIMBUS_PREVIEW,
+    targeting_context_file_name="RecordedNimbusContext.swift",
 )
 
 APPLICATION_CONFIG_MONITOR_WEB = ApplicationConfig(

--- a/experimenter/experimenter/targeting/targeting_context_parser.py
+++ b/experimenter/experimenter/targeting/targeting_context_parser.py
@@ -1,0 +1,129 @@
+import re
+
+from django.conf import settings
+
+from experimenter.experiments.constants import NimbusConstants
+
+
+class TargetingContextFields:
+    _desktop_targeting_fields = None
+    _fenix_targeting_fields = None
+    _ios_targeting_fields = None
+
+    _CACHE_FIELDS = {
+        NimbusConstants.Application.DESKTOP: "_desktop_targeting_fields",
+        NimbusConstants.Application.FENIX: "_fenix_targeting_fields",
+        NimbusConstants.Application.IOS: "_ios_targeting_fields",
+    }
+
+    @staticmethod
+    def _parse_desktop_targeting_fields(targeting_context_code):
+        found_block = False
+        targeting_fields = []
+        # This regex is meant to only match lines on the primary level of the object
+        # literal, so it looks for lines that start with two spaces followed by a letter.
+        # This is to avoid matching nested lines.
+        target_line_match = re.compile(r"^  [a-zA-Z]")
+
+        for line in targeting_context_code.splitlines():
+            stripped_line = line.strip()
+
+            if stripped_line == "export const ATTRIBUTE_TRANSFORMS = Object.freeze({":
+                found_block = True
+            elif found_block and stripped_line == "});":
+                break
+            elif found_block:
+                if target_line_match.match(line):
+                    targeting_fields.append(stripped_line.split(":")[0].strip())
+
+        return targeting_fields
+
+    @staticmethod
+    def _parse_fenix_targeting_fields(targeting_context_code):
+        found_block = False
+        targeting_fields = []
+        target_line_match = re.compile(r'"([^"]+)"')
+
+        for line in targeting_context_code.splitlines():
+            stripped_line = line.strip()
+
+            if stripped_line == "val obj = JSONObject(":
+                found_block = True
+            elif found_block and stripped_line == "),":
+                break
+            elif found_block:
+                res = target_line_match.search(stripped_line)
+                if res:
+                    targeting_fields.append(res.group(1))
+
+        return targeting_fields
+
+    @staticmethod
+    def _parse_ios_targeting_fields(targeting_context_code):
+        found_block = False
+        targeting_fields = []
+        target_line_match = re.compile(r'"([^"]+)"')
+
+        for line in targeting_context_code.splitlines():
+            stripped_line = line.strip()
+
+            if (
+                stripped_line
+                == "guard let data = try? JSONSerialization.data(withJSONObject: ["
+            ):
+                found_block = True
+            elif found_block and stripped_line == "]),":
+                break
+            elif found_block:
+                res = target_line_match.search(stripped_line)
+                if res:
+                    targeting_fields.append(res.group(1))
+
+        return targeting_fields
+
+    @classmethod
+    def _load_targeting_fields(cls, app, version=None):
+        app_path = (
+            settings.FEATURE_MANIFESTS_PATH / app / version
+            if version
+            else settings.FEATURE_MANIFESTS_PATH / app
+        )
+        targeting_context_path = (
+            app_path
+            / NimbusConstants.APPLICATION_CONFIGS[app].targeting_context_file_name
+        )
+
+        targeting_context_code = targeting_context_path.read_text()
+
+        match app:
+            case NimbusConstants.Application.DESKTOP:
+                return cls._parse_desktop_targeting_fields(targeting_context_code)
+            case NimbusConstants.Application.FENIX:
+                return cls._parse_fenix_targeting_fields(targeting_context_code)
+            case NimbusConstants.Application.IOS:
+                return cls._parse_ios_targeting_fields(targeting_context_code)
+
+    @classmethod
+    def clear_cache(cls, application=None):
+        if application is None:
+            for field_name in cls._CACHE_FIELDS.values():
+                setattr(cls, field_name, None)
+            return
+
+        field_name = cls._CACHE_FIELDS.get(application)
+        if field_name is not None:
+            setattr(cls, field_name, None)
+
+    @classmethod
+    def for_application(cls, app, version=None):
+        field_name = cls._CACHE_FIELDS.get(app)
+        if field_name is None:
+            raise ValueError(f"Unknown application: {app}")
+
+        cached_fields = getattr(cls, field_name)
+        if cached_fields is not None:
+            return cached_fields
+
+        targeting_fields = cls._load_targeting_fields(app, version)
+        setattr(cls, field_name, targeting_fields)
+        return targeting_fields

--- a/experimenter/experimenter/targeting/tests/__init__.py
+++ b/experimenter/experimenter/targeting/tests/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from django.test import override_settings
+
+mock_targeting_manifests = override_settings(
+    FEATURE_MANIFESTS_PATH=(Path(__file__).parent.absolute() / "mock-manifests"),
+)

--- a/experimenter/experimenter/targeting/tests/mock-manifests/fenix/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/fenix/RecordedNimbusContext.kt
@@ -1,0 +1,283 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.experiments
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import mozilla.components.support.locale.LocaleManager
+import mozilla.components.support.locale.LocaleManager.getSystemDefault
+import mozilla.components.support.utils.ext.packageManagerCompatHelper
+import org.json.JSONArray
+import org.json.JSONObject
+import org.mozilla.experiments.nimbus.NIMBUS_DATA_DIR
+import org.mozilla.experiments.nimbus.NimbusDeviceInfo
+import org.mozilla.experiments.nimbus.internal.JsonObject
+import org.mozilla.experiments.nimbus.internal.RecordedContext
+import org.mozilla.experiments.nimbus.internal.getCalculatedAttributes
+import org.mozilla.fenix.GleanMetrics.NimbusSystem
+import org.mozilla.fenix.GleanMetrics.Pings
+import org.mozilla.fenix.ext.settings
+import org.mozilla.fenix.home.pocket.ContentRecommendationsFeatureHelper
+import org.mozilla.fenix.termsofuse.experimentation.TermsOfUseAdvancedTargetingHelper
+import org.mozilla.fenix.termsofuse.experimentation.utils.DefaultTermsOfUseDataProvider
+import org.mozilla.fenix.utils.Settings
+import java.io.File
+
+/**
+ * The following constants are string constants of the keys that appear in the [EVENT_QUERIES] map.
+ */
+const val DAYS_OPENED_IN_LAST_28 = "days_opened_in_last_28"
+
+/**
+ * [EVENT_QUERIES] is a map of keys to Nimbus SDK EventStore queries.
+ */
+private val EVENT_QUERIES = mapOf(
+    DAYS_OPENED_IN_LAST_28 to "'events.app_opened'|eventCountNonZero('Days', 28, 0)",
+)
+
+/**
+ * The RecordedNimbusContext class inherits from an internal Nimbus interface that provides methods
+ * for obtaining a JSON value for the object and recording the object's value to Glean. Its JSON
+ * value is loaded into the Nimbus targeting context.
+ *
+ * The value recorded to Glean is used to automate population sizing. Any additions to this object
+ * require a new data review for the `nimbus_system.recorded_nimbus_context` metric.
+ */
+@Suppress("complexity:LongParameterList")
+class RecordedNimbusContext(
+    val isFirstRun: Boolean,
+    private val eventQueries: Map<String, String> = mapOf(),
+    private var eventQueryValues: Map<String, Double> = mapOf(),
+    val utmSource: String,
+    val utmMedium: String,
+    val utmCampaign: String,
+    val utmTerm: String,
+    val utmContent: String,
+    val androidSdkVersion: String = Build.VERSION.SDK_INT.toString(),
+    val appVersion: String?,
+    val locale: String,
+    val daysSinceInstall: Int?,
+    val daysSinceUpdate: Int?,
+    val language: String?,
+    val region: String?,
+    val deviceManufacturer: String = Build.MANUFACTURER,
+    val deviceModel: String = Build.MODEL,
+    val userAcceptedTou: Boolean,
+    val noShortcutsOrStoriesOptOuts: Boolean,
+    val addonIds: List<String>,
+    val touPoints: Int?,
+) : RecordedContext {
+    /**
+     * [getEventQueries] is called by the Nimbus SDK Rust code to retrieve the map of event
+     * queries. The are then executed against the Nimbus SDK's EventStore to retrieve their values.
+     *
+     * @return Map<String, String>
+     */
+    override fun getEventQueries(): Map<String, String> {
+        return eventQueries
+    }
+
+    /**
+     * [record] is called when experiment enrollments are evolved. It should apply the
+     * [RecordedNimbusContext]'s values to a [NimbusSystem.RecordedNimbusContextObject] instance,
+     * and use that instance to record the values to Glean.
+     */
+    override fun record() {
+        val eventQueryValuesObject = NimbusSystem.RecordedNimbusContextObjectItemEventQueryValuesObject(
+            daysOpenedInLast28 = eventQueryValues[DAYS_OPENED_IN_LAST_28]?.toInt(),
+        )
+        NimbusSystem.recordedNimbusContext.set(
+            NimbusSystem.RecordedNimbusContextObject(
+                isFirstRun = isFirstRun,
+                eventQueryValues = eventQueryValuesObject,
+                installReferrerResponseUtmSource = utmSource,
+                installReferrerResponseUtmMedium = utmMedium,
+                installReferrerResponseUtmCampaign = utmCampaign,
+                installReferrerResponseUtmTerm = utmTerm,
+                installReferrerResponseUtmContent = utmContent,
+                androidSdkVersion = androidSdkVersion,
+                appVersion = appVersion,
+                locale = locale,
+                daysSinceInstall = daysSinceInstall,
+                daysSinceUpdate = daysSinceUpdate,
+                language = language,
+                region = region,
+                deviceManufacturer = deviceManufacturer,
+                deviceModel = deviceModel,
+                userAcceptedTou = userAcceptedTou,
+                noShortcutsOrStoriesOptOuts = noShortcutsOrStoriesOptOuts,
+                addonIds = NimbusSystem.RecordedNimbusContextObjectAddonIds(addonIds.toMutableList()),
+                touPoints = touPoints,
+            ),
+        )
+        Pings.nimbus.submit()
+    }
+
+    /**
+     * [setEventQueryValues] is called by the Nimbus SDK Rust code after the event queries have been
+     * executed. The [eventQueryValues] should be written back to the Kotlin object.
+     *
+     * @param [eventQueryValues] The values for each query after they have been executed in the
+     * Nimbus SDK Rust environment.
+     */
+    override fun setEventQueryValues(eventQueryValues: Map<String, Double>) {
+        this.eventQueryValues = eventQueryValues
+    }
+
+    /**
+     * [toJson] is called by the Nimbus SDK Rust code after the event queries have been executed,
+     * and before experiment enrollments have been evolved. The value returned from this method
+     * will be applied directly to the Nimbus targeting context, and its keys/values take
+     * precedence over those in the main Nimbus targeting context.
+     *
+     * @return JSONObject
+     */
+    override fun toJson(): JsonObject {
+        val obj = JSONObject(
+            mapOf(
+                "is_first_run" to isFirstRun,
+                "events" to JSONObject(eventQueryValues),
+                "install_referrer_response_utm_source" to utmSource,
+                "install_referrer_response_utm_medium" to utmMedium,
+                "install_referrer_response_utm_campaign" to utmCampaign,
+                "install_referrer_response_utm_term" to utmTerm,
+                "install_referrer_response_utm_content" to utmContent,
+                "android_sdk_version" to androidSdkVersion,
+                "app_version" to appVersion,
+                "locale" to locale,
+                "days_since_install" to daysSinceInstall,
+                "days_since_update" to daysSinceUpdate,
+                "language" to language,
+                "region" to region,
+                "device_manufacturer" to deviceManufacturer,
+                "device_model" to deviceModel,
+                "user_accepted_tou" to userAcceptedTou,
+                "no_shortcuts_or_stories_opt_outs" to noShortcutsOrStoriesOptOuts,
+                "addon_ids" to JSONArray(addonIds),
+                "tou_points" to touPoints,
+            ),
+        )
+        return obj
+    }
+
+    /**
+     * Companion object for RecordedNimbusContext
+     */
+    companion object {
+
+        /**
+         * Creates a RecordedNimbusContext instance, populated with the application-defined
+         * eventQueries
+         *
+         * @return RecordedNimbusContext
+         */
+        fun create(
+            context: Context,
+            isFirstRun: Boolean,
+        ): RecordedNimbusContext {
+            val settings = context.settings()
+            val langTag = LocaleManager.getCurrentLocale(context)
+                ?.toLanguageTag() ?: getSystemDefault().toLanguageTag()
+            val termsOfUseAdvancedTargetingHelper = TermsOfUseAdvancedTargetingHelper(
+                DefaultTermsOfUseDataProvider(settings),
+                langTag,
+            )
+
+            val packageInfo =
+                context.packageManagerCompatHelper.getPackageInfoCompat(context.packageName, 0)
+            val deviceInfo = NimbusDeviceInfo.default()
+            val db = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR)
+            val calculatedAttributes = getCalculatedAttributes(
+                packageInfo.firstInstallTime,
+                db.path,
+                deviceInfo.localeTag,
+            )
+
+            return RecordedNimbusContext(
+                isFirstRun = isFirstRun,
+                eventQueries = EVENT_QUERIES,
+                utmSource = settings.utmSource,
+                utmMedium = settings.utmMedium,
+                utmCampaign = settings.utmCampaign,
+                utmTerm = settings.utmTerm,
+                utmContent = settings.utmContent,
+                appVersion = packageInfo.versionName,
+                locale = deviceInfo.localeTag,
+                daysSinceInstall = calculatedAttributes.daysSinceInstall,
+                daysSinceUpdate = calculatedAttributes.daysSinceUpdate,
+                language = calculatedAttributes.language,
+                region = calculatedAttributes.region,
+                userAcceptedTou = settings.hasAcceptedTermsOfService,
+                noShortcutsOrStoriesOptOuts = settings.noShortcutsOrStoriesOptOuts(context),
+                addonIds = getFormattedAddons(settings),
+                touPoints = termsOfUseAdvancedTargetingHelper.getTouPoints(),
+            )
+        }
+
+        @VisibleForTesting
+        internal fun getFormattedAddons(settings: Settings): List<String> =
+            settings.installedAddonsList.split(",").map { it.trim() }
+
+        /**
+         * Checks whether an eligible user has opted out of any sponsored top sites or stories.
+         *
+         *  @return `true` if the user has opted out of any sponsored top sites or stories,
+         * `false` otherwise.
+         */
+        private fun Settings.noShortcutsOrStoriesOptOuts(context: Context) =
+            !optedOutOfSponsoredTopSites() && !optedOutOfSponsoredStories(context)
+
+        /**
+         * Checks whether an eligible user has opted out of the sponsored top sites feature.
+         *
+         * This is not entirely self evident from the API descriptions, please note:
+         * [Settings.showContileFeature] indicates whether the sponsored shortcuts are shown.
+         * [Settings.showTopSitesFeature] indicates whether the feature should be shown at all.
+         */
+        private fun Settings.optedOutOfSponsoredTopSites() =
+            !showContileFeature || !showTopSitesFeature
+
+        private fun Settings.optedOutOfSponsoredStories(context: Context) =
+            isEligibleForStories(context) && (!showPocketSponsoredStories || !showPocketRecommendationsFeature)
+
+        private fun isEligibleForStories(context: Context): Boolean =
+            ContentRecommendationsFeatureHelper.isContentRecommendationsFeatureEnabled(context)
+
+        /**
+         * Creates a RecordedNimbusContext instance for test purposes
+         *
+         * @return RecordedNimbusContext
+         */
+        @VisibleForTesting
+        internal fun createForTest(
+            isFirstRun: Boolean = false,
+            eventQueries: Map<String, String> = EVENT_QUERIES,
+            eventQueryValues: Map<String, Double> = mapOf(),
+            addonIds: List<String> = emptyList(),
+        ): RecordedNimbusContext {
+            return RecordedNimbusContext(
+                isFirstRun = isFirstRun,
+                eventQueries = eventQueries,
+                eventQueryValues = eventQueryValues,
+                utmSource = "",
+                utmMedium = "",
+                utmCampaign = "",
+                utmTerm = "",
+                utmContent = "",
+                appVersion = "",
+                locale = "",
+                daysSinceInstall = 5,
+                daysSinceUpdate = 0,
+                language = "en",
+                region = "US",
+                userAcceptedTou = true,
+                noShortcutsOrStoriesOptOuts = true,
+                addonIds = addonIds,
+                touPoints = 3,
+            )
+        }
+    }
+}

--- a/experimenter/experimenter/targeting/tests/mock-manifests/fenix/v100.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/fenix/v100.0.0/RecordedNimbusContext.kt
@@ -1,0 +1,222 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+package org.mozilla.fenix.experiments
+
+import android.content.Context
+import android.os.Build
+import androidx.annotation.VisibleForTesting
+import mozilla.components.support.utils.ext.getPackageInfoCompat
+import org.json.JSONObject
+import org.mozilla.experiments.nimbus.NIMBUS_DATA_DIR
+import org.mozilla.experiments.nimbus.NimbusDeviceInfo
+import org.mozilla.experiments.nimbus.internal.JsonObject
+import org.mozilla.experiments.nimbus.internal.RecordedContext
+import org.mozilla.experiments.nimbus.internal.getCalculatedAttributes
+import org.mozilla.fenix.GleanMetrics.NimbusSystem
+import org.mozilla.fenix.ext.settings
+import java.io.File
+
+/**
+ * The following constants are string constants of the keys that appear in the [EVENT_QUERIES] map.
+ */
+const val DAYS_OPENED_IN_LAST_28 = "days_opened_in_last_28"
+
+/**
+ * [EVENT_QUERIES] is a map of keys to Nimbus SDK EventStore queries.
+ */
+private val EVENT_QUERIES = mapOf(
+    DAYS_OPENED_IN_LAST_28 to "'events.app_opened'|eventCountNonZero('Days', 28, 0)",
+)
+
+/**
+ * The RecordedNimbusContext class inherits from an internal Nimbus interface that provides methods
+ * for obtaining a JSON value for the object and recording the object's value to Glean. Its JSON
+ * value is loaded into the Nimbus targeting context.
+ *
+ * The value recorded to Glean is used to automate population sizing. Any additions to this object
+ * require a new data review for the `nimbus_system.recorded_nimbus_context` metric.
+ */
+@Suppress("complexity:LongParameterList")
+class RecordedNimbusContext(
+    val isFirstRun: Boolean,
+    private val eventQueries: Map<String, String> = mapOf(),
+    private var eventQueryValues: Map<String, Double> = mapOf(),
+    val utmSource: String,
+    val utmMedium: String,
+    val utmCampaign: String,
+    val utmTerm: String,
+    val utmContent: String,
+    val isReviewCheckerEnabled: Boolean,
+    val androidSdkVersion: String = Build.VERSION.SDK_INT.toString(),
+    val appVersion: String?,
+    val locale: String,
+    val daysSinceInstall: Int?,
+    val daysSinceUpdate: Int?,
+    val language: String?,
+    val region: String?,
+    val deviceManufacturer: String = Build.MANUFACTURER,
+    val deviceModel: String = Build.MODEL,
+) : RecordedContext {
+    /**
+     * [getEventQueries] is called by the Nimbus SDK Rust code to retrieve the map of event
+     * queries. The are then executed against the Nimbus SDK's EventStore to retrieve their values.
+     *
+     * @return Map<String, String>
+     */
+    override fun getEventQueries(): Map<String, String> {
+        return eventQueries
+    }
+
+    /**
+     * [record] is called when experiment enrollments are evolved. It should apply the
+     * [RecordedNimbusContext]'s values to a [NimbusSystem.RecordedNimbusContextObject] instance,
+     * and use that instance to record the values to Glean.
+     */
+    override fun record() {
+        val eventQueryValuesObject = NimbusSystem.RecordedNimbusContextObjectItemEventQueryValuesObject(
+            daysOpenedInLast28 = eventQueryValues[DAYS_OPENED_IN_LAST_28]?.toInt(),
+        )
+        NimbusSystem.recordedNimbusContext.set(
+            NimbusSystem.RecordedNimbusContextObject(
+                isFirstRun = isFirstRun,
+                eventQueryValues = eventQueryValuesObject,
+                installReferrerResponseUtmSource = utmSource,
+                installReferrerResponseUtmMedium = utmMedium,
+                installReferrerResponseUtmCampaign = utmCampaign,
+                installReferrerResponseUtmTerm = utmTerm,
+                installReferrerResponseUtmContent = utmContent,
+                isReviewCheckerEnabled = isReviewCheckerEnabled,
+                androidSdkVersion = androidSdkVersion,
+                appVersion = appVersion,
+                locale = locale,
+                daysSinceInstall = daysSinceInstall,
+                daysSinceUpdate = daysSinceUpdate,
+                language = language,
+                region = region,
+                deviceManufacturer = deviceManufacturer,
+                deviceModel = deviceModel,
+            ),
+        )
+    }
+
+    /**
+     * [setEventQueryValues] is called by the Nimbus SDK Rust code after the event queries have been
+     * executed. The [eventQueryValues] should be written back to the Kotlin object.
+     *
+     * @param [eventQueryValues] The values for each query after they have been executed in the
+     * Nimbus SDK Rust environment.
+     */
+    override fun setEventQueryValues(eventQueryValues: Map<String, Double>) {
+        this.eventQueryValues = eventQueryValues
+    }
+
+    /**
+     * [toJson] is called by the Nimbus SDK Rust code after the event queries have been executed,
+     * and before experiment enrollments have been evolved. The value returned from this method
+     * will be applied directly to the Nimbus targeting context, and its keys/values take
+     * precedence over those in the main Nimbus targeting context.
+     *
+     * @return JSONObject
+     */
+    override fun toJson(): JsonObject {
+        val obj = JSONObject(
+            mapOf(
+                "is_first_run" to isFirstRun,
+                "events" to JSONObject(eventQueryValues),
+                "install_referrer_response_utm_source" to utmSource,
+                "install_referrer_response_utm_medium" to utmMedium,
+                "install_referrer_response_utm_campaign" to utmCampaign,
+                "install_referrer_response_utm_term" to utmTerm,
+                "install_referrer_response_utm_content" to utmContent,
+                "is_review_checker_enabled" to isReviewCheckerEnabled,
+                "android_sdk_version" to androidSdkVersion,
+                "app_version" to appVersion,
+                "locale" to locale,
+                "days_since_install" to daysSinceInstall,
+                "days_since_update" to daysSinceUpdate,
+                "language" to language,
+                "region" to region,
+                "device_manufacturer" to deviceManufacturer,
+                "device_model" to deviceModel,
+            ),
+        )
+        return obj
+    }
+
+    /**
+     * Companion object for RecordedNimbusContext
+     */
+    companion object {
+
+        /**
+         * Creates a RecordedNimbusContext instance, populated with the application-defined
+         * eventQueries
+         *
+         * @return RecordedNimbusContext
+         */
+        fun create(
+            context: Context,
+            isFirstRun: Boolean,
+        ): RecordedNimbusContext {z
+            val settings = context.settings()
+
+            val packageInfo = context.packageManager.getPackageInfoCompat(context.packageName, 0)
+            val deviceInfo = NimbusDeviceInfo.default()
+            val db = File(context.applicationInfo.dataDir, NIMBUS_DATA_DIR)
+            val calculatedAttributes = getCalculatedAttributes(
+                packageInfo.firstInstallTime,
+                db.path,
+                deviceInfo.localeTag,
+            )
+
+            return RecordedNimbusContext(
+                isFirstRun = isFirstRun,
+                eventQueries = EVENT_QUERIES,
+                utmSource = settings.utmSource,
+                utmMedium = settings.utmMedium,
+                utmCampaign = settings.utmCampaign,
+                utmTerm = settings.utmTerm,
+                utmContent = settings.utmContent,
+                isReviewCheckerEnabled = settings.isReviewQualityCheckEnabled,
+                appVersion = packageInfo.versionName,
+                locale = deviceInfo.localeTag,
+                daysSinceInstall = calculatedAttributes.daysSinceInstall,
+                daysSinceUpdate = calculatedAttributes.daysSinceUpdate,
+                language = calculatedAttributes.language,
+                region = calculatedAttributes.region,
+            )
+        }
+
+        /**
+         * Creates a RecordedNimbusContext instance for test purposes
+         *
+         * @return RecordedNimbusContext
+         */
+        @VisibleForTesting
+        internal fun createForTest(
+            isFirstRun: Boolean = false,
+            eventQueries: Map<String, String> = EVENT_QUERIES,
+            eventQueryValues: Map<String, Double> = mapOf(),
+        ): RecordedNimbusContext {
+            return RecordedNimbusContext(
+                isFirstRun = isFirstRun,
+                eventQueries = eventQueries,
+                eventQueryValues = eventQueryValues,
+                utmSource = "",
+                utmMedium = "",
+                utmCampaign = "",
+                utmTerm = "",
+                utmContent = "",
+                isReviewCheckerEnabled = false,
+                appVersion = "",
+                locale = "",
+                daysSinceInstall = 5,
+                daysSinceUpdate = 0,
+                language = "en",
+                region = "US",
+            )
+        }
+    }
+}

--- a/experimenter/experimenter/targeting/tests/mock-manifests/firefox-desktop/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/firefox-desktop/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,401 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  ASRouterTargeting:
+    // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
+    "resource:///modules/asrouter/ASRouterTargeting.sys.mjs",
+  ClientID: "resource://gre/modules/ClientID.sys.mjs",
+  ExperimentAPI: "resource://nimbus/ExperimentAPI.sys.mjs",
+  NimbusFeatures: "resource://nimbus/ExperimentAPI.sys.mjs",
+  TargetingContext: "resource://messaging-system/targeting/Targeting.sys.mjs",
+});
+
+const { PREF_INVALID, PREF_STRING, PREF_INT, PREF_BOOL } = Ci.nsIPrefBranch;
+const PREF_TYPES = Object.freeze({
+  [PREF_STRING]: "Ci.nsIPrefBranch.PREF_STRING",
+  [PREF_INT]: "Ci.nsIPrefBranch.PREF_INT",
+  [PREF_BOOL]: "Ci.nsIPrefBranch.PREF_BOOL",
+});
+
+/**
+ * Return a function that returns specific keys of an object.
+ *
+ * All values will be awaited, so objects containing promises will be flattened
+ * into objects.
+ *
+ * Any exceptions encountered will not prevent the key from being recorded in
+ * the metric.
+ *
+ * @param {string[]} keys - The keys to include.
+ * @returns The function.
+ */
+function pick(...keys) {
+  const identity = x => x;
+  return pickWith(Object.fromEntries(keys.map(key => [key, identity])));
+}
+
+/**
+ * Return a function that returns a specific keys of an object, with transforms.
+ *
+ * All values will be awaited, as will their transform functions, so objects
+ * containing promises will be flattened into objects.
+ *
+ * Any exceptions encountered will not prevent the key from being recorded in
+ * the metric.
+ *
+ * @param {Record<string, () => any>} shape
+ *        A mapping of keys to transformation functions.
+ *
+ * @returns The function.
+ */
+function pickWith(shape) {
+  return async function (object) {
+    const transformed = {};
+    if (typeof object !== "undefined" && object !== null) {
+      for (const [key, transform] of Object.entries(shape)) {
+        try {
+          transformed[key] = await transform(await object[key]);
+        } catch (ex) {}
+      }
+    }
+    return transformed;
+  };
+}
+
+/**
+ * Assert that the attribute matches the given type (via typeof).
+ *
+ * @param {string} expectedType
+ *        The expected type.
+ *        If the attribute is not of this type, this function will throw.
+ * @param {any} attribute
+ *        The value whose type is to be checked.
+ *
+ * @returns The attribute.
+ */
+function assertType(expectedType, attribute) {
+  const type = typeof attribute;
+
+  if (type !== expectedType) {
+    throw new Error(`Expected ${expectedType} but got ${type} instead`);
+  }
+
+  return attribute;
+}
+
+/**
+ * Transforms that assert that the type of the attribute matches an expected
+ * type.
+ */
+const typeAssertions = {
+  integer: attribute =>
+    assertType("number", attribute) && Number.isSafeInteger(attribute),
+  string: attribute => assertType("string", attribute),
+  boolean: attribute => assertType("boolean", attribute),
+  quantity: attribute => Math.floor(assertType("number", attribute)),
+  array: attribute => {
+    if (!Array.isArray(attribute)) {
+      throw new Error(`Expected Array but got ${typeof attribute} instead`);
+    }
+
+    return attribute;
+  },
+  // NB: Date methods will throw if called on a non-Date object. We can't simply
+  // use `attribute instanceof Date` because the Date constructor might be from
+  // a different context (and thus the expression would evaluate to false).
+  date: attribute => Date.prototype.toUTCString.call(attribute),
+};
+
+/**
+ * This contains the set of all top-level targeting attributes in the Nimbus
+ * Targeting context and optional transforms functions that will be applied
+ * before the value is recorded.
+ */
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  activeExperiments: typeAssertions.array,
+  activeRollouts: typeAssertions.array,
+  addonsInfo: addonsInfo => ({
+    addons: Object.keys(addonsInfo?.addons ?? {}).sort(),
+    hasInstalledAddons: !!addonsInfo?.hasInstalledAddons,
+  }),
+  addressesSaved: typeAssertions.quantity,
+  archBits: typeAssertions.quantity,
+  attributionData: pick("medium", "source", "ua"),
+  browserSettings: pickWith({
+    update: pick("channel"),
+  }),
+  buildId: typeAssertions.integer,
+  currentDate: typeAssertions.date,
+  defaultPDFHandler: pick("knownBrowser", "registered"),
+  distributionId: typeAssertions.string,
+  doesAppNeedPin: typeAssertions.boolean,
+  enrollmentsMap: enrollmentsMap =>
+    Object.entries(enrollmentsMap).map(([experimentSlug, branchSlug]) => ({
+      experimentSlug,
+      branchSlug,
+    })),
+  firefoxVersion: typeAssertions.quantity,
+  hasActiveEnterprisePolicies: typeAssertions.boolean,
+  homePageSettings: pick("isCustomUrl", "isDefault", "isLocked", "isWebExt"),
+  isDefaultHandler: pick("html", "pdf"),
+  isDefaultBrowser: typeAssertions.boolean,
+  isFirstStartup: typeAssertions.boolean,
+  isFxAEnabled: typeAssertions.boolean,
+  isFxASignedIn: typeAssertions.boolean,
+  isMSIX: typeAssertions.boolean,
+  locale: typeAssertions.string,
+  memoryMB: typeAssertions.quantity,
+  os: pick(
+    "isLinux",
+    "isMac",
+    "isWindow",
+    "windowsBuildNumber",
+    "windowsVersion"
+  ),
+  primaryResolution: pick("height", "width"),
+  profileAgeCreated: typeAssertions.quantity,
+  region: typeAssertions.string,
+  totalBookmarksCount: typeAssertions.quantity,
+  userMonthlyActivity: userMonthlyActivity =>
+    userMonthlyActivity.map(([numberOfURLsVisited, date]) => ({
+      numberOfURLsVisited,
+      date,
+    })),
+  // userPrefersReducedMotion can only be false in xpcshell tests because it
+  // uses a stubbed nsIXULAppInfo (/testing/modules/AppInfo.sys.mjs).
+  userPrefersReducedMotion: userPrefersReducedMotion =>
+    userPrefersReducedMotion ?? false,
+  usesFirefoxSync: typeAssertions.boolean,
+  version: typeAssertions.string,
+});
+
+/**
+ * Transform a targeting context attribute name to the name that Glean expects
+ * for the corresponding metric.
+ *
+ * Glean metrics are defined in `snake_case` and are translated to `camelCase`
+ * for JavaScript. Most of our targeting attributes and their Glean metric
+ * equivalent have names that line up cleanly, but this falls apart when the
+ * targeting attribute has a name with an all-uppercase acronym.
+ *
+ * For example, the metric corresponding to the `defaultPDFHandler` attribute
+ * has the name `default_pdf_handler` in the metrics.yaml which would become
+ * `defaultPdfhandler` in JavaScript.
+ *
+ * @param {string} The attribute name.
+ * @returns {string} The metric name.
+ */
+export function normalizeAttributeName(attr) {
+  switch (attr) {
+    case "isFxAEnabled": // Would transform to `isFxAenabled`.
+    case "isFxASignedIn": // Would transform to `isFxAsignedIn`.
+      return attr;
+
+    case "defaultPDFHandler":
+      // Would transform to `defaultPdfhandler`.
+      return "defaultPdfHandler";
+
+    default:
+      return attr.replaceAll(/[A-Z]+/g, substr => {
+        return `${substr[0]}${substr.slice(1).toLowerCase()}`;
+      });
+  }
+}
+
+/**
+ * These are the prefs that can be used in evaluation of a JEXL expression by
+ * Nimbus via the `getPrefValue` filter.
+ */
+export const PREFS = Object.freeze({
+  "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons": PREF_BOOL,
+  "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features":
+    PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.section.highlights": PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.section.topstories": PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.topsites": PREF_BOOL,
+  "browser.newtabpage.activity-stream.showSearch": PREF_BOOL,
+  "browser.newtabpage.activity-stream.showSponsoredTopSites": PREF_BOOL,
+  "browser.newtabpage.enabled": PREF_BOOL,
+  "browser.toolbars.bookmarks.visibility": PREF_STRING,
+  "browser.urlbar.quicksuggest.dataCollection.enabled": PREF_BOOL,
+  "browser.urlbar.showSearchSuggestionsFirst": PREF_BOOL,
+  "browser.urlbar.suggest.quicksuggest.sponsored": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.enabled": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.video-toggle.enabled": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.video-toggle.has-used": PREF_BOOL,
+  "messaging-system-action.testday": PREF_STRING,
+  "network.trr.mode": PREF_INT,
+  "nimbus.qa.pref-1": PREF_STRING,
+  "nimbus.qa.pref-2": PREF_STRING,
+  "security.sandbox.content.level": PREF_INT,
+  "trailhead.firstrun.didSeeAboutWelcome": PREF_BOOL,
+});
+
+/**
+ * Transform a pref name to its key in the targeting context metric.
+ *
+ * Using dashes and periods in the object metric type would make the resulting
+ * data harder to query, so we replace them with single and double underscores,
+ * respectively.
+ *
+ * @param {string} The pref name.
+ * @returns {string} The normalized pref name.
+ */
+export function normalizePrefName(pref) {
+  return pref.replaceAll(/-/g, "_").replaceAll(/\./g, "__");
+}
+
+/**
+ * Get the list of all prefs that Nimbus cares about and determine whether or
+ * not they have user branch values.
+ *
+ * This will walk the Feature Manifest, collecting every setPref entry.
+ *
+ * This does not return any errors because prefHasUserValue cannot throw.
+ *
+ * @returns {string[]} The array of prefs.
+ */
+function recordUserSetPrefs() {
+  const prefs = Object.values(lazy.NimbusFeatures)
+    .filter(feature => feature.manifest)
+    .flatMap(feature => feature.manifest.variables)
+    .flatMap(Object.values)
+    .filter(variable => variable.setPref)
+    .map(variable => variable.setPref.pref)
+    .filter(pref => Services.prefs.prefHasUserValue(pref));
+
+  Glean.nimbusTargetingEnvironment.userSetPrefs.set(prefs);
+}
+
+/**
+ * Record pref values to the nimbus_targeting_environment.pref_values metric.
+ *
+ * The prefs queried are determined by `PREFS`.
+ *
+ * Any type errors will encountered will be recorded in the
+ * `nimbus_targeting_environment.pref_type_errors` metric.
+ */
+function recordPrefValues() {
+  const prefValues = {};
+
+  for (const [pref, expectedType] of Object.entries(PREFS)) {
+    const key = normalizePrefName(pref);
+
+    const prefType = Services.prefs.getPrefType(pref);
+    if (prefType === PREF_INVALID) {
+      // The pref doesn't have a value on either branch. This is not an actual
+      // error.
+      continue;
+    }
+
+    if (prefType !== expectedType) {
+      // We cannot record this value since the pref has the wrong type.
+      Glean.nimbusTargetingEnvironment.prefTypeErrors[pref].add();
+      console.error(
+        `TargetingContextRecorder: Pref "${pref}" has the wrong type. Expected ${PREF_TYPES[expectedType]} but found ${PREF_TYPES[prefType]}`
+      );
+      continue;
+    }
+
+    try {
+      switch (expectedType) {
+        case PREF_STRING:
+          prefValues[key] = Services.prefs.getStringPref(pref);
+          break;
+
+        case PREF_INT:
+          prefValues[key] = Services.prefs.getIntPref(pref);
+          break;
+
+        case PREF_BOOL:
+          prefValues[key] = Services.prefs.getBoolPref(pref);
+          break;
+      }
+    } catch (ex) {
+      // `nsIPrefBranch::Get{String,Int,Bool}Pref` only fails for three reasons:
+      //  - you request a pref that does not exist
+      //  - you request a pref with the wrongly-typed method (e.g., you try to
+      //    get the value of an int pref with `GetStringPref`)
+      //  - the pref service is not available (likely because we are shutting down).
+      //
+      // The first two cases are covered before we attempt to read the pref
+      // value and the last case is not worth recording telemetry about.
+      console.error(
+        `TargetingContextRecorder: Could not get value of pref "${pref}; are we shutting down?"`,
+        ex
+      );
+    }
+  }
+
+  Glean.nimbusTargetingEnvironment.prefValues.set(prefValues);
+}
+
+/**
+ * Evaluate the values of the `nimbus_targeting_context` category metrics and
+ * record them.
+ *
+ * Any errors encountered during evaluation will be recorded in the
+ * `nimbus_targeting_environment.attr_eval_errors` metric.
+ *
+ * The entire targeting context will be recorded inside the
+ * `nimbus_targeting_environment.targeting_context_value` metric as stringified
+ * JSON. The metric is disabled by default, but can be enabled via the
+ * `nimbusTelemetry` feature to debug evaluation failures.
+ */
+async function recordTargetingContextAttributes() {
+  const context = new lazy.TargetingContext(
+    lazy.TargetingContext.combineContexts(
+      lazy.ExperimentAPI.manager.createTargetingContext(),
+      lazy.ASRouterTargeting.Environment
+    )
+  ).ctx;
+
+  const recordAttrs =
+    lazy.NimbusFeatures.nimbusTelemetry.getVariable(
+      "nimbusTargetingEnvironment"
+    )?.recordAttrs ?? null;
+  const values = {};
+
+  for (const [attr, transform] of Object.entries(ATTRIBUTE_TRANSFORMS)) {
+    const metric = normalizeAttributeName(attr);
+    try {
+      const value = await transform(await context[attr]);
+
+      if (recordAttrs === null || recordAttrs.includes(attr)) {
+        values[metric] = value;
+      }
+
+      Glean.nimbusTargetingContext[metric].set(value);
+    } catch (ex) {
+      Glean.nimbusTargetingEnvironment.attrEvalErrors[metric].add();
+      console.error(`TargetingContextRecorder: Could not get "${attr}"`, ex);
+    }
+  }
+
+  let stringifiedCtx;
+  try {
+    stringifiedCtx = JSON.stringify(values);
+  } catch (ex) {
+    stringifiedCtx = "(JSON.stringify error)";
+  }
+
+  Glean.nimbusTargetingEnvironment.targetingContextValue.set(stringifiedCtx);
+}
+
+/**
+ * Record the metrics for the nimbus-targeting-context ping and submit it.
+ */
+export async function recordTargetingContext() {
+  recordPrefValues();
+  recordUserSetPrefs();
+  await recordTargetingContextAttributes();
+
+  // This will ensure that the profile group ID metric has been set.
+  await lazy.ClientID.getProfileGroupID();
+
+  GleanPings.nimbusTargetingContext.submit();
+}

--- a/experimenter/experimenter/targeting/tests/mock-manifests/firefox-desktop/v100.0.0/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/firefox-desktop/v100.0.0/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,392 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+const lazy = {};
+
+ChromeUtils.defineESModuleGetters(lazy, {
+  ExperimentAPI: "resource://nimbus/ExperimentAPI.sys.mjs",
+  ASRouterTargeting:
+    // eslint-disable-next-line mozilla/no-browser-refs-in-toolkit
+    "resource:///modules/asrouter/ASRouterTargeting.sys.mjs",
+  NimbusFeatures: "resource://nimbus/ExperimentAPI.sys.mjs",
+  TargetingContext: "resource://messaging-system/targeting/Targeting.sys.mjs",
+});
+
+// Don't use ChromeUtils.defineLazyPropertyGetter because that will replace the
+// property with the value upon first access, which prevents us from stubbing the ExperimentManager
+// in unit tests.
+Object.defineProperty(lazy, "ExperimentManager", {
+  get: () => lazy.ExperimentAPI._manager,
+});
+
+const { PREF_INVALID, PREF_STRING, PREF_INT, PREF_BOOL } = Ci.nsIPrefBranch;
+const PREF_TYPES = {
+  [PREF_STRING]: "Ci.nsIPrefBranch.PREF_STRING",
+  [PREF_INT]: "Ci.nsIPrefBranch.PREF_INT",
+  [PREF_BOOL]: "Ci.nsIPrefBranch.PREF_BOOL",
+};
+
+/**
+ * Return a function that returns specific keys of an object.
+ *
+ * All values will be awaited, so objects containing promises will be flattened
+ * into objects.
+ *
+ * Any exceptions encountered will not prevent the key from being recorded in
+ * the metric.
+ *
+ * @param {string[]} keys - The keys to include.
+ * @returns The function.
+ */
+function pick(...keys) {
+  const identity = x => x;
+  return pickWith(Object.fromEntries(keys.map(key => [key, identity])));
+}
+
+/**
+ * Return a function that returns a specific keys of an object, with transforms.
+ *
+ * All values will be awaited, as will their transform functions, so objects
+ * containing promises will be flattened into objects.
+ *
+ * Any exceptions encountered will not prevent the key from being recorded in
+ * the metric.
+ *
+ * @param {Record<string, () => any>} shape
+ *        A mapping of keys to transformation functions.
+ *
+ * @returns The function.
+ */
+function pickWith(shape) {
+  return async function (object) {
+    const transformed = {};
+    if (typeof object !== "undefined" && object !== null) {
+      for (const [key, transform] of Object.entries(shape)) {
+        try {
+          transformed[key] = await transform(await object[key]);
+        } catch (ex) {}
+      }
+    }
+    return transformed;
+  };
+}
+
+/**
+ * Assert that the attribute matches the given type (via typeof).
+ *
+ * @param {string} expectedType
+ *        The expected type.
+ *        If the attribute is not of this type, this function will throw.
+ * @param {any} attribute
+ *        The value whose type is to be checked.
+ *
+ * @returns The attribute.
+ */
+function assertType(expectedType, attribute) {
+  const type = typeof attribute;
+
+  if (type !== expectedType) {
+    throw new Error(`Expected ${expectedType} but got ${type} instead`);
+  }
+
+  return attribute;
+}
+
+/**
+ * Transforms that assert that the type of the attribute matches an expected
+ * type.
+ */
+const typeAssertions = {
+  string: attribute => assertType("string", attribute),
+  boolean: attribute => assertType("boolean", attribute),
+  quantity: attribute => Math.floor(assertType("number", attribute)),
+  array: attribute => {
+    if (!Array.isArray(attribute)) {
+      throw new Error(`Expected Array but got ${typeof attribute} instead`);
+    }
+
+    return attribute;
+  },
+  // NB: Date methods will throw if called on a non-Date object. We can't simply
+  // use `attribute instanceof Date` because the Date constructor might be from
+  // a different context (and thus the expression would evaluate to false).
+  date: attribute => Date.prototype.toUTCString.call(attribute),
+};
+
+/**
+ * This contains the set of all top-level targeting attributes in the Nimbus
+ * Targeting context and optional transforms functions that will be applied
+ * before the value is recorded.
+ */
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  activeExperiments: typeAssertions.array,
+  activeRollouts: typeAssertions.array,
+  addressesSaved: typeAssertions.quantity,
+  archBits: typeAssertions.quantity,
+  attributionData: pick("medium", "source", "ua"),
+  browserSettings: pickWith({
+    update: pick("channel"),
+  }),
+  currentDate: typeAssertions.date,
+  defaultPDFHandler: pick("knownBrowser", "registered"),
+  distributionId: typeAssertions.string,
+  doesAppNeedPin: typeAssertions.boolean,
+  enrollmentsMap: enrollmentsMap =>
+    Object.entries(enrollmentsMap).map(([experimentSlug, branchSlug]) => ({
+      experimentSlug,
+      branchSlug,
+    })),
+  firefoxVersion: typeAssertions.quantity,
+  hasActiveEnterprisePolicies: typeAssertions.boolean,
+  homePageSettings: pick("isCustomUrl", "isDefault", "isLocked", "isWebExt"),
+  isDefaultHandler: pick("html", "pdf"),
+  isDefaultBrowser: typeAssertions.boolean,
+  isFirstStartup: typeAssertions.boolean,
+  isFxAEnabled: typeAssertions.boolean,
+  isMSIX: typeAssertions.boolean,
+  memoryMB: typeAssertions.quantity,
+  os: pick(
+    "isLinux",
+    "isMac",
+    "isWindow",
+    "windowsBuildNumber",
+    "windowsVersion"
+  ),
+  profileAgeCreated: typeAssertions.quantity,
+  totalBookmarksCount: typeAssertions.quantity,
+  userMonthlyActivity: userMonthlyActivity =>
+    userMonthlyActivity.map(([numberOfURLsVisited, date]) => ({
+      numberOfURLsVisited,
+      date,
+    })),
+  userPrefersReducedMotion: typeAssertions.boolean,
+  usesFirefoxSync: typeAssertions.boolean,
+  version: typeAssertions.string,
+});
+
+/**
+ * Transform a targeting context attribute name to the name that Glean expects
+ * for the corresponding metric.
+ *
+ * Glean metrics are defined in `snake_case` and are translated to `camelCase`
+ * for JavaScript. Most of our targeting attributes and their Glean metric
+ * equivalent have names that line up cleanly, but this falls apart when the
+ * targeting attribute has a name with an all-uppercase acronym.
+ *
+ * For example, the metric corresponding to the `defaultPDFHandler` attribute
+ * has the name `default_pdf_handler` in the metrics.yaml which would become
+ * `defaultPdfhandler` in JavaScript.
+ *
+ * @param {string} The attribute name.
+ * @returns {string} The metric name.
+ */
+export function normalizeAttributeName(attr) {
+  switch (attr) {
+    case "isFxAEnabled":
+      // Would transform to `isFxAenabled";
+      return attr;
+
+    case "defaultPDFHandler":
+      // Would transform to `defaultPdfhandler`.
+      return "defaultPdfHandler";
+
+    default:
+      return attr.replaceAll(/[A-Z]+/g, substr => {
+        return `${substr[0]}${substr.slice(1).toLowerCase()}`;
+      });
+  }
+}
+
+/**
+ * These are the prefs that can be used in evaluation of a JEXL expression by
+ * Nimbus via the `getPrefValue` filter.
+ */
+export const PREFS = Object.freeze({
+  "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons": PREF_BOOL,
+  "browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features":
+    PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.section.highlights": PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.section.topstories": PREF_BOOL,
+  "browser.newtabpage.activity-stream.feeds.topsites": PREF_BOOL,
+  "browser.newtabpage.activity-stream.showSearch": PREF_BOOL,
+  "browser.newtabpage.activity-stream.showSponsoredTopSites": PREF_BOOL,
+  "browser.newtabpage.enabled": PREF_BOOL,
+  "browser.shopping.experience2023.autoActivateCount": PREF_INT,
+  "browser.shopping.experience2023.optedIn": PREF_INT,
+  "browser.toolbars.bookmarks.visibility": PREF_STRING,
+  "browser.urlbar.quicksuggest.dataCollection.enabled": PREF_BOOL,
+  "browser.urlbar.showSearchSuggestionsFirst": PREF_BOOL,
+  "browser.urlbar.suggest.quicksuggest.sponsored": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.enabled": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.video-toggle.enabled": PREF_BOOL,
+  "media.videocontrols.picture-in-picture.video-toggle.has-used": PREF_BOOL,
+  "messaging-system-action.testday": PREF_STRING,
+  "network.trr.mode": PREF_INT,
+  "nimbus.qa.pref-1": PREF_STRING,
+  "nimbus.qa.pref-2": PREF_STRING,
+  "security.sandbox.content.level": PREF_INT,
+  "trailhead.firstrun.didSeeAboutWelcome": PREF_BOOL,
+});
+
+/**
+ * Transform a pref name to its key in the targeting context metric.
+ *
+ * Using dashes and periods in the object metric type would make the resulting
+ * data harder to query, so we replace them with single and double underscores,
+ * respectively.
+ *
+ * @param {string} The pref name.
+ * @returns {string} The normalized pref name.
+ */
+export function normalizePrefName(pref) {
+  return pref.replaceAll(/-/g, "_").replaceAll(/\./g, "__");
+}
+
+/**
+ * Get the list of all prefs that Nimbus cares about and determine whether or
+ * not they have user branch values.
+ *
+ * This will walk the Feature Manifest, collecting every setPref entry.
+ *
+ * This does not return any errors because prefHasUserValue cannot throw.
+ *
+ * @returns {string[]} The array of prefs.
+ */
+function recordUserSetPrefs() {
+  const prefs = Object.values(lazy.NimbusFeatures)
+    .filter(feature => feature.manifest)
+    .flatMap(feature => feature.manifest.variables)
+    .flatMap(Object.values)
+    .filter(variable => variable.setPref)
+    .map(variable => variable.setPref.pref)
+    .filter(pref => Services.prefs.prefHasUserValue(pref));
+
+  Glean.nimbusTargetingEnvironment.userSetPrefs.set(prefs);
+}
+
+/**
+ * Record pref values to the nimbus_targeting_environment.pref_values metric.
+ *
+ * The prefs queried are determined by `PREFS`.
+ *
+ * Any type errors will encountered will be recorded in the
+ * `nimbus_targeting_environment.pref_type_errors` metric.
+ */
+function recordPrefValues() {
+  const prefValues = {};
+
+  for (const [pref, expectedType] of Object.entries(PREFS)) {
+    const key = normalizePrefName(pref);
+
+    const prefType = Services.prefs.getPrefType(pref);
+    if (prefType === PREF_INVALID) {
+      // The pref doesn't have a value on either branch. This is not an actual
+      // error.
+      continue;
+    }
+
+    if (prefType !== expectedType) {
+      // We cannot record this value since the pref has the wrong type.
+      Glean.nimbusTargetingEnvironment.prefTypeErrors[pref].add();
+      console.error(
+        `TargetingContextRecorder: Pref "${pref}" has the wrong type. Expected ${PREF_TYPES[expectedType]} but found ${PREF_TYPES[prefType]}`
+      );
+      continue;
+    }
+
+    try {
+      switch (expectedType) {
+        case PREF_STRING:
+          prefValues[key] = Services.prefs.getStringPref(pref);
+          break;
+
+        case PREF_INT:
+          prefValues[key] = Services.prefs.getIntPref(pref);
+          break;
+
+        case PREF_BOOL:
+          prefValues[key] = Services.prefs.getBoolPref(pref);
+          break;
+      }
+    } catch (ex) {
+      // `nsIPrefBranch::Get{String,Int,Bool}Pref` only fails for three reasons:
+      //  - you request a pref that does not exist
+      //  - you request a pref with the wrongly-typed method (e.g., you try to
+      //    get the value of an int pref with `GetStringPref`)
+      //  - the pref service is not available (likely because we are shutting down).
+      //
+      // The first two cases are covered before we attempt to read the pref
+      // value and the last case is not worth recording telemetry about.
+      console.error(
+        `TargetingContextRecorder: Could not get value of pref "${pref}; are we shutting down?"`,
+        ex
+      );
+    }
+  }
+
+  Glean.nimbusTargetingEnvironment.prefValues.set(prefValues);
+}
+
+/**
+ * Evaluate the values of the `nimbus_targeting_context` category metrics and
+ * record them.
+ *
+ * Any errors encountered during evaluation will be recorded in the
+ * `nimbus_targeting_environment.attr_eval_errors` metric.
+ *
+ * The entire targeting context will be recorded inside the
+ * `nimbus_targeting_environment.targeting_context_value` metric as stringified
+ * JSON. The metric is disabled by default, but can be enabled via the
+ * `nimbusTelemetry` feature to debug evaluation failures.
+ */
+async function recordTargetingContextAttributes() {
+  const context = new lazy.TargetingContext(
+    lazy.TargetingContext.combineContexts(
+      lazy.ExperimentManager.createTargetingContext(),
+      lazy.ASRouterTargeting.Environment
+    )
+  ).ctx;
+
+  const recordAttrs =
+    lazy.NimbusFeatures.nimbusTelemetry.getVariable(
+      "nimbusTargetingEnvironment"
+    )?.recordAttrs ?? null;
+  const values = {};
+
+  for (const [attr, transform] of Object.entries(ATTRIBUTE_TRANSFORMS)) {
+    const metric = normalizeAttributeName(attr);
+    try {
+      const value = await transform(await context[attr]);
+
+      if (recordAttrs === null || recordAttrs.includes(attr)) {
+        values[metric] = value;
+      }
+
+      Glean.nimbusTargetingContext[metric].set(value);
+    } catch (ex) {
+      Glean.nimbusTargetingEnvironment.attrEvalErrors[metric].add();
+      console.error(`TargetingContextRecorder: Could not get "${attr}"`, ex);
+    }
+  }
+
+  let stringifiedCtx;
+  try {
+    stringifiedCtx = JSON.stringify(values);
+  } catch (ex) {
+    stringifiedCtx = "(JSON.stringify error)";
+  }
+
+  Glean.nimbusTargetingEnvironment.targetingContextValue.set(stringifiedCtx);
+}
+
+/**
+ * Record the metrics for the nimbus-targeting-context ping and submit it.
+ */
+export async function recordTargetingContext() {
+  recordPrefValues();
+  recordUserSetPrefs();
+  await recordTargetingContextAttributes();
+
+  GleanPings.nimbusTargetingContext.submit();
+}

--- a/experimenter/experimenter/targeting/tests/mock-manifests/ios/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/ios/RecordedNimbusContext.swift
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Glean
+import Shared
+
+import class MozillaAppServices.NimbusGleanPings
+import func MozillaAppServices.getCalculatedAttributes
+import func MozillaAppServices.getLocaleTag
+import struct MozillaAppServices.JsonObject
+import protocol MozillaAppServices.RecordedContext
+import MozillaRustComponents
+
+private extension Double? {
+    func toInt64() -> Int64? {
+        guard let self = self else { return nil }
+        return Int64(self)
+    }
+}
+
+extension Int32? {
+    func toInt64() -> Int64? {
+        guard let self = self else { return nil }
+        return Int64(self)
+    }
+}
+
+/// TODO(FXIOS-12942): Implement proper thread-safety
+final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
+    /**
+     * The following constants are string constants of the keys that appear in the [EVENT_QUERIES] map.
+     */
+    static let DAYS_OPENED_IN_LAST_28 = "days_opened_in_last_28"
+
+    /**
+     * [EVENT_QUERIES] is a map of keys to Nimbus SDK EventStore queries.
+     */
+    static let EVENT_QUERIES = [
+        DAYS_OPENED_IN_LAST_28: "'events.app_opened'|eventCountNonZero('Days', 28, 0)",
+    ]
+
+    var isFirstRun: Bool
+    var isPhone: Bool
+    var isDefaultBrowser: Bool
+    var isBottomToolbarUser: Bool
+    var hasEnabledTipsNotifications: Bool
+    var hasAcceptedTermsOfUse: Bool
+    var isAppleIntelligenceAvailable: Bool
+    var cannotUseAppleIntelligence: Bool
+    var appVersion: String?
+    var region: String?
+    var language: String?
+    var locale: String
+    var daysSinceInstall: Int32?
+    var daysSinceUpdate: Int32?
+    var touExperiencePoints: Int32?
+
+    private var eventQueries: [String: String]
+    private var eventQueryValues: [String: Double] = [:]
+
+    private var logger: Logger
+
+    init(isFirstRun: Bool,
+         isDefaultBrowser: Bool,
+         isBottomToolbarUser: Bool,
+         hasEnabledTipsNotifications: Bool,
+         hasAcceptedTermsOfUse: Bool,
+         isAppleIntelligenceAvailable: Bool,
+         cannotUseAppleIntelligence: Bool,
+         eventQueries: [String: String] = RecordedNimbusContext.EVENT_QUERIES,
+         isPhone: Bool = UIDeviceDetails.userInterfaceIdiom == .phone,
+         bundle: Bundle = Bundle.main,
+         logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+        logger.log("init start", level: .debug, category: .experiments)
+        self.eventQueries = eventQueries
+
+        self.isFirstRun = isFirstRun
+        self.isPhone = isPhone
+        self.isDefaultBrowser = isDefaultBrowser
+        self.isBottomToolbarUser = isBottomToolbarUser
+        self.hasEnabledTipsNotifications = hasEnabledTipsNotifications
+        self.hasAcceptedTermsOfUse = hasAcceptedTermsOfUse
+        self.isAppleIntelligenceAvailable = isAppleIntelligenceAvailable
+        self.cannotUseAppleIntelligence = cannotUseAppleIntelligence
+
+        let info = bundle.infoDictionary ?? [:]
+        appVersion = info["CFBundleShortVersionString"] as? String
+
+        locale = getLocaleTag()
+        var inferredDateInstalledOn: Date? {
+            guard
+                let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last,
+                let attributes = try? FileManager.default.attributesOfItem(atPath: documentsURL.path)
+            else { return nil }
+            return attributes[.creationDate] as? Date
+        }
+        let installationDateSinceEpoch = inferredDateInstalledOn.map {
+            Int64(($0.timeIntervalSince1970 * 1000).rounded())
+        }
+        guard let dbPath = Experiments.dbPath else {
+            self.logger.log("Unable to obtain dbPath, skipping calculating attributes",
+                            level: .warning,
+                            category: .experiments)
+            return
+        }
+        guard let calculatedAttributes = try? getCalculatedAttributes(installationDate: installationDateSinceEpoch,
+                                                                      dbPath: dbPath,
+                                                                      locale: locale)
+        else { return }
+
+        daysSinceInstall = calculatedAttributes.daysSinceInstall
+        daysSinceUpdate = calculatedAttributes.daysSinceUpdate
+        language = calculatedAttributes.language
+        region = calculatedAttributes.region
+        touExperiencePoints = Experiments.touExperiencePoints(region: region)
+        self.logger.log("init end", level: .debug, category: .experiments)
+    }
+
+    /**
+     * [getEventQueries] is called by the Nimbus SDK Rust code to retrieve the map of event
+     * queries. The are then executed against the Nimbus SDK's EventStore to retrieve their values.
+     *
+     * @return Map<String, String>
+     */
+    func getEventQueries() -> [String: String] {
+        logger.log("getEventQueries", level: .debug, category: .experiments)
+        return eventQueries
+    }
+
+    /**
+     * [record] is called when experiment enrollments are evolved. It should apply the
+     * [RecordedNimbusContext]'s values to a [NimbusSystem.RecordedNimbusContextObject] instance,
+     * and use that instance to record the values to Glean.
+     */
+    func record() {
+        logger.log("record start", level: .debug, category: .experiments)
+
+        // Bring the ping into scope so that Glean knows it exists and includes NimbusSystem.recordedNimbusContext
+        _ = NimbusGleanPings.nimbusTargetingContext
+
+        let eventQueryValuesObject = GleanMetrics.NimbusSystem.RecordedNimbusContextObjectItemEventQueryValuesObject(
+            daysOpenedInLast28: eventQueryValues[RecordedNimbusContext.DAYS_OPENED_IN_LAST_28].toInt64()
+        )
+
+        GleanMetrics.NimbusSystem.recordedNimbusContext.set(
+            GleanMetrics.NimbusSystem.RecordedNimbusContextObject(
+                isFirstRun: isFirstRun,
+                eventQueryValues: eventQueryValuesObject,
+                isPhone: isPhone,
+                appVersion: appVersion,
+                locale: locale,
+                daysSinceInstall: daysSinceInstall.toInt64(),
+                daysSinceUpdate: daysSinceUpdate.toInt64(),
+                language: language,
+                region: region,
+                isDefaultBrowser: isDefaultBrowser,
+                isBottomToolbarUser: isBottomToolbarUser,
+                hasEnabledTipsNotifications: hasEnabledTipsNotifications,
+                hasAcceptedTermsOfUse: hasAcceptedTermsOfUse,
+                isAppleIntelligenceAvailable: isAppleIntelligenceAvailable,
+                cannotUseAppleIntelligence: cannotUseAppleIntelligence,
+                touExperiencePoints: touExperiencePoints.toInt64()
+            )
+        )
+        GleanMetrics.Pings.shared.nimbus.submit()
+        logger.log("record end", level: .debug, category: .experiments)
+    }
+
+    /**
+     * [setEventQueryValues] is called by the Nimbus SDK Rust code after the event queries have been
+     * executed. The [eventQueryValues] should be written back to the Kotlin object.
+     *
+     * @param [eventQueryValues] The values for each query after they have been executed in the
+     * Nimbus SDK Rust environment.
+     */
+    func setEventQueryValues(eventQueryValues: [String: Double]) {
+        logger.log("setEventQueryValues", level: .debug, category: .experiments)
+        self.eventQueryValues = eventQueryValues
+    }
+
+    /**
+     * [toJson] is called by the Nimbus SDK Rust code after the event queries have been executed,
+     * and before experiment enrollments have been evolved. The value returned from this method
+     * will be applied directly to the Nimbus targeting context, and its keys/values take
+     * precedence over those in the main Nimbus targeting context.
+     *
+     * @return JsonObject
+     */
+    func toJson() -> JsonObject {
+        logger.log("toJson start", level: .debug, category: .experiments)
+        guard let data = try? JSONSerialization.data(withJSONObject: [
+            "is_first_run": isFirstRun,
+            "isFirstRun": "\(isFirstRun)",
+            "is_phone": isPhone,
+            "events": eventQueryValues,
+            "app_version": appVersion as Any,
+            "region": region as Any,
+            "language": language as Any,
+            "locale": locale as Any,
+            "days_since_install": daysSinceInstall as Any,
+            "days_since_update": daysSinceUpdate as Any,
+            "is_default_browser": isDefaultBrowser,
+            "is_bottom_toolbar_user": isBottomToolbarUser,
+            "has_enabled_tips_notifications": hasEnabledTipsNotifications,
+            "has_accepted_terms_of_use": hasAcceptedTermsOfUse,
+            "is_apple_intelligence_available": isAppleIntelligenceAvailable,
+            "cannot_use_apple_intelligence": cannotUseAppleIntelligence,
+            "tou_experience_points": touExperiencePoints as Any
+        ]),
+            let jsonString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+        else {
+            logger.log("toJson error thrown while creating JSON string", level: .warning, category: .experiments)
+            return "{}"
+        }
+        logger.log("toJson end", level: .debug, category: .experiments, extra: ["json": jsonString])
+        return jsonString
+    }
+}

--- a/experimenter/experimenter/targeting/tests/mock-manifests/ios/v100.0.0/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/targeting/tests/mock-manifests/ios/v100.0.0/RecordedNimbusContext.swift
@@ -1,0 +1,222 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/
+
+import Common
+import Foundation
+import Glean
+import Shared
+
+import class MozillaAppServices.NimbusGleanPings
+import func MozillaAppServices.getCalculatedAttributes
+import func MozillaAppServices.getLocaleTag
+import struct MozillaAppServices.JsonObject
+import protocol MozillaAppServices.RecordedContext
+import MozillaRustComponents
+
+private extension Double? {
+    func toInt64() -> Int64? {
+        guard let self = self else { return nil }
+        return Int64(self)
+    }
+}
+
+extension Int32? {
+    func toInt64() -> Int64? {
+        guard let self = self else { return nil }
+        return Int64(self)
+    }
+}
+
+/// TODO(FXIOS-12942): Implement proper thread-safety
+final class RecordedNimbusContext: RecordedContext, @unchecked Sendable {
+    /**
+     * The following constants are string constants of the keys that appear in the [EVENT_QUERIES] map.
+     */
+    static let DAYS_OPENED_IN_LAST_28 = "days_opened_in_last_28"
+
+    /**
+     * [EVENT_QUERIES] is a map of keys to Nimbus SDK EventStore queries.
+     */
+    static let EVENT_QUERIES = [
+        DAYS_OPENED_IN_LAST_28: "'events.app_opened'|eventCountNonZero('Days', 28, 0)",
+    ]
+
+    var isFirstRun: Bool
+    var isPhone: Bool
+    var isDefaultBrowser: Bool
+    var isBottomToolbarUser: Bool
+    var hasEnabledTipsNotifications: Bool
+    var hasAcceptedTermsOfUse: Bool
+    var isAppleIntelligenceAvailable: Bool
+    var cannotUseAppleIntelligence: Bool
+    var appVersion: String?
+    var region: String?
+    var language: String?
+    var locale: String
+    var daysSinceInstall: Int32?
+    var daysSinceUpdate: Int32?
+    var touExperiencePoints: Int32?
+
+    private var eventQueries: [String: String]
+    private var eventQueryValues: [String: Double] = [:]
+
+    private var logger: Logger
+
+    init(isFirstRun: Bool,
+         isDefaultBrowser: Bool,
+         isBottomToolbarUser: Bool,
+         hasEnabledTipsNotifications: Bool,
+         hasAcceptedTermsOfUse: Bool,
+         isAppleIntelligenceAvailable: Bool,
+         cannotUseAppleIntelligence: Bool,
+         eventQueries: [String: String] = RecordedNimbusContext.EVENT_QUERIES,
+         isPhone: Bool = UIDeviceDetails.userInterfaceIdiom == .phone,
+         bundle: Bundle = Bundle.main,
+         logger: Logger = DefaultLogger.shared) {
+        self.logger = logger
+        logger.log("init start", level: .debug, category: .experiments)
+        self.eventQueries = eventQueries
+
+        self.isFirstRun = isFirstRun
+        self.isPhone = isPhone
+        self.isDefaultBrowser = isDefaultBrowser
+        self.isBottomToolbarUser = isBottomToolbarUser
+        self.hasEnabledTipsNotifications = hasEnabledTipsNotifications
+        self.hasAcceptedTermsOfUse = hasAcceptedTermsOfUse
+        self.isAppleIntelligenceAvailable = isAppleIntelligenceAvailable
+        self.cannotUseAppleIntelligence = cannotUseAppleIntelligence
+
+        let info = bundle.infoDictionary ?? [:]
+        appVersion = info["CFBundleShortVersionString"] as? String
+
+        locale = getLocaleTag()
+        var inferredDateInstalledOn: Date? {
+            guard
+                let documentsURL = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).last,
+                let attributes = try? FileManager.default.attributesOfItem(atPath: documentsURL.path)
+            else { return nil }
+            return attributes[.creationDate] as? Date
+        }
+        let installationDateSinceEpoch = inferredDateInstalledOn.map {
+            Int64(($0.timeIntervalSince1970 * 1000).rounded())
+        }
+        guard let dbPath = Experiments.dbPath else {
+            self.logger.log("Unable to obtain dbPath, skipping calculating attributes",
+                            level: .warning,
+                            category: .experiments)
+            return
+        }
+        guard let calculatedAttributes = try? getCalculatedAttributes(installationDate: installationDateSinceEpoch,
+                                                                      dbPath: dbPath,
+                                                                      locale: locale)
+        else { return }
+
+        daysSinceInstall = calculatedAttributes.daysSinceInstall
+        daysSinceUpdate = calculatedAttributes.daysSinceUpdate
+        language = calculatedAttributes.language
+        region = calculatedAttributes.region
+        touExperiencePoints = Experiments.touExperiencePoints(region: region)
+        self.logger.log("init end", level: .debug, category: .experiments)
+    }
+
+    /**
+     * [getEventQueries] is called by the Nimbus SDK Rust code to retrieve the map of event
+     * queries. The are then executed against the Nimbus SDK's EventStore to retrieve their values.
+     *
+     * @return Map<String, String>
+     */
+    func getEventQueries() -> [String: String] {
+        logger.log("getEventQueries", level: .debug, category: .experiments)
+        return eventQueries
+    }
+
+    /**
+     * [record] is called when experiment enrollments are evolved. It should apply the
+     * [RecordedNimbusContext]'s values to a [NimbusSystem.RecordedNimbusContextObject] instance,
+     * and use that instance to record the values to Glean.
+     */
+    func record() {
+        logger.log("record start", level: .debug, category: .experiments)
+
+        // Bring the ping into scope so that Glean knows it exists and includes NimbusSystem.recordedNimbusContext
+        _ = NimbusGleanPings.nimbusTargetingContext
+
+        let eventQueryValuesObject = GleanMetrics.NimbusSystem.RecordedNimbusContextObjectItemEventQueryValuesObject(
+            daysOpenedInLast28: eventQueryValues[RecordedNimbusContext.DAYS_OPENED_IN_LAST_28].toInt64()
+        )
+
+        GleanMetrics.NimbusSystem.recordedNimbusContext.set(
+            GleanMetrics.NimbusSystem.RecordedNimbusContextObject(
+                isFirstRun: isFirstRun,
+                eventQueryValues: eventQueryValuesObject,
+                isPhone: isPhone,
+                appVersion: appVersion,
+                locale: locale,
+                daysSinceInstall: daysSinceInstall.toInt64(),
+                daysSinceUpdate: daysSinceUpdate.toInt64(),
+                language: language,
+                region: region,
+                isDefaultBrowser: isDefaultBrowser,
+                isBottomToolbarUser: isBottomToolbarUser,
+                hasEnabledTipsNotifications: hasEnabledTipsNotifications,
+                hasAcceptedTermsOfUse: hasAcceptedTermsOfUse,
+                isAppleIntelligenceAvailable: isAppleIntelligenceAvailable,
+                cannotUseAppleIntelligence: cannotUseAppleIntelligence,
+                touExperiencePoints: touExperiencePoints.toInt64()
+            )
+        )
+        GleanMetrics.Pings.shared.nimbus.submit()
+        logger.log("record end", level: .debug, category: .experiments)
+    }
+
+    /**
+     * [setEventQueryValues] is called by the Nimbus SDK Rust code after the event queries have been
+     * executed. The [eventQueryValues] should be written back to the Kotlin object.
+     *
+     * @param [eventQueryValues] The values for each query after they have been executed in the
+     * Nimbus SDK Rust environment.
+     */
+    func setEventQueryValues(eventQueryValues: [String: Double]) {
+        logger.log("setEventQueryValues", level: .debug, category: .experiments)
+        self.eventQueryValues = eventQueryValues
+    }
+
+    /**
+     * [toJson] is called by the Nimbus SDK Rust code after the event queries have been executed,
+     * and before experiment enrollments have been evolved. The value returned from this method
+     * will be applied directly to the Nimbus targeting context, and its keys/values take
+     * precedence over those in the main Nimbus targeting context.
+     *
+     * @return JsonObject
+     */
+    func toJson() -> JsonObject {
+        logger.log("toJson start", level: .debug, category: .experiments)
+        guard let data = try? JSONSerialization.data(withJSONObject: [
+            "is_first_run": isFirstRun,
+            "isFirstRun": "\(isFirstRun)",
+            "is_phone": isPhone,
+            "events": eventQueryValues,
+            "app_version": appVersion as Any,
+            "region": region as Any,
+            "language": language as Any,
+            "locale": locale as Any,
+            "days_since_install": daysSinceInstall as Any,
+            "days_since_update": daysSinceUpdate as Any,
+            "is_default_browser": isDefaultBrowser,
+            "is_bottom_toolbar_user": isBottomToolbarUser,
+            "has_enabled_tips_notifications": hasEnabledTipsNotifications,
+            "has_accepted_terms_of_use": hasAcceptedTermsOfUse,
+            "is_apple_intelligence_available": isAppleIntelligenceAvailable,
+            "cannot_use_apple_intelligence": cannotUseAppleIntelligence,
+            "tou_experience_points": touExperiencePoints as Any
+        ]),
+            let jsonString = NSString(data: data, encoding: String.Encoding.utf8.rawValue) as? String
+        else {
+            logger.log("toJson error thrown while creating JSON string", level: .warning, category: .experiments)
+            return "{}"
+        }
+        logger.log("toJson end", level: .debug, category: .experiments, extra: ["json": jsonString])
+        return jsonString
+    }
+}

--- a/experimenter/experimenter/targeting/tests/test_targeting_context_parser.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_context_parser.py
@@ -1,0 +1,175 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from parameterized.parameterized import parameterized
+
+from experimenter.experiments.constants import NimbusConstants
+from experimenter.targeting.targeting_context_parser import TargetingContextFields
+from experimenter.targeting.tests import mock_targeting_manifests
+
+
+@mock_targeting_manifests
+class TestTargetingContextFields(TestCase):
+    def setUp(self):
+        super().setUp()
+        TargetingContextFields.clear_cache()
+
+    @parameterized.expand(
+        [
+            (
+                NimbusConstants.Application.DESKTOP,
+                [
+                    "activeExperiments",
+                    "activeRollouts",
+                    "addonsInfo",
+                    "addressesSaved",
+                    "archBits",
+                    "attributionData",
+                    "browserSettings",
+                    "buildId",
+                    "currentDate",
+                    "defaultPDFHandler",
+                    "distributionId",
+                    "doesAppNeedPin",
+                    "enrollmentsMap",
+                    "firefoxVersion",
+                    "hasActiveEnterprisePolicies",
+                    "homePageSettings",
+                    "isDefaultHandler",
+                    "isDefaultBrowser",
+                    "isFirstStartup",
+                    "isFxAEnabled",
+                    "isFxASignedIn",
+                    "isMSIX",
+                    "locale",
+                    "memoryMB",
+                    "os",
+                    "primaryResolution",
+                    "profileAgeCreated",
+                    "region",
+                    "totalBookmarksCount",
+                    "userMonthlyActivity",
+                    "userPrefersReducedMotion",
+                    "usesFirefoxSync",
+                    "version",
+                ],
+            ),
+            (
+                NimbusConstants.Application.FENIX,
+                [
+                    "is_first_run",
+                    "events",
+                    "install_referrer_response_utm_source",
+                    "install_referrer_response_utm_medium",
+                    "install_referrer_response_utm_campaign",
+                    "install_referrer_response_utm_term",
+                    "install_referrer_response_utm_content",
+                    "android_sdk_version",
+                    "app_version",
+                    "locale",
+                    "days_since_install",
+                    "days_since_update",
+                    "language",
+                    "region",
+                    "device_manufacturer",
+                    "device_model",
+                    "user_accepted_tou",
+                    "no_shortcuts_or_stories_opt_outs",
+                    "addon_ids",
+                    "tou_points",
+                ],
+            ),
+            (
+                NimbusConstants.Application.IOS,
+                [
+                    "is_first_run",
+                    "isFirstRun",
+                    "is_phone",
+                    "events",
+                    "app_version",
+                    "region",
+                    "language",
+                    "locale",
+                    "days_since_install",
+                    "days_since_update",
+                    "is_default_browser",
+                    "is_bottom_toolbar_user",
+                    "has_enabled_tips_notifications",
+                    "has_accepted_terms_of_use",
+                    "is_apple_intelligence_available",
+                    "cannot_use_apple_intelligence",
+                    "tou_experience_points",
+                ],
+            ),
+        ]
+    )
+    def test_load_unversioned_targeting_fields(self, app, expected_fields):
+        targeting_fields = TargetingContextFields.for_application(app)
+
+        self.assertEqual(len(targeting_fields), len(expected_fields))
+
+        for field in expected_fields:
+            self.assertIn(field, targeting_fields)
+
+    def test_load_versioned_targeting_fields(self):
+        targeting_fields = TargetingContextFields.for_application(
+            NimbusConstants.Application.FENIX, "v100.0.0"
+        )
+        expected_fields = [
+            "is_first_run",
+            "events",
+            "install_referrer_response_utm_source",
+            "install_referrer_response_utm_medium",
+            "install_referrer_response_utm_campaign",
+            "install_referrer_response_utm_term",
+            "install_referrer_response_utm_content",
+            "is_review_checker_enabled",
+            "android_sdk_version",
+            "app_version",
+            "locale",
+            "days_since_install",
+            "days_since_update",
+            "language",
+            "region",
+            "device_manufacturer",
+            "device_model",
+        ]
+
+        self.assertEqual(len(targeting_fields), len(expected_fields))
+
+        for field in expected_fields:
+            self.assertIn(field, targeting_fields)
+
+    def test_attempt_load_targeting_fields_for_unknown_application(self):
+        self.assertRaises(
+            ValueError, TargetingContextFields.for_application, "unknown_app"
+        )
+
+    def test_targeting_fields_cached(self):
+        mock_fields = ["field_one", "field_two"]
+
+        with patch.object(
+            TargetingContextFields,
+            "_load_targeting_fields",
+            return_value=mock_fields,
+        ) as mock_loader:
+            targeting_fields_1 = TargetingContextFields.for_application(
+                NimbusConstants.Application.DESKTOP
+            )
+            targeting_fields_2 = TargetingContextFields.for_application(
+                NimbusConstants.Application.DESKTOP
+            )
+
+            self.assertIs(targeting_fields_1, targeting_fields_2)
+            mock_loader.assert_called_once_with(NimbusConstants.Application.DESKTOP, None)
+
+    def test_clear_cache_specific_application_only(self):
+        TargetingContextFields._desktop_targeting_fields = ["desktop"]
+        TargetingContextFields._fenix_targeting_fields = ["fenix"]
+        TargetingContextFields._ios_targeting_fields = ["ios"]
+
+        TargetingContextFields.clear_cache(NimbusConstants.Application.DESKTOP)
+
+        self.assertIsNone(TargetingContextFields._desktop_targeting_fields)
+        self.assertEqual(TargetingContextFields._fenix_targeting_fields, ["fenix"])
+        self.assertEqual(TargetingContextFields._ios_targeting_fields, ["ios"])


### PR DESCRIPTION
Because

- We needed a single, version-aware way to extract valid targeting context fields from each platform's source code

This commit

- Adds a dedicated targeting context parser class that follows the same lazy-loading cache pattern used by `Outcomes`, including per-app cache lifecycle and explicit cache clearing
- Introduces version-aware lookup via for_application(app, version=None) so callers can resolve fields from default versioned targeting field files or a specific versioned manifest path using the same method

Fixes #14923