### PR TITLE
fix(project): use docker buildx driver for fork PRs without GAR access

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -39,6 +39,8 @@ runs:
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
+      with:
+        driver: docker
 
     - name: Build megazords with cache
       if: inputs.gcp-project-number != ''


### PR DESCRIPTION
Because

* Fork PRs don't have GCP credentials so setup-cached-build falls back
  to local builds without registry cache
* The docker-container buildx driver can't resolve local daemon images
  via docker-image:// references, causing cirrus and experimenter builds
  to fail with "pull access denied"

This commit

* Switches to the docker buildx driver which can resolve local daemon
  images and also supports registry cache when GAR credentials are
  available

Fixes #15176