### PR TITLE
fix(nimbus): omit monitoring data when cloning experiments

### DIFF
--- a/experimenter/experimenter/experiments/migrations/0326_clear_monitoring_data_non_live_complete.py
+++ b/experimenter/experimenter/experiments/migrations/0326_clear_monitoring_data_non_live_complete.py
@@ -1,0 +1,18 @@
+from django.db import migrations
+
+
+def clear_monitoring_data(apps, schema_editor):
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+    NimbusExperiment.objects.exclude(status__in=["Live", "Complete"]).update(
+        monitoring_data=None
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0325_remove_nimbusexperiment_klaatu_fields"),
+    ]
+
+    operations = [
+        migrations.RunPython(clear_monitoring_data),
+    ]

--- a/experimenter/experimenter/experiments/migrations/0327_clear_monitoring_data_non_live_complete.py
+++ b/experimenter/experimenter/experiments/migrations/0327_clear_monitoring_data_non_live_complete.py
@@ -10,7 +10,7 @@ def clear_monitoring_data(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("experiments", "0325_remove_nimbusexperiment_klaatu_fields"),
+        ("experiments", "0326_alter_nimbusexperiment_next_steps_and_more"),
     ]
 
     operations = [

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2079,6 +2079,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned.published_dto = None
         cloned.published_date = None
         cloned.results_data = None
+        cloned.monitoring_data = None
         cloned.takeaways_summary = None
         cloned.next_steps = None
         cloned.project_impact = None

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -43,9 +43,10 @@ class TestClearMonitoringDataMigration(MigratorTestCase):
         self.assertIsNone(
             NimbusExperiment.objects.get(slug="test-preview").monitoring_data
         )
-        self.assertIsNotNone(
-            NimbusExperiment.objects.get(slug="test-live").monitoring_data
+        monitoring = {"total_enrollments": 100, "total_unenrollments": 5}
+        self.assertEqual(
+            NimbusExperiment.objects.get(slug="test-live").monitoring_data, monitoring
         )
-        self.assertIsNotNone(
-            NimbusExperiment.objects.get(slug="test-complete").monitoring_data
+        self.assertEqual(
+            NimbusExperiment.objects.get(slug="test-complete").monitoring_data, monitoring
         )

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -22,7 +22,7 @@ class TestClearMonitoringDataMigration(MigratorTestCase):
             defaults={"email": "test@example.com"},
         )
 
-        monitoring = {"total_enrollments": 100, "total_unenrollments": 5}
+        self.monitoring_data = {"total_enrollments": 100, "total_unenrollments": 5}
 
         for status in ("Draft", "Preview", "Live", "Complete"):
             NimbusExperiment.objects.create(
@@ -31,7 +31,7 @@ class TestClearMonitoringDataMigration(MigratorTestCase):
                 application="firefox-desktop",
                 owner=owner,
                 status=status,
-                monitoring_data=monitoring,
+                monitoring_data=self.monitoring_data,
             )
 
     def test_migration(self):
@@ -43,10 +43,11 @@ class TestClearMonitoringDataMigration(MigratorTestCase):
         self.assertIsNone(
             NimbusExperiment.objects.get(slug="test-preview").monitoring_data
         )
-        monitoring = {"total_enrollments": 100, "total_unenrollments": 5}
         self.assertEqual(
-            NimbusExperiment.objects.get(slug="test-live").monitoring_data, monitoring
+            NimbusExperiment.objects.get(slug="test-live").monitoring_data,
+            self.monitoring_data,
         )
         self.assertEqual(
-            NimbusExperiment.objects.get(slug="test-complete").monitoring_data, monitoring
+            NimbusExperiment.objects.get(slug="test-complete").monitoring_data,
+            self.monitoring_data,
         )

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -1,26 +1,20 @@
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
-class TestRemoveVpnApplicationsMigration(MigratorTestCase):
+class TestClearMonitoringDataMigration(MigratorTestCase):
     migrate_from = (
         "experiments",
-        "0318_alter_nimbusexperiment_application_and_more",
+        "0325_remove_nimbusexperiment_klaatu_fields",
     )
     migrate_to = (
         "experiments",
-        "0319_delete_vpn_features",
+        "0326_clear_monitoring_data_non_live_complete",
     )
 
     def prepare(self):
         User = self.old_state.apps.get_model("auth", "User")
-        NimbusFeatureConfig = self.old_state.apps.get_model(
-            "experiments", "NimbusFeatureConfig"
-        )
         NimbusExperiment = self.old_state.apps.get_model(
             "experiments", "NimbusExperiment"
-        )
-        NimbusIsolationGroup = self.old_state.apps.get_model(
-            "experiments", "NimbusIsolationGroup"
         )
 
         owner, _ = User.objects.get_or_create(
@@ -28,77 +22,30 @@ class TestRemoveVpnApplicationsMigration(MigratorTestCase):
             defaults={"email": "test@example.com"},
         )
 
-        NimbusFeatureConfig.objects.get_or_create(
-            slug="no-feature-vpn-web",
-            defaults={
-                "name": "No Feature VPN Web",
-                "application": "vpn-web",
-            },
-        )
+        monitoring = {"total_enrollments": 100, "total_unenrollments": 5}
 
-        NimbusFeatureConfig.objects.get_or_create(
-            slug="no-feature-fenix",
-            defaults={
-                "name": "No Feature Fenix",
-                "application": "fenix",
-            },
-        )
-
-        NimbusExperiment.objects.get_or_create(
-            slug="test-vpn-web",
-            defaults={
-                "name": "Test VPN Web",
-                "application": "vpn-web",
-                "owner": owner,
-            },
-        )
-
-        NimbusExperiment.objects.get_or_create(
-            slug="test-fenix",
-            defaults={
-                "name": "Test Fenix",
-                "application": "fenix",
-                "owner": owner,
-            },
-        )
-
-        NimbusIsolationGroup.objects.get_or_create(
-            application="vpn-web",
-            name="test-group",
-            instance=1,
-        )
-
-        NimbusIsolationGroup.objects.get_or_create(
-            application="fenix",
-            name="test-group",
-            instance=1,
-        )
+        for status in ("Draft", "Preview", "Live", "Complete"):
+            NimbusExperiment.objects.create(
+                slug=f"test-{status.lower()}",
+                name=f"Test {status}",
+                application="firefox-desktop",
+                owner=owner,
+                status=status,
+                monitoring_data=monitoring,
+            )
 
     def test_migration(self):
-        NimbusFeatureConfig = self.new_state.apps.get_model(
-            "experiments", "NimbusFeatureConfig"
-        )
         NimbusExperiment = self.new_state.apps.get_model(
             "experiments", "NimbusExperiment"
         )
-        NimbusIsolationGroup = self.new_state.apps.get_model(
-            "experiments", "NimbusIsolationGroup"
+
+        self.assertIsNone(NimbusExperiment.objects.get(slug="test-draft").monitoring_data)
+        self.assertIsNone(
+            NimbusExperiment.objects.get(slug="test-preview").monitoring_data
         )
-
-        self.assertFalse(
-            NimbusFeatureConfig.objects.filter(slug="no-feature-vpn-web").exists()
+        self.assertIsNotNone(
+            NimbusExperiment.objects.get(slug="test-live").monitoring_data
         )
-
-        self.assertTrue(
-            NimbusFeatureConfig.objects.filter(slug="no-feature-fenix").exists()
+        self.assertIsNotNone(
+            NimbusExperiment.objects.get(slug="test-complete").monitoring_data
         )
-
-        self.assertFalse(NimbusExperiment.objects.filter(application="vpn-web").exists())
-
-        self.assertTrue(NimbusExperiment.objects.filter(application="fenix").exists())
-
-        self.assertFalse(
-            NimbusIsolationGroup.objects.filter(application="vpn-web").exists()
-        )
-
-        self.assertTrue(NimbusIsolationGroup.objects.filter(application="fenix").exists())

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -4,11 +4,11 @@ from django_test_migrations.contrib.unittest_case import MigratorTestCase
 class TestClearMonitoringDataMigration(MigratorTestCase):
     migrate_from = (
         "experiments",
-        "0325_remove_nimbusexperiment_klaatu_fields",
+        "0326_alter_nimbusexperiment_next_steps_and_more",
     )
     migrate_to = (
         "experiments",
-        "0326_clear_monitoring_data_non_live_complete",
+        "0327_clear_monitoring_data_non_live_complete",
     )
 
     def prepare(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4093,6 +4093,7 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             conclusion_recommendations=["RERUN", "STOP"],
             takeaways_summary="takeaway",
+            monitoring_data={"total_enrollments": 500, "total_unenrollments": 10},
         )
         NimbusExperimentBranchThroughRequired.objects.create(
             parent_experiment=parent,
@@ -4216,6 +4217,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.published_dto, None)
         self.assertEqual(child.published_date, None)
         self.assertEqual(child.results_data, None)
+        self.assertEqual(child.monitoring_data, None)
         self.assertEqual(child.takeaways_gain_amount, None)
         self.assertEqual(child.takeaways_metric_gain, False)
         self.assertEqual(child.takeaways_qbr_learning, False)


### PR DESCRIPTION
Because

* Cloned experiments carried over monitoring data from the parent
* Monitoring data is specific to the parent experiment's lifecycle and
  is not relevant to the new clone

This commit

* Nulls out `monitoring_data` during the clone step
* Adds a data migration to clear `monitoring_data` on non-Live/Complete
  experiments
* Updates clone test to set `monitoring_data` on parent and assert it is
  `None` on the child
* Updates migration test to cover the new data migration

Fixes #15247