### PR TITLE
feat(nimbus): add validation to nimbus review serializer for targeting context fields within version range

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -22,7 +22,10 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
-from experimenter.experiments.jexl_utils import JEXLParser
+from experimenter.experiments.jexl_utils import (
+    JEXLParser,
+    extract_targeting_fields,
+)
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchFeatureValue,
@@ -34,6 +37,7 @@ from experimenter.experiments.models import (
     NimbusVersionedSchema,
 )
 from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
+from experimenter.targeting.targeting_context_parser import TargetingContextFields
 
 logger = logging.getLogger()
 
@@ -1811,6 +1815,77 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return data
 
+    def _validate_targeting_configs(self, data):
+        targeting_config_slug = data.get("targeting_config_slug")
+        targeting_config = NimbusExperiment.TARGETING_CONFIGS[targeting_config_slug]
+        result = self.ValidateFeatureResult()
+
+        if not targeting_config.targeting:
+            return data
+
+        min_version = None
+        max_version = None
+        assume_unversioned = False
+        if not NimbusExperiment.Application.is_web(self.instance.application):
+            raw_min_version = data.get("firefox_min_version", "")
+            raw_max_version = data.get("firefox_max_version", "")
+
+            min_version = NimbusExperiment.Version.parse(raw_min_version)
+            if raw_max_version:
+                max_version = NimbusExperiment.Version.parse(raw_max_version)
+
+        if min_supported_version := NimbusConstants.MIN_VERSIONED_FEATURE_VERSION.get(
+            data.get("application")
+        ):
+            min_supported_version = NimbusExperiment.Version.parse(min_supported_version)
+
+            if min_supported_version > min_version:
+                if max_version is not None and min_supported_version > max_version:
+                    assume_unversioned = True
+                elif max_version is None or min_supported_version < max_version:
+                    min_version = min_supported_version
+
+        extracted_root_fields = extract_targeting_fields(targeting_config.targeting)
+
+        versions = (
+            NimbusFeatureVersion.objects.filter(
+                NimbusFeatureVersion.objects.between_versions_q(min_version, max_version)
+            )
+            .order_by("-major", "-minor", "-patch")
+            .distinct()
+        )
+
+        unsupported_versions = defaultdict(list)
+        for version in versions:
+            targeting_context_version = None if assume_unversioned else f"v{version}"
+            fields = set(
+                TargetingContextFields.for_application(
+                    data.get("application"), targeting_context_version
+                )
+            )
+
+            unknown_fields = extracted_root_fields - fields
+
+            for field in unknown_fields:
+                unsupported_versions[field].append(str(version))
+
+        for field, versions in unsupported_versions.items():
+            result.append(
+                NimbusConstants.ERROR_TARGETING_FIELD_UNSUPPORTED_IN_VERSIONS.format(
+                    field=field,
+                    versions=versions,
+                ),
+                data.get("warn_feature_schema", False),
+            )
+
+        if result.errors:
+            raise serializers.ValidationError({"targeting_config_slug": result.errors})
+
+        if result.warnings:
+            self.warnings["targeting_config_slug"] = result.warnings
+
+        return data
+
     def validate(self, data):
         application = data.get("application")
         channel = data.get("channel")
@@ -1836,6 +1911,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_feature_value_variables(data)
         data = self._validate_primary_secondary_outcomes(data)
         data = self._validate_firefox_labs(data)
+        data = self._validate_targeting_configs(data)
         if application == NimbusExperiment.Application.DESKTOP:
             data = self._validate_desktop_pref_rollouts(data)
             data = self._validate_desktop_pref_flips(data)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1067,6 +1067,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "In versions {versions}: Feature {feature_config} is not supported"
     )
 
+    ERROR_TARGETING_FIELD_UNSUPPORTED_IN_RANGE = (
+        "Targeting field {field} is not supported by any version in this range."
+    )
+
+    ERROR_TARGETING_FIELD_UNSUPPORTED_IN_VERSIONS = (
+        "In versions {versions}: Targeting field {field} is not supported"
+    )
+
     ERROR_FEATURE_VALUE_IN_VERSIONS = "In versions {versions}: {error}"
     WARNING_FEATURE_VALUE_IN_VERSIONS = "Warning: In versions {versions}: {warning}"
 

