### PR TITLE
feat(nimbus): add usage stats CSV report for owners and reviewers

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -60,6 +60,29 @@
         ]
       }
     },
+    "/api/v5/csv/usage/": {
+      "get": {
+        "operationId": "listNimbusExperimentUsageStats",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v5/yaml/": {
       "get": {
         "operationId": "listNimbusExperiments",

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -72,6 +72,29 @@
         ]
       }
     },
+    "/api/v5/csv/usage/": {
+      "get": {
+        "operationId": "listNimbusExperimentUsageStats",
+        "description": "",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {}
+                }
+              }
+            },
+            "description": ""
+          }
+        },
+        "tags": [
+          "api"
+        ]
+      }
+    },
     "/api/v5/yaml/": {
       "get": {
         "operationId": "listNimbusExperiments",

--- a/experimenter/experimenter/experiments/api/v5/urls.py
+++ b/experimenter/experimenter/experiments/api/v5/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, re_path
 from experimenter.experiments.api.v5.views import (
     FmlErrorsView,
     NimbusExperimentCsvListView,
+    NimbusExperimentUsageStatsView,
     NimbusExperimentYamlListView,
 )
 
@@ -11,6 +12,11 @@ urlpatterns = [
         r"^csv/$",
         NimbusExperimentCsvListView.as_view(),
         name="nimbus-experiments-csv",
+    ),
+    re_path(
+        r"^csv/usage/$",
+        NimbusExperimentUsageStatsView.as_view(),
+        name="nimbus-experiments-csv-usage",
     ),
     re_path(
         r"^yaml/$",

--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -1,8 +1,16 @@
+import csv
+import datetime
+import io
+from collections import defaultdict
+
 import yaml
+from dateutil.relativedelta import relativedelta
 from django.db.models import F
+from django.http import HttpResponse
 from rest_framework.generics import ListAPIView, UpdateAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.renderers import BaseRenderer
+from rest_framework.views import APIView
 from rest_framework_csv.renderers import CSVRenderer
 
 from experimenter.experiments.api.cache import CachedListMixin
@@ -11,7 +19,7 @@ from experimenter.experiments.api.v5.serializers import (
     NimbusExperimentCsvSerializer,
     NimbusExperimentYamlSerializer,
 )
-from experimenter.experiments.models import NimbusExperiment
+from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
 
 
 class NimbusExperimentCsvRenderer(CSVRenderer):
@@ -39,6 +47,98 @@ class NimbusExperimentCsvListView(CachedListMixin, ListAPIView):
             ),
             reverse=True,
         )
+
+
+class NimbusExperimentUsageStatsView(APIView):
+    NOVICE_MAX = 3
+    INTERMEDIATE_MAX = 9
+
+    @staticmethod
+    def _generate_usage_csv():
+        experiments = (
+            NimbusExperiment.objects.filter(
+                _start_date__isnull=False,
+                status=NimbusExperiment.Status.COMPLETE,
+            )
+            .values_list("owner__email", "_start_date")
+            .order_by("_start_date")
+        )
+        approvals = (
+            NimbusChangeLog.objects.filter(
+                old_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+                new_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+                experiment___start_date__isnull=False,
+            )
+            .values_list("changed_by__email", "experiment___start_date")
+            .order_by("experiment___start_date")
+        )
+
+        owner_events = defaultdict(list)
+        for email, start_date in experiments:
+            owner_events[start_date.strftime("%Y-%m")].append(email)
+
+        reviewer_events = defaultdict(set)
+        for email, start_date in approvals:
+            reviewer_events[start_date.strftime("%Y-%m")].add(email)
+
+        if not owner_events and not reviewer_events:
+            return ""
+
+        last_month = max(set(owner_events) | set(reviewer_events))
+        end_date = datetime.datetime.strptime(last_month, "%Y-%m").date()
+
+        seen_owners = set()
+        seen_reviewers = set()
+        counts = defaultdict(int)
+        rows = []
+        current = datetime.date(2020, 1, 1)
+        novice_max = NimbusExperimentUsageStatsView.NOVICE_MAX
+        intermediate_max = NimbusExperimentUsageStatsView.INTERMEDIATE_MAX
+        while current <= end_date:
+            month = current.strftime("%Y-%m")
+            for email in owner_events.get(month, []):
+                seen_owners.add(email)
+                counts[email] += 1
+            seen_reviewers |= reviewer_events.get(month, set())
+
+            experience_levels = [0, 0, 0]
+            for count in counts.values():
+                experience_levels[
+                    0 if count <= novice_max else 1 if count <= intermediate_max else 2
+                ] += 1
+
+            rows.append(
+                [month, len(seen_owners), len(seen_reviewers), *experience_levels]
+            )
+            current += relativedelta(months=1)
+
+        output = io.StringIO()
+        header = [
+            "Month",
+            "Owners",
+            "Reviewers",
+            f"Novice (0-{novice_max})",
+            f"Intermediate ({novice_max + 1}-{intermediate_max})",
+            f"Advanced ({intermediate_max + 1}+)",
+        ]
+        writer = csv.writer(output)
+        writer.writerow(header)
+        quarter_ends = {}
+        for row in rows:
+            writer.writerow(row)
+            row_date = datetime.datetime.strptime(row[0], "%Y-%m").date()
+            quarter = f"{row_date.year} Q{(row_date.month - 1) // 3 + 1}"
+            quarter_ends[quarter] = row
+
+        writer.writerow([])
+        for quarter in sorted(quarter_ends):
+            writer.writerow([quarter, *quarter_ends[quarter][1:]])
+
+        return output.getvalue()
+
+    def get(self, request):
+        csv_content = self._generate_usage_csv()
+        return HttpResponse(csv_content, content_type="text/csv; charset=utf-8")
 
 
 class NimbusExperimentYamlRenderer(BaseRenderer):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_usage_stats_view.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_usage_stats_view.py
@@ -1,0 +1,133 @@
+import csv
+import datetime
+import io
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+
+from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
+from experimenter.experiments.tests.factories import NimbusExperimentFactory
+from experimenter.openidc.tests.factories import UserFactory
+
+LIFECYCLE = NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
+
+
+def _create_experiment(owner, start_date):
+    return NimbusExperimentFactory.create_with_lifecycle(
+        LIFECYCLE,
+        start_date=start_date,
+        end_date=start_date + datetime.timedelta(days=28),
+        owner=owner,
+    )
+
+
+class TestNimbusExperimentUsageStatsView(TestCase):
+    def _get_csv_rows(self):
+        response = self.client.get(
+            reverse("nimbus-experiments-csv-usage"),
+            **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/csv; charset=utf-8")
+        content = response.content.decode("utf-8")
+        reader = csv.DictReader(io.StringIO(content))
+        return list(reader)
+
+    @staticmethod
+    def _month_index(year, month):
+        return (year - 2020) * 12 + (month - 1)
+
+    def test_empty_database_returns_empty_csv(self):
+        response = self.client.get(
+            reverse("nimbus-experiments-csv-usage"),
+            **{settings.OPENIDC_EMAIL_HEADER: "user@example.com"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content.decode("utf-8"), "")
+
+    def test_single_experiment_counts_owner(self):
+        owner = UserFactory.create(email="owner1@example.com")
+        _create_experiment(owner, datetime.date(2023, 3, 15))
+
+        rows = self._get_csv_rows()
+
+        self.assertEqual(len(rows), 52)
+        self.assertEqual(rows[0]["Month"], "2020-01")
+
+        march = rows[self._month_index(2023, 3)]
+        self.assertEqual(march["Month"], "2023-03")
+        self.assertEqual(march["Owners"], "1")
+        self.assertEqual(march["Novice (0-3)"], "1")
+        self.assertEqual(march["Intermediate (4-9)"], "0")
+        self.assertEqual(march["Advanced (10+)"], "0")
+
+    def test_cumulative_owners_across_months(self):
+        owner1 = UserFactory.create(email="owner1@example.com")
+        owner2 = UserFactory.create(email="owner2@example.com")
+
+        _create_experiment(owner1, datetime.date(2023, 1, 10))
+        _create_experiment(owner2, datetime.date(2023, 3, 10))
+
+        rows = self._get_csv_rows()
+
+        self.assertEqual(rows[self._month_index(2023, 1)]["Owners"], "1")
+        self.assertEqual(rows[self._month_index(2023, 2)]["Owners"], "1")
+        self.assertEqual(rows[self._month_index(2023, 3)]["Owners"], "2")
+
+    def test_reviewer_counted_from_approval_changelog(self):
+        owner = UserFactory.create(email="owner@example.com")
+        reviewer = UserFactory.create(email="reviewer@example.com")
+
+        experiment = _create_experiment(owner, datetime.date(2023, 6, 1))
+
+        rows = self._get_csv_rows()
+        self.assertEqual(rows[self._month_index(2023, 6)]["Reviewers"], "1")
+
+        NimbusChangeLog.objects.create(
+            experiment=experiment,
+            changed_by=reviewer,
+            old_status=NimbusExperiment.Status.DRAFT,
+            new_status=NimbusExperiment.Status.DRAFT,
+            old_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            new_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        )
+
+        rows = self._get_csv_rows()
+        self.assertEqual(rows[self._month_index(2023, 6)]["Reviewers"], "2")
+
+    def test_experience_levels_advance_with_experiment_count(self):
+        owner = UserFactory.create(email="prolific@example.com")
+
+        for i in range(12):
+            _create_experiment(
+                owner,
+                datetime.date(2023, 1, 1) + datetime.timedelta(days=30 * i),
+            )
+
+        rows = self._get_csv_rows()
+
+        jan = rows[self._month_index(2023, 1)]
+        self.assertEqual(jan["Novice (0-3)"], "1")
+        self.assertEqual(jan["Intermediate (4-9)"], "0")
+
+        apr = rows[self._month_index(2023, 4)]
+        self.assertEqual(apr["Novice (0-3)"], "0")
+        self.assertEqual(apr["Intermediate (4-9)"], "1")
+
+        oct_row = rows[self._month_index(2023, 10)]
+        self.assertEqual(oct_row["Intermediate (4-9)"], "0")
+        self.assertEqual(oct_row["Advanced (10+)"], "1")
+
+    def test_quarterly_rollups(self):
+        owner = UserFactory.create(email="owner@example.com")
+        _create_experiment(owner, datetime.date(2023, 6, 1))
+
+        rows = self._get_csv_rows()
+
+        self.assertEqual(len(rows), 56)
+        self.assertEqual(rows[42]["Month"], "2020 Q1")
+        self.assertEqual(rows[42]["Owners"], "0")
+
+        self.assertEqual(rows[-1]["Month"], "2023 Q2")
+        self.assertEqual(rows[-1]["Owners"], "1")

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -91,6 +91,15 @@
             </a>
           </li>
           <li>
+            <a href="{% url "nimbus-experiments-csv-usage" %}"
+               class="dropdown-item link-primary"
+               target="_blank"
+               rel="noreferrer">
+              <i class="fa-solid fa-chart-line me-2"></i>
+              Usage Stats
+            </a>
+          </li>
+          <li>
             <a href="{% url "nimbus-experiments-yaml" %}"
                class="dropdown-item link-primary"
                target="_blank"


### PR DESCRIPTION
Because

* We have a per-experiment CSV report but no report tracking platform user engagement over time
* Product needs monthly and quarterly metrics on unique owners, reviewers, and experience levels

This commit

* Adds a new `/api/v5/csv/usage/` endpoint that generates a usage stats CSV with columns: Month, Owners, Reviewers, Novice (0-3), Intermediate (4-9), Advanced (10+)
* Tracks cumulative unique experiment owners and reviewers per month
* Buckets owners by experience level based on running experiment count
* Includes quarterly rollup rows at the end of the CSV
* Adds a "Usage Stats" link in the header dropdown
* Adds tests for the new view

Fixes #15128