### PR TITLE
chore(project): stop running CI twice on bot PRs

### DIFF
--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/integration-desktop-enrollment.yml
+++ b/.github/workflows/integration-desktop-enrollment.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/integration-desktop-targeting.yml
+++ b/.github/workflows/integration-desktop-targeting.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/integration-nimbus-ui.yml
+++ b/.github/workflows/integration-nimbus-ui.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/integration-remote-settings-all.yml
+++ b/.github/workflows/integration-remote-settings-all.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]

--- a/.github/workflows/integration-remote-settings-launch.yml
+++ b/.github/workflows/integration-remote-settings-launch.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-      - external-config
-      - update-application-services
-      - update_firefox_desktop_release
-      - update_firefox_desktop_beta
   pull_request:
   merge_group:
     types: [checks_requested]


### PR DESCRIPTION
Because

* Every check and integration workflow listed four bot branches (`external-config`, `update-application-services`, `update_firefox_desktop_release`, `update_firefox_desktop_beta`) in its `push:` trigger, in addition to the `pull_request:` trigger
* When a bot PR is recreated, the App force-pushes the branch (firing `push`) and then `gh pr create` fires `pull_request: opened` on the same commit — so every workflow runs twice
* The bot branches were listed under `push:` as a workaround for GitHub App tokens not firing `pull_request: synchronize`, but #15217 landed the close-and-recreate flow which always produces a fresh `pull_request: opened` event, making the `push:` fallback redundant

This commit

* Drops the four bot branches from `push: branches:` in every check and integration workflow, leaving only `main`
* Deploy workflows already only triggered on `push: main`, so they're unchanged

Fixes #15367