### PR TITLE
feat(nimbus): Add widgets for debugging targeting with nimbus-devtools

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_audience.html
@@ -131,7 +131,7 @@
       <tr>
         <th>Full targeting expression</th>
         <td colspan="3">
-          {% include "common/readonly_json.html" with json_content=experiment.targeting_formatted %}
+          {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
 
         </td>
       </tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_targeting.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/readonly_targeting.html
@@ -1,0 +1,21 @@
+{% extends "common/readonly_json.html" %}
+
+{% block json %}
+  <textarea class="readonly-json" data-nimbus-devtools-targeting-expression>{{ json_content }}</textarea>
+{% endblock %}
+{% block json_controls_collapsed %}
+  <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
+          type="button"
+          title="Debug with nimbus-devtools"
+          data-nimbus-devtools-debug-jexl-button>
+    <span class="fa-solid fa-bug">
+    </button>
+  {% endblock %}
+  {% block json_controls_expanded %}
+    <button class="btn btn-sm btn-outline-secondary ms-1 d-none"
+            type="button"
+            title="Debug with nimbus-devtools"
+            data-nimbus-devtools-debug-jexl-button>
+      <span class="fa-solid fa-bug">
+      </button>
+    {% endblock %}


### PR DESCRIPTION
Because:

- we want to be able to debug experiment targeting

this commit:

- adds a new template that extends the base JSON template with an extra "debug in nimbus-devtools" widget.

Fixes #14977