### PR TITLE
fix(project): stop creating duplicate hourly PRs in update cron jobs

### DIFF
--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -47,12 +47,13 @@ jobs:
             git checkout -B external-config
             git add experimenter/ schemas/
             git commit -m 'chore(nimbus): Update External Configs'
-            if (( $((git diff external-config origin/external-config || git diff HEAD~1) | wc -c) > 0 )); then
+            git fetch origin external-config 2>/dev/null || true
+            if git show-ref --verify --quiet refs/remotes/origin/external-config && [ -z "$(git diff external-config origin/external-config)" ]; then
+              echo "Content matches existing PR, skipping"
+            else
               gh pr close external-config --repo mozilla/experimenter 2>/dev/null || true
               git push origin external-config -f
               gh pr create -t "chore(nimbus): Update External Configs" -F /tmp/pr-body.txt --base main --head external-config --repo mozilla/experimenter
-            else
-              echo "Changes already committed, skipping"
             fi
           else
             echo "No config changes, skipping"
@@ -97,12 +98,13 @@ jobs:
             git checkout -B update-application-services
             git add application-services/
             git commit -m "chore(nimbus): Update Application Services"
-            if (( $((git diff update-application-services origin/update-application-services || git diff HEAD~1) | wc -c) > 0 )); then
+            git fetch origin update-application-services 2>/dev/null || true
+            if git show-ref --verify --quiet refs/remotes/origin/update-application-services && [ -z "$(git diff update-application-services origin/update-application-services)" ]; then
+              echo "Content matches existing PR, skipping"
+            else
               gh pr close update-application-services --repo mozilla/experimenter 2>/dev/null || true
               git push origin update-application-services -f
               gh pr create -t "chore(nimbus): Update Application Services" -b "" --base main --head update-application-services --repo mozilla/experimenter
-            else
-              echo "Changes already committed, skipping"
             fi
           else
             echo "No config changes, skipping"

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -120,9 +120,14 @@ if (($(git status --porcelain | wc -c) > 0)); then
     fi
 
     git commit -m "${COMMIT_MSG}"
-    gh pr close "${BRANCH_NAME}" --repo mozilla/experimenter 2>/dev/null || true
-    git push origin -f "${BRANCH_NAME}"
-    gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" --base main --head "${BRANCH_NAME}" --repo mozilla/experimenter
+    git fetch origin "${BRANCH_NAME}" 2>/dev/null || true
+    if git show-ref --verify --quiet "refs/remotes/origin/${BRANCH_NAME}" && [ -z "$(git diff "${BRANCH_NAME}" "origin/${BRANCH_NAME}")" ]; then
+        echo "Content matches existing PR, skipping"
+    else
+        gh pr close "${BRANCH_NAME}" --repo mozilla/experimenter 2>/dev/null || true
+        git push origin -f "${BRANCH_NAME}"
+        gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" --base main --head "${BRANCH_NAME}" --repo mozilla/experimenter
+    fi
 else
     echo "No config changes, skipping"
 fi


### PR DESCRIPTION
Because

* The update cron jobs were creating a new PR every hour even when the
  tree content was identical, because the "skip if no changes" check
  was broken
* git diff external-config origin/external-config fails with "unknown
  revision" because remote branches aren't fetched by default
* The || fallback to git diff HEAD~1 always has content (we just
  committed), so the check always passed

This commit

* Fetches the remote branch before comparing
* Only proceeds to close/recreate PR if the remote branch doesn't
  exist yet OR the tree content differs
* Applies the same fix to the Firefox version updater script

Fixes #15317