### PR TITLE
fix(project): retry GHA docker builds on transient failures

### DIFF
--- a/.github/actions/retry/action.yml
+++ b/.github/actions/retry/action.yml
@@ -1,0 +1,41 @@
+name: "Retry"
+description: "Run a shell command with retry on failure"
+
+inputs:
+  run:
+    description: "Shell command to run"
+    required: true
+  label:
+    description: "Human-readable label for log grouping"
+    required: true
+  attempts:
+    description: "Total number of attempts (including the first)"
+    default: "3"
+  backoff-seconds:
+    description: "Seconds to sleep before each retry, multiplied by the attempt number"
+    default: "10"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      env:
+        RETRY_RUN: ${{ inputs.run }}
+        RETRY_LABEL: ${{ inputs.label }}
+        RETRY_ATTEMPTS: ${{ inputs.attempts }}
+        RETRY_BACKOFF: ${{ inputs.backoff-seconds }}
+      run: |
+        for attempt in $(seq 1 "$RETRY_ATTEMPTS"); do
+          echo "::group::${RETRY_LABEL} (attempt ${attempt} of ${RETRY_ATTEMPTS})"
+          if bash -c "$RETRY_RUN"; then
+            echo "::endgroup::"
+            exit 0
+          fi
+          echo "::endgroup::"
+          if [ "$attempt" -eq "$RETRY_ATTEMPTS" ]; then
+            echo "::error::${RETRY_LABEL} failed after ${RETRY_ATTEMPTS} attempts"
+            exit 1
+          fi
+          echo "::warning::${RETRY_LABEL} attempt ${attempt} failed, retrying..."
+          sleep $((attempt * RETRY_BACKOFF))
+        done

--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Docker Build"
-description: "Free disk space, set up Buildx, and build megazords/schemas/cirrus images"
+description: "Free disk space, set up Buildx, and build megazords/schemas/cirrus images with retry"
 
 runs:
   using: composite
@@ -18,32 +18,34 @@ runs:
       with:
         driver: docker
 
-    - name: Build megazords
-      shell: bash
-      env:
-        MEGAZORD_BUILD_FLAGS: --load
-      run: make build_megazords
-
-    - name: Build schemas
-      uses: docker/build-push-action@v6
+    - uses: ./.github/actions/retry
       with:
-        context: schemas/
-        file: schemas/Dockerfile
-        target: dev
-        tags: schemas:dev
-        load: true
+        label: Build megazords
+        run: MEGAZORD_BUILD_FLAGS=--load make build_megazords
 
-    - name: Build cirrus
-      uses: docker/build-push-action@v6
+    - uses: ./.github/actions/retry
       with:
-        context: cirrus/server/
-        file: cirrus/server/Dockerfile
-        target: deploy
-        tags: cirrus:deploy
-        load: true
-        build-contexts: |
-          experimenter:megazords=docker-image://experimenter:megazords
-          fml=experimenter/experimenter/features/manifests/
+        label: Build schemas
+        run: |
+          docker buildx build \
+            --file schemas/Dockerfile \
+            --target dev \
+            --tag schemas:dev \
+            --load \
+            schemas/
+
+    - uses: ./.github/actions/retry
+      with:
+        label: Build cirrus
+        run: |
+          docker buildx build \
+            --file cirrus/server/Dockerfile \
+            --target deploy \
+            --tag cirrus:deploy \
+            --load \
+            --build-context experimenter:megazords=docker-image://experimenter:megazords \
+            --build-context fml=experimenter/experimenter/features/manifests/ \
+            cirrus/server/
 
     - name: Export build flags
       shell: bash

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -39,8 +39,14 @@ jobs:
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
 
+      - uses: ./.github/actions/retry
+        if: steps.check-paths.outputs.should-run == 'true'
+        with:
+          label: Build experimenter test image
+          run: |
+            cp .env.sample .env
+            make build_test
+
       - name: Run tests and linting
         if: steps.check-paths.outputs.should-run == 'true'
-        run: |
-          cp .env.sample .env
-          make check
+        run: make check

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -31,10 +31,17 @@ jobs:
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
 
+      - uses: ./.github/actions/retry
+        if: steps.check-paths.outputs.should-run == 'true'
+        with:
+          label: Build experimenter dev image
+          run: |
+            cp .env.sample .env
+            make build_dev
+
       - name: Check local feature manifests
         if: steps.check-paths.outputs.should-run == 'true'
         run: |
-          cp .env.sample .env
           make feature_manifests FETCH_ARGS="--local-apps"
           if ! git diff --quiet experimenter/experimenter/features/manifests/; then
             echo 'Please commit generated updates to local feature manifests:'

--- a/.github/workflows/deploy-cirrus.yml
+++ b/.github/workflows/deploy-cirrus.yml
@@ -32,9 +32,11 @@ jobs:
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
 
-      - name: Build Cirrus
+      - uses: ./.github/actions/retry
         if: steps.check-paths.outputs.should-run == 'true'
-        run: make cirrus_build
+        with:
+          label: Build Cirrus
+          run: make cirrus_build
 
       - name: Generate image tag
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -33,11 +33,13 @@ jobs:
             echo "changed=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build schemas
+      - uses: ./.github/actions/retry
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
-        run: |
-          cp .env.sample .env
-          make schemas_build
+        with:
+          label: Build schemas
+          run: |
+            cp .env.sample .env
+            make schemas_build
 
       - name: Upload to PyPI
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'

--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -40,11 +40,13 @@ jobs:
         with:
           paths: "experimenter/"
 
-      - name: Build (make build_prod)
+      - uses: ./.github/actions/retry
         if: steps.check-paths.outputs.should-run == 'true'
-        run: |
-          ./scripts/store_git_info.sh
-          make build_prod
+        with:
+          label: Build experimenter prod image
+          run: |
+            ./scripts/store_git_info.sh
+            make build_prod
 
       - name: Generate MozCloud Tag
         if: steps.check-paths.outputs.should-run == 'true'


### PR DESCRIPTION
Because

* GHA check runs sometimes fail during docker build steps when a transient network error (most commonly `apt-get install` returning "Connection reset by peer" from upstream Debian mirrors) interrupts a layer build
* A single flake fails the whole job and the user has to manually re-run it from the GHA UI, which in GHA only re-runs one workflow at a time and not the full job matrix

This commit

* Adds a reusable `.github/actions/retry` composite action that runs a shell command in a bash retry loop (3 attempts by default with linear backoff)
* Uses the retry action to wrap every docker build across the workflows: megazords/schemas/cirrus in `setup-cached-build`, experimenter test image in `check-experimenter`, experimenter dev image in `check-feature-manifests`, `cirrus_build` in `deploy-cirrus`, `schemas_build` in `deploy-schemas`, and `build_prod` in `experimenter-mozcloud-publish`
* Converts the `docker/build-push-action@v6` invocations for schemas and cirrus to shell `docker buildx build` commands so they're reinvokable by the retry loop
* Leaves `run-integration-test` alone since it already retries the full build+test sequence at a higher level, and leaves `check-cirrus`/`check-schemas` alone since they're served by the `setup-cached-build` cache

Fixes #15364