### PR TITLE
fix(nimbus): add guardrail to prevent adding fetched targeting files into nonexistent directories

### DIFF
--- a/experimenter/manifesttool/fetch.py
+++ b/experimenter/manifesttool/fetch.py
@@ -37,19 +37,28 @@ class FetchResult:
 
 
 def fetch_targeting_files(
-    save_path: Path,
-    logging_msg: str,
+    manifest_dir: Path,
+    version: Optional[Version],
     app_config: AppConfig,
+    app_name: str,
     ref: Ref,
 ) -> None:
     targeting_files_path = app_config.targeting_files
     if targeting_files_path:
+        logging_msg = (
+            f"fetch: {app_name} at {ref} version {version} downloading targeting files"
+        )
+        path = manifest_dir / app_config.slug
+
+        if version:
+            path /= f"v{version}"
+
         try:
             github_api.fetch_file(
                 app_config.repo.name,
                 targeting_files_path[0],
                 ref.target,
-                save_path / Path(targeting_files_path[0]).name,
+                path / Path(targeting_files_path[0]).name,
             )
             print(logging_msg)
         except HTTPError as e:
@@ -132,9 +141,10 @@ def fetch_fml_app(
             )
 
         fetch_targeting_files(
-            manifest_dir / app_config.slug / f"v{version}",
-            f"fetch: {app_name} at {ref} version {version} downloading targeting files",
+            manifest_dir,
+            version,
             app_config,
+            app_name,
             ref,
         )
 
@@ -201,9 +211,10 @@ def fetch_legacy_app(
         )
 
         fetch_targeting_files(
-            manifest_dir / app_config.slug / f"v{version}",
-            f"fetch: {app_name} at {ref} version {version} downloading targeting files",
+            manifest_dir,
+            version,
             app_config,
+            app_name,
             ref,
         )
 
@@ -290,12 +301,6 @@ def fetch_releases(
 
         results.append(result)
 
-    fetch_targeting_files(
-        manifest_dir / app_config.slug,
-        f"fetch: {app_name} at {ref.name} downloading targeting files ",
-        app_config,
-        ref,
-    )
     return results
 
 

--- a/experimenter/manifesttool/tests/test_fetch.py
+++ b/experimenter/manifesttool/tests/test_fetch.py
@@ -943,16 +943,19 @@ class FetchTests(TestCase):
         )
 
         with TemporaryDirectory() as tmp:
-            save_path = Path(tmp) / "legacy-app" / "v1.0.0"
-            save_path.mkdir(parents=True)
+            manifest_dir = Path(tmp)
             # Should not raise — 404s are handled gracefully.
             fetch_targeting_files(
-                save_path,
-                "fetch: legacy-app at tip version 1.0.0 downloading targeting files",
+                manifest_dir,
+                Version(1, 0, 0),
                 app_config,
+                "legacy-app",
                 Ref("tip", "foo"),
             )
-            self.assertFalse((save_path / "targeting_files.txt").exists())
+
+            self.assertFalse(
+                (manifest_dir / "legacy-app" / "v1.0.0" / "targeting_files.txt").exists()
+            )
             fetch_file.assert_called_once()
 
     def test_fetch_releases_unsupported_apps(self):
@@ -1218,11 +1221,8 @@ class FetchTests(TestCase):
             self.assertTrue(
                 (manifest_dir / "fml-app" / "v1.2.3" / "targeting-contexts.yaml").exists()
             )
-            self.assertTrue(
-                (manifest_dir / "fml-app" / "targeting-contexts.yaml").exists()
-            )
 
-            self.assertEqual(fetch_file.call_count, 3)
+            self.assertEqual(fetch_file.call_count, 2)
 
     @patch.object(
         manifesttool.fetch,
@@ -1284,11 +1284,8 @@ class FetchTests(TestCase):
             self.assertTrue(
                 (manifest_dir / "fml-app" / "v1.2.3" / "targeting-contexts.yaml").exists()
             )
-            self.assertTrue(
-                (manifest_dir / "fml-app" / "targeting-contexts.yaml").exists()
-            )
 
-            self.assertEqual(fetch_file.call_count, 3)
+            self.assertEqual(fetch_file.call_count, 2)
 
     def test_summarize_results(self):
         buffer = StringIO()


### PR DESCRIPTION
Because

- After fetching the targeting context files we were impartially attempting to insert files into `manifest_dir / app_config.slug / f"v{version}"`
- This would not always work because `version` could occasionaly be set to `None` leading to errors when saving files to this path

This commit

- Adds a check to only fetch and insert targeting files if the app version is available

Fixes #15129 