### PR TITLE
feat(nimbus): Summary page improvements

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -45,7 +45,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     MONITORING_SRM_HEALTHY_DETAIL = "Branches are at the expected distribution."
     MONITORING_UNENROLLMENT_HEALTHY_DETAIL = (
-        "Unenrollment rate is within a healthy range — below the alert threshold."
+        "within a healthy range — below the alert threshold."
     )
 
     EXCLUDING_EXPERIMENTS_WARNING = """The following experiments are being excluded by

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -52,7 +52,9 @@
         </thead>
         <tbody>
           <tr class="table-secondary">
-            <td><strong>Total</strong></td>
+            <td>
+              <strong>Total</strong>
+            </td>
             <td class="text-end">{{ summary.total_enrollments }}</td>
             <td class="text-end">{{ summary.total_unenrollments }}</td>
             <td></td>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -46,7 +46,9 @@
         </thead>
         <tbody>
           <tr class="table-secondary">
-            <td><strong>Total</strong></td>
+            <td>
+              <strong>Total</strong>
+            </td>
             <td class="text-end">{{ summary.total_enrollments }}</td>
             <td class="text-end">{{ summary.total_unenrollments }}</td>
             <td></td>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -20,22 +20,16 @@
     <div class="mb-3">
       {% if summary.is_unenrollment_spike %}
         <div class="alert alert-warning mx-3 mt-3 mb-3" role="alert">
-          <div class="d-flex align-items-center gap-2 mb-1">
-            <span class="fs-5">⚠️</span>
-            <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
-          </div>
-          Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.
+          ⚠️ <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong>
+          &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
              rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
         </div>
       {% else %}
         <div class="alert alert-success mx-3 mt-3 mb-3" role="alert">
-          <div class="d-flex align-items-center gap-2 mb-1">
-            <span class="fs-5">✅</span>
-            <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
-          </div>
-          <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong> — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
+          ✅ <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong>
+          — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
              rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
@@ -52,9 +46,7 @@
         </thead>
         <tbody>
           <tr class="table-secondary">
-            <td>
-              <strong>Total</strong>
-            </td>
+            <td><strong>Total</strong></td>
             <td class="text-end">{{ summary.total_enrollments }}</td>
             <td class="text-end">{{ summary.total_unenrollments }}</td>
             <td></td>
@@ -78,36 +70,28 @@
       <div>
         {% if summary.is_srm %}
           <div class="alert alert-warning mx-3 mt-3 mb-3" role="alert">
-            <div class="d-flex align-items-center gap-2 mb-1">
-              <span class="fs-5">⚠️</span>
-              <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-              <i class="fa-regular fa-circle-question"
-                 tabindex="0"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                 style="cursor: help"></i>
-              <span class="fw-normal small">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
-            </div>
-            {{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}
+            ⚠️ <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+            <i class="fa-regular fa-circle-question"
+               tabindex="0"
+               data-bs-toggle="tooltip"
+               data-bs-placement="top"
+               title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+               style="cursor: help"></i>
+            — {{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}
             <a href="{{ experiment.monitoring_dashboard_url }}"
                target="_blank"
                rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
           </div>
         {% else %}
           <div class="alert alert-success mx-3 mt-3 mb-3" role="alert">
-            <div class="d-flex align-items-center gap-2 mb-1">
-              <span class="fs-5">✅</span>
-              <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-              <i class="fa-regular fa-circle-question"
-                 tabindex="0"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                 style="cursor: help"></i>
-              <span class="fw-normal small">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
-            </div>
-            {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
+            ✅ <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+            <i class="fa-regular fa-circle-question"
+               tabindex="0"
+               data-bs-toggle="tooltip"
+               data-bs-placement="top"
+               title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+               style="cursor: help"></i>
+            — {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
           </div>
         {% endif %}
         <table class="table table-sm table-bordered mb-0">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -27,45 +27,41 @@
         <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
       </div>
       {% if summary.is_unenrollment_spike %}
-        <div class="alert alert-warning mb-3" role="alert">
+        <div class="alert alert-warning mx-3 mb-3" role="alert">
           <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.</strong>
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
              rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
         </div>
       {% else %}
-        <div class="alert alert-success mb-3" role="alert">
+        <div class="alert alert-success mx-3 mb-3" role="alert">
           <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong> — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
              rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
         </div>
       {% endif %}
-      <table class="table table-sm mb-2">
-        <tbody>
-          <tr>
-            <th>Total Enrollments</th>
-            <td>{{ summary.total_enrollments }}</td>
-            <th>Total Unenrollments</th>
-            <td>{{ summary.total_unenrollments }}</td>
-          </tr>
-        </tbody>
-      </table>
       <table class="table table-sm table-bordered mb-0">
         <thead>
           <tr>
             <th>Branch</th>
-            <th>Enrollments</th>
-            <th>Unenrollments</th>
+            <th class="text-end">Enrollments</th>
+            <th class="text-end">Unenrollments</th>
             <th>Top Unenrollment Reason</th>
           </tr>
         </thead>
         <tbody>
+          <tr class="table-secondary">
+            <td><strong>Total</strong></td>
+            <td class="text-end">{{ summary.total_enrollments }}</td>
+            <td class="text-end">{{ summary.total_unenrollments }}</td>
+            <td></td>
+          </tr>
           {% for branch in summary.branches %}
             <tr>
               <td>{{ branch.name }}</td>
-              <td>{{ branch.enrollments }}</td>
-              <td>{{ branch.unenrollments }}</td>
+              <td class="text-end">{{ branch.enrollments }}</td>
+              <td class="text-end">{{ branch.unenrollments }}</td>
               <td>{{ branch.top_reason|default:"—" }}</td>
             </tr>
           {% empty %}
@@ -94,31 +90,31 @@
           <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
         </div>
         {% if summary.is_srm %}
-          <div class="alert alert-warning mb-3" role="alert">
+          <div class="alert alert-warning mx-3 mb-3" role="alert">
             <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
             <a href="{{ experiment.monitoring_dashboard_url }}"
                target="_blank"
                rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
           </div>
         {% else %}
-          <div class="alert alert-success mb-3" role="alert">{{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}</div>
+          <div class="alert alert-success mx-3 mb-3" role="alert">{{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}</div>
         {% endif %}
         <table class="table table-sm table-bordered mb-0">
           <thead>
             <tr>
               <th>Branch</th>
-              <th>Enrollments</th>
-              <th>Expected Ratio</th>
-              <th>Actual Ratio</th>
+              <th class="text-end">Enrollments</th>
+              <th class="text-end text-nowrap">Expected Ratio</th>
+              <th class="text-end text-nowrap">Actual Ratio</th>
             </tr>
           </thead>
           <tbody>
             {% for branch in summary.branches %}
               <tr>
                 <td>{{ branch.name }}</td>
-                <td>{{ branch.enrollments }}</td>
-                <td>{{ branch.expected_ratio|floatformat:1 }}%</td>
-                <td>{{ branch.actual_ratio|floatformat:1 }}%</td>
+                <td class="text-end">{{ branch.enrollments }}</td>
+                <td class="text-end">{{ branch.expected_ratio|floatformat:1 }}%</td>
+                <td class="text-end">{{ branch.actual_ratio|floatformat:1 }}%</td>
               </tr>
             {% empty %}
               <tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -17,8 +17,8 @@
 {% endblock %}
 {% block card_body %}
   {% with summary=experiment.monitoring_summary %}
-    <div class="card mb-3">
-      <div class="card-header d-flex align-items-center gap-2">
+    <div class="mb-3">
+      <div class="d-flex align-items-center gap-2 mb-2">
         {% if summary.is_unenrollment_spike %}
           <span class="text-warning fs-5">⚠️</span>
         {% else %}
@@ -26,39 +26,90 @@
         {% endif %}
         <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
       </div>
-      <div class="card-body">
-        {% if summary.is_unenrollment_spike %}
+      {% if summary.is_unenrollment_spike %}
+        <div class="alert alert-warning mb-3" role="alert">
+          <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.</strong>
+          <a href="{{ experiment.monitoring_dashboard_url }}"
+             target="_blank"
+             rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
+        </div>
+      {% else %}
+        <div class="alert alert-success mb-3" role="alert">
+          <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong> — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
+          <a href="{{ experiment.monitoring_dashboard_url }}"
+             target="_blank"
+             rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
+        </div>
+      {% endif %}
+      <table class="table table-sm mb-2">
+        <tbody>
+          <tr>
+            <th>Total Enrollments</th>
+            <td>{{ summary.total_enrollments }}</td>
+            <th>Total Unenrollments</th>
+            <td>{{ summary.total_unenrollments }}</td>
+          </tr>
+        </tbody>
+      </table>
+      <table class="table table-sm table-bordered mb-0">
+        <thead>
+          <tr>
+            <th>Branch</th>
+            <th>Enrollments</th>
+            <th>Unenrollments</th>
+            <th>Top Unenrollment Reason</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for branch in summary.branches %}
+            <tr>
+              <td>{{ branch.name }}</td>
+              <td>{{ branch.enrollments }}</td>
+              <td>{{ branch.unenrollments }}</td>
+              <td>{{ branch.top_reason|default:"—" }}</td>
+            </tr>
+          {% empty %}
+            <tr>
+              <td colspan="4" class="text-muted">No branch data available</td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    {% if not experiment.is_rollout %}
+      <div>
+        <div class="d-flex align-items-center gap-2 mb-2">
+          {% if summary.is_srm %}
+            <span class="text-warning fs-5">⚠️</span>
+          {% else %}
+            <span class="text-success fs-5">✅</span>
+          {% endif %}
+          <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+          <i class="fa-regular fa-circle-question text-muted"
+             tabindex="0"
+             data-bs-toggle="tooltip"
+             data-bs-placement="top"
+             title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+             style="cursor: help"></i>
+          <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
+        </div>
+        {% if summary.is_srm %}
           <div class="alert alert-warning mb-3" role="alert">
-            <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.</strong>
+            <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
             <a href="{{ experiment.monitoring_dashboard_url }}"
                target="_blank"
                rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
           </div>
         {% else %}
-          <div class="alert alert-success mb-3" role="alert">
-            <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong> — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
-            <a href="{{ experiment.monitoring_dashboard_url }}"
-               target="_blank"
-               rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-          </div>
+          <div class="alert alert-success mb-3" role="alert">{{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}</div>
         {% endif %}
-        <table class="table table-sm mb-2">
-          <tbody>
-            <tr>
-              <th>Total Enrollments</th>
-              <td>{{ summary.total_enrollments }}</td>
-              <th>Total Unenrollments</th>
-              <td>{{ summary.total_unenrollments }}</td>
-            </tr>
-          </tbody>
-        </table>
         <table class="table table-sm table-bordered mb-0">
           <thead>
             <tr>
               <th>Branch</th>
               <th>Enrollments</th>
-              <th>Unenrollments</th>
-              <th>Top Unenrollment Reason</th>
+              <th>Expected Ratio</th>
+              <th>Actual Ratio</th>
             </tr>
           </thead>
           <tbody>
@@ -66,8 +117,8 @@
               <tr>
                 <td>{{ branch.name }}</td>
                 <td>{{ branch.enrollments }}</td>
-                <td>{{ branch.unenrollments }}</td>
-                <td>{{ branch.top_reason|default:"—" }}</td>
+                <td>{{ branch.expected_ratio|floatformat:1 }}%</td>
+                <td>{{ branch.actual_ratio|floatformat:1 }}%</td>
               </tr>
             {% empty %}
               <tr>
@@ -76,69 +127,6 @@
             {% endfor %}
           </tbody>
         </table>
-      </div>
-    </div>
-    {% if not experiment.is_rollout %}
-      <div class="card">
-        <div class="card-header d-flex align-items-center gap-2">
-          {% if summary.is_srm %}
-            <span class="text-warning fs-5">⚠️</span>
-          {% else %}
-            <span class="text-success fs-5">✅</span>
-          {% endif %}
-          <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-          <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
-        </div>
-        <div class="card-body">
-          {% if summary.is_srm %}
-            <div class="alert alert-warning mb-3" role="alert">
-              <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
-              <span tabindex="0"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                    style="cursor: help;
-                           text-decoration: underline dotted">ℹ️</span>
-              <a href="{{ experiment.monitoring_dashboard_url }}"
-                 target="_blank"
-                 rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-            </div>
-          {% else %}
-            <div class="alert alert-success mb-3" role="alert">
-              {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
-              <span tabindex="0"
-                    data-bs-toggle="tooltip"
-                    data-bs-placement="top"
-                    title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                    style="cursor: help;
-                           text-decoration: underline dotted">ℹ️</span>
-            </div>
-          {% endif %}
-          <table class="table table-sm table-bordered mb-0">
-            <thead>
-              <tr>
-                <th>Branch</th>
-                <th>Enrollments</th>
-                <th>Expected Ratio</th>
-                <th>Actual Ratio</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for branch in summary.branches %}
-                <tr>
-                  <td>{{ branch.name }}</td>
-                  <td>{{ branch.enrollments }}</td>
-                  <td>{{ branch.expected_ratio|floatformat:1 }}%</td>
-                  <td>{{ branch.actual_ratio|floatformat:1 }}%</td>
-                </tr>
-              {% empty %}
-                <tr>
-                  <td colspan="4" class="text-muted">No branch data available</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
       </div>
     {% endif %}
   {% endwith %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -18,23 +18,23 @@
 {% block card_body %}
   {% with summary=experiment.monitoring_summary %}
     <div class="mb-3">
-      <div class="d-flex align-items-center gap-2 mb-2">
-        {% if summary.is_unenrollment_spike %}
-          <span class="text-warning fs-5">⚠️</span>
-        {% else %}
-          <span class="text-success fs-5">✅</span>
-        {% endif %}
-        <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
-      </div>
       {% if summary.is_unenrollment_spike %}
-        <div class="alert alert-warning mx-3 mb-3" role="alert">
-          <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.</strong>
+        <div class="alert alert-warning mx-3 mt-3 mb-3" role="alert">
+          <div class="d-flex align-items-center gap-2 mb-1">
+            <span class="fs-5">⚠️</span>
+            <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
+          </div>
+          Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}% &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
              rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
         </div>
       {% else %}
-        <div class="alert alert-success mx-3 mb-3" role="alert">
+        <div class="alert alert-success mx-3 mt-3 mb-3" role="alert">
+          <div class="d-flex align-items-center gap-2 mb-1">
+            <span class="fs-5">✅</span>
+            <strong>{{ NimbusUIConstants.MONITORING_SECTION_UNENROLLMENT }}</strong>
+          </div>
           <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong> — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
           <a href="{{ experiment.monitoring_dashboard_url }}"
              target="_blank"
@@ -76,30 +76,39 @@
     </div>
     {% if not experiment.is_rollout %}
       <div>
-        <div class="d-flex align-items-center gap-2 mb-2">
-          {% if summary.is_srm %}
-            <span class="text-warning fs-5">⚠️</span>
-          {% else %}
-            <span class="text-success fs-5">✅</span>
-          {% endif %}
-          <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-          <i class="fa-regular fa-circle-question text-muted"
-             tabindex="0"
-             data-bs-toggle="tooltip"
-             data-bs-placement="top"
-             title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-             style="cursor: help"></i>
-          <span class="text-muted small fw-normal">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
-        </div>
         {% if summary.is_srm %}
-          <div class="alert alert-warning mx-3 mb-3" role="alert">
-            <strong>{{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}</strong>
+          <div class="alert alert-warning mx-3 mt-3 mb-3" role="alert">
+            <div class="d-flex align-items-center gap-2 mb-1">
+              <span class="fs-5">⚠️</span>
+              <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+              <i class="fa-regular fa-circle-question"
+                 tabindex="0"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+                 style="cursor: help"></i>
+              <span class="fw-normal small">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
+            </div>
+            {{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}
             <a href="{{ experiment.monitoring_dashboard_url }}"
                target="_blank"
                rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
           </div>
         {% else %}
-          <div class="alert alert-success mx-3 mb-3" role="alert">{{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}</div>
+          <div class="alert alert-success mx-3 mt-3 mb-3" role="alert">
+            <div class="d-flex align-items-center gap-2 mb-1">
+              <span class="fs-5">✅</span>
+              <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
+              <i class="fa-regular fa-circle-question"
+                 tabindex="0"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
+                 style="cursor: help"></i>
+              <span class="fw-normal small">— {{ NimbusUIConstants.MONITORING_SRM_SUBTITLE }}</span>
+            </div>
+            {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
+          </div>
         {% endif %}
         <table class="table table-sm table-bordered mb-0">
           <thead>

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -384,5 +384,5 @@ def format_p_value(value):
     except (TypeError, ValueError):
         return "N/A"
     if value < 0.0001:
-        return f"{value:.2e}"
+        return "< 0.0001"
     return f"{value:.4f}"

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -1894,8 +1894,8 @@ class TestHomeFilters(AuthTestCase):
 class TestFormatPValue(TestCase):
     @parameterized.expand(
         [
-            ("very_small", 1.23e-24, "1.23e-24"),
-            ("small_below_threshold", 0.00005, "5.00e-05"),
+            ("very_small", 1.23e-24, "< 0.0001"),
+            ("small_below_threshold", 0.00005, "< 0.0001"),
             ("above_threshold", 0.0003, "0.0003"),
             ("exactly_at_threshold", 0.0001, "0.0001"),
             ("invalid_string", "not-a-number", "N/A"),

--- a/experimenter/experimenter/slack/constants.py
+++ b/experimenter/experimenter/slack/constants.py
@@ -79,7 +79,7 @@ class SlackConstants:
     SLACK_RESULTS_READY_MESSAGE = "📈 {window} analysis results are now available"
     SLACK_ANALYSIS_ERRORS_MESSAGE = "⚠️ Analysis errors detected:\n{error_lines}"
     SLACK_UNENROLLMENT_SPIKE_MESSAGE = (
-        "⚠️ Unexpectedly large unenrollment in *{experiment}*\n"
+        "⚠️ Unexpectedly large unenrollment in *{experiment}* after {days} days\n"
         "Primary reason: {reason}\n"
         "Unenrollment rate: {rate:.1%} (threshold: {threshold:.1%})"
     )

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -319,7 +319,7 @@ def _send_error_alert(experiment, error_items):
         raise
 
 
-def _send_unenrollment_spike_alert(experiment, rate, reason):
+def _send_unenrollment_spike_alert(experiment, rate, reason, days):
     if NimbusAlert.objects.filter(
         experiment=experiment,
         alert_type=NimbusConstants.AlertType.UNENROLLMENT_SPIKE,
@@ -332,6 +332,7 @@ def _send_unenrollment_spike_alert(experiment, rate, reason):
             reason=reason,
             rate=rate,
             threshold=SlackConstants.UNENROLLMENT_SPIKE_THRESHOLD,
+            days=days,
         )
         email_addresses = [experiment.owner.email] if experiment.owner else []
         launch_alert = get_launch_request_thread(experiment.id)
@@ -427,16 +428,18 @@ def _check_monitoring_alerts(experiment):
     if not experiment.monitoring_data:
         return
 
-    if experiment.start_date and (
+    if not experiment.start_date or (
         datetime.date.today() - experiment.start_date
     ) < datetime.timedelta(days=NimbusConstants.MONITORING_ALERT_MINIMUM_DAYS):
         return
+
+    days_since_start = (datetime.date.today() - experiment.start_date).days
 
     try:
         is_spike, rate = check_unenrollment_spike(experiment.monitoring_data)
         if is_spike:
             reason = get_top_unenrollment_reason(experiment.monitoring_data)
-            _send_unenrollment_spike_alert(experiment, rate, reason)
+            _send_unenrollment_spike_alert(experiment, rate, reason, days_since_start)
 
         if not experiment.is_rollout:
             is_srm, p_value = check_srm_mismatch(experiment.monitoring_data)

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -1059,6 +1059,8 @@ class TestCheckMonitoringAlerts(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             monitoring_data=_SPIKE_MONITORING_DATA,
+            start_date=datetime.date.today()
+            - datetime.timedelta(days=NimbusConstants.MONITORING_ALERT_MINIMUM_DAYS),
         )
         with mock.patch(
             "experimenter.slack.tasks.send_slack_notification",
@@ -1068,7 +1070,11 @@ class TestCheckMonitoringAlerts(TestCase):
             mock_send_slack.assert_called_once()
             call_args = mock_send_slack.call_args
             self.assertEqual(call_args[1]["experiment_id"], experiment.id)
-            self.assertIn("Unexpectedly large unenrollment", call_args[1]["action_text"])
+            action_text = call_args[1]["action_text"]
+            self.assertIn("Unexpectedly large unenrollment", action_text)
+            self.assertIn(
+                f"after {NimbusConstants.MONITORING_ALERT_MINIMUM_DAYS} days", action_text
+            )
 
         self.assertTrue(
             NimbusAlert.objects.filter(


### PR DESCRIPTION
Because

- The p-value tooltip icon blended into the dashboard link, making it unclear it was hoverable
- Scientific notation (e.g. 4.72e-07) was not user-friendly and the threshold direction was ambiguous
- The square ℹ️ emoji was inconsistent with the round icons used elsewhere in the UI
- Nested .card elements were causing double borders on the monitoring cards
-  We should add a days after which unernollment spikes happened to clear things up in the alert

This commit

- Replaces ℹ️ with fa-circle-question and moves it into the section header, clearly separated from the dashboard link
- Formats small p-values as < 0.0001 and clarifies threshold direction: p-value < 0.0001 (threshold: < 0.001)
- Removes nested .card wrappers to fix double borders
- Adds MONITORING_ALERT_MINIMUM_DAYS in the alert message

Fixes #15316 