### PR TITLE
fix(nimbus): fix retention displaying incorrect values

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -280,9 +280,9 @@ def get_experiment_data(experiment: NimbusExperiment):
                 raw_data[window][AnalysisBasis.EXPOSURES] = {}
 
         for segment, segment_data in segment_points_enrollments.items():
-            data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
-                segment_data
-            )
+            raw_segment_data = JetstreamData(segment_data)
+            raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = raw_segment_data
+            data = raw_segment_data.model_copy(deep=True)
             (
                 result_metrics,
                 primary_metrics_set,
@@ -300,11 +300,36 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
-                data.append_retention_data(
+                weekly_data = (
                     raw_data.get(AnalysisWindow.WEEKLY, {})
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
+                week_2_retention = data.get_retention_by_window(
+                    2,
+                    weekly_data,
+                    Metric.RETENTION,
+                )
+                has_retention = any(
+                    point.metric == Metric.RETENTION for point in weekly_data or []
+                )
+
+                if has_retention and not week_2_retention and segment == Segment.ALL:
+                    runtime_errors.append(
+                        AnalysisError(
+                            experiment=experiment.slug,
+                            filename="experimenter/jetstream/client.py",
+                            func_name="get_experiment_data",
+                            log_level="WARNING",
+                            message=(
+                                "Week 2 retention is unavailable because this "
+                                "experiment did not run long enough."
+                            ),
+                            metric=Metric.RETENTION,
+                            timestamp=timezone.now(),
+                        )
+                    )
+                data.extend(week_2_retention)
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -318,6 +343,12 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
+                data.replace_retention_weeks(
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
+                )
+
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -345,9 +376,9 @@ def get_experiment_data(experiment: NimbusExperiment):
             experiment_data[window][AnalysisBasis.ENROLLMENTS][segment] = transformed_data
 
         for segment, segment_data in segment_points_exposures.items():
-            data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
-                segment_data
-            )
+            raw_segment_data = JetstreamData(segment_data)
+            raw_data[window][AnalysisBasis.EXPOSURES][segment] = raw_segment_data
+            data = raw_segment_data.model_copy(deep=True)
             (
                 result_metrics,
                 primary_metrics_set,
@@ -383,6 +414,12 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
+                data.replace_retention_weeks(
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
+                )
+
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -439,14 +476,17 @@ def get_experiment_data(experiment: NimbusExperiment):
                     errors_experiment_overall.append(err)
 
     for e in runtime_errors:
-        analysis_error = AnalysisError(
-            experiment=experiment.slug,
-            filename="experimenter/jetstream/client.py",
-            func_name="load_data_from_gcs",
-            log_level="WARNING",
-            message=e,
-            timestamp=timezone.now(),
-        )
+        if isinstance(e, AnalysisError):
+            analysis_error = e
+        else:
+            analysis_error = AnalysisError(
+                experiment=experiment.slug,
+                filename="experimenter/jetstream/client.py",
+                func_name="load_data_from_gcs",
+                log_level="WARNING",
+                message=e,
+                timestamp=timezone.now(),
+            )
         errors_experiment_overall.append(analysis_error.model_dump())
 
     errors_by_metric["experiment"] = errors_experiment_overall

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -77,6 +77,7 @@ GROUPED_METRICS = {
     Group.SEARCH: SEARCH_METRICS,
     Group.USAGE: USAGE_METRICS,
 }
+RETENTION_2_WEEKS_WINDOW_INDEX = 2
 RETENTION_3_DAYS_WINDOW_INDEX = 4
 
 
@@ -151,18 +152,28 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
             jetstream_data_point
             for jetstream_data_point in data
             if jetstream_data_point.window_index == str(window_index)
-            and jetstream_data_point.metric == metric
+            and jetstream_data_point.metric == metric.value
         ]
 
     def append_retention_data(self, weekly_data):
-        # Try to get the two-week retention data. If it doesn't
-        # exist (experiment was too short), settle for 1 week.
-        retention_data = self.get_retention_by_window(2, weekly_data, Metric.RETENTION)
-        if len(retention_data) == 0:
-            retention_data = self.get_retention_by_window(
-                1, weekly_data, Metric.RETENTION
-            )
+        # Only use two-week retention data.
+        retention_data = self.get_retention_by_window(
+            RETENTION_2_WEEKS_WINDOW_INDEX, weekly_data, Metric.RETENTION
+        )
 
+        self.extend(retention_data)
+
+    def replace_retention_weeks(self, weekly_data):
+        # Remove all weekly retention data except for week 2.
+        retention_data = self.get_retention_by_window(
+            RETENTION_2_WEEKS_WINDOW_INDEX, weekly_data, Metric.RETENTION
+        )
+
+        self.root = [
+            jetstream_data_point
+            for jetstream_data_point in self.root
+            if jetstream_data_point.metric != Metric.RETENTION
+        ]
         self.extend(retention_data)
 
     def append_retention_3_days(self, daily_data):
@@ -285,10 +296,11 @@ class ResultsObjectModelBase(BaseModel):
 
                 # Need window index for weekly DataPoint objects and for storing
                 # significance for each window. Overall should always be 1 because
-                # there is only ever one overall window.
+                # there is only ever one overall window, except retained data which
+                # is pulled from week 2.
                 window_index = (
                     "1"
-                    if window == AnalysisWindow.OVERALL
+                    if window == AnalysisWindow.OVERALL and metric != Metric.RETENTION
                     else jetstream_data_point.window_index
                 )
 

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -133,6 +133,7 @@ class JetstreamTestData:
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.lower = -5.0
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.metric = Metric.RETENTION
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.statistic = Statistic.BINOMIAL
+        VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.window_index = "2"
 
         CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW = (
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_copy()
@@ -217,9 +218,9 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C,
+            DATA_POINT_C.model_copy(update={"window_index": "2"}),
             SignificanceData(
-                daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
+                daily={"2": Significance.NEGATIVE.value}, weekly={}, overall={}
             ),
             comparison_to_branch="control",
         )
@@ -234,8 +235,8 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C,
-            SignificanceData(weekly={"1": Significance.NEGATIVE.value}, overall={}),
+            DATA_POINT_C.model_copy(update={"window_index": "2"}),
+            SignificanceData(weekly={"2": Significance.NEGATIVE.value}, overall={}),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_CONTROL = cls.get_difference_metric_data(
@@ -249,15 +250,15 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
-            SignificanceData(weekly={}, overall={"1": Significance.NEGATIVE.value}),
+            DATA_POINT_D.model_copy(update={"window_index": "2"}),
+            SignificanceData(weekly={}, overall={"2": Significance.NEGATIVE.value}),
             is_retention=True,
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B,
+            DATA_POINT_B.model_copy(update={"window_index": "2"}),
             SignificanceData(
-                daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
+                daily={"2": Significance.NEUTRAL.value}, weekly={}, overall={}
             ),
             comparison_to_branch="variant",
         )
@@ -276,8 +277,8 @@ class JetstreamTestData:
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B,
-            SignificanceData(weekly={"1": Significance.NEUTRAL.value}, overall={}),
+            DATA_POINT_B.model_copy(update={"window_index": "2"}),
+            SignificanceData(weekly={"2": Significance.NEUTRAL.value}, overall={}),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_VARIANT = cls.get_difference_metric_data(
@@ -291,8 +292,8 @@ class JetstreamTestData:
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E,
-            SignificanceData(weekly={}, overall={"1": Significance.NEUTRAL.value}),
+            DATA_POINT_E.model_copy(update={"window_index": "2"}),
+            SignificanceData(weekly={}, overall={"2": Significance.NEUTRAL.value}),
             is_retention=True,
             comparison_to_branch="variant",
         )
@@ -1537,6 +1538,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.lower = 0.0
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.metric = Metric.RETENTION
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.statistic = Statistic.BINOMIAL
+        VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.window_index = "2"
 
         CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW = (
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_copy()
@@ -1606,7 +1608,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C,
+            DATA_POINT_C.model_copy(update={"window_index": "2"}),
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="control",
         )
@@ -1621,7 +1623,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C,
+            DATA_POINT_C.model_copy(update={"window_index": "2"}),
             SignificanceData(weekly={}, overall={}),
             comparison_to_branch="control",
         )
@@ -1636,13 +1638,13 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D,
+            DATA_POINT_D.model_copy(update={"window_index": "2"}),
             SignificanceData(weekly={}, overall={}),
             is_retention=True,
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B,
+            DATA_POINT_B.model_copy(update={"window_index": "2"}),
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="variant",
         )
