### PR TITLE
Fix enrollmentsMap slug in 48h targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2689,7 +2689,7 @@ RETURNING_CHURNED_USER_48_HR_OS_NOTIFICATION = NimbusTargetingConfig(
         "(os.isWindows && (os.windowsVersion >= 10)) "
         "&& isBackgroundTaskMode "
         "&& (defaultProfile.enrollmentsMap"
-        "['48hr-os-notification-for-resurrected-users-enrollment-rollout'] "
+        "['48hr-os-notification-for-resurrected-users-enrollment-rollout-v2'] "
         "== 'control') "
         "&& ((currentDate|date - defaultProfile.currentDate|date) / 3600000 >= 48)"
     ),


### PR DESCRIPTION
We had to restart the enrollment rollout that the 48h notification will rely on, so this just updates the targeting expression with the correct slug.
