### PR TITLE
fix(nimbus): remove API caching from experiments-first-run endpoint

### DIFF
--- a/experimenter/experimenter/experiments/api/v6/views.py
+++ b/experimenter/experimenter/experiments/api/v6/views.py
@@ -35,20 +35,22 @@ class NimbusDraftExperimentFilterSet(BaseExperimentFilterSet):
         fields = (*BaseExperimentFilterSet.Meta.fields, "is_first_run")
 
 
-class NimbusExperimentViewSet(
-    CachedListMixin,
+class BaseNimbusExperimentViewSet(
     mixins.RetrieveModelMixin,
     mixins.ListModelMixin,
     viewsets.GenericViewSet,
 ):
     lookup_field = "slug"
+    serializer_class = NimbusExperimentSerializer
+    filter_backends = [DjangoFilterBackend]
+
+
+class NimbusExperimentViewSet(CachedListMixin, BaseNimbusExperimentViewSet):
     queryset = (
         NimbusExperiment.objects.with_related()
         .exclude(status__in=[NimbusExperiment.Status.DRAFT])
         .order_by("slug")
     )
-    serializer_class = NimbusExperimentSerializer
-    filter_backends = [DjangoFilterBackend]
     filterset_class = NimbusExperimentFilterSet
     cache_key_prefix = "v6:experiments"
 
@@ -64,9 +66,8 @@ class NimbusExperimentDraftViewSet(NimbusExperimentViewSet):
     )
 
 
-class NimbusExperimentFirstRunViewSet(NimbusExperimentViewSet):
+class NimbusExperimentFirstRunViewSet(BaseNimbusExperimentViewSet):
     filterset_class = BaseExperimentFilterSet
-    cache_key_prefix = "v6:first-run"
 
     queryset = (
         NimbusExperiment.objects.with_related()

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -50,12 +50,6 @@ def _get_warm_cache_endpoints():
             {},
         ),
         (
-            "v6:first-run",
-            v6_views.NimbusExperimentFirstRunViewSet.queryset,
-            v6_ser.NimbusExperimentSerializer,
-            {},
-        ),
-        (
             "v7:experiments",
             v7_views.NimbusExperimentViewSet.queryset,
             v7_ser.NimbusExperimentSerializer,

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -94,25 +94,6 @@ class TestWarmApiCaches(TestCase):
             cached = cache.get(cache_key)
             self.assertIsNotNone(cached)
 
-    def test_warm_api_caches_first_run_endpoint(self):
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            slug="first-run-exp",
-            is_first_run=True,
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            slug="not-first-run-exp",
-            is_first_run=False,
-        )
-
-        warm_api_caches()
-
-        first_run_data = json.loads(cache.get(get_api_cache_key("v6:first-run")))
-        slugs = [exp["slug"] for exp in first_run_data]
-        self.assertIn("first-run-exp", slugs)
-        self.assertNotIn("not-first-run-exp", slugs)
-
     def test_warm_api_caches_json_endpoints_produce_valid_json(self):
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,


### PR DESCRIPTION
Because

* The /api/v6/experiments-first-run/ endpoint should serve fresh data
  from the database rather than cached responses
* The data is small enough that caching shouldn't matter
* The builds sometimes want rapid turn around on launching then baking right into a build

This commit

* Extracts BaseNimbusExperimentViewSet without CachedListMixin
* Changes NimbusExperimentFirstRunViewSet to inherit from the uncached base
* Removes v6:first-run from the warm_api_caches task
* Removes the corresponding cache warming test

Fixes #15288