### PR TITLE
fix(nimbus): fix 3 days retention showing incorrect values

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -306,9 +306,25 @@ def get_experiment_data(experiment: NimbusExperiment):
 
                 if segment == Segment.ALL:
                     experiment_data["other_metrics"] = other_metrics
-            elif (data and window == AnalysisWindow.WEEKLY) or (
-                data and window == AnalysisWindow.DAILY
-            ):
+            elif data and window == AnalysisWindow.WEEKLY:
+                # Append 3-day retention from daily data
+                data.append_retention_3_days(
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
+                )
+
+                ResultsObjectModel = create_results_object_model(data)
+
+                data = ResultsObjectModel(result_metrics, data, experiment, window)
+            elif data and window == AnalysisWindow.DAILY:
+                # Replace the daily 3-day retention data with only the correct fourth
+                # window (if it exists)
+                data.replace_retention_3_days(
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
+                )
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
@@ -353,9 +369,26 @@ def get_experiment_data(experiment: NimbusExperiment):
 
                 if segment == Segment.ALL:
                     experiment_data["other_metrics"].update(other_metrics)
-            elif (data and window == AnalysisWindow.WEEKLY) or (
-                data and window == AnalysisWindow.DAILY
-            ):
+            elif data and window == AnalysisWindow.WEEKLY:
+                # Append 3-day retention from daily data
+                data.append_retention_3_days(
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
+                )
+
+                ResultsObjectModel = create_results_object_model(data)
+
+                data = ResultsObjectModel(result_metrics, data, experiment, window)
+            elif data and window == AnalysisWindow.DAILY:
+                # Replace the daily 3-day retention data with only the correct fourth
+                # window (if it exists)
+                data.replace_retention_3_days(
+                    raw_data.get(AnalysisWindow.DAILY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
+                )
+
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -77,6 +77,7 @@ GROUPED_METRICS = {
     Group.SEARCH: SEARCH_METRICS,
     Group.USAGE: USAGE_METRICS,
 }
+RETENTION_3_DAYS_WINDOW_INDEX = 4
 
 
 # A map of metric -> group for quick lookups.
@@ -168,9 +169,22 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
         # Extract the 3-day retention data (window index 4)
         # without falling back to earlier windows
         retention_data = self.get_retention_by_window(
-            4, daily_data, Metric.RETENTION_3_DAYS
+            RETENTION_3_DAYS_WINDOW_INDEX, daily_data, Metric.RETENTION_3_DAYS
         )
 
+        self.extend(retention_data)
+
+    def replace_retention_3_days(self, daily_data):
+        # Extract and replace with the 3-day retention data (window index 4)
+        retention_data = self.get_retention_by_window(
+            RETENTION_3_DAYS_WINDOW_INDEX, daily_data, Metric.RETENTION_3_DAYS
+        )
+
+        self.root = [
+            jetstream_data_point
+            for jetstream_data_point in self.root
+            if jetstream_data_point.metric != Metric.RETENTION_3_DAYS
+        ]
         self.extend(retention_data)
 
 

--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -180,11 +180,11 @@ class ExperimentResultsManager:
         absolute_data_list = metric_src.get("absolute", {}).get("all", [])
         absolute_data_list.sort(key=self.window_index_for_sort)
         abs_entries = []
-        for i, data_point in enumerate(absolute_data_list):
+        for data_point in absolute_data_list:
             lower = data_point.get("lower")
             upper = data_point.get("upper")
             window_index = data_point.get("window_index", None)
-            significance = significance_map.get(str(i + 1), MetricSignificance.NEUTRAL)
+            significance = significance_map.get(window_index, MetricSignificance.NEUTRAL)
             abs_entries.append(
                 {
                     "lower": lower,
@@ -201,7 +201,7 @@ class ExperimentResultsManager:
         )
         relative_data_list.sort(key=self.window_index_for_sort)
         rel_entries = []
-        for i, data_point in enumerate(relative_data_list):
+        for data_point in relative_data_list:
             if not data_point:
                 continue
 
@@ -211,7 +211,7 @@ class ExperimentResultsManager:
                 abs(data_point.get("point")) if data_point.get("point") else None
             )
             window_index = data_point.get("window_index", None)
-            significance = significance_map.get(str(i + 1), MetricSignificance.NEUTRAL)
+            significance = significance_map.get(window_index, MetricSignificance.NEUTRAL)
             rel_entries.append(
                 {
                     "lower": lower,

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -60,3 +60,52 @@ class TestJetstreamData(TestCase):
         data.append_retention_3_days([retention])
 
         self.assertIn(retention, data)
+
+    def test_replace_retention_3_days_replaces_existing_entries(self):
+        existing_retention_1 = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.5,
+            segment=Segment.ALL,
+            window_index="1",
+        )
+        existing_retention_2 = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.25,
+            segment=Segment.ALL,
+            window_index="2",
+        )
+        existing_retention_3 = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.25,
+            segment=Segment.ALL,
+            window_index="3",
+        )
+        kept_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="4",
+        )
+
+        data = JetstreamData(
+            [
+                existing_retention_1,
+                existing_retention_2,
+                existing_retention_3,
+                kept_retention,
+            ]
+        )
+        data.replace_retention_3_days(data)
+
+        self.assertNotIn(existing_retention_1, data)
+        self.assertNotIn(existing_retention_2, data)
+        self.assertNotIn(existing_retention_3, data)
+        self.assertIn(kept_retention, data)

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -780,6 +780,7 @@ class TestExperimentResultsManager(TestCase):
                                                         "lower": 1.49,
                                                         "upper": 1.74,
                                                         "point": 1.62,
