### PR TITLE
feat(nimbus): Skip SRM section on summary page and alerts for rollouts

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -78,66 +78,68 @@
         </table>
       </div>
     </div>
-    <div class="card">
-      <div class="card-header d-flex align-items-center gap-2">
-        {% if summary.is_srm %}
-          <span class="text-warning fs-5">⚠️</span>
-        {% else %}
-          <span class="text-success fs-5">✅</span>
-        {% endif %}
-        <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-        <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
-      </div>
-      <div class="card-body">
-        {% if summary.is_srm %}
-          <div class="alert alert-warning mb-3" role="alert">
-            <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
-            <span tabindex="0"
-                  data-bs-toggle="tooltip"
-                  data-bs-placement="top"
-                  title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                  style="cursor: help;
-                         text-decoration: underline dotted">ℹ️</span>
-            <a href="{{ experiment.monitoring_dashboard_url }}"
-               target="_blank"
-               rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-          </div>
-        {% else %}
-          <div class="alert alert-success mb-3" role="alert">
-            {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
-            <span tabindex="0"
-                  data-bs-toggle="tooltip"
-                  data-bs-placement="top"
-                  title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                  style="cursor: help;
-                         text-decoration: underline dotted">ℹ️</span>
-          </div>
-        {% endif %}
-        <table class="table table-sm table-bordered mb-0">
-          <thead>
-            <tr>
-              <th>Branch</th>
-              <th>Enrollments</th>
-              <th>Expected Ratio</th>
-              <th>Actual Ratio</th>
-            </tr>
-          </thead>
-          <tbody>
-            {% for branch in summary.branches %}
+    {% if not experiment.is_rollout %}
+      <div class="card">
+        <div class="card-header d-flex align-items-center gap-2">
+          {% if summary.is_srm %}
+            <span class="text-warning fs-5">⚠️</span>
+          {% else %}
+            <span class="text-success fs-5">✅</span>
+          {% endif %}
+          <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+          <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
+        </div>
+        <div class="card-body">
+          {% if summary.is_srm %}
+            <div class="alert alert-warning mb-3" role="alert">
+              <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
+              <span tabindex="0"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+                    style="cursor: help;
+                           text-decoration: underline dotted">ℹ️</span>
+              <a href="{{ experiment.monitoring_dashboard_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
+            </div>
+          {% else %}
+            <div class="alert alert-success mb-3" role="alert">
+              {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
+              <span tabindex="0"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="top"
+                    title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+                    style="cursor: help;
+                           text-decoration: underline dotted">ℹ️</span>
+            </div>
+          {% endif %}
+          <table class="table table-sm table-bordered mb-0">
+            <thead>
               <tr>
-                <td>{{ branch.name }}</td>
-                <td>{{ branch.enrollments }}</td>
-                <td>{{ branch.expected_ratio|floatformat:1 }}%</td>
-                <td>{{ branch.actual_ratio|floatformat:1 }}%</td>
+                <th>Branch</th>
+                <th>Enrollments</th>
+                <th>Expected Ratio</th>
+                <th>Actual Ratio</th>
               </tr>
-            {% empty %}
-              <tr>
-                <td colspan="4" class="text-muted">No branch data available</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
+            </thead>
+            <tbody>
+              {% for branch in summary.branches %}
+                <tr>
+                  <td>{{ branch.name }}</td>
+                  <td>{{ branch.enrollments }}</td>
+                  <td>{{ branch.expected_ratio|floatformat:1 }}%</td>
+                  <td>{{ branch.actual_ratio|floatformat:1 }}%</td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="4" class="text-muted">No branch data available</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
       </div>
-    </div>
+    {% endif %}
   {% endwith %}
 {% endblock %}

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -432,9 +432,10 @@ def _check_monitoring_alerts(experiment):
             reason = get_top_unenrollment_reason(experiment.monitoring_data)
             _send_unenrollment_spike_alert(experiment, rate, reason)
 
-        is_srm, p_value = check_srm_mismatch(experiment.monitoring_data)
-        if is_srm:
-            _send_srm_mismatch_alert(experiment, p_value)
+        if not experiment.is_rollout:
+            is_srm, p_value = check_srm_mismatch(experiment.monitoring_data)
+            if is_srm:
+                _send_srm_mismatch_alert(experiment, p_value)
 
     except Exception as e:
         msg = SlackConstants.SLACK_LOG_MONITORING_ALERTS_ERROR.format(

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -1083,6 +1083,25 @@ class TestCheckMonitoringAlerts(TestCase):
             ).exists()
         )
 
+    def test_skips_srm_alert_for_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            monitoring_data=_SRM_MONITORING_DATA,
+            is_rollout=True,
+        )
+        with mock.patch(
+            "experimenter.slack.tasks.send_slack_notification"
+        ) as mock_send_slack:
+            tasks._check_monitoring_alerts(experiment)
+            mock_send_slack.assert_not_called()
+
+        self.assertFalse(
+            NimbusAlert.objects.filter(
+                experiment=experiment,
+                alert_type=NimbusConstants.AlertType.SRM_MISMATCH,
+            ).exists()
+        )
+
     def test_sends_both_alerts_when_both_conditions_met(self):
         monitoring_data = {
             "total_enrollments": 1000,


### PR DESCRIPTION
Because

- We should not be sending SRM alerts for the rollouts and similarly SRM section is not applicable to show on summary page

This commit

- Skips SRM alerts for the rollouts
- Does not dispaly SRM results for the rollouts

Fixes #15282 