--- a/experimenter/experimenter/experiments/jexl_utils.py
+++ b/experimenter/experimenter/experiments/jexl_utils.py
@@ -194,3 +194,18 @@ def format_jexl(expression):
         logging.exception(f"Failed to parse JEXL expression `{expression}'")
 
         return expression
+
+
+def extract_targeting_fields(targeting_config):
+    extracted_root_fields = set()
+
+    for subexpr in collect_exprs(targeting_config):
+        try:
+            json.loads(subexpr)
+            continue
+        except json.JSONDecodeError:
+            if subexpr.startswith("."):
+                continue
+            extracted_root_fields.add(subexpr.partition(".")[0])
+
+    return extracted_root_fields

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/__init__.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/__init__.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+from django.test import override_settings
+
+mock_targeting_manifests = override_settings(
+    FEATURE_MANIFESTS_PATH=(Path(__file__).parent.absolute() / "fixtures"),
+)

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,3 @@
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  knownField: typeAssertions.string,
+});

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v120.0.0/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v120.0.0/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,3 @@
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  knownField: typeAssertions.string,
+});

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v121.0.0/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v121.0.0/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,4 @@
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  knownField: typeAssertions.string,
+  anotherKnownField: typeAssertions.string,
+});

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v122.0.0/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v122.0.0/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,5 @@
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  knownField: typeAssertions.string,
+  anotherKnownField: typeAssertions.string,
+  thirdKnownField: typeAssertions.string,
+});

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v123.0.0/TargetingContextRecorder.sys.mjs
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/firefox-desktop/v123.0.0/TargetingContextRecorder.sys.mjs
@@ -1,0 +1,3 @@
+export const ATTRIBUTE_TRANSFORMS = Object.freeze({
+  knownField: typeAssertions.string,
+});

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -14,6 +14,9 @@ from experimenter.base.tests.factories import (
 from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusExperiment, NimbusFeatureVersion
+from experimenter.experiments.tests.api.v5.test_serializers import (
+    mock_targeting_manifests,
+)
 from experimenter.experiments.tests.api.v5.test_serializers.mixins import (
     MockFmlErrorMixin,
 )
@@ -26,6 +29,7 @@ from experimenter.experiments.tests.factories import (
     NimbusVersionedSchemaFactory,
 )
 from experimenter.openidc.tests.factories import UserFactory
+from experimenter.targeting.targeting_context_parser import TargetingContextFields
 
 BASIC_JSON_SCHEMA = """\
 {
@@ -3371,11 +3375,13 @@ class TestNimbusReviewSerializerSingleFeature(MockFmlErrorMixin, TestCase):
         )
 
 
+@mock_targeting_manifests
 class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
     maxDiff = None
 
     def setUp(self):
         super().setUp()
+        TargetingContextFields.clear_cache()
 
         self.user = UserFactory()
 
@@ -4403,6 +4409,110 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         self.assertTrue(serializer.is_valid())
         self.assertEqual(serializer.errors, {})
+
+    @parameterized.expand(
+        [
+            (False, False),
+            (True, True),
+        ]
+    )
+    def test_validate_targeting_configs_unknown_field_is_error_or_warning(
+        self,
+        warn_feature_schema,
+        expected_valid,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_121,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+            warn_feature_schema=warn_feature_schema,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        with patch(
+            "experimenter.experiments.api.v5.serializers.extract_targeting_fields",
+            return_value={"knownField", "unknownField"},
+        ):
+            self.assertEqual(serializer.is_valid(), expected_valid, serializer.errors)
+
+        if expected_valid:
+            self.assertEqual(len(serializer.warnings["targeting_config_slug"]), 1)
+            self.assertIn("unknownField", serializer.warnings["targeting_config_slug"][0])
+        else:
+            self.assertEqual(len(serializer.errors["targeting_config_slug"]), 1)
+            self.assertIn("unknownField", serializer.errors["targeting_config_slug"][0])
+
+    @parameterized.expand(
+        [
+            # min == max
+            (NimbusExperiment.Version.FIREFOX_120, NimbusExperiment.Version.FIREFOX_120),
+            (NimbusExperiment.Version.FIREFOX_121, NimbusExperiment.Version.FIREFOX_121),
+            (NimbusExperiment.Version.FIREFOX_122, NimbusExperiment.Version.FIREFOX_122),
+            # min <= max (bounded)
+            (NimbusExperiment.Version.FIREFOX_120, NimbusExperiment.Version.FIREFOX_121),
+            (NimbusExperiment.Version.FIREFOX_120, NimbusExperiment.Version.FIREFOX_122),
+            (NimbusExperiment.Version.FIREFOX_121, NimbusExperiment.Version.FIREFOX_122),
+            # min <= max (unbounded)
+            (NimbusExperiment.Version.FIREFOX_120, NimbusExperiment.Version.NO_VERSION),
+            (NimbusExperiment.Version.FIREFOX_121, NimbusExperiment.Version.NO_VERSION),
+            (NimbusExperiment.Version.FIREFOX_122, NimbusExperiment.Version.NO_VERSION),
+        ]
+    )
+    def test_validate_targeting_configs_valid_version_ranges(
+        self,
+        min_version,
+        max_version,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=min_version,
+            firefox_max_version=max_version,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        with (
+            patch(
+                "experimenter.experiments.api.v5.serializers.extract_targeting_fields",
+                return_value={"knownField"},
+            ),
+        ):
+            self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        self.assertEqual(serializer.warnings, {})
+
+    def test_validate_targeting_configs_assume_unversioned_uses_unversioned_context(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_119,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_119,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        with patch(
+            "experimenter.experiments.api.v5.serializers.extract_targeting_fields",
+            return_value={"knownField"},
+        ):
+            self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        self.assertEqual(serializer.warnings, {})
 
 
 class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -1,10 +1,8 @@
-import json
-
 from django.test import TestCase
 from parameterized import parameterized
 
 from experimenter.experiments.constants import Application
-from experimenter.experiments.jexl_utils import collect_exprs
+from experimenter.experiments.jexl_utils import extract_targeting_fields
 from experimenter.experiments.tests.jexl_utils import validate_jexl_expr
 from experimenter.targeting.constants import (
     PRESERVED_TARGETING_KEYS_BY_APPLICATION,
@@ -14,6 +12,10 @@ from experimenter.targeting.targeting_context_parser import TargetingContextFiel
 
 
 class TestTargetingConfigs(TestCase):
+    def setUp(self):
+        super().setUp()
+        TargetingContextFields.clear_cache()
+
     def test_all_targeting_configs_defined_in_constants(self):
         self.assertEqual(
             {t.value for t in TargetingConstants.TargetingConfig},
@@ -66,18 +68,9 @@ class TestTargetingConfigs(TestCase):
                     )
 
         if targeting_config.targeting:
-            extracted_root_fields = set()
-
-            for subexpr in collect_exprs(targeting_config.targeting):
-                try:
-                    json.loads(subexpr)
-                    continue
-                except json.JSONDecodeError:
-                    if subexpr.startswith("."):
-                        continue
-                    extracted_root_fields.add(subexpr.partition(".")[0])
-
-            unknown_fields = extracted_root_fields - valid_fields
+            unknown_fields = (
+                extract_targeting_fields(targeting_config.targeting) - valid_fields
+            )
 
             self.assertFalse(
                 unknown_fields,


### PR DESCRIPTION
Because

- Targeting configs were not validated against versioned targeting context fields, allowing JEXL expressions to reference fields that may not exist across the selected version range

This commit

- Adds version-range validation for targeting config JEXL expressions during experiment review
- Extracts referenced identifiers from the JEXL expression and validates them against targeting context fields for all versions in the selected range
- Reports unsupported fields with specific version breakdowns when they are only partially available

Fixes #14925 