### PR TITLE
feat(nimbus): Should skip same day alert for unenrollments

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1173,6 +1173,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     EXPOSURE_CLIENT_CUTOFF = 10
 
+    MONITORING_ALERT_MINIMUM_DAYS = 1
+
 
 EXTERNAL_URLS = {
     "SIGNOFF_QA": "https://experimenter.info/workflow/risk-mitigation#qa-sign-off",

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from datetime import timedelta
 
@@ -424,6 +425,11 @@ def _check_monitoring_alerts(experiment):
         return
 
     if not experiment.monitoring_data:
+        return
+
+    if experiment.start_date and (
+        datetime.date.today() - experiment.start_date
+    ) < datetime.timedelta(days=1):
         return
 
     try:

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -429,7 +429,7 @@ def _check_monitoring_alerts(experiment):
 
     if experiment.start_date and (
         datetime.date.today() - experiment.start_date
-    ) < datetime.timedelta(days=1):
+    ) < datetime.timedelta(days=NimbusConstants.MONITORING_ALERT_MINIMUM_DAYS):
         return
 
     try:

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -1040,11 +1040,12 @@ class TestCheckMonitoringAlerts(TestCase):
 
         self.assertEqual(NimbusAlert.objects.filter(experiment=experiment).count(), 0)
 
-    def test_skips_when_experiment_started_less_than_one_day_ago(self):
+    def test_skips_when_experiment_started_less_than_minimum_days_ago(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             monitoring_data=_SPIKE_MONITORING_DATA,
-            start_date=datetime.date.today(),
+            start_date=datetime.date.today()
+            - datetime.timedelta(days=NimbusConstants.MONITORING_ALERT_MINIMUM_DAYS - 1),
         )
         with mock.patch(
             "experimenter.slack.tasks.send_slack_notification"

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import timedelta
 from unittest import mock
 
@@ -1030,6 +1031,20 @@ class TestCheckMonitoringAlerts(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             monitoring_data=None,
+        )
+        with mock.patch(
+            "experimenter.slack.tasks.send_slack_notification"
+        ) as mock_send_slack:
+            tasks._check_monitoring_alerts(experiment)
+            mock_send_slack.assert_not_called()
+
+        self.assertEqual(NimbusAlert.objects.filter(experiment=experiment).count(), 0)
+
+    def test_skips_when_experiment_started_less_than_one_day_ago(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            monitoring_data=_SPIKE_MONITORING_DATA,
+            start_date=datetime.date.today(),
         )
         with mock.patch(
             "experimenter.slack.tasks.send_slack_notification"


### PR DESCRIPTION
Because

- If the enrollment just started and the job task ran just after that, then it may notifies the users false positive about enrollment monitoring, we should wait at least a day and then should notify on the next job task run

This commit

- Skips the alert and only sends the alert if its more than 1 day

Fixes #15221 