### PR TITLE
feat(nimbus): resynchronize live experiments with Remote Settings

### DIFF
--- a/experimenter/experimenter/experiments/admin.py
+++ b/experimenter/experimenter/experiments/admin.py
@@ -35,6 +35,7 @@ from experimenter.experiments.models import (
     Tag,
 )
 from experimenter.jetstream import tasks
+from experimenter.kinto import tasks as kinto_tasks
 from experimenter.settings import DEV_USER_EMAIL
 
 
@@ -42,6 +43,12 @@ from experimenter.settings import DEV_USER_EMAIL
 def force_fetch_jetstream_data(modeladmin, request, queryset):
     for experiment in queryset:
         tasks.fetch_experiment_data.delay(experiment.id)
+
+
+@admin.action(description="Force resync published DTO from Remote Settings.")
+def force_resync_published_dto(modeladmin, request, queryset):
+    for experiment in queryset:
+        kinto_tasks.nimbus_sync_published_dto.delay(experiment.id)
 
 
 # Monkeypatch DecimalWidget render fn to work around a bug exporting Decimal to YAML
@@ -354,7 +361,7 @@ class NimbusExperimentAdmin(
     search_fields = ("name", "slug")
     prepopulated_fields = {"slug": ("name",)}
     form = NimbusExperimentAdminForm
-    actions = [force_fetch_jetstream_data]
+    actions = [force_fetch_jetstream_data, force_resync_published_dto]
     resource_class = NimbusExperimentResource
     readonly_fields = ("_firefox_min_version_parsed", "changelog_display")
     summernote_fields = ("takeaways_summary", "next_steps")

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2913,6 +2913,7 @@ class NimbusChangeLog(FilterMixin, models.Model):
         EXPIRED_FROM_PREVIEW = "Expired from preview collection after 30 days"
         REMOVED_FROM_PREVIEW = "Removed from preview collection"
         PUSHED_TO_PREVIEW = "Pushed to preview collection"
+        RESYNCHRONIZED_FROM_RS = "Resynchronized from Remote Settings"
 
     def __str__(self):
         return self.message or (

--- a/experimenter/experimenter/experiments/tests/test_admin.py
+++ b/experimenter/experimenter/experiments/tests/test_admin.py
@@ -173,6 +173,26 @@ class TestNimbusExperimentAdmin(TestCase):
         self.assertEqual(response.status_code, 200)
         mock_fetch_experiment_data.delay.assert_called_with(experiment.id)
 
+    @mock.patch("experimenter.experiments.admin.kinto_tasks.nimbus_sync_published_dto")
+    def test_admin_force_resync_published_dto(self, mock_resync):
+        user = UserFactory.create(is_staff=True, is_superuser=True)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE
+        )
+        response = self.client.post(
+            reverse(
+                "admin:experiments_nimbusexperiment_changelist",
+            ),
+            {
+                "action": "force_resync_published_dto",
+                "_selected_action": [experiment.id],
+            },
+            follow=True,
+            **{settings.OPENIDC_EMAIL_HEADER: user.email},
+        )
+        self.assertEqual(response.status_code, 200)
+        mock_resync.delay.assert_called_with(experiment.id)
+
     def test_admin_save_creates_changelog(self):
         admin = NimbusExperimentAdmin(NimbusExperiment, None)
         user = UserFactory.create()

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -608,44 +608,60 @@ def nimbus_send_emails():
 
 @app.task
 @metrics.timer_decorator("nimbus_sync_published_dto")
-def nimbus_sync_published_dto():
+def nimbus_sync_published_dto(experiment_id=None):
     """
-    A scheduled task that finds live experiments with published_dto=null,
-    reads their record from Kinto, and saves it to the published_dto field.
+    A scheduled task that reads the published record of all live experiments
+    from Remote Settings and overwrites the local published_dto if they differ,
+    creating a changelog entry for any resynchronized experiments. Can also be
+    invoked for a single experiment by passing experiment_id.
     """
     metrics.incr("nimbus_sync_published_dto.started")
 
     kinto_clients = {
-        app_config.slug: KintoClient(app_config.preview_collection, review=False)
+        collection: KintoClient(collection)
         for app_config in NimbusConstants.APPLICATION_CONFIGS.values()
+        for collection in app_config.kinto_collections
     }
 
     try:
         experiments = NimbusExperiment.objects.filter(
             status=NimbusExperiment.Status.LIVE,
-            published_dto__isnull=True,
         )
+        if experiment_id:
+            experiments = experiments.filter(id=experiment_id)
 
         for experiment in experiments:
-            logger.info(f"Syncing published_dto for {experiment.slug}")
+            collection = experiment.kinto_collection
+            if collection is None:
+                continue
 
-            kinto_client = kinto_clients[experiment.application]
-            records = kinto_client.get_main_records()
+            records = kinto_clients[collection].get_main_records()
 
-            if experiment.slug in records:
-                published_record = records[experiment.slug].copy()
-                published_record.pop("last_modified", None)
-
-                experiment.published_dto = published_record
-                experiment.save()
-
-                logger.info(f"Synced published_dto for {experiment.slug}")
-                metrics.incr("nimbus_sync_published_dto.synced")
-            else:
-                logger.warning(
-                    f"Experiment {experiment.slug} not found in Kinto collection"
-                )
+            if experiment.slug not in records:
+                logger.info(f"Experiment {experiment.slug} not found in Remote Settings")
                 metrics.incr("nimbus_sync_published_dto.not_found")
+                continue
+
+            published_record = records[experiment.slug].copy()
+            published_record.pop("last_modified", None)
+
+            stored_record = (experiment.published_dto or {}).copy()
+            stored_record.pop("last_modified", None)
+
+            if published_record != stored_record:
+                logger.info(f"Resynchronizing {experiment.slug} from Remote Settings")
+
+                with transaction.atomic():
+                    experiment.published_dto = published_record
+                    experiment.save()
+
+                    generate_nimbus_changelog(
+                        experiment,
+                        get_kinto_user(),
+                        message=NimbusChangeLog.Messages.RESYNCHRONIZED_FROM_RS,
+                    )
+
+                metrics.incr("nimbus_sync_published_dto.resynced")
 
         metrics.incr("nimbus_sync_published_dto.completed")
 

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1825,6 +1825,10 @@ class TestNimbusSyncPublishedDto(MockKintoClientMixin, TestCase):
 
         experiment.refresh_from_db()
         self.assertEqual(experiment.published_dto, {"id": experiment.slug})
+        self.assertEqual(
+            experiment.changes.latest_change().message,
+            NimbusChangeLog.Messages.RESYNCHRONIZED_FROM_RS,
+        )
 
     @parameterized.expand(
         [
@@ -1833,22 +1837,54 @@ class TestNimbusSyncPublishedDto(MockKintoClientMixin, TestCase):
             NimbusExperiment.Application.IOS,
         ]
     )
-    def test_does_not_sync_published_dto_for_experiments_with_existing_published_dto(
-        self, application
-    ):
-        existing_dto = {"id": "test-experiment", "some": "data"}
+    def test_resyncs_when_published_dto_differs(self, application):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
             application=application,
-            published_dto=existing_dto,
+            published_dto={"id": "old-data"},
         )
 
-        self.setup_kinto_get_main_records([experiment.slug])
+        self.mock_kinto_client.get_records.return_value = [
+            {"id": experiment.slug, "isEnrollmentPaused": True, "last_modified": "0"}
+        ]
 
         tasks.nimbus_sync_published_dto()
 
         experiment.refresh_from_db()
-        self.assertEqual(experiment.published_dto, existing_dto)
+        self.assertEqual(
+            experiment.published_dto,
+            {"id": experiment.slug, "isEnrollmentPaused": True},
+        )
+        self.assertEqual(
+            experiment.changes.latest_change().message,
+            NimbusChangeLog.Messages.RESYNCHRONIZED_FROM_RS,
+        )
+
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.DESKTOP,
+            NimbusExperiment.Application.FENIX,
+            NimbusExperiment.Application.IOS,
+        ]
+    )
+    def test_does_not_resync_when_published_dto_matches(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=application,
+        )
+        experiment.published_dto = {"id": experiment.slug, "key": "value"}
+        experiment.save()
+
+        self.mock_kinto_client.get_records.return_value = [
+            {"id": experiment.slug, "key": "value", "last_modified": "0"}
+        ]
+
+        changes_before = experiment.changes.count()
+
+        tasks.nimbus_sync_published_dto()
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.changes.count(), changes_before)
 
     @parameterized.expand(
         [
@@ -1870,6 +1906,38 @@ class TestNimbusSyncPublishedDto(MockKintoClientMixin, TestCase):
 
         experiment.refresh_from_db()
         self.assertIsNone(experiment.published_dto)
+
+    def test_syncs_single_experiment_by_id(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            published_dto={"id": "old-data"},
+        )
+
+        other_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            published_dto={"id": "other-old-data"},
+        )
+
+        self.mock_kinto_client.get_records.return_value = [
+            {"id": experiment.slug, "updated": True, "last_modified": "0"},
+            {"id": other_experiment.slug, "updated": True, "last_modified": "0"},
+        ]
+
+        other_changes_before = other_experiment.changes.count()
+
+        tasks.nimbus_sync_published_dto(experiment_id=experiment.id)
+
+        experiment.refresh_from_db()
+        self.assertEqual(
+            experiment.published_dto,
+            {"id": experiment.slug, "updated": True},
+        )
+
+        other_experiment.refresh_from_db()
+        self.assertEqual(other_experiment.published_dto, {"id": "other-old-data"})
+        self.assertEqual(other_experiment.changes.count(), other_changes_before)
 
     @parameterized.expand(
         [
@@ -1908,6 +1976,26 @@ class TestNimbusSyncPublishedDto(MockKintoClientMixin, TestCase):
         experiment.refresh_from_db()
         self.assertEqual(experiment.published_dto, {"id": experiment.slug})
         self.assertNotIn("last_modified", experiment.published_dto)
+
+    @mock.patch(
+        "experimenter.experiments.models.NimbusExperiment.kinto_collection",
+        new_callable=mock.PropertyMock,
+        return_value=None,
+    )
+    def test_skips_experiment_with_no_kinto_collection(self, _mock_collection):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            published_dto={"id": "old-data"},
+        )
+
+        changes_before = experiment.changes.count()
+
+        tasks.nimbus_sync_published_dto()
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.published_dto, {"id": "old-data"})
+        self.assertEqual(experiment.changes.count(), changes_before)
 
     def test_reraises_exception(self):
         NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* An experiment completed the pause flow but the published DTO was not
  synchronized back into Experimenter, leaving it out of sync with
  Remote Settings
* The existing `nimbus_sync_published_dto` task only handled experiments
  with `published_dto=null` and had a bug reading from the preview
  collection instead of the main collection
* There was no way to recover the state of an out-of-sync experiment

This commit

* Extends the existing `nimbus_sync_published_dto` task to read the
  published record of all live experiments from Remote Settings, compare
  with the stored `published_dto`, and overwrite it if they differ with
  a changelog entry saying "Resynchronized from Remote Settings"
* Fixes the collection bug by using `app_config.kinto_collections` to
  build clients for all collections (including `nimbus-secure`)
* Adds an optional `experiment_id` parameter so the task can target a
  single experiment when triggered manually
* Adds an admin action "Force resync published DTO from Remote Settings"
  to manually trigger the task for selected experiments
* Adds a `RESYNCHRONIZED_FROM_RS` changelog message constant

Fixes #15161