### PR TITLE
feat(nimbus): Update message preview dropdowns for multi-message support

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -150,12 +150,6 @@
                              data-feature-id="{{ branch_feature_values_form.instance.feature_config.slug }}">
                           {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
                           <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
-                            <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
-                                    type="button"
-                                    title="Preview with about:messagepreview"
-                                    data-nimbus-devtools-try-preview-button>
-                              <span class="fa fa-eye"></span>
-                            </button>
                             <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
                               <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
                                       type="button"
@@ -164,7 +158,7 @@
                                       aria-expanded="false">
                                 <span class="fa fa-eye"></span>
                               </button>
-                              <ul class="dropdown-menu">
+                              <ul class="dropdown-menu dropdown-menu-end text-nowrap">
                               </ul>
                             </div>
                           </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_feature_value.html
@@ -25,17 +25,11 @@
             aria-expanded="false">
       <span class="fa fa-eye"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropdown-menu-end text-nowrap">
     </ul>
   </div>
 {% endblock %}
 {% block json_controls_expanded %}
-  <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
-          type="button"
-          title="Preview with about:messagepreview"
-          data-nimbus-devtools-preview-button>
-    <span class="fa fa-eye"></span>
-  </button>
   <div class="btn btn-sm btn-outline-danger ms-1 d-none"
        type="button"
        data-nimbus-devtools-cannot-preview-notice>
@@ -50,7 +44,7 @@
             aria-expanded="false">
       <span class="fa fa-eye"></span>
     </button>
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropdown-menu-end text-nowrap">
     </ul>
   </div>
 {% endblock %}


### PR DESCRIPTION
Because:

- we want to be able to preview multi-message messages with Nimbus Devtools; and
- we're going to be putting more text into the preview dropdown

this commit:

- updates the classes on the preview dropdowns to support this; and
- removes the old preview button as it is no longer user by devtools.

Fixes #14910