+                                                        "window_index": "1",
                                                     }
                                                 ]
                                             },
@@ -791,6 +792,7 @@ class TestExperimentResultsManager(TestCase):
                                                             "lower": -0.12,
                                                             "upper": 0.15,
                                                             "point": 0.02,
+                                                            "window_index": "1",
                                                         }
                                                     ]
                                                 },
@@ -807,6 +809,7 @@ class TestExperimentResultsManager(TestCase):
                                                             "lower": 0.01,
                                                             "upper": 0.03,
                                                             "point": 0.02,
+                                                            "window_index": "1",
                                                         }
                                                     ]
                                                 },
@@ -825,6 +828,7 @@ class TestExperimentResultsManager(TestCase):
                                                         "lower": 1.24,
                                                         "upper": 1.63,
                                                         "point": 1.43,
+                                                        "window_index": "1",
                                                     }
                                                 ]
                                             },
@@ -845,6 +849,7 @@ class TestExperimentResultsManager(TestCase):
                                                             "lower": 0.01,
                                                             "upper": 0.03,
                                                             "point": 0.02,
+                                                            "window_index": "1",
                                                         }
                                                     ]
                                                 },
@@ -882,7 +887,7 @@ class TestExperimentResultsManager(TestCase):
                     "lower": 1.49,
                     "upper": 1.74,
                     "significance": "neutral",
-                    "window_index": None,
+                    "window_index": "1",
                 }
             ],
         )
@@ -894,7 +899,7 @@ class TestExperimentResultsManager(TestCase):
                     "upper": 0.15,
                     "significance": "neutral",
                     "avg_rel_change": 0.02,
-                    "window_index": None,
+                    "window_index": "1",
                 }
             ],
         )
@@ -906,7 +911,7 @@ class TestExperimentResultsManager(TestCase):
                     "lower": 1.24,
                     "upper": 1.63,
                     "significance": "positive",
-                    "window_index": None,
+                    "window_index": "1",
                 }
             ],
         )

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -61,7 +61,7 @@
           </div>
         </div>
         {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
-          {% if weekly_metric_data.has_weekly_data %}
+          {% if weekly_metric_data.has_weekly_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
             <div class="border border-1 rounded py-4 px-5 rounded-4">
               <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
               <div class="d-flex mt-3">
@@ -123,7 +123,7 @@
           {% endif %}
         {% endwith %}
         {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
-          {% if daily_metric_data.has_daily_data %}
+          {% if daily_metric_data.has_daily_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
             <div class="border border-1 rounded py-4 px-5 rounded-4">
               <h2 class="fs-6 fw-bold">Daily breakdown</h2>
               <div class="d-flex mt-3">


### PR DESCRIPTION
Because

- We were displaying incorrect values for 3 day retention on the main page particularly affecting experiments with 4 < days <= 7 of results

This commit

- Ensures that only day 4 of the 3 day retention metric is inserted into the results data object
- Hides the weekly/daily breakdown for 3 day retention popout view
- This approach allows minimal changes to the results view which otherwise would require numerous edge case handling and ultimately make for much harder code to maintain

Fixes #15050 