### PR TITLE
fix(nimbus): fix metric significance showing incorrectly for overall results

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1175,6 +1175,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     MONITORING_ALERT_MINIMUM_DAYS = 1
 
+    OVERALL_WINDOW_INDEX = "1"
+
 
 EXTERNAL_URLS = {
     "SIGNOFF_QA": "https://experimenter.info/workflow/risk-mitigation#qa-sign-off",

--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -177,14 +177,18 @@ class ExperimentResultsManager:
         wi = point.get("window_index")
         return int(wi) if wi is not None else 0
 
-    def format_absolute_entries(self, metric_src, significance_map):
+    def format_absolute_entries(self, metric_src, significance_map, window=None):
         absolute_data_list = metric_src.get("absolute", {}).get("all", [])
         absolute_data_list.sort(key=self.window_index_for_sort)
         abs_entries = []
         for data_point in absolute_data_list:
             lower = data_point.get("lower")
             upper = data_point.get("upper")
-            window_index = data_point.get("window_index", None)
+            window_index = (
+                NimbusConstants.OVERALL_WINDOW_INDEX
+                if window == "overall"
+                else data_point.get("window_index")
+            )
             significance = significance_map.get(window_index, MetricSignificance.UNKNOWN)
             abs_entries.append(
                 {
@@ -196,7 +200,9 @@ class ExperimentResultsManager:
             )
         return abs_entries
 
-    def format_relative_entries(self, metric_src, significance_map, reference_branch):
+    def format_relative_entries(
+        self, metric_src, significance_map, reference_branch, window=None
+    ):
         relative_data_list = (
             metric_src.get("relative_uplift", {}).get(reference_branch, {}).get("all", [])
         )
@@ -211,7 +217,11 @@ class ExperimentResultsManager:
             avg_rel_change = (
                 abs(data_point.get("point")) if data_point.get("point") else None
             )
-            window_index = data_point.get("window_index", None)
+            window_index = (
+                NimbusConstants.OVERALL_WINDOW_INDEX
+                if window == "overall"
+                else data_point.get("window_index")
+            )
             significance = significance_map.get(window_index, MetricSignificance.UNKNOWN)
             rel_entries.append(
                 {
@@ -236,9 +246,11 @@ class ExperimentResultsManager:
                 .get(window, {})
             )
 
-            abs_entries = self.format_absolute_entries(metric_src, significance_map)
+            abs_entries = self.format_absolute_entries(
+                metric_src, significance_map, window
+            )
             rel_entries = self.format_relative_entries(
-                metric_src, significance_map, reference_branch
+                metric_src, significance_map, reference_branch, window
             )
 
             branch_metrics[branch.slug] = {

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -2775,3 +2775,181 @@ class TestExperimentResultsManager(TestCase):
         self.assertAlmostEqual(
             self.results_manager.exposure_rate("all"), expected_exposure_rate
         )
+
+    @parameterized.expand(
+        [
+            # This test case uses the updated results data strucutre where we give points
+            # in the overall window a value for window_index
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-b": {
+                                                            "all": [
+                                                                {
+                                                                    "window_index": "1",
+                                                                    "lower": -0.12,
+                                                                    "upper": 0.15,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "significance": {
+                                                        "branch-b": {
+                                                            "overall": {"1": "negative"}
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "window_index": "1",
+                                                                    "lower": -0.12,
+                                                                    "upper": 0.15,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"}
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                },
+                            }
+                        }
+                    }
+                },
+                [
+                    {
+                        "lower": -0.12,
+                        "upper": 0.15,
+                        "significance": MetricSignificance.NEGATIVE,
+                        "avg_rel_change": 0.02,
+                        "window_index": "1",
+                    }
+                ],
+            ),
+            # This test case uses the old results data structure where points in the
+            # overall window do not have a value for window_index, and ensures that the
+            # code correctly defaults to using "1" as the window index for overall
+            # metrics when it's not provided
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-b": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.12,
+                                                                    "upper": 0.15,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "significance": {
+                                                        "branch-b": {
+                                                            "overall": {"1": "negative"}
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.12,
+                                                                    "upper": 0.15,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"}
+                                                        }
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                },
+                            }
+                        }
+                    }
+                },
+                [
+                    {
+                        "lower": -0.12,
+                        "upper": 0.15,
+                        "significance": MetricSignificance.NEGATIVE,
+                        "avg_rel_change": 0.02,
+                        "window_index": "1",
+                    }
+                ],
+            ),
+        ]
+    )
+    def test_metric_significance_correctness_on_overall_window(
+        self, results_data, expected_significance
+    ):
+        self.experiment.results_data = results_data
+        self.experiment.save()
+
+        metric_src = (
+            results_data.get("v3")
+            .get("overall")
+            .get("enrollments")
+            .get("all")
+            .get("branch-a", {})
+            .get("branch_data")
+            .get("other_metrics")
+            .get("retained")
+        )
+        reference_branch = "branch-b"
+
+        self.assertEqual(
+            self.results_manager.format_relative_entries(
+                metric_src,
+                metric_src.get("significance").get(reference_branch).get("overall"),
+                reference_branch,
+                "overall",
+            ),
+            expected_significance,
+        )


### PR DESCRIPTION
Because

- We recently added the `window_index` field to all points in the overall window
- This change isn’t present in all completed experiments, which is causing issues with UI features that expect it

This commit

- Adds a fallback for `window_index` in the overall window, defaulting it to "1"

Fixes #15379