@@ -1657,7 +1659,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B,
+            DATA_POINT_B.model_copy(update={"window_index": "2"}),
             SignificanceData(weekly={}, overall={}),
             comparison_to_branch="variant",
         )
@@ -1672,7 +1674,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E,
+            DATA_POINT_E.model_copy(update={"window_index": "2"}),
             SignificanceData(weekly={}, overall={}),
             is_retention=True,
             comparison_to_branch="variant",

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -61,6 +61,75 @@ class TestJetstreamData(TestCase):
 
         self.assertIn(retention, data)
 
+    def test_append_retention_data_ignores_week_1_only_data(self):
+        week_1_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="1",
+        )
+
+        data = JetstreamData([])
+        data.append_retention_data([week_1_retention])
+
+        self.assertNotIn(week_1_retention, data)
+
+    def test_append_retention_data_uses_week_2_data(self):
+        week_2_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="2",
+        )
+
+        data = JetstreamData([])
+        data.append_retention_data([week_2_retention])
+
+        self.assertIn(week_2_retention, data)
+
+    def test_replace_retention_replaces_existing_entries(self):
+        existing_retention_1 = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.5,
+            segment=Segment.ALL,
+            window_index="1",
+        )
+        kept_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.25,
+            segment=Segment.ALL,
+            window_index="2",
+        )
+        existing_retention_2 = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.25,
+            segment=Segment.ALL,
+            window_index="3",
+        )
+
+        data = JetstreamData(
+            [
+                existing_retention_1,
+                kept_retention,
+                existing_retention_2,
+            ]
+        )
+        data.replace_retention_weeks(data)
+
+        self.assertNotIn(existing_retention_1, data)
+        self.assertNotIn(existing_retention_2, data)
+        self.assertIn(kept_retention, data)
+
     def test_replace_retention_3_days_replaces_existing_entries(self):
         existing_retention_1 = JetstreamDataPoint(
             metric=Metric.RETENTION_3_DAYS,

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -20,7 +20,7 @@ from experimenter.jetstream.client import (
     get_featmon_slugs,
     get_monitoring_data,
 )
-from experimenter.jetstream.models import AnalysisWindow, Group
+from experimenter.jetstream.models import AnalysisWindow, Group, Metric
 from experimenter.jetstream.tests import mock_valid_outcomes
 from experimenter.jetstream.tests.constants import (
     JetstreamTestData,
@@ -1052,6 +1052,61 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             mock_get_metadata.return_value = None
             mock_get_errors.return_value = None
             tasks.fetch_experiment_data(experiment.id)
+
+    def test_results_data_warns_when_week_2_retention_is_missing(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        experiment.reference_branch.slug = "control"
+        experiment.reference_branch.save()
+
+        def mock_jetstream_data_by_window(_, window):
+            if window == AnalysisWindow.WEEKLY:
+                return [
+                    {
+                        "metric": Metric.RETENTION,
+                        "statistic": "binomial",
+                        "branch": "control",
+                        "point": 0.5,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "1",
+                    }
+                ]
+            if window == AnalysisWindow.OVERALL:
+                return [
+                    {
+                        "metric": "identity",
+                        "statistic": "count",
+                        "branch": "control",
+                        "point": 10,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "1",
+                    }
+                ]
+            return []
+
+        with (
+            patch("experimenter.jetstream.client.get_data") as mock_get_data,
+            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
+            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
+        ):
+            mock_get_data.side_effect = mock_jetstream_data_by_window
+            mock_get_metadata.return_value = None
+            mock_get_errors.return_value = None
+
+            tasks.fetch_experiment_data(experiment.id)
+
+        experiment.refresh_from_db()
+        errors = experiment.results_data["v3"]["errors"]["experiment"]
+        self.assertEqual(len(errors), 1)
+        self.assertEqual(errors[0]["metric"], Metric.RETENTION)
+        self.assertEqual(
+            errors[0]["message"],
+            "Week 2 retention is unavailable because this experiment did not run "
+            "long enough.",
+        )
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Because

- We were not showing week 2 retention on the main page for experiments that ran for less than 2 weeks and for those still in the observation phase

This commit

- Adds an analysis error if an experiment was running for less than 2 weeks and was thus unable to get week 2 retention data
-  Applies a similar approach to #15287 where we only keep the second window index in the weekly analysis basis for retention so that we are not displaying incorrect values

Fixes #12647