### PR TITLE
bug(project): Fix docker tags for deploys

### DIFF
--- a/.github/workflows/deploy-cirrus.yml
+++ b/.github/workflows/deploy-cirrus.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Generate image tag
         id: tag
         run: |
-          TAG="$(git rev-parse --short=10 HEAD)"
+          TAG="$(git rev-parse --short=9 HEAD)"
           echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Tag image for GAR

--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -43,7 +43,6 @@ jobs:
           ./scripts/store_git_info.sh
           make build_prod
 
-      # Generate MozCloud Tag (use tag name on tag events, else 10-char short SHA)
       - name: Generate MozCloud Tag
         id: mozcloud-tag
         shell: bash
@@ -54,7 +53,7 @@ jobs:
           if [[ "${REF_TYPE}" == "tag" ]]; then
             tag="${REF_NAME}"
           else
-            tag="$(git rev-parse --short=10 HEAD)"
+            tag="$(git rev-parse --short=9 HEAD)"
           fi
 
           echo "Setting IMAGE_TAG=${tag} as output"


### PR DESCRIPTION
Because:

- ArgoCD expects a image tag of the format `sha-{SHA9}` where SHA9 is *exactly* the first 9 characters of the SHA;
- the mozcloud publish action was added to use 10 characters of the SHA; and
- we recently removed our CircleCI action that was pushing with the correct format, causing deploys to stop

this commit:

- updates our tags to correctly use 9 characters of SHAs.

See-also #14004

Fixes #15237