### PR TITLE
fix(nimbus): resolve test intermittency in monitoring data factory

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -474,7 +474,7 @@ def build_random_monitoring_data(branches):
         }
         top_reason = random.choice(UNENROLLMENT_REASONS)
         reasons_by_branch[name] = {
-            top_reason: {"1pct_count": random.randint(50, unenrollments or 100)},
+            top_reason: {"1pct_count": random.randint(50, max(unenrollments, 100))},
         }
 
     total_unenrollments = sum(b["unenrollments"] for b in branch_data.values())


### PR DESCRIPTION
Because

- in the `build_random_monitoring_data` method we set a value for `unenrollments` using a series of randomly generated values then use it to make a final call to `random.randint(50, unenrollments or 100)`
- In some cases the returned value of enrollments would be <=50 which was causing some tests to intermittently fail 

This commit

- Forces the value used int `randint` to be the max between a fixed value and the randomly generated one

Fixes #15243 