### PR TITLE
fix(project): populate build URL in version.json with GHA run URL

### DIFF
--- a/scripts/echo_version_json.sh
+++ b/scripts/echo_version_json.sh
@@ -1,4 +1,4 @@
 printf '{"commit":"%s","source":"%s","build":"%s"}\n' \
   "$(git rev-parse HEAD)" \
   "$(git config --local remote.origin.url | sed -e s,git@github.com:,https://github.com/,)" \
-  "$CIRCLE_BUILD_URL"
+  "${GITHUB_SERVER_URL:+${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}}${CIRCLE_BUILD_URL}"


### PR DESCRIPTION
Because

* The /__version__ endpoint shows an empty build field since migrating
  deploys from CircleCI to GHA
* scripts/echo_version_json.sh referenced $CIRCLE_BUILD_URL which
  doesn't exist in GHA

This commit

* Replaces $CIRCLE_BUILD_URL with the GHA equivalent URL constructed
  from GITHUB_SERVER_URL, GITHUB_REPOSITORY, and GITHUB_RUN_ID
* Falls back to $CIRCLE_BUILD_URL if GHA vars aren't set

Fixes #15244