### PR TITLE
chore(project): rename GHA check job names for clarity

### DIFF
--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -22,7 +22,7 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
-    name: "${{ matrix.arch }}"
+    name: "Cirrus Check (${{ matrix.arch }})"
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -22,7 +22,7 @@ jobs:
             runner: ubuntu-24.04
           - arch: aarch64
             runner: ubuntu-24.04-arm
-    name: "${{ matrix.arch }}"
+    name: "Experimenter Check (${{ matrix.arch }})"
     runs-on: ${{ matrix.runner }}
     permissions:
       contents: read


### PR DESCRIPTION
Because

* The Experimenter Check and Cirrus Check matrix jobs were both named
  just "x86_64" and "aarch64" which is ambiguous in branch protections
  and the PR checks list

This commit

* Renames to "Experimenter Check (x86_64)" / "Experimenter Check (aarch64)"
  and "Cirrus Check (x86_64)" / "Cirrus Check (aarch64)"

Fixes #15292