### PR TITLE
fix(project): scope external-config equivalence diff to bot-managed paths

### DIFF
--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -48,8 +48,8 @@ jobs:
             git add experimenter/ schemas/
             git commit -m 'chore(nimbus): Update External Configs'
             git fetch origin external-config 2>/dev/null || true
-            if git show-ref --verify --quiet refs/remotes/origin/external-config && [ -z "$(git diff external-config origin/external-config -- ':(exclude,glob)**/.ref-cache.yaml')" ]; then
-              echo "Content matches existing PR (ignoring ref-cache bumps), skipping"
+            if git show-ref --verify --quiet refs/remotes/origin/external-config && [ -z "$(git diff external-config origin/external-config -- experimenter/experimenter/features/manifests/ schemas/ ':(exclude,glob)**/.ref-cache.yaml')" ]; then
+              echo "Content matches existing PR (ignoring ref-cache bumps and main-only advancement), skipping"
             else
               gh pr close external-config --repo mozilla/experimenter 2>/dev/null || true
               git push origin external-config -f


### PR DESCRIPTION
Because

* The equivalence check added in #15318 (and narrowed in #15349 to exclude ref-cache bumps) compares the entire tree between the freshly-built branch and the open PR's branch, so any main commit that lands between bot runs registers as a diff and forces the bot to close and recreate the PR
* Observed on 2026-04-20: `external-config` recreated 13 times in 36 hours, with bot-managed paths byte-identical between consecutive PRs — only main code commits differed
* Main advancement should not force PR recreation; only changes in the bot's actual output (manifests, schemas) should

This commit

* Restricts the equivalence diff in `update-external-configs` to paths the bot actually writes to (`experimenter/experimenter/features/manifests/` and `schemas/`), while keeping the `.ref-cache.yaml` exclusion
* Leaves `update-application-services` and the firefox-versions script alone since they don't overlap with arbitrary main commits the way the manifests do

Fixes #15393