### PR TITLE
Add 48 hour churned user targeting && lapsed user targeting for Windows

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2633,21 +2633,7 @@ LAPSED_USER_WINDOWS_ONLY = NimbusTargetingConfig(
         "Users with a profile age of 28 days and 0 days of activity "
         "in the past 28 days, using Windows"
     ),
-    targeting=(
-        f"{PROFILE28DAYS} && "
-        "(os.isWindows && (os.windowsVersion >= 10)) && "
-        "((userMonthlyActivity|length == 0) || "
-        "(userMonthlyActivity|length == 1 && "
-        "(currentDate|date - userMonthlyActivity|mapToProperty('1')"
-        "[userMonthlyActivity|mapToProperty('1')|length - 1]|date < 86400000)) || "
-        "(userMonthlyActivity|mapToProperty('1')[userMonthlyActivity|length - 1]|date "
-        "<= currentDate|date - (86400000 * 28)) || "
-        "(((userMonthlyActivity|length > 1) && "
-        "(currentDate|date - userMonthlyActivity|mapToProperty('1')"
-        "[userMonthlyActivity|mapToProperty('1')|length - 1]|date < 86400000) && "
-        "(userMonthlyActivity|mapToProperty('1')[userMonthlyActivity|length - 2]|date "
-        "<= currentDate|date - (86400000 * 28)))))"
-    ),
+    targeting=(f"{LAPSED_USER.targeting} && (os.isWindows && (os.windowsVersion >= 10))"),
     desktop_telemetry="",
     sticky_required=False,
     is_first_run_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2626,6 +2626,56 @@ LAPSED_USER = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+LAPSED_USER_WINDOWS_ONLY = NimbusTargetingConfig(
+    name="Lapsed Windows users (No activity in the past 28 days)",
+    slug="lapsed_user_28_days_windows",
+    description=(
+        "Users with a profile age of 28 days and 0 days of activity "
+        "in the past 28 days, using Windows"
+    ),
+    targeting=(
+        f"{PROFILE28DAYS} && "
+        "(os.isWindows && (os.windowsVersion >= 10)) && "
+        "((userMonthlyActivity|length == 0) || "
+        "(userMonthlyActivity|length == 1 && "
+        "(currentDate|date - userMonthlyActivity|mapToProperty('1')"
+        "[userMonthlyActivity|mapToProperty('1')|length - 1]|date < 86400000)) || "
+        "(userMonthlyActivity|mapToProperty('1')[userMonthlyActivity|length - 1]|date "
+        "<= currentDate|date - (86400000 * 28)) || "
+        "(((userMonthlyActivity|length > 1) && "
+        "(currentDate|date - userMonthlyActivity|mapToProperty('1')"
+        "[userMonthlyActivity|mapToProperty('1')|length - 1]|date < 86400000) && "
+        "(userMonthlyActivity|mapToProperty('1')[userMonthlyActivity|length - 2]|date "
+        "<= currentDate|date - (86400000 * 28)))))"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+RETURNING_CHURNED_USER_48_HR_OS_NOTIFICATION = NimbusTargetingConfig(
+    name="Returning users who have lapsed a second time",
+    slug="returning_churned_user_48_hr",
+    description=(
+        "Users lapsed for 48 hours after returning to the browser after 28 days, "
+        "enrolled in the lapsed users rollout, "
+        "running a background task"
+    ),
+    targeting=(
+        "(os.isWindows && (os.windowsVersion >= 10)) "
+        "&& isBackgroundTaskMode "
+        "&& (defaultProfile.enrollmentsMap"
+        "['48hr-os-notification-for-resurrected-users-enrollment-rollout'] "
+        "== 'control') "
+        "&& ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 48)"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 CORE_USER_FULLY_ACTIVE = NimbusTargetingConfig(
     name="Core user (Active Every Day)",
     slug="core_user_active_every_day",


### PR DESCRIPTION
To support the [48h churned returning user](https://docs.google.com/document/d/1yIynQ67mVarSx0sy1287wL_gkeZIPF5uMfGLD9UuOG4/edit?tab=t.0) experiment,
This commit adds two targeting expressions. 

The first is a LAPSED_USER targeting expression updated to target only Windows users, which will be used to enroll users in a "dummy rollout" when they return to the browser after having been lapsed for 28 days. (Based on `userMonthlyActivity.)

The second expression will target the users enrolled in this first rollout, who have now lapsed for an additional 2 days after returning. (based on the `currentDate` of the default profile, seen from backgroundTask.) This is necessary since once the user has returned to the browser, their `userMonthlyActivity` will update and can no longer be used for the second expression.