### PR TITLE
fix(project): skip bot PR recreation on ref-cache-only bumps

### DIFF
--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -48,8 +48,8 @@ jobs:
             git add experimenter/ schemas/
             git commit -m 'chore(nimbus): Update External Configs'
             git fetch origin external-config 2>/dev/null || true
-            if git show-ref --verify --quiet refs/remotes/origin/external-config && [ -z "$(git diff external-config origin/external-config)" ]; then
-              echo "Content matches existing PR, skipping"
+            if git show-ref --verify --quiet refs/remotes/origin/external-config && [ -z "$(git diff external-config origin/external-config -- ':(exclude,glob)**/.ref-cache.yaml')" ]; then
+              echo "Content matches existing PR (ignoring ref-cache bumps), skipping"
             else
               gh pr close external-config --repo mozilla/experimenter 2>/dev/null || true
               git push origin external-config -f


### PR DESCRIPTION
Because

* The content-equivalence check added in #15318 uses a plain `git diff` between the freshly-built branch and the existing PR branch, which flags any byte difference — including `.ref-cache.yaml` hash pointers that advance independently of any manifest content change
* This caused `update-external-configs` to close and recreate the open bot PR (e.g. #15346 → #15347) every hour when the only difference was an upstream `main`-SHA bump in a ref-cache file

This commit

* Excludes `.ref-cache.yaml` files from the equivalence diff used by the `update-external-configs` job via a pathspec exclusion (`':(exclude,glob)**/.ref-cache.yaml'`), so ref-cache churn no longer triggers PR recreation
* Leaves `update-application-services` and the firefox-versions script untouched — neither touches ref-cache files

Fixes #15348