### PR TITLE
feat(nimbus): Handle remove emoji if already removed

### DIFF
--- a/experimenter/experimenter/slack/constants.py
+++ b/experimenter/experimenter/slack/constants.py
@@ -54,6 +54,7 @@ class SlackConstants:
     # Slack API error codes
     class ErrorCode:
         ALREADY_REACTED = "already_reacted"
+        NO_REACTION = "no_reaction"
 
     # Enrollment monitoring thresholds
     UNENROLLMENT_SPIKE_THRESHOLD = 0.10  # 10%
@@ -126,6 +127,9 @@ class SlackConstants:
         "Failed to add {emoji_name} emoji to message for {experiment}"
     )
     SLACK_LOG_EMOJI_REMOVED = "Removed {emoji_name} emoji from message for {experiment}"
+    SLACK_LOG_EMOJI_ALREADY_REMOVED = (
+        "{emoji_name} emoji already removed or never existed for {experiment}"
+    )
     SLACK_LOG_FAILED_REMOVE_EMOJI = (
         "Failed to remove {emoji_name} emoji from message for {experiment}"
     )

--- a/experimenter/experimenter/slack/notification.py
+++ b/experimenter/experimenter/slack/notification.py
@@ -323,6 +323,13 @@ def remove_emoji_from_slack_message(experiment, alert_type, emoji_name):
         return True
 
     except SlackApiError as e:
+        if e.response.get("error") == SlackConstants.ErrorCode.NO_REACTION:
+            logger.info(
+                SlackConstants.SLACK_LOG_EMOJI_ALREADY_REMOVED.format(
+                    emoji_name=emoji_name, experiment=experiment.slug
+                )
+            )
+            return False
         msg = SlackConstants.SLACK_LOG_FAILED_REMOVE_EMOJI.format(
             emoji_name=emoji_name, experiment=experiment.slug
         )

--- a/experimenter/experimenter/slack/tests/test_notification.py
+++ b/experimenter/experimenter/slack/tests/test_notification.py
@@ -1042,3 +1042,34 @@ class TestSlackNotifications(TestCase):
             call_args = mock_logger.error.call_args[0][0]
             self.assertIn("No channel ID found", call_args)
             mock_client.reactions_remove.assert_not_called()
+
+    @override_settings(SLACK_AUTH_TOKEN="test-token")
+    @patch("experimenter.slack.notification.WebClient")
+    def test_remove_emoji_from_slack_message_no_reaction(self, mock_webclient):
+        mock_client = Mock()
+        mock_webclient.return_value = mock_client
+        mock_client.reactions_remove.side_effect = SlackApiError(
+            message="no_reaction",
+            response={"error": "no_reaction"},
+        )
+
+        NimbusAlert.objects.create(
+            experiment=self.experiment,
+            alert_type=NimbusConstants.AlertType.LAUNCH_REQUEST,
+            message="Test launch request",
+            slack_thread_id="1234567890.123456",
+            slack_channel_id="C123456",
+        )
+
+        with patch("experimenter.slack.notification.logger") as mock_logger:
+            result = remove_emoji_from_slack_message(
+                self.experiment,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+                "question",
+            )
+
+            self.assertFalse(result)
+            mock_logger.error.assert_not_called()
+            mock_logger.info.assert_called()
+            call_args = mock_logger.info.call_args[0][0]
+            self.assertIn("already removed", call_args)


### PR DESCRIPTION
Because

- If we have already removed the emoji and if the tasks tries to do retry for some reason, it will gives us the error as no reaction, we should handle this case gracefully.

This commit

- Adds the exception handling to handle the above case.

Fixes #15156 