### PR TITLE
feat(nimbus): Enforce experiment key in messaging messages

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1133,15 +1133,18 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         schemas_in_range: NimbusFeatureConfig.VersionedSchemaRange,
         loader: NimbusFmlLoader,
         feature_config: NimbusFeatureConfig,
-        blob: str,
+        value: str,
     ) -> list[str]:
         errors = []
         schema_errors_versions = defaultdict(set)
         for schema in schemas_in_range.schemas:
             for fml_error in loader.get_fml_errors(
-                blob, feature_config.slug, schema.version
+                value, feature_config.slug, schema.version
             ):
                 schema_errors_versions[fml_error.message].add(schema.version)
+
+        if feature_config.slug == NimbusConstants.MOBILE_MESSAGING_SLUG:
+            errors.extend(cls._validate_mobile_messaging(value))
 
         for fml_error, versions in schema_errors_versions.items():
             version_strs = [str(v) for v in versions]
@@ -1495,7 +1498,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(
                     {
                         "localizations": [
-                            f"Experiment locale {locale_code} not present in "
+                            f"Experimen locale {locale_code} not present in "
                             f"localizations."
                         ]
                     }
@@ -1636,6 +1639,32 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             )
 
         return data
+
+    @classmethod
+    def _validate_mobile_messaging(cls, value: str):
+        json_value = None
+        try:
+            json_value = json.loads(value)
+        except:
+            # Invalid JSON errors are handled by the FML loader
+            return []
+
+        errors = []
+        if messages := json_value.get(NimbusConstants.MOBILE_MESSAGING_MESSAGES_FIELD):
+            for message_id, message_value in messages.items():
+                if (
+                    message_value.get(
+                        NimbusConstants.MOBILE_MESSAGING_MESSAGE_EXPERIMENT_FIELD
+                    )
+                    != NimbusConstants.MOBILE_MESSAGING_EXPERIMENT_PLACEHOLDER
+                ):
+                    errors.append(
+                        NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                            message_id=message_id
+                        )
+                    )
+
+        return errors
 
     def _validate_feature_value_variables(self, data):
         warn_feature_schema = data.get("warn_feature_schema", False)

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1138,15 +1138,18 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         schemas_in_range: NimbusFeatureConfig.VersionedSchemaRange,
         loader: NimbusFmlLoader,
         feature_config: NimbusFeatureConfig,
-        blob: str,
+        value: str,
     ) -> list[str]:
         errors = []
         schema_errors_versions = defaultdict(set)
         for schema in schemas_in_range.schemas:
             for fml_error in loader.get_fml_errors(
-                blob, feature_config.slug, schema.version
+                value, feature_config.slug, schema.version
             ):
                 schema_errors_versions[fml_error.message].add(schema.version)
+
+        if feature_config.slug == NimbusConstants.MOBILE_MESSAGING_SLUG:
+            errors.extend(cls._validate_mobile_messaging(value))
 
         for fml_error, versions in schema_errors_versions.items():
             version_strs = [str(v) for v in versions]
@@ -1641,6 +1644,32 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             )
 
         return data
+
+    @classmethod
+    def _validate_mobile_messaging(cls, value: str):
+        json_value = None
+        try:
+            json_value = json.loads(value)
+        except Exception:  # pragma: no cover
+            # Invalid JSON errors are handled by the FML loader
+            return []
+
+        errors = []
+        if messages := json_value.get(NimbusConstants.MOBILE_MESSAGING_MESSAGES_FIELD):
+            for message_id, message_value in messages.items():
+                if (
+                    message_value.get(
+                        NimbusConstants.MOBILE_MESSAGING_MESSAGE_EXPERIMENT_FIELD
+                    )
+                    != NimbusConstants.MOBILE_MESSAGING_EXPERIMENT_PLACEHOLDER
+                ):
+                    errors.append(
+                        NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                            message_id=message_id
+                        )
+                    )
+
+        return errors
 
     def _validate_feature_value_variables(self, data):
         warn_feature_schema = data.get("warn_feature_schema", False)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -403,6 +403,13 @@ class NimbusConstants:
     DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
     DESKTOP_NEWTAB_ADDON_SLUG = DESKTOP_NEWTAB_ADDON_SLUG
 
+    MOBILE_MESSAGING_SLUG = "messaging"
+    MOBILE_MESSAGING_MESSAGES_FIELD = "messages"
+    MOBILE_MESSAGING_MESSAGE_EXPERIMENT_FIELD = "experiment"
+
+    # https://searchfox.org/mozilla-mobile/rev/7d8e9f43399a128c5b31b306ef62d160d12bf525/application-services/components/nimbus/src/lib.rs#44
+    MOBILE_MESSAGING_EXPERIMENT_PLACEHOLDER = "{experiment}"
+
     Channel = Channel
 
     class DocumentationLink(models.TextChoices):
@@ -1164,6 +1171,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_CANNOT_PAUSE_INVALID = "Cannot end enrollment at this time"
 
     ERROR_CANNOT_PARSE_TARGETING = "Cannot parse targeting expression"
+
+    ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD = (
+        'The message "{message_id}" requires a "experiment" key with the '
+        'value "{{experiment}}"'
+    )
 
     # Analysis window to alert type mappings
     ANALYSIS_WINDOW_TO_ALERT_TYPE = {

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -403,6 +403,13 @@ class NimbusConstants:
     DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
     DESKTOP_NEWTAB_ADDON_SLUG = DESKTOP_NEWTAB_ADDON_SLUG
 
+    MOBILE_MESSAGING_SLUG = "messaging"
+    MOBILE_MESSAGING_MESSAGES_FIELD = "messages"
+    MOBILE_MESSAGING_MESSAGE_EXPERIMENT_FIELD = "experiment"
+
+    # https://searchfox.org/mozilla-mobile/rev/7d8e9f43399a128c5b31b306ef62d160d12bf525/application-services/components/nimbus/src/lib.rs#44
+    MOBILE_MESSAGING_EXPERIMENT_PLACEHOLDER = "{experiment}"
+
     Channel = Channel
 
     class DocumentationLink(models.TextChoices):
@@ -1174,6 +1181,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_CANNOT_PAUSE_INVALID = "Cannot end enrollment at this time"
 
     ERROR_CANNOT_PARSE_TARGETING = "Cannot parse targeting expression"
+
+    ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD = (
+        'The message "{message_id}" requires a "experiment" key with the '
+        'value "{{experiment}}"'
+    )
 
     # Analysis window to alert type mappings
     ANALYSIS_WINDOW_TO_ALERT_TYPE = {

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -3374,6 +3374,74 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             },
         )
 
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.FENIX,
+            NimbusExperiment.Application.IOS,
+        ]
+    )
+    def test_mobile_messaging_requires_experiment_placeholder(self, application):
+        messaging_feature = NimbusFeatureConfigFactory.create_mobile_messaging_feature(
+            application
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_140,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_150,
+            feature_configs=[messaging_feature],
+            channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
+        )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=messaging_feature
+        )
+        feature_value.value = json.dumps(
+            {
+                "messages": {
+                    "invalid-message-missing": {},
+                    "invalid-message-value": {
+                        "experiment": experiment.slug,
+                    },
+                    "valid-message": {
+                        "experiment": "{experiment}",
+                    },
+                }
+            }
+        )
+        feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "reference_branch": {
+                    "feature_values": [
+                        {
+                            "value": [
+                                NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                                    message_id="invalid-message-missing"
+                                ),
+                                NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                                    message_id="invalid-message-value"
+                                ),
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
+
 
 @mock_targeting_manifests
 class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -3370,6 +3370,74 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
             },
         )
 
+    @parameterized.expand(
+        [
+            NimbusExperiment.Application.FENIX,
+            NimbusExperiment.Application.IOS,
+        ]
+    )
+    def test_mobile_messaging_requires_experiment_placeholder(self, application):
+        messaging_feature = NimbusFeatureConfigFactory.create_mobile_messaging_feature(
+            application
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_140,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_150,
+            feature_configs=[messaging_feature],
+            channel=NimbusExperiment.Channel.RELEASE,
+            channels=[],
+        )
+
+        for branch in experiment.treatment_branches:
+            branch.delete()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=messaging_feature
+        )
+        feature_value.value = json.dumps(
+            {
+                "messages": {
+                    "invalid-message-missing": {},
+                    "invalid-message-value": {
+                        "experiment": experiment.slug,
+                    },
+                    "valid-message": {
+                        "experiment": "{experiment}",
+                    },
+                }
+            }
+        )
+        feature_value.save()
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "reference_branch": {
+                    "feature_values": [
+                        {
+                            "value": [
+                                NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                                    message_id="invalid-message-missing"
+                                ),
+                                NimbusConstants.ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD.format(
+                                    message_id="invalid-message-value"
+                                ),
+                            ]
+                        }
+                    ]
+                }
+            },
+        )
+
 
 class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
     maxDiff = None

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -136,6 +136,14 @@ class NimbusFeatureConfigFactory(factory.django.DjangoModelFactory):
             ],
         )
 
+    @classmethod
+    def create_mobile_messaging_feature(cls, application):
+        return cls.create(
+            name=NimbusExperiment.MOBILE_MESSAGING_SLUG,
+            slug=NimbusExperiment.MOBILE_MESSAGING_SLUG,
+            application=application,
+        )
+
     class Meta:
         model = NimbusFeatureConfig
 


### PR DESCRIPTION
Because:

- iOS and Fenix have a "messaging" feature with a special "experiment" key in the message;
- this key needs to have a value of "{experiment}", but is optional; and
- if this key is not present, telemetry may not be submitted correctly

this commit:

- enforces that the key exists and is the correct value.

Fixes #15210