### PR TITLE
fix(nimbus): render ConditionalExpression and ObjectLiteral nodes as jexl

### DIFF
--- a/experimenter/experimenter/experiments/jexl_utils.py
+++ b/experimenter/experimenter/experiments/jexl_utils.py
@@ -102,11 +102,18 @@ def format_jexl(expression):
     def node_to_str(node):
         if isinstance(node, Identifier):
             subject = f"{node_to_str(node.subject)}." if node.subject else ""
-            return f"{'.{subject}' if node.relative else subject}{node.value}"
+            prefix = f".{subject}" if node.relative else subject
+            return f"{prefix}{node.value}"
         if isinstance(node, Literal):
             return json.dumps(node.value)
         if isinstance(node, ArrayLiteral):
             return f"[{', '.join(node_to_str(a) for a in node.value)}]"
+        if isinstance(node, ObjectLiteral):
+            items = ", ".join(
+                f"{k}: {node_to_str(v) or format_node(v, False, 0)}"
+                for k, v in node.value.items()
+            )
+            return f"{{{items}}}"
         if isinstance(node, Transform):
             args_list = [node_to_str(a) or format_node(a, False, 0) for a in node.args]
             args_str = ", ".join(args_list)
@@ -169,6 +176,15 @@ def format_jexl(expression):
         if isinstance(node, UnaryExpression):
             right = node_to_str(node.right) or format_node(node.right, False, indent)
             return f"{node.operator.symbol}({right})"
+        if isinstance(node, ConditionalExpression):
+            test = node_to_str(node.test) or format_node(node.test, False, indent)
+            consequent = node_to_str(node.consequent) or format_node(
+                node.consequent, False, indent
+            )
+            alternate = node_to_str(node.alternate) or format_node(
+                node.alternate, False, indent
+            )
+            return f"({test} ? {consequent} : {alternate})"
         return node_to_str(node) or str(node)
 
     try:

--- a/experimenter/experimenter/experiments/tests/test_jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_utils.py
@@ -195,6 +195,34 @@ e"""
     def test_invalid_operator(self):
         self.assertEqual(format_jexl(")))))"), ")))))")
 
+    def test_conditional_expression(self):
+        result = format_jexl("a ? b : c")
+        self.assertEqual(result, "(a ? b : c)")
+
+    def test_conditional_expression_with_complex_children(self):
+        result = format_jexl(
+            '("id" in things|mapToProperty("id")) '
+            '? (things[.id == "id"].days > 29) '
+            ": true"
+        )
+        self.assertEqual(
+            result,
+            '("id" in things|mapToProperty("id") ? things[.id == "id"].days > 29 : true)',
+        )
+
+    def test_conditional_expression_inside_and(self):
+        result = format_jexl("a && (b ? c : d)")
+        expected = "a &&\n(b ? c : d)"
+        self.assertEqual(result, expected)
+
+    def test_filter_expression_with_relative_identifier(self):
+        result = format_jexl('things[.id == "x"].days > 5')
+        self.assertEqual(result, 'things[.id == "x"].days > 5')
+
+    def test_object_literal(self):
+        result = format_jexl("{foo: 1, bar: 2}")
+        self.assertEqual(result, "{foo: 1, bar: 2}")
+
 
 class TestToStr(TestCase):
     parser = JEXLParser()


### PR DESCRIPTION
Because

* The Full targeting expression panel on the experiment detail page leaks the Python AST repr of `ConditionalExpression` (ternary) nodes into the output because `format_jexl`'s `node_to_str` / `format_node` helpers never learned how to serialize them back to jexl.
* A relative `Identifier` inside a filter (e.g. `things[.id == "x"]`) also leaks a literal `".{subject}"` into the output because `node_to_str` uses a plain string instead of an f-string when prepending the relative-access dot.
* `ObjectLiteral` nodes likewise fall through to `str(node)` since `node_to_str` never handles them.

This commit

* Adds a `ConditionalExpression` branch to `format_node` that renders `(test ? consequent : alternate)` using recursion so children with their own nested `&&` / `||` formatting still come out correctly.
* Fixes the relative `Identifier` prefix to build the dot-prefixed subject in a separate expression, matching the style of `to_str`.
* Adds an `ObjectLiteral` branch to `node_to_str` that serializes `{key: value, ...}` using the dict's string keys and recursing for values.
* Adds regression tests covering each case, plus one mirroring the real bug-report expression so the ternary + relative identifier interaction is locked in.

Fixes #15328