### PR TITLE
feat(nimbus): Handle already reacted slack emojis

### DIFF
--- a/experimenter/experimenter/slack/notification.py
+++ b/experimenter/experimenter/slack/notification.py
@@ -273,11 +273,15 @@ def add_emoji_to_slack_message(experiment, alert_type, emoji_name):
             return False
 
         # Add emoji reaction to the message
-        client.reactions_add(
-            channel=channel_id,
-            name=emoji_name,
-            timestamp=thread_ts,
-        )
+        try:
+            client.reactions_add(
+                channel=channel_id,
+                name=emoji_name,
+                timestamp=thread_ts,
+            )
+        except SlackApiError as e:
+            if e.response.get("error") != SlackConstants.ErrorCode.ALREADY_REACTED:
+                raise
 
         logger.info(
             SlackConstants.SLACK_LOG_EMOJI_ADDED.format(

--- a/experimenter/experimenter/slack/tests/test_notification.py
+++ b/experimenter/experimenter/slack/tests/test_notification.py
@@ -895,6 +895,32 @@ class TestSlackNotifications(TestCase):
         self.assertEqual(call_args.kwargs["name"], "tada")
         self.assertEqual(call_args.kwargs["timestamp"], "1234567890.123456")
 
+    @override_settings(SLACK_AUTH_TOKEN="test-token")
+    @patch("experimenter.slack.notification.WebClient")
+    def test_add_emoji_to_slack_message_already_reacted(self, mock_webclient):
+        mock_client = Mock()
+        mock_webclient.return_value = mock_client
+        mock_client.reactions_add.side_effect = SlackApiError(
+            message="already_reacted",
+            response={"error": "already_reacted"},
+        )
+
+        NimbusAlert.objects.create(
+            experiment=self.experiment,
+            alert_type=NimbusConstants.AlertType.LAUNCH_REQUEST,
+            message="Test launch request",
+            slack_thread_id="1234567890.123456",
+            slack_channel_id="C123456",
+        )
+
+        result = add_emoji_to_slack_message(
+            self.experiment,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            "eyes",
+        )
+
+        self.assertTrue(result)
+
     @override_settings(SLACK_AUTH_TOKEN=None)
     def test_add_emoji_to_slack_message_not_configured(self):
         NimbusAlert.objects.create(


### PR DESCRIPTION
Because

- The Slack API returns already_reacted when an emoji reaction is already present on a message. This caused add_emoji_to_message_async to log an error and retry unnecessarily via Celery's retry backoff.

This commit

- Suppress already_reacted SlackApiError inline in add_emoji_to_slack_message

Fixes #15226 