### PR TITLE
feat(nimbus): add user_disabled_ai targeting for Fenix and iOS

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1357,6 +1357,21 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                     ],
                 }
             )
+
+        if (
+            risk_ai
+            and NimbusExperiment.Application.is_mobile(application)
+            and firefox_min_version
+            and NimbusExperiment.Version.parse(firefox_min_version)
+            < NimbusExperiment.Version.parse(NimbusExperiment.AI_RISK_MIN_VERSION_MOBILE)
+        ):
+            raise serializers.ValidationError(
+                {
+                    "firefox_min_version": [
+                        NimbusConstants.ERROR_FIREFOX_VERSION_MIN_151_FOR_AI_RISK_MOBILE
+                    ],
+                }
+            )
         return data
 
     def _validate_enrollment_targeting(self, data):

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -972,6 +972,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_FIREFOX_VERSION_MIN_148_FOR_AI_RISK = (
         "Experiments using AI features require Firefox version 148 or higher"
     )
+    ERROR_FIREFOX_VERSION_MIN_151_FOR_AI_RISK_MOBILE = (
+        "Mobile experiments using AI features require version 151 or higher"
+    )
     ERROR_FIREFOX_VERSION_MAX = (
         "Ensure this value is greater than or equal to the minimum version"
     )
@@ -1048,6 +1051,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     EXCLUDED_REQUIRED_MIN_VERSION = Version.FIREFOX_116
 
     AI_RISK_MIN_VERSION = Version.FIREFOX_148
+
+    AI_RISK_MIN_VERSION_MOBILE = Version.FIREFOX_151
 
     MULTIFEATURE_MAX_FEATURES = 20
     ERROR_MULTIFEATURE_TOO_MANY_FEATURES = (

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -780,6 +780,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 "'browser.ai.control.default'|preferenceValue == 'available'"
             )
 
+        if self.risk_ai and self.is_mobile:
+            expressions.append("user_disabled_ai == false")
+
         #  If there is no targeting defined all clients should match, so we return "true"
         return (
             " && ".join(f"({expression})" for expression in expressions)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -5379,11 +5379,53 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
         )
         self.assertTrue(serializer.is_valid(), serializer.errors)
 
-    def test_risk_ai_mobile_allows_any_version(self):
+    def test_risk_ai_requires_firefox_151_mobile(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.FENIX,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_150,
+            risk_ai=True,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "firefox_min_version": [
+                    NimbusConstants.ERROR_FIREFOX_VERSION_MIN_151_FOR_AI_RISK_MOBILE
+                ],
+            },
+        )
+
+    def test_risk_ai_accepts_firefox_151_mobile(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_151,
+            risk_ai=True,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(
+                experiment,
+                context={"user": self.user},
+            ).data,
+            context={"user": self.user},
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_risk_ai_accepts_firefox_151_ios(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.IOS,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_151,
             risk_ai=True,
         )
         serializer = NimbusReviewSerializer(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1405,10 +1405,11 @@ class TestNimbusExperiment(TestCase):
             (True, NimbusExperiment.Application.DESKTOP, True),
             (False, NimbusExperiment.Application.DESKTOP, False),
             (None, NimbusExperiment.Application.DESKTOP, False),
-            (True, NimbusExperiment.Application.FENIX, False),
         ]
     )
-    def test_targeting_with_risk_ai(self, risk_ai, application, should_include_targeting):
+    def test_targeting_with_risk_ai_desktop(
+        self, risk_ai, application, should_include_targeting
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=application,
@@ -1423,6 +1424,37 @@ class TestNimbusExperiment(TestCase):
             self.assertIn(ai_targeting_expr, experiment.targeting)
         else:
             self.assertNotIn(ai_targeting_expr, experiment.targeting)
+        validate_jexl_expr(experiment.targeting, experiment.application)
+
+    @parameterized.expand(
+        [
+            (True, NimbusExperiment.Application.FENIX, True),
+            (True, NimbusExperiment.Application.IOS, True),
+            (False, NimbusExperiment.Application.FENIX, False),
+            (None, NimbusExperiment.Application.IOS, False),
+        ]
+    )
+    def test_targeting_with_risk_ai_mobile(
+        self, risk_ai, application, should_include_targeting
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_151,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[],
+            risk_ai=risk_ai,
+        )
+        mobile_ai_targeting_expr = "user_disabled_ai == false"
+        desktop_ai_targeting_expr = (
+            "'browser.ai.control.default'|preferenceValue == 'available'"
+        )
+        if should_include_targeting:
+            self.assertIn(mobile_ai_targeting_expr, experiment.targeting)
+        else:
+            self.assertNotIn(mobile_ai_targeting_expr, experiment.targeting)
+        self.assertNotIn(desktop_ai_targeting_expr, experiment.targeting)
         validate_jexl_expr(experiment.targeting, experiment.application)
 
     def test_start_date_returns_None_for_not_started_experiment(self):


### PR DESCRIPTION
Because

* The risk_ai flag on experiments currently only generates targeting
  for Desktop using the `browser.ai.control.default` preference
* Fenix ([Bug 2028993](https://bugzilla.mozilla.org/show_bug.cgi?id=2028993) / [D291861](https://phabricator.services.mozilla.com/D291861)) and iOS (mozilla-mobile/firefox-ios#32929) have added
  `user_disabled_ai` to their RecordedNimbusContext, shipping in v151
* Experiments using AI features need to exclude mobile users who have
  opted out of AI functionality

This commit

* Adds `user_disabled_ai == false` targeting expression when `risk_ai` is
  true and the application is Fenix or iOS
* Adds version validation requiring >= v151 for mobile apps with
  `risk_ai` enabled
* Adds model and serializer tests for both Fenix and iOS

Fixes #15160