### PR TITLE
fix(project): move path filters to job-level conditions in GHA workflows

### DIFF
--- a/.github/actions/check-changed-paths/action.yml
+++ b/.github/actions/check-changed-paths/action.yml
@@ -1,0 +1,60 @@
+name: "Check Changed Paths"
+description: "Check if any files matching the given patterns were changed, always true for merge_group and push to main"
+
+inputs:
+  paths:
+    description: "Space-separated list of path patterns to check (e.g. 'experimenter/ application-services/')"
+    required: true
+
+outputs:
+  should-run:
+    description: "Whether the job should run based on changed paths"
+    value: ${{ steps.check.outputs.should_run }}
+
+runs:
+  using: composite
+  steps:
+    - name: Check changed paths
+      id: check
+      shell: bash
+      run: |
+        if [[ "${{ github.event_name }}" == "merge_group" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "${{ github.event_name }}" == "push" && "${{ github.ref }}" == "refs/heads/main" ]]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          BASE="${{ github.event.pull_request.base.sha }}"
+        elif [[ "${{ github.event_name }}" == "push" ]]; then
+          BASE="${{ github.event.before }}"
+        else
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        CHANGED=$(git diff --name-only "$BASE" HEAD 2>/dev/null || echo "")
+
+        if [ -z "$CHANGED" ]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        ROOT_OR_GITHUB=$(echo "$CHANGED" | grep -E '^[^/]+$|^\.github/' || true)
+        if [ -n "$ROOT_OR_GITHUB" ]; then
+          echo "should_run=true" >> "$GITHUB_OUTPUT"
+          exit 0
+        fi
+
+        for pattern in ${{ inputs.paths }}; do
+          if echo "$CHANGED" | grep -q "^${pattern}"; then
+            echo "should_run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+        done
+
+        echo "should_run=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -8,15 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "cirrus/**"
-      - "application-services/**"
-      - ".github/workflows/check-cirrus.yml"
   pull_request:
-    paths:
-      - "cirrus/**"
-      - "application-services/**"
-      - ".github/workflows/check-cirrus.yml"
   merge_group:
     types: [checks_requested]
 
@@ -36,10 +28,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "cirrus/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - name: Run Cirrus tests and linting
+        if: steps.check-paths.outputs.should-run == 'true'
         run: |
           cp .env.sample .env
           make cirrus_check

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -8,15 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/workflows/check-experimenter.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/workflows/check-experimenter.yml"
   merge_group:
     types: [checks_requested]
 
@@ -36,10 +28,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - name: Run tests and linting
+        if: steps.check-paths.outputs.should-run == 'true'
         run: |
           cp .env.sample .env
           make check

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/experimenter/features/manifests/**"
-      - "experimenter/manifesttool/**"
-      - "application-services/**"
-      - ".github/workflows/check-feature-manifests.yml"
   pull_request:
-    paths:
-      - "experimenter/experimenter/features/manifests/**"
-      - "experimenter/manifesttool/**"
-      - "application-services/**"
-      - ".github/workflows/check-feature-manifests.yml"
   merge_group:
     types: [checks_requested]
 
@@ -30,10 +20,19 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/experimenter/features/manifests/ experimenter/manifesttool/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - name: Check local feature manifests
+        if: steps.check-paths.outputs.should-run == 'true'
         run: |
           cp .env.sample .env
           make feature_manifests FETCH_ARGS="--local-apps"

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -8,13 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "schemas/**"
-      - ".github/workflows/check-schemas.yml"
   pull_request:
-    paths:
-      - "schemas/**"
-      - ".github/workflows/check-schemas.yml"
   merge_group:
     types: [checks_requested]
 
@@ -26,8 +20,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "schemas/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - name: Run schemas tests and linting
+        if: steps.check-paths.outputs.should-run == 'true'
         run: make schemas_check

--- a/.github/workflows/integration-desktop-enrollment.yml
+++ b/.github/workflows/integration-desktop-enrollment.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-desktop-enrollment.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-desktop-enrollment.yml"
   merge_group:
     types: [checks_requested]
 
@@ -38,9 +28,18 @@ jobs:
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
         with:
           artifact-name: desktop-enrollment-${{ matrix.split }}-test-report

--- a/.github/workflows/integration-desktop-targeting.yml
+++ b/.github/workflows/integration-desktop-targeting.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-desktop-targeting.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-desktop-targeting.yml"
   merge_group:
     types: [checks_requested]
 
@@ -39,10 +29,19 @@ jobs:
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
         with:
           make-args: FIREFOX_CHANNEL=${{ matrix.channel }}
           artifact-name: desktop-targeting-${{ matrix.channel }}-${{ matrix.split }}-test-report

--- a/.github/workflows/integration-nimbus-ui.yml
+++ b/.github/workflows/integration-nimbus-ui.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-nimbus-ui.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-nimbus-ui.yml"
   merge_group:
     types: [checks_requested]
 
@@ -34,9 +24,18 @@ jobs:
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
         with:
           artifact-name: nimbus-ui-test-report

--- a/.github/workflows/integration-remote-settings-all.yml
+++ b/.github/workflows/integration-remote-settings-all.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-remote-settings-all.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-remote-settings-all.yml"
   merge_group:
     types: [checks_requested]
 
@@ -44,9 +34,18 @@ jobs:
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
         with:
           artifact-name: remote-settings-all-${{ matrix.marker }}-test-report

--- a/.github/workflows/integration-remote-settings-launch.yml
+++ b/.github/workflows/integration-remote-settings-launch.yml
@@ -8,17 +8,7 @@ on:
       - update-application-services
       - update_firefox_desktop_release
       - update_firefox_desktop_beta
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-remote-settings-launch.yml"
   pull_request:
-    paths:
-      - "experimenter/**"
-      - "application-services/**"
-      - ".github/actions/run-integration-test/**"
-      - ".github/workflows/integration-remote-settings-launch.yml"
   merge_group:
     types: [checks_requested]
 
@@ -34,9 +24,18 @@ jobs:
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/ application-services/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
         with:
           artifact-name: remote-settings-launch-test-report


### PR DESCRIPTION
Because

* Workflow-level `paths:` filters cause checks to stay in Pending state
  when the paths don't match, which blocks PRs when those checks are
  required
* [GitHub docs confirm](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks):
  "If a workflow is skipped due to path filtering, then checks
  associated with that workflow will remain in a Pending state"
* Changes to root-level files or `.github/` should trigger all workflows
  to catch CI config breakage

This commit

* Adds `check-changed-paths` composite action that uses git diff to
  determine if relevant paths changed
* Always runs on merge_group, workflow_dispatch, and push to main
* Always runs when root-level files or `.github/` are changed
* Removes `paths:` from all workflow triggers, replaced with job-level
  `if:` conditions that skip heavy steps but still report green

Fixes #15218