### PR TITLE
fix(project): add bot branches to push triggers for all GHA workflows

### DIFF
--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "cirrus/**"
       - "application-services/**"

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -4,8 +4,10 @@ on:
   push:
     branches:
       - main
-      - update_firefox_versions
+      - external-config
       - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -1,6 +1,18 @@
 name: Feature Manifest Tests
 
 on:
+  push:
+    branches:
+      - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
+    paths:
+      - "experimenter/experimenter/features/manifests/**"
+      - "experimenter/manifesttool/**"
+      - "application-services/**"
+      - ".github/workflows/check-feature-manifests.yml"
   pull_request:
     paths:
       - "experimenter/experimenter/features/manifests/**"

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -1,6 +1,16 @@
 name: Schema Tests
 
 on:
+  push:
+    branches:
+      - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
+    paths:
+      - "schemas/**"
+      - ".github/workflows/check-schemas.yml"
   pull_request:
     paths:
       - "schemas/**"

--- a/.github/workflows/integration-desktop-enrollment.yml
+++ b/.github/workflows/integration-desktop-enrollment.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"

--- a/.github/workflows/integration-desktop-targeting.yml
+++ b/.github/workflows/integration-desktop-targeting.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"

--- a/.github/workflows/integration-nimbus-ui.yml
+++ b/.github/workflows/integration-nimbus-ui.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"

--- a/.github/workflows/integration-remote-settings-all.yml
+++ b/.github/workflows/integration-remote-settings-all.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"

--- a/.github/workflows/integration-remote-settings-launch.yml
+++ b/.github/workflows/integration-remote-settings-launch.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+      - external-config
+      - update-application-services
+      - update_firefox_desktop_release
+      - update_firefox_desktop_beta
     paths:
       - "experimenter/**"
       - "application-services/**"


### PR DESCRIPTION
Because

* Force-pushes from the GitHub App bot to existing PR branches don't
  trigger pull_request:synchronize events in GHA
* This means cron job PRs (external-config, update-application-services,
  update_firefox_desktop_*) only get CI on the initial push, not on
  subsequent updates

This commit

* Adds bot branch names to the push trigger in all check and integration
  test workflows so force-pushes trigger CI via the push event
* Removes the dead update_firefox_versions branch reference

Fixes #15173