### PR TITLE
fix(nimbus): add check for weekly results before appending error

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -242,7 +242,19 @@ def get_experiment_data(experiment: NimbusExperiment):
         try:
             data_from_jetstream = get_data(recipe_slug, window)
         except RuntimeError as e:
-            runtime_errors.append(str(e))
+            # only store runtime errors for weekly/overall windows if we expect those
+            # results (overall also lags by one day so there is time for analysis to
+            # complete)
+            if (
+                (window == AnalysisWindow.DAILY)
+                or (window == AnalysisWindow.WEEKLY and experiment.results_ready)
+                or (
+                    window == AnalysisWindow.OVERALL
+                    and experiment.end_date
+                    and experiment.end_date < (date.today() - timedelta(days=1))
+                )
+            ):
+                runtime_errors.append(str(e))
 
         segment_points_enrollments = defaultdict(list)
         segment_points_exposures = defaultdict(list)
@@ -376,22 +388,15 @@ def get_experiment_data(experiment: NimbusExperiment):
                     errors_experiment_overall.append(err)
 
     for e in runtime_errors:
-        # only store runtime errors for overall window if we expect those results
-        # (and lag by one day so there is time for analysis to complete)
-        if "overall.json" not in e or (
-            "overall.json" in e
-            and experiment.end_date
-            and experiment.end_date < (date.today() - timedelta(days=1))
-        ):
-            analysis_error = AnalysisError(
-                experiment=experiment.slug,
-                filename="experimenter/jetstream/client.py",
-                func_name="load_data_from_gcs",
-                log_level="WARNING",
-                message=e,
-                timestamp=timezone.now(),
-            )
-            errors_experiment_overall.append(analysis_error.model_dump())
+        analysis_error = AnalysisError(
+            experiment=experiment.slug,
+            filename="experimenter/jetstream/client.py",
+            func_name="load_data_from_gcs",
+            log_level="WARNING",
+            message=e,
+            timestamp=timezone.now(),
+        )
+        errors_experiment_overall.append(analysis_error.model_dump())
 
     errors_by_metric["experiment"] = errors_experiment_overall
 

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -3102,25 +3102,29 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                     )
                     + "Z",
                 },
-                {
-                    "analysis_basis": None,
-                    "source": None,
-                    "exception": None,
-                    "exception_type": None,
-                    "experiment": experiment.slug,
-                    "filename": "experimenter/jetstream/client.py",
-                    "func_name": "load_data_from_gcs",
-                    "log_level": "WARNING",
-                    "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_weekly.json",  # noqa: E501
-                    "metric": None,
-                    "segment": None,
-                    "statistic": None,
-                    "timestamp": now.isoformat(timespec="milliseconds").removesuffix(
-                        "+00:00"
-                    )
-                    + "Z",
-                },
             ]
+            if experiment.results_ready:
+                experiment_errors.append(
+                    {
+                        "analysis_basis": None,
+                        "source": None,
+                        "exception": None,
+                        "exception_type": None,
+                        "experiment": experiment.slug,
+                        "filename": "experimenter/jetstream/client.py",
+                        "func_name": "load_data_from_gcs",
+                        "log_level": "WARNING",
+                        "message": f"Could not find data in analysis bucket at path statistics/statistics_{experiment.slug.replace('-', '_')}_weekly.json",  # noqa: E501
+                        "metric": None,
+                        "segment": None,
+                        "statistic": None,
+                        "timestamp": now.isoformat(timespec="milliseconds").removesuffix(
+                            "+00:00"
+                        )
+                        + "Z",
+                    }
+                )
+
             if (
                 lifecycle == NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE
                 and offset > 1


### PR DESCRIPTION
Because

- The results page used to only be available once an experiment had weekly results available
- To further enforce this we would inject weekly errors into the results data object regardless of whether they were actually ready or not
- Since we now fetch and display daily results we must change this so weekly errors are only included if we should be expecting them i.e. if it has been more than a week since the end of enrollment

This commit

- Adds a check to verify if weekly results should be expected before including an error
- Weekly results being expected is dependent on the `results_ready` field which is true whenever it has been more than a week since an experiment completes enrollment

Fixes #15033