### PR TITLE
fix(project): move path filters to job-level conditions in deploy workflows

### DIFF
--- a/.github/workflows/deploy-cirrus.yml
+++ b/.github/workflows/deploy-cirrus.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "cirrus/**"
-      - "application-services/**"
-      - "experimenter/experimenter/features/manifests/**"
   workflow_dispatch: {}
 
 env:
@@ -26,19 +22,29 @@ jobs:
         with:
           persist-credentials: false
           fetch-tags: true
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "cirrus/ application-services/ experimenter/experimenter/features/manifests/"
 
       - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
 
       - name: Build Cirrus
+        if: steps.check-paths.outputs.should-run == 'true'
         run: make cirrus_build
 
       - name: Generate image tag
+        if: steps.check-paths.outputs.should-run == 'true'
         id: tag
         run: |
-          TAG="$(git rev-parse --short=9 HEAD)"
+          TAG="sha-$(git rev-parse --short=9 HEAD)"
           echo "image_tag=${TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Tag image for GAR
+        if: steps.check-paths.outputs.should-run == 'true'
         env:
           IMAGE_TAG: ${{ steps.tag.outputs.image_tag }}
         run: |
@@ -46,6 +52,7 @@ jobs:
           docker tag cirrus:deploy "${IMAGE_BASE}:${IMAGE_TAG}"
 
       - name: Push to Google Artifact Registry
+        if: steps.check-paths.outputs.should-run == 'true'
         uses: mozilla-it/deploy-actions/docker-push@v4.3.2
         with:
           image_tags: |-

--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    paths:
-      - "schemas/**"
   workflow_dispatch: {}
 
 jobs:
@@ -19,7 +17,13 @@ jobs:
         with:
           fetch-depth: 2
 
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "schemas/"
+
       - name: Check for version change
+        if: steps.check-paths.outputs.should-run == 'true'
         id: version-check
         run: |
           if git diff HEAD~1 schemas/pyproject.toml | grep 'version'; then
@@ -30,17 +34,17 @@ jobs:
           fi
 
       - name: Build schemas
-        if: steps.version-check.outputs.changed == 'true'
+        if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
         run: |
           cp .env.sample .env
           make schemas_build
 
       - name: Upload to PyPI
-        if: steps.version-check.outputs.changed == 'true'
+        if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
         run: |
           make schemas_deploy_pypi SCHEMAS_ENV="-e TWINE_USERNAME=${{ secrets.TWINE_USERNAME }} -e TWINE_PASSWORD=${{ secrets.TWINE_PASSWORD }}"
 
       - name: Upload to NPM
-        if: steps.version-check.outputs.changed == 'true'
+        if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
         run: |
           make schemas_deploy_npm SCHEMAS_ENV="-e NPM_TOKEN=${{ secrets.NPM_TOKEN }}"

--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -3,13 +3,9 @@ name: Experimenter -- Build, Tag and Push Container Images to GAR Repository
 on:
   pull_request:
     types: [labeled, unlabeled, synchronize]
-    paths:
-      - 'experimenter/**'
   push:
     branches:
       - main
-    paths:
-      - 'experimenter/**'
   workflow_dispatch: {}
 
 env:
@@ -37,13 +33,21 @@ jobs:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.ref }}
           persist-credentials: false
           fetch-tags: true
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/"
 
       - name: Build (make build_prod)
+        if: steps.check-paths.outputs.should-run == 'true'
         run: |
           ./scripts/store_git_info.sh
           make build_prod
 
       - name: Generate MozCloud Tag
+        if: steps.check-paths.outputs.should-run == 'true'
         id: mozcloud-tag
         shell: bash
         env:
@@ -53,24 +57,25 @@ jobs:
           if [[ "${REF_TYPE}" == "tag" ]]; then
             tag="${REF_NAME}"
           else
-            tag="$(git rev-parse --short=9 HEAD)"
+            tag="sha-$(git rev-parse --short=9 HEAD)"
           fi
 
           echo "Setting IMAGE_TAG=${tag} as output"
           echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
 
       - name: Tag image(s) for GAR
+        if: steps.check-paths.outputs.should-run == 'true'
         id: meta
         shell: bash
         env:
           IMAGE_TAG: ${{ steps.mozcloud-tag.outputs.image_tag }}
         run: |
-          # Re-tag the image built by make build_prod (experimenter:deploy)
           docker tag experimenter:deploy "${IMAGE_BASE}:latest"
           docker tag experimenter:deploy "${IMAGE_BASE}:${IMAGE_TAG}"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Push to Google Artifact Registry
+        if: steps.check-paths.outputs.should-run == 'true'
         uses: mozilla-it/deploy-actions/docker-push@v4.3.2
         with:
           image_tags: |-


### PR DESCRIPTION
Because

* Deploy workflows use trigger-level paths: filters which prevent them
  from running when only .github/ or root files change
* This means deploy workflow changes don't get tested/triggered until
  the next commit that touches the relevant source paths
* Follow-up to #15219 which did this for check and integration workflows
* The GHA deploy workflows were also missing the `sha-` prefix on image
  tags, causing ArgoCD image updater to not detect new images (it expects
  `sha-<9char>` format)

This commit

* Removes paths: from deploy workflow triggers, replaced with job-level
  check-changed-paths conditions (same pattern as check/integration
  workflows)
* Changes to .github/ or root files now trigger all deploys
* Adds `sha-` prefix to image tags in experimenter and cirrus deploy
  workflows to match ArgoCD image updater expectations

Fixes #15242