### PR TITLE
fix(project): close and recreate bot PRs to trigger GHA CI

### DIFF
--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -48,9 +48,9 @@ jobs:
             git add experimenter/ schemas/
             git commit -m 'chore(nimbus): Update External Configs'
             if (( $((git diff external-config origin/external-config || git diff HEAD~1) | wc -c) > 0 )); then
+              gh pr close external-config --repo mozilla/experimenter 2>/dev/null || true
               git push origin external-config -f
-              gh pr create -t "chore(nimbus): Update External Configs" -F /tmp/pr-body.txt --base main --head external-config --repo mozilla/experimenter || \
-                gh pr edit external-config -F /tmp/pr-body.txt
+              gh pr create -t "chore(nimbus): Update External Configs" -F /tmp/pr-body.txt --base main --head external-config --repo mozilla/experimenter
             else
               echo "Changes already committed, skipping"
             fi
@@ -98,8 +98,9 @@ jobs:
             git add application-services/
             git commit -m "chore(nimbus): Update Application Services"
             if (( $((git diff update-application-services origin/update-application-services || git diff HEAD~1) | wc -c) > 0 )); then
+              gh pr close update-application-services --repo mozilla/experimenter 2>/dev/null || true
               git push origin update-application-services -f
-              gh pr create -t "chore(nimbus): Update Application Services" -b "" --base main --head update-application-services --repo mozilla/experimenter || echo "PR already exists, skipping"
+              gh pr create -t "chore(nimbus): Update Application Services" -b "" --base main --head update-application-services --repo mozilla/experimenter
             else
               echo "Changes already committed, skipping"
             fi

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -120,8 +120,9 @@ if (($(git status --porcelain | wc -c) > 0)); then
     fi
 
     git commit -m "${COMMIT_MSG}"
+    gh pr close "${BRANCH_NAME}" --repo mozilla/experimenter 2>/dev/null || true
     git push origin -f "${BRANCH_NAME}"
-    gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" --base main --head "${BRANCH_NAME}" --repo mozilla/experimenter || echo "PR already exists, skipping"
+    gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" --base main --head "${BRANCH_NAME}" --repo mozilla/experimenter
 else
     echo "No config changes, skipping"
 fi


### PR DESCRIPTION
Because

* GitHub App installation tokens don't generate push/synchronize
  events on existing PRs, so subsequent force-pushes to bot PRs
  don't trigger GHA CI workflows
* Only pull_request:opened events trigger CI from App tokens
* See [Triggering a workflow from a workflow](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

This commit

* Closes the existing PR before pushing and creating a fresh one
  in the update-configs and update-firefox workflows
* This ensures every update gets a pull_request:opened event which
  triggers the full CI suite
* The close/recreate only fires when the content actually changed
  (gated by the existing git diff check)

Fixes #15215