### PR TITLE
fix(nimbus): include region, language, locale in overlap warnings

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1653,6 +1653,33 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
+    def _audience_overlapping_candidates(self, candidates):
+        self_locales = [locale.code for locale in self.locales.all()]
+        self_countries = [country.code for country in self.countries.all()]
+        self_languages = [language.code for language in self.languages.all()]
+        return [
+            candidate
+            for candidate in candidates
+            if self._audience_dimension_overlap(
+                self_locales,
+                self.exclude_locales,
+                candidate["locale_codes"],
+                candidate["exclude_locales"],
+            )
+            and self._audience_dimension_overlap(
+                self_countries,
+                self.exclude_countries,
+                candidate["country_codes"],
+                candidate["exclude_countries"],
+            )
+            and self._audience_dimension_overlap(
+                self_languages,
+                self.exclude_languages,
+                candidate["language_codes"],
+                candidate["exclude_languages"],
+            )
+        ]
+
     @property
     def feature_has_live_multifeature_experiments(self):
         matching = []
@@ -1683,30 +1710,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "language_codes",
                 )
             )
-            self_locales = [locale.code for locale in self.locales.all()]
-            self_countries = [country.code for country in self.countries.all()]
-            self_languages = [language.code for language in self.languages.all()]
             matching = [
                 candidate["slug"]
-                for candidate in candidates
-                if self._audience_dimension_overlap(
-                    self_locales,
-                    self.exclude_locales,
-                    candidate["locale_codes"],
-                    candidate["exclude_locales"],
-                )
-                and self._audience_dimension_overlap(
-                    self_countries,
-                    self.exclude_countries,
-                    candidate["country_codes"],
-                    candidate["exclude_countries"],
-                )
-                and self._audience_dimension_overlap(
-                    self_languages,
-                    self.exclude_languages,
-                    candidate["language_codes"],
-                    candidate["exclude_languages"],
-                )
+                for candidate in self._audience_overlapping_candidates(candidates)
             ]
         return matching
 
@@ -1754,30 +1760,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 "language_codes",
             )
         )
-        self_locales = [locale.code for locale in self.locales.all()]
-        self_countries = [country.code for country in self.countries.all()]
-        self_languages = [language.code for language in self.languages.all()]
         return [
             candidate["slug"]
-            for candidate in candidates
-            if self._audience_dimension_overlap(
-                self_locales,
-                self.exclude_locales,
-                candidate["locale_codes"],
-                candidate["exclude_locales"],
-            )
-            and self._audience_dimension_overlap(
-                self_countries,
-                self.exclude_countries,
-                candidate["country_codes"],
-                candidate["exclude_countries"],
-            )
-            and self._audience_dimension_overlap(
-                self_languages,
-                self.exclude_languages,
-                candidate["language_codes"],
-                candidate["exclude_languages"],
-            )
+            for candidate in self._audience_overlapping_candidates(candidates)
         ]
 
     @property
@@ -1997,36 +1982,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
         )
 
-        self_locales = [locale.code for locale in self.locales.all()]
-        self_countries = [country.code for country in self.countries.all()]
-        self_languages = [language.code for language in self.languages.all()]
-        for candidate in duplicate_rollouts:
-            if (
-                self._audience_dimension_overlap(
-                    self_locales,
-                    self.exclude_locales,
-                    candidate["locale_codes"],
-                    candidate["exclude_locales"],
-                )
-                and self._audience_dimension_overlap(
-                    self_countries,
-                    self.exclude_countries,
-                    candidate["country_codes"],
-                    candidate["exclude_countries"],
-                )
-                and self._audience_dimension_overlap(
-                    self_languages,
-                    self.exclude_languages,
-                    candidate["language_codes"],
-                    candidate["exclude_languages"],
-                )
-            ):
-                return {
-                    "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
-                    "variant": "danger",
-                    "slugs": [],
-                    "learn_more_link": NimbusUIConstants.ROLLOUT_BUCKET_WARNING,
-                }
+        if self._audience_overlapping_candidates(duplicate_rollouts):
+            return {
+                "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
+                "variant": "danger",
+                "slugs": [],
+                "learn_more_link": NimbusUIConstants.ROLLOUT_BUCKET_WARNING,
+            }
 
     @property
     def rollout_version_warning(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1653,7 +1653,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
-    def audience_targeting_overlap(self, candidates):
+    def audience_overlap(self, candidates):
         self_locales = [locale.code for locale in self.locales.all()]
         self_countries = [country.code for country in self.countries.all()]
         self_languages = [language.code for language in self.languages.all()]
@@ -1709,7 +1709,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 .exclude(id=self.id)
                 .order_by("slug")
             )
-            matching = self.audience_targeting_overlap(candidates)
+            matching = self.audience_overlap(candidates)
         return matching
 
     @property
@@ -1742,7 +1742,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .exclude(id=self.id)
             .order_by("slug")
         )
-        return self.audience_targeting_overlap(candidates)
+        return self.audience_overlap(candidates)
 
     @property
     def can_edit(self):
@@ -1945,7 +1945,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             is_rollout=True,
         ).exclude(id=self.id)
 
-        if self.audience_targeting_overlap(duplicate_rollouts):
+        if self.audience_overlap(duplicate_rollouts):
             return {
                 "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
                 "variant": "danger",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -14,6 +14,7 @@ import packaging
 from django.apps import apps
 from django.conf import settings
 from django.contrib.auth.models import User
+from django.contrib.postgres.aggregates import ArrayAgg
 from django.contrib.postgres.fields import ArrayField
 from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
@@ -1640,10 +1641,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @staticmethod
     def _audience_dimension_overlap(self_items, self_exclude, other_items, other_exclude):
-        if not self_items or not other_items:
+        self_set = {code for code in (self_items or ()) if code is not None}
+        other_set = {code for code in (other_items or ()) if code is not None}
+        if not self_set or not other_set:
             return True
-        self_set = set(self_items)
-        other_set = set(other_items)
         if not self_exclude and not other_exclude:
             return bool(self_set & other_set)
         if self_exclude and other_exclude:
@@ -1651,36 +1652,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self_exclude:
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
-
-    def _audience_overlapping_experiments(self, queryset):
-        candidates = queryset.prefetch_related("locales", "countries", "languages")
-        self_locales = [loc.code for loc in self.locales.all()]
-        self_countries = [cty.code for cty in self.countries.all()]
-        self_languages = [lng.code for lng in self.languages.all()]
-        matching = []
-        for candidate in candidates:
-            if (
-                self._audience_dimension_overlap(
-                    self_locales,
-                    self.exclude_locales,
-                    [loc.code for loc in candidate.locales.all()],
-                    candidate.exclude_locales,
-                )
-                and self._audience_dimension_overlap(
-                    self_countries,
-                    self.exclude_countries,
-                    [cty.code for cty in candidate.countries.all()],
-                    candidate.exclude_countries,
-                )
-                and self._audience_dimension_overlap(
-                    self_languages,
-                    self.exclude_languages,
-                    [lng.code for lng in candidate.languages.all()],
-                    candidate.exclude_languages,
-                )
-            ):
-                matching.append(candidate)
-        return matching
 
     @property
     def feature_has_live_multifeature_experiments(self):
@@ -1696,11 +1667,46 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 .filter(n_feature_configs__gt=1)
                 .filter(feature_configs__slug__in=feature_slugs)
                 .exclude(id=self.id)
-                .distinct()
+                .annotate(
+                    locale_codes=ArrayAgg("locales__code", distinct=True),
+                    country_codes=ArrayAgg("countries__code", distinct=True),
+                    language_codes=ArrayAgg("languages__code", distinct=True),
+                )
                 .order_by("slug")
+                .values(
+                    "slug",
+                    "exclude_locales",
+                    "exclude_countries",
+                    "exclude_languages",
+                    "locale_codes",
+                    "country_codes",
+                    "language_codes",
+                )
             )
+            self_locales = [locale.code for locale in self.locales.all()]
+            self_countries = [country.code for country in self.countries.all()]
+            self_languages = [language.code for language in self.languages.all()]
             matching = [
-                c.slug for c in self._audience_overlapping_experiments(candidates)
+                candidate["slug"]
+                for candidate in candidates
+                if self._audience_dimension_overlap(
+                    self_locales,
+                    self.exclude_locales,
+                    candidate["locale_codes"],
+                    candidate["exclude_locales"],
+                )
+                and self._audience_dimension_overlap(
+                    self_countries,
+                    self.exclude_countries,
+                    candidate["country_codes"],
+                    candidate["exclude_countries"],
+                )
+                and self._audience_dimension_overlap(
+                    self_languages,
+                    self.exclude_languages,
+                    candidate["language_codes"],
+                    candidate["exclude_languages"],
+                )
             ]
         return matching
 
@@ -1732,10 +1738,47 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 status=NimbusExperiment.Status.LIVE,
             )
             .exclude(id=self.id)
-            .distinct()
+            .annotate(
+                locale_codes=ArrayAgg("locales__code", distinct=True),
+                country_codes=ArrayAgg("countries__code", distinct=True),
+                language_codes=ArrayAgg("languages__code", distinct=True),
+            )
             .order_by("slug")
+            .values(
+                "slug",
+                "exclude_locales",
+                "exclude_countries",
+                "exclude_languages",
+                "locale_codes",
+                "country_codes",
+                "language_codes",
+            )
         )
-        return [c.slug for c in self._audience_overlapping_experiments(candidates)]
+        self_locales = [locale.code for locale in self.locales.all()]
+        self_countries = [country.code for country in self.countries.all()]
+        self_languages = [language.code for language in self.languages.all()]
+        return [
+            candidate["slug"]
+            for candidate in candidates
+            if self._audience_dimension_overlap(
+                self_locales,
+                self.exclude_locales,
+                candidate["locale_codes"],
+                candidate["exclude_locales"],
+            )
+            and self._audience_dimension_overlap(
+                self_countries,
+                self.exclude_countries,
+                candidate["country_codes"],
+                candidate["exclude_countries"],
+            )
+            and self._audience_dimension_overlap(
+                self_languages,
+                self.exclude_languages,
+                candidate["language_codes"],
+                candidate["exclude_languages"],
+            )
+        ]
 
     @property
     def can_edit(self):
@@ -1939,16 +1982,51 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 is_rollout=True,
             )
             .exclude(id=self.id)
-            .distinct()
+            .annotate(
+                locale_codes=ArrayAgg("locales__code", distinct=True),
+                country_codes=ArrayAgg("countries__code", distinct=True),
+                language_codes=ArrayAgg("languages__code", distinct=True),
+            )
+            .values(
+                "exclude_locales",
+                "exclude_countries",
+                "exclude_languages",
+                "locale_codes",
+                "country_codes",
+                "language_codes",
+            )
         )
 
-        if self._audience_overlapping_experiments(duplicate_rollouts):
-            return {
-                "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
-                "variant": "danger",
-                "slugs": [],
-                "learn_more_link": NimbusUIConstants.ROLLOUT_BUCKET_WARNING,
-            }
+        self_locales = [locale.code for locale in self.locales.all()]
+        self_countries = [country.code for country in self.countries.all()]
+        self_languages = [language.code for language in self.languages.all()]
+        for candidate in duplicate_rollouts:
+            if (
+                self._audience_dimension_overlap(
+                    self_locales,
+                    self.exclude_locales,
+                    candidate["locale_codes"],
+                    candidate["exclude_locales"],
+                )
+                and self._audience_dimension_overlap(
+                    self_countries,
+                    self.exclude_countries,
+                    candidate["country_codes"],
+                    candidate["exclude_countries"],
+                )
+                and self._audience_dimension_overlap(
+                    self_languages,
+                    self.exclude_languages,
+                    candidate["language_codes"],
+                    candidate["exclude_languages"],
+                )
+            ):
+                return {
+                    "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
+                    "variant": "danger",
+                    "slugs": [],
+                    "learn_more_link": NimbusUIConstants.ROLLOUT_BUCKET_WARNING,
+                }
 
     @property
     def rollout_version_warning(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2,6 +2,7 @@ import copy
 import datetime
 import json
 from collections import defaultdict
+from collections.abc import Iterable
 from dataclasses import dataclass
 from decimal import Decimal
 from itertools import chain
@@ -1640,7 +1641,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
 
     @staticmethod
-    def audience_set_overlap(self_items, self_exclude, other_items, other_exclude):
+    def audience_set_overlap(
+        self_items: Iterable[Optional[str]] | None,
+        self_exclude: bool,
+        other_items: Iterable[Optional[str]] | None,
+        other_exclude: bool,
+    ) -> bool:
         self_set = set(self_items or ()) - {None}
         other_set = set(other_items or ()) - {None}
         if not self_set or not other_set:
@@ -1653,7 +1659,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
-    def audience_overlap(self, candidates):
+    def audience_overlap(self, candidates: "QuerySet[NimbusExperiment]") -> list[str]:
         self_locales = [locale.code for locale in self.locales.all()]
         self_countries = [country.code for country in self.countries.all()]
         self_languages = [language.code for language in self.languages.all()]

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1638,6 +1638,38 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             ),
         )
 
+    @staticmethod
+    def _audience_dimension_overlap(self_items, self_exclude, other_items, other_exclude):
+        if not self_items or not other_items:
+            return True
+        self_set = set(self_items)
+        other_set = set(other_items)
+        if not self_exclude and not other_exclude:
+            return bool(self_set & other_set)
+        if self_exclude and other_exclude:
+            return True
+        if self_exclude:
+            return not other_set.issubset(self_set)
+        return not self_set.issubset(other_set)
+
+    def audiences_overlap(self, other):
+        dimensions = (
+            ("locales", "exclude_locales"),
+            ("countries", "exclude_countries"),
+            ("languages", "exclude_languages"),
+        )
+        for field, exclude_field in dimensions:
+            self_items = list(getattr(self, field).values_list("code", flat=True))
+            other_items = list(getattr(other, field).values_list("code", flat=True))
+            if not self._audience_dimension_overlap(
+                self_items,
+                getattr(self, exclude_field),
+                other_items,
+                getattr(other, exclude_field),
+            ):
+                return False
+        return True
+
     @property
     def feature_has_live_multifeature_experiments(self):
         matching = []
@@ -1647,15 +1679,15 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
         if live_experiments.exists():
             feature_slugs = self.feature_configs.all().values_list("slug", flat=True)
-            matching = (
+            candidates = (
                 live_experiments.annotate(n_feature_configs=Count("feature_configs"))
                 .filter(n_feature_configs__gt=1)
                 .filter(feature_configs__slug__in=feature_slugs)
                 .exclude(id=self.id)
-                .values_list("slug", flat=True)
                 .distinct()
                 .order_by("slug")
             )
+            matching = [c.slug for c in candidates if self.audiences_overlap(c)]
         return matching
 
     @property
@@ -1680,16 +1712,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             isolation_group__name=self.bucket_namespace,
             isolation_group__application=self.application,
         ).values_list("experiment_id", flat=True)
-        return (
+        candidates = (
             NimbusExperiment.objects.filter(
                 id__in=experiment_ids,
                 status=NimbusExperiment.Status.LIVE,
             )
             .exclude(id=self.id)
-            .values_list("slug", flat=True)
             .distinct()
             .order_by("slug")
         )
+        return [c.slug for c in candidates if self.audiences_overlap(c)]
 
     @property
     def can_edit(self):
@@ -1883,7 +1915,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if not self.is_rollout:
             return None
 
-        duplicate_rollout_count = (
+        duplicate_rollouts = (
             NimbusExperiment.objects.filter(
                 status=self.Status.LIVE,
                 channel=self.channel,
@@ -1893,10 +1925,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 is_rollout=True,
             )
             .exclude(id=self.id)
-            .count()
+            .distinct()
         )
 
-        if duplicate_rollout_count > 0:
+        if any(self.audiences_overlap(r) for r in duplicate_rollouts):
             return {
                 "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
                 "variant": "danger",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1640,7 +1640,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
 
     @staticmethod
-    def audience_dimension_overlap(self_items, self_exclude, other_items, other_exclude):
+    def audience_targeting_overlap(self_items, self_exclude, other_items, other_exclude):
         self_set = set(self_items or ()) - {None}
         other_set = set(other_items or ()) - {None}
         if not self_set or not other_set:
@@ -1673,19 +1673,19 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return [
             candidate["slug"]
             for candidate in candidates
-            if self.audience_dimension_overlap(
+            if self.audience_targeting_overlap(
                 self_locales,
                 self.exclude_locales,
                 candidate["locale_codes"],
                 candidate["exclude_locales"],
             )
-            and self.audience_dimension_overlap(
+            and self.audience_targeting_overlap(
                 self_countries,
                 self.exclude_countries,
                 candidate["country_codes"],
                 candidate["exclude_countries"],
             )
-            and self.audience_dimension_overlap(
+            and self.audience_targeting_overlap(
                 self_languages,
                 self.exclude_languages,
                 candidate["language_codes"],

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1653,22 +1653,26 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return not self_set.issubset(other_set)
 
     def audiences_overlap(self, other):
-        dimensions = (
-            ("locales", "exclude_locales"),
-            ("countries", "exclude_countries"),
-            ("languages", "exclude_languages"),
+        return (
+            self._audience_dimension_overlap(
+                list(self.locales.values_list("code", flat=True)),
+                self.exclude_locales,
+                list(other.locales.values_list("code", flat=True)),
+                other.exclude_locales,
+            )
+            and self._audience_dimension_overlap(
+                list(self.countries.values_list("code", flat=True)),
+                self.exclude_countries,
+                list(other.countries.values_list("code", flat=True)),
+                other.exclude_countries,
+            )
+            and self._audience_dimension_overlap(
+                list(self.languages.values_list("code", flat=True)),
+                self.exclude_languages,
+                list(other.languages.values_list("code", flat=True)),
+                other.exclude_languages,
+            )
         )
-        for field, exclude_field in dimensions:
-            self_items = list(getattr(self, field).values_list("code", flat=True))
-            other_items = list(getattr(other, field).values_list("code", flat=True))
-            if not self._audience_dimension_overlap(
-                self_items,
-                getattr(self, exclude_field),
-                other_items,
-                getattr(other, exclude_field),
-            ):
-                return False
-        return True
 
     @property
     def feature_has_live_multifeature_experiments(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1640,9 +1640,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
 
     @staticmethod
-    def _audience_dimension_overlap(self_items, self_exclude, other_items, other_exclude):
-        self_set = {code for code in (self_items or ()) if code is not None}
-        other_set = {code for code in (other_items or ()) if code is not None}
+    def audience_dimension_overlap(self_items, self_exclude, other_items, other_exclude):
+        self_set = set(self_items or ()) - {None}
+        other_set = set(other_items or ()) - {None}
         if not self_set or not other_set:
             return True
         if not self_exclude and not other_exclude:
@@ -1653,26 +1653,39 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
-    def _audience_overlapping_candidates(self, candidates):
+    def audience_overlapping_slugs(self, candidates):
         self_locales = [locale.code for locale in self.locales.all()]
         self_countries = [country.code for country in self.countries.all()]
         self_languages = [language.code for language in self.languages.all()]
+        candidates = candidates.annotate(
+            locale_codes=ArrayAgg("locales__code", distinct=True),
+            country_codes=ArrayAgg("countries__code", distinct=True),
+            language_codes=ArrayAgg("languages__code", distinct=True),
+        ).values(
+            "slug",
+            "exclude_locales",
+            "exclude_countries",
+            "exclude_languages",
+            "locale_codes",
+            "country_codes",
+            "language_codes",
+        )
         return [
-            candidate
+            candidate["slug"]
             for candidate in candidates
-            if self._audience_dimension_overlap(
+            if self.audience_dimension_overlap(
                 self_locales,
                 self.exclude_locales,
                 candidate["locale_codes"],
                 candidate["exclude_locales"],
             )
-            and self._audience_dimension_overlap(
+            and self.audience_dimension_overlap(
                 self_countries,
                 self.exclude_countries,
                 candidate["country_codes"],
                 candidate["exclude_countries"],
             )
-            and self._audience_dimension_overlap(
+            and self.audience_dimension_overlap(
                 self_languages,
                 self.exclude_languages,
                 candidate["language_codes"],
@@ -1694,26 +1707,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 .filter(n_feature_configs__gt=1)
                 .filter(feature_configs__slug__in=feature_slugs)
                 .exclude(id=self.id)
-                .annotate(
-                    locale_codes=ArrayAgg("locales__code", distinct=True),
-                    country_codes=ArrayAgg("countries__code", distinct=True),
-                    language_codes=ArrayAgg("languages__code", distinct=True),
-                )
                 .order_by("slug")
-                .values(
-                    "slug",
-                    "exclude_locales",
-                    "exclude_countries",
-                    "exclude_languages",
-                    "locale_codes",
-                    "country_codes",
-                    "language_codes",
-                )
             )
-            matching = [
-                candidate["slug"]
-                for candidate in self._audience_overlapping_candidates(candidates)
-            ]
+            matching = self.audience_overlapping_slugs(candidates)
         return matching
 
     @property
@@ -1744,26 +1740,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 status=NimbusExperiment.Status.LIVE,
             )
             .exclude(id=self.id)
-            .annotate(
-                locale_codes=ArrayAgg("locales__code", distinct=True),
-                country_codes=ArrayAgg("countries__code", distinct=True),
-                language_codes=ArrayAgg("languages__code", distinct=True),
-            )
             .order_by("slug")
-            .values(
-                "slug",
-                "exclude_locales",
-                "exclude_countries",
-                "exclude_languages",
-                "locale_codes",
-                "country_codes",
-                "language_codes",
-            )
         )
-        return [
-            candidate["slug"]
-            for candidate in self._audience_overlapping_candidates(candidates)
-        ]
+        return self.audience_overlapping_slugs(candidates)
 
     @property
     def can_edit(self):
@@ -1957,32 +1936,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if not self.is_rollout:
             return None
 
-        duplicate_rollouts = (
-            NimbusExperiment.objects.filter(
-                status=self.Status.LIVE,
-                channel=self.channel,
-                application=self.application,
-                targeting_config_slug=self.targeting_config_slug,
-                feature_configs__in=self.feature_configs.all(),
-                is_rollout=True,
-            )
-            .exclude(id=self.id)
-            .annotate(
-                locale_codes=ArrayAgg("locales__code", distinct=True),
-                country_codes=ArrayAgg("countries__code", distinct=True),
-                language_codes=ArrayAgg("languages__code", distinct=True),
-            )
-            .values(
-                "exclude_locales",
-                "exclude_countries",
-                "exclude_languages",
-                "locale_codes",
-                "country_codes",
-                "language_codes",
-            )
-        )
+        duplicate_rollouts = NimbusExperiment.objects.filter(
+            status=self.Status.LIVE,
+            channel=self.channel,
+            application=self.application,
+            targeting_config_slug=self.targeting_config_slug,
+            feature_configs__in=self.feature_configs.all(),
+            is_rollout=True,
+        ).exclude(id=self.id)
 
-        if self._audience_overlapping_candidates(duplicate_rollouts):
+        if self.audience_overlapping_slugs(duplicate_rollouts):
             return {
                 "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
                 "variant": "danger",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1640,7 +1640,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         )
 
     @staticmethod
-    def audience_targeting_overlap(self_items, self_exclude, other_items, other_exclude):
+    def audience_set_overlap(self_items, self_exclude, other_items, other_exclude):
         self_set = set(self_items or ()) - {None}
         other_set = set(other_items or ()) - {None}
         if not self_set or not other_set:
@@ -1653,7 +1653,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
-    def audience_overlapping_slugs(self, candidates):
+    def audience_targeting_overlap(self, candidates):
         self_locales = [locale.code for locale in self.locales.all()]
         self_countries = [country.code for country in self.countries.all()]
         self_languages = [language.code for language in self.languages.all()]
@@ -1673,19 +1673,19 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return [
             candidate["slug"]
             for candidate in candidates
-            if self.audience_targeting_overlap(
+            if self.audience_set_overlap(
                 self_locales,
                 self.exclude_locales,
                 candidate["locale_codes"],
                 candidate["exclude_locales"],
             )
-            and self.audience_targeting_overlap(
+            and self.audience_set_overlap(
                 self_countries,
                 self.exclude_countries,
                 candidate["country_codes"],
                 candidate["exclude_countries"],
             )
-            and self.audience_targeting_overlap(
+            and self.audience_set_overlap(
                 self_languages,
                 self.exclude_languages,
                 candidate["language_codes"],
@@ -1709,7 +1709,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 .exclude(id=self.id)
                 .order_by("slug")
             )
-            matching = self.audience_overlapping_slugs(candidates)
+            matching = self.audience_targeting_overlap(candidates)
         return matching
 
     @property
@@ -1742,7 +1742,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .exclude(id=self.id)
             .order_by("slug")
         )
-        return self.audience_overlapping_slugs(candidates)
+        return self.audience_targeting_overlap(candidates)
 
     @property
     def can_edit(self):
@@ -1945,7 +1945,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             is_rollout=True,
         ).exclude(id=self.id)
 
-        if self.audience_overlapping_slugs(duplicate_rollouts):
+        if self.audience_targeting_overlap(duplicate_rollouts):
             return {
                 "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
                 "variant": "danger",

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1652,27 +1652,35 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return not other_set.issubset(self_set)
         return not self_set.issubset(other_set)
 
-    def audiences_overlap(self, other):
-        return (
-            self._audience_dimension_overlap(
-                list(self.locales.values_list("code", flat=True)),
-                self.exclude_locales,
-                list(other.locales.values_list("code", flat=True)),
-                other.exclude_locales,
-            )
-            and self._audience_dimension_overlap(
-                list(self.countries.values_list("code", flat=True)),
-                self.exclude_countries,
-                list(other.countries.values_list("code", flat=True)),
-                other.exclude_countries,
-            )
-            and self._audience_dimension_overlap(
-                list(self.languages.values_list("code", flat=True)),
-                self.exclude_languages,
-                list(other.languages.values_list("code", flat=True)),
-                other.exclude_languages,
-            )
-        )
+    def _audience_overlapping_experiments(self, queryset):
+        candidates = queryset.prefetch_related("locales", "countries", "languages")
+        self_locales = [loc.code for loc in self.locales.all()]
+        self_countries = [cty.code for cty in self.countries.all()]
+        self_languages = [lng.code for lng in self.languages.all()]
+        matching = []
+        for candidate in candidates:
+            if (
+                self._audience_dimension_overlap(
+                    self_locales,
+                    self.exclude_locales,
+                    [loc.code for loc in candidate.locales.all()],
+                    candidate.exclude_locales,
+                )
+                and self._audience_dimension_overlap(
+                    self_countries,
+                    self.exclude_countries,
+                    [cty.code for cty in candidate.countries.all()],
+                    candidate.exclude_countries,
+                )
+                and self._audience_dimension_overlap(
+                    self_languages,
+                    self.exclude_languages,
+                    [lng.code for lng in candidate.languages.all()],
+                    candidate.exclude_languages,
+                )
+            ):
+                matching.append(candidate)
+        return matching
 
     @property
     def feature_has_live_multifeature_experiments(self):
@@ -1691,7 +1699,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 .distinct()
                 .order_by("slug")
             )
-            matching = [c.slug for c in candidates if self.audiences_overlap(c)]
+            matching = [
+                c.slug for c in self._audience_overlapping_experiments(candidates)
+            ]
         return matching
 
     @property
@@ -1725,7 +1735,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .distinct()
             .order_by("slug")
         )
-        return [c.slug for c in candidates if self.audiences_overlap(c)]
+        return [c.slug for c in self._audience_overlapping_experiments(candidates)]
 
     @property
     def can_edit(self):
@@ -1932,7 +1942,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .distinct()
         )
 
-        if any(self.audiences_overlap(r) for r in duplicate_rollouts):
+        if self._audience_overlapping_experiments(duplicate_rollouts):
             return {
                 "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
                 "variant": "danger",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4793,6 +4793,402 @@ class TestNimbusExperiment(TestCase):
         matching_experiments = experiment.live_experiments_in_namespace
         self.assertEqual(len(matching_experiments), 0)
 
+    def _make_namespace_peer(self, feature, **kwargs):
+        defaults = {
+            "application": NimbusExperiment.Application.DESKTOP,
+            "channels": [NimbusExperiment.Channel.RELEASE],
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_129,
+            "firefox_max_version": NimbusExperiment.Version.FIREFOX_130,
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
+            "feature_configs": [feature],
+        }
+        defaults.update(kwargs)
+        return NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE, **defaults
+        )
+
+    def _make_namespace_draft(self, feature, **kwargs):
+        defaults = {
+            "application": NimbusExperiment.Application.DESKTOP,
+            "channels": [NimbusExperiment.Channel.RELEASE],
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_129,
+            "firefox_max_version": NimbusExperiment.Version.FIREFOX_130,
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
+            "feature_configs": [feature],
+        }
+        defaults.update(kwargs)
+        return NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, **defaults
+        )
+
+    def test_audiences_overlap_both_empty(self):
+        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
+        b = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
+        self.assertTrue(a.audiences_overlap(b))
+
+    def test_audiences_overlap_empty_vs_nonempty_is_overlap(self):
+        en = LocaleFactory.create(code="en-US")
+        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
+        b = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
+        self.assertTrue(a.audiences_overlap(b))
+        self.assertTrue(b.audiences_overlap(a))
+
+    def test_audiences_overlap_disjoint_locales_no_overlap(self):
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
+        b = NimbusExperimentFactory.create(locales=[fr], countries=[], languages=[])
+        self.assertFalse(a.audiences_overlap(b))
+        self.assertFalse(b.audiences_overlap(a))
+
+    def test_audiences_overlap_overlapping_locales_overlap(self):
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(locales=[en, fr], countries=[], languages=[])
+        b = NimbusExperimentFactory.create(locales=[fr], countries=[], languages=[])
+        self.assertTrue(a.audiences_overlap(b))
+
+    def test_audiences_overlap_locales_match_but_countries_disjoint(self):
+        en = LocaleFactory.create(code="en-US")
+        us = CountryFactory.create(code="US")
+        de = CountryFactory.create(code="DE")
+        a = NimbusExperimentFactory.create(locales=[en], countries=[us], languages=[])
+        b = NimbusExperimentFactory.create(locales=[en], countries=[de], languages=[])
+        self.assertFalse(a.audiences_overlap(b))
+
+    def test_audiences_overlap_disjoint_languages_no_overlap(self):
+        en_lang = LanguageFactory.create(code="en")
+        fr_lang = LanguageFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[en_lang])
+        b = NimbusExperimentFactory.create(locales=[], countries=[], languages=[fr_lang])
+        self.assertFalse(a.audiences_overlap(b))
+
+    def test_audiences_overlap_exclude_self_covers_other(self):
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(
+            locales=[en, fr],
+            countries=[],
+            languages=[],
+            exclude_locales=True,
+        )
+        b = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
+        self.assertFalse(a.audiences_overlap(b))
+        self.assertFalse(b.audiences_overlap(a))
+
+    def test_audiences_overlap_exclude_partial_covers_other(self):
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(
+            locales=[en],
+            countries=[],
+            languages=[],
+            exclude_locales=True,
+        )
+        b = NimbusExperimentFactory.create(locales=[en, fr], countries=[], languages=[])
+        self.assertTrue(a.audiences_overlap(b))
+
+    def test_audiences_overlap_both_exclude_overlap(self):
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        a = NimbusExperimentFactory.create(
+            locales=[en],
+            countries=[],
+            languages=[],
+            exclude_locales=True,
+        )
+        b = NimbusExperimentFactory.create(
+            locales=[fr],
+            countries=[],
+            languages=[],
+            exclude_locales=True,
+        )
+        self.assertTrue(a.audiences_overlap(b))
+
+    def test_live_experiments_in_namespace_excludes_disjoint_locales(self):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        self._make_namespace_peer(feature, slug="live-en", locales=[en])
+        experiment = self._make_namespace_draft(feature, slug="draft-fr", locales=[fr])
+        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
+
+    def test_live_experiments_in_namespace_includes_overlapping_locales(self):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en = LocaleFactory.create(code="en-US")
+        self._make_namespace_peer(feature, slug="live-en", locales=[en])
+        experiment = self._make_namespace_draft(feature, slug="draft-en", locales=[en])
+        self.assertEqual(list(experiment.live_experiments_in_namespace), ["live-en"])
+
+    def test_live_experiments_in_namespace_includes_when_draft_all(self):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en = LocaleFactory.create(code="en-US")
+        self._make_namespace_peer(feature, slug="live-en", locales=[en])
+        experiment = self._make_namespace_draft(feature, slug="draft-all")
+        self.assertEqual(list(experiment.live_experiments_in_namespace), ["live-en"])
+
+    def test_live_experiments_in_namespace_excludes_disjoint_countries(self):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        us = CountryFactory.create(code="US")
+        de = CountryFactory.create(code="DE")
+        self._make_namespace_peer(feature, slug="live-us", countries=[us])
+        experiment = self._make_namespace_draft(feature, slug="draft-de", countries=[de])
+        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
+
+    def test_live_experiments_in_namespace_excludes_disjoint_languages(self):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en_lang = LanguageFactory.create(code="en")
+        fr_lang = LanguageFactory.create(code="fr")
+        self._make_namespace_peer(feature, slug="live-en", languages=[en_lang])
+        experiment = self._make_namespace_draft(
+            feature, slug="draft-fr", languages=[fr_lang]
+        )
+        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
+
+    def test_feature_has_live_multifeature_experiments_excludes_disjoint_locales(
+        self,
+    ):
+        feature1 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        feature2 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-multi",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature1, feature2],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature1],
+            locales=[fr],
+        )
+        self.assertEqual(list(experiment.feature_has_live_multifeature_experiments), [])
+
+    def test_feature_has_live_multifeature_experiments_includes_overlapping_locales(
+        self,
+    ):
+        feature1 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        feature2 = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        en = LocaleFactory.create(code="en-US")
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-multi",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature1, feature2],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature1],
+            locales=[en],
+        )
+        self.assertEqual(
+            list(experiment.feature_has_live_multifeature_experiments),
+            ["live-multi"],
+        )
+
+    def test_rollout_conflict_warning_disjoint_locales_no_warning(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[fr],
+        )
+        self.assertIsNone(experiment.rollout_conflict_warning)
+
+    def test_rollout_conflict_warning_disjoint_countries_no_warning(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        us = CountryFactory.create(code="US")
+        de = CountryFactory.create(code="DE")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            countries=[us],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            countries=[de],
+        )
+        self.assertIsNone(experiment.rollout_conflict_warning)
+
+    def test_rollout_conflict_warning_disjoint_languages_no_warning(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        en_lang = LanguageFactory.create(code="en")
+        fr_lang = LanguageFactory.create(code="fr")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            languages=[en_lang],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            languages=[fr_lang],
+        )
+        self.assertIsNone(experiment.rollout_conflict_warning)
+
+    def test_rollout_conflict_warning_overlapping_locales_fires(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        en = LocaleFactory.create(code="en-US")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en],
+        )
+        warning = experiment.rollout_conflict_warning
+        self.assertIsNotNone(warning)
+        self.assertEqual(warning["text"], NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS)
+
+    def test_rollout_conflict_warning_draft_empty_locales_fires(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        en = LocaleFactory.create(code="en-US")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[],
+        )
+        self.assertIsNotNone(experiment.rollout_conflict_warning)
+
+    def test_rollout_conflict_warning_one_overlapping_of_many_fires(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="test-feature",
+            name="test-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        en = LocaleFactory.create(code="en-US")
+        fr = LocaleFactory.create(code="fr")
+        de = LocaleFactory.create(code="de")
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[fr],
+        )
+        NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en],
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            locales=[en, de],
+        )
+        self.assertIsNotNone(experiment.rollout_conflict_warning)
+
     @parameterized.expand(
         [
             (

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4793,25 +4793,6 @@ class TestNimbusExperiment(TestCase):
         matching_experiments = experiment.live_experiments_in_namespace
         self.assertEqual(len(matching_experiments), 0)
 
-    def _namespace_base(self, feature):
-        return {
-            "application": NimbusExperiment.Application.DESKTOP,
-            "channels": [NimbusExperiment.Channel.RELEASE],
-            "firefox_min_version": NimbusExperiment.Version.FIREFOX_129,
-            "firefox_max_version": NimbusExperiment.Version.FIREFOX_130,
-            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
-            "feature_configs": [feature],
-        }
-
-    def _rollout_base(self, feature):
-        return {
-            "is_rollout": True,
-            "channels": [NimbusExperiment.Channel.BETA],
-            "application": NimbusExperiment.Application.DESKTOP,
-            "targeting_config_slug": NimbusExperiment.TargetingConfig.FIRST_RUN,
-            "feature_configs": [feature],
-        }
-
     @parameterized.expand(
         [
             ("both_empty_locales", LocaleFactory, "locales", [], False, [], False, True),
@@ -4940,13 +4921,23 @@ class TestNimbusExperiment(TestCase):
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
             slug="peer",
-            **self._namespace_base(feature),
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+            feature_configs=[feature],
             **{field: [factory.create(code=live_code)]},
         )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="draft",
-            **self._namespace_base(feature),
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+            feature_configs=[feature],
             **{field: [factory.create(code=draft_code)]},
         )
         self.assertEqual(list(experiment.live_experiments_in_namespace), [])
@@ -5000,12 +4991,20 @@ class TestNimbusExperiment(TestCase):
         )
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            **self._rollout_base(feature),
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.BETA],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
             **{field: [factory.create(code=live_code)]},
         )
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
-            **self._rollout_base(feature),
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.BETA],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
             **{field: [factory.create(code=draft_code)]},
         )
         self.assertIsNone(experiment.rollout_conflict_warning)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4901,7 +4901,7 @@ class TestNimbusExperiment(TestCase):
         )
         candidates = NimbusExperiment.objects.filter(id=other_experiment.id)
         self.assertEqual(
-            self_experiment.audience_targeting_overlap(candidates),
+            self_experiment.audience_overlap(candidates),
             ["other-exp"] if expected_overlap else [],
         )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4793,8 +4793,8 @@ class TestNimbusExperiment(TestCase):
         matching_experiments = experiment.live_experiments_in_namespace
         self.assertEqual(len(matching_experiments), 0)
 
-    def _make_namespace_peer(self, feature, **kwargs):
-        defaults = {
+    def _namespace_base(self, feature):
+        return {
             "application": NimbusExperiment.Application.DESKTOP,
             "channels": [NimbusExperiment.Channel.RELEASE],
             "firefox_min_version": NimbusExperiment.Version.FIREFOX_129,
@@ -4802,161 +4802,116 @@ class TestNimbusExperiment(TestCase):
             "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
             "feature_configs": [feature],
         }
-        defaults.update(kwargs)
-        return NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE, **defaults
-        )
 
-    def _make_namespace_draft(self, feature, **kwargs):
-        defaults = {
+    def _rollout_base(self, feature):
+        return {
+            "is_rollout": True,
+            "channels": [NimbusExperiment.Channel.BETA],
             "application": NimbusExperiment.Application.DESKTOP,
-            "channels": [NimbusExperiment.Channel.RELEASE],
-            "firefox_min_version": NimbusExperiment.Version.FIREFOX_129,
-            "firefox_max_version": NimbusExperiment.Version.FIREFOX_130,
-            "targeting_config_slug": NimbusExperiment.TargetingConfig.MAC_ONLY,
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.FIRST_RUN,
             "feature_configs": [feature],
         }
-        defaults.update(kwargs)
-        return NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED, **defaults
+
+    @parameterized.expand(
+        [
+            ("both_empty", [], False, [], False, True),
+            ("self_empty", [], False, ["en-US"], False, True),
+            ("other_empty", ["en-US"], False, [], False, True),
+            ("include_overlap", ["en-US", "fr"], False, ["fr"], False, True),
+            ("include_disjoint", ["en-US"], False, ["fr"], False, False),
+            ("self_exclude_covers_other", ["en-US", "fr"], True, ["en-US"], False, False),
+            ("self_exclude_partial", ["en-US"], True, ["en-US", "fr"], False, True),
+            ("other_exclude_covers_self", ["en-US"], False, ["en-US", "fr"], True, False),
+            ("both_exclude", ["en-US"], True, ["fr"], True, True),
+        ]
+    )
+    def test_audience_dimension_overlap(
+        self, _name, self_items, self_exclude, other_items, other_exclude, expected
+    ):
+        self.assertEqual(
+            NimbusExperiment._audience_dimension_overlap(
+                self_items, self_exclude, other_items, other_exclude
+            ),
+            expected,
         )
 
-    def test_audiences_overlap_both_empty(self):
-        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
-        b = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
-        self.assertTrue(a.audiences_overlap(b))
-
-    def test_audiences_overlap_empty_vs_nonempty_is_overlap(self):
-        en = LocaleFactory.create(code="en-US")
-        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[])
-        b = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
-        self.assertTrue(a.audiences_overlap(b))
-        self.assertTrue(b.audiences_overlap(a))
-
-    def test_audiences_overlap_disjoint_locales_no_overlap(self):
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        a = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
-        b = NimbusExperimentFactory.create(locales=[fr], countries=[], languages=[])
-        self.assertFalse(a.audiences_overlap(b))
-        self.assertFalse(b.audiences_overlap(a))
-
-    def test_audiences_overlap_overlapping_locales_overlap(self):
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        a = NimbusExperimentFactory.create(locales=[en, fr], countries=[], languages=[])
-        b = NimbusExperimentFactory.create(locales=[fr], countries=[], languages=[])
-        self.assertTrue(a.audiences_overlap(b))
-
-    def test_audiences_overlap_locales_match_but_countries_disjoint(self):
-        en = LocaleFactory.create(code="en-US")
-        us = CountryFactory.create(code="US")
-        de = CountryFactory.create(code="DE")
-        a = NimbusExperimentFactory.create(locales=[en], countries=[us], languages=[])
-        b = NimbusExperimentFactory.create(locales=[en], countries=[de], languages=[])
-        self.assertFalse(a.audiences_overlap(b))
-
-    def test_audiences_overlap_disjoint_languages_no_overlap(self):
-        en_lang = LanguageFactory.create(code="en")
-        fr_lang = LanguageFactory.create(code="fr")
-        a = NimbusExperimentFactory.create(locales=[], countries=[], languages=[en_lang])
-        b = NimbusExperimentFactory.create(locales=[], countries=[], languages=[fr_lang])
-        self.assertFalse(a.audiences_overlap(b))
-
-    def test_audiences_overlap_exclude_self_covers_other(self):
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
+    @parameterized.expand(
+        [
+            ("all_match", "en-US", "US", "en", "en-US", "US", "en", True),
+            ("locales_disjoint", "en-US", "US", "en", "fr", "US", "en", False),
+            ("countries_disjoint", "en-US", "US", "en", "en-US", "DE", "en", False),
+            ("languages_disjoint", "en-US", "US", "en", "en-US", "US", "fr", False),
+        ]
+    )
+    def test_audiences_overlap(
+        self, _name, a_loc, a_cty, a_lng, b_loc, b_cty, b_lng, expected
+    ):
         a = NimbusExperimentFactory.create(
-            locales=[en, fr],
-            countries=[],
-            languages=[],
-            exclude_locales=True,
-        )
-        b = NimbusExperimentFactory.create(locales=[en], countries=[], languages=[])
-        self.assertFalse(a.audiences_overlap(b))
-        self.assertFalse(b.audiences_overlap(a))
-
-    def test_audiences_overlap_exclude_partial_covers_other(self):
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        a = NimbusExperimentFactory.create(
-            locales=[en],
-            countries=[],
-            languages=[],
-            exclude_locales=True,
-        )
-        b = NimbusExperimentFactory.create(locales=[en, fr], countries=[], languages=[])
-        self.assertTrue(a.audiences_overlap(b))
-
-    def test_audiences_overlap_both_exclude_overlap(self):
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        a = NimbusExperimentFactory.create(
-            locales=[en],
-            countries=[],
-            languages=[],
-            exclude_locales=True,
+            locales=[LocaleFactory.create(code=a_loc)],
+            countries=[CountryFactory.create(code=a_cty)],
+            languages=[LanguageFactory.create(code=a_lng)],
         )
         b = NimbusExperimentFactory.create(
-            locales=[fr],
-            countries=[],
-            languages=[],
-            exclude_locales=True,
+            locales=[LocaleFactory.create(code=b_loc)],
+            countries=[CountryFactory.create(code=b_cty)],
+            languages=[LanguageFactory.create(code=b_lng)],
         )
-        self.assertTrue(a.audiences_overlap(b))
+        self.assertEqual(a.audiences_overlap(b), expected)
 
-    def test_live_experiments_in_namespace_excludes_disjoint_locales(self):
+    @parameterized.expand(
+        [
+            ("locales_disjoint", LocaleFactory, "locales", "en-US", "fr", []),
+            ("countries_disjoint", CountryFactory, "countries", "US", "DE", []),
+            ("languages_disjoint", LanguageFactory, "languages", "en", "fr", []),
+            ("locales_overlap", LocaleFactory, "locales", "en-US", "en-US", ["peer"]),
+        ]
+    )
+    def test_live_experiments_in_namespace_honors_audience(
+        self, _name, factory, field, live_code, draft_code, expected
+    ):
+        feature = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="peer",
+            **self._namespace_base(feature),
+            **{field: [factory.create(code=live_code)]},
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            **self._namespace_base(feature),
+            **{field: [factory.create(code=draft_code)]},
+        )
+        self.assertEqual(list(experiment.live_experiments_in_namespace), expected)
+
+    def test_live_experiments_in_namespace_empty_draft_audience_overlaps(self):
         feature = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
         )
         en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        self._make_namespace_peer(feature, slug="live-en", locales=[en])
-        experiment = self._make_namespace_draft(feature, slug="draft-fr", locales=[fr])
-        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
-
-    def test_live_experiments_in_namespace_includes_overlapping_locales(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="peer",
+            locales=[en],
+            **self._namespace_base(feature),
         )
-        en = LocaleFactory.create(code="en-US")
-        self._make_namespace_peer(feature, slug="live-en", locales=[en])
-        experiment = self._make_namespace_draft(feature, slug="draft-en", locales=[en])
-        self.assertEqual(list(experiment.live_experiments_in_namespace), ["live-en"])
-
-    def test_live_experiments_in_namespace_includes_when_draft_all(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            **self._namespace_base(feature),
         )
-        en = LocaleFactory.create(code="en-US")
-        self._make_namespace_peer(feature, slug="live-en", locales=[en])
-        experiment = self._make_namespace_draft(feature, slug="draft-all")
-        self.assertEqual(list(experiment.live_experiments_in_namespace), ["live-en"])
+        self.assertEqual(list(experiment.live_experiments_in_namespace), ["peer"])
 
-    def test_live_experiments_in_namespace_excludes_disjoint_countries(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        us = CountryFactory.create(code="US")
-        de = CountryFactory.create(code="DE")
-        self._make_namespace_peer(feature, slug="live-us", countries=[us])
-        experiment = self._make_namespace_draft(feature, slug="draft-de", countries=[de])
-        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
-
-    def test_live_experiments_in_namespace_excludes_disjoint_languages(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        en_lang = LanguageFactory.create(code="en")
-        fr_lang = LanguageFactory.create(code="fr")
-        self._make_namespace_peer(feature, slug="live-en", languages=[en_lang])
-        experiment = self._make_namespace_draft(
-            feature, slug="draft-fr", languages=[fr_lang]
-        )
-        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
-
-    def test_feature_has_live_multifeature_experiments_excludes_disjoint_locales(
-        self,
+    @parameterized.expand(
+        [
+            ("disjoint", "fr", []),
+            ("overlap", "en-US", ["live-multi"]),
+        ]
+    )
+    def test_feature_has_live_multifeature_experiments_honors_locales(
+        self, _name, draft_code, expected
     ):
         feature1 = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
@@ -4964,189 +4919,74 @@ class TestNimbusExperiment(TestCase):
         feature2 = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
         )
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
             slug="live-multi",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature1, feature2],
-            locales=[en],
+            locales=[LocaleFactory.create(code="en-US")],
         )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="draft",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature1],
-            locales=[fr],
-        )
-        self.assertEqual(list(experiment.feature_has_live_multifeature_experiments), [])
-
-    def test_feature_has_live_multifeature_experiments_includes_overlapping_locales(
-        self,
-    ):
-        feature1 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        feature2 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        en = LocaleFactory.create(code="en-US")
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-multi",
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1, feature2],
-            locales=[en],
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft",
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1],
-            locales=[en],
+            locales=[LocaleFactory.create(code=draft_code)],
         )
         self.assertEqual(
-            list(experiment.feature_has_live_multifeature_experiments),
-            ["live-multi"],
+            list(experiment.feature_has_live_multifeature_experiments), expected
         )
 
-    def test_rollout_conflict_warning_disjoint_locales_no_warning(self):
+    @parameterized.expand(
+        [
+            ("locales_disjoint", LocaleFactory, "locales", "en-US", "fr", True),
+            ("countries_disjoint", CountryFactory, "countries", "US", "DE", True),
+            ("languages_disjoint", LanguageFactory, "languages", "en", "fr", True),
+            ("locales_overlap", LocaleFactory, "locales", "en-US", "en-US", False),
+            ("countries_overlap", CountryFactory, "countries", "US", "US", False),
+            ("languages_overlap", LanguageFactory, "languages", "en", "en", False),
+        ]
+    )
+    def test_rollout_conflict_warning_honors_audience(
+        self, _name, factory, field, live_code, draft_code, expect_none
+    ):
         feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            locales=[en],
+            **self._rollout_base(feature),
+            **{field: [factory.create(code=live_code)]},
         )
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            locales=[fr],
+            **self._rollout_base(feature),
+            **{field: [factory.create(code=draft_code)]},
         )
-        self.assertIsNone(experiment.rollout_conflict_warning)
+        if expect_none:
+            self.assertIsNone(experiment.rollout_conflict_warning)
+        else:
+            self.assertEqual(
+                experiment.rollout_conflict_warning["text"],
+                NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
+            )
 
-    def test_rollout_conflict_warning_disjoint_countries_no_warning(self):
+    def test_rollout_conflict_warning_empty_draft_audience_fires(self):
         feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
             name="test-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-        us = CountryFactory.create(code="US")
-        de = CountryFactory.create(code="DE")
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            countries=[us],
+            **self._rollout_base(feature),
+            locales=[LocaleFactory.create(code="en-US")],
         )
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            countries=[de],
-        )
-        self.assertIsNone(experiment.rollout_conflict_warning)
-
-    def test_rollout_conflict_warning_disjoint_languages_no_warning(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        en_lang = LanguageFactory.create(code="en")
-        fr_lang = LanguageFactory.create(code="fr")
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            languages=[en_lang],
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            languages=[fr_lang],
-        )
-        self.assertIsNone(experiment.rollout_conflict_warning)
-
-    def test_rollout_conflict_warning_overlapping_locales_fires(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        en = LocaleFactory.create(code="en-US")
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            locales=[en],
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            locales=[en],
-        )
-        warning = experiment.rollout_conflict_warning
-        self.assertIsNotNone(warning)
-        self.assertEqual(warning["text"], NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS)
-
-    def test_rollout_conflict_warning_draft_empty_locales_fires(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        en = LocaleFactory.create(code="en-US")
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            locales=[en],
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
+            **self._rollout_base(feature),
             locales=[],
         )
         self.assertIsNotNone(experiment.rollout_conflict_warning)
@@ -5162,29 +5002,17 @@ class TestNimbusExperiment(TestCase):
         de = LocaleFactory.create(code="de")
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
+            **self._rollout_base(feature),
             locales=[fr],
         )
         NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
+            **self._rollout_base(feature),
             locales=[en],
         )
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
+            **self._rollout_base(feature),
             locales=[en, de],
         )
         self.assertIsNotNone(experiment.rollout_conflict_warning)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4837,29 +4837,6 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            ("all_match", "en-US", "US", "en", "en-US", "US", "en", True),
-            ("locales_disjoint", "en-US", "US", "en", "fr", "US", "en", False),
-            ("countries_disjoint", "en-US", "US", "en", "en-US", "DE", "en", False),
-            ("languages_disjoint", "en-US", "US", "en", "en-US", "US", "fr", False),
-        ]
-    )
-    def test_audiences_overlap(
-        self, _name, a_loc, a_cty, a_lng, b_loc, b_cty, b_lng, expected
-    ):
-        a = NimbusExperimentFactory.create(
-            locales=[LocaleFactory.create(code=a_loc)],
-            countries=[CountryFactory.create(code=a_cty)],
-            languages=[LanguageFactory.create(code=a_lng)],
-        )
-        b = NimbusExperimentFactory.create(
-            locales=[LocaleFactory.create(code=b_loc)],
-            countries=[CountryFactory.create(code=b_cty)],
-            languages=[LanguageFactory.create(code=b_lng)],
-        )
-        self.assertEqual(a.audiences_overlap(b), expected)
-
-    @parameterized.expand(
-        [
             ("locales_disjoint", LocaleFactory, "locales", "en-US", "fr", []),
             ("countries_disjoint", CountryFactory, "countries", "US", "DE", []),
             ("languages_disjoint", LanguageFactory, "languages", "en", "fr", []),

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4829,7 +4829,7 @@ class TestNimbusExperiment(TestCase):
         self, _name, self_items, self_exclude, other_items, other_exclude, expected
     ):
         self.assertEqual(
-            NimbusExperiment._audience_dimension_overlap(
+            NimbusExperiment.audience_dimension_overlap(
                 self_items, self_exclude, other_items, other_exclude
             ),
             expected,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4814,37 +4814,125 @@ class TestNimbusExperiment(TestCase):
 
     @parameterized.expand(
         [
-            ("both_empty", [], False, [], False, True),
-            ("self_empty", [], False, ["en-US"], False, True),
-            ("other_empty", ["en-US"], False, [], False, True),
-            ("include_overlap", ["en-US", "fr"], False, ["fr"], False, True),
-            ("include_disjoint", ["en-US"], False, ["fr"], False, False),
-            ("self_exclude_covers_other", ["en-US", "fr"], True, ["en-US"], False, False),
-            ("self_exclude_partial", ["en-US"], True, ["en-US", "fr"], False, True),
-            ("other_exclude_covers_self", ["en-US"], False, ["en-US", "fr"], True, False),
-            ("both_exclude", ["en-US"], True, ["fr"], True, True),
+            ("both_empty_locales", LocaleFactory, "locales", [], False, [], False, True),
+            (
+                "self_empty_countries",
+                CountryFactory,
+                "countries",
+                [],
+                False,
+                ["US"],
+                False,
+                True,
+            ),
+            (
+                "other_empty_languages",
+                LanguageFactory,
+                "languages",
+                ["en"],
+                False,
+                [],
+                False,
+                True,
+            ),
+            (
+                "include_match_locales",
+                LocaleFactory,
+                "locales",
+                ["en-US"],
+                False,
+                ["en-US"],
+                False,
+                True,
+            ),
+            (
+                "include_disjoint_countries",
+                CountryFactory,
+                "countries",
+                ["US"],
+                False,
+                ["DE"],
+                False,
+                False,
+            ),
+            (
+                "self_exclude_covers_other_locales",
+                LocaleFactory,
+                "locales",
+                ["en-US", "fr"],
+                True,
+                ["en-US"],
+                False,
+                False,
+            ),
+            (
+                "self_exclude_partial_languages",
+                LanguageFactory,
+                "languages",
+                ["en"],
+                True,
+                ["en", "fr"],
+                False,
+                True,
+            ),
+            (
+                "other_exclude_covers_self_countries",
+                CountryFactory,
+                "countries",
+                ["US"],
+                False,
+                ["US", "DE"],
+                True,
+                False,
+            ),
+            (
+                "both_exclude_languages",
+                LanguageFactory,
+                "languages",
+                ["en"],
+                True,
+                ["fr"],
+                True,
+                True,
+            ),
         ]
     )
-    def test_audience_dimension_overlap(
-        self, _name, self_items, self_exclude, other_items, other_exclude, expected
+    def test_audience_overlap(
+        self,
+        _name,
+        factory,
+        field,
+        self_codes,
+        self_exclude,
+        other_codes,
+        other_exclude,
+        expected_overlap,
     ):
+        self_experiment = NimbusExperimentFactory.create(
+            slug="self-exp",
+            **{field: [factory.create(code=code) for code in self_codes]},
+            **{f"exclude_{field}": self_exclude},
+        )
+        other_experiment = NimbusExperimentFactory.create(
+            slug="other-exp",
+            **{field: [factory.create(code=code) for code in other_codes]},
+            **{f"exclude_{field}": other_exclude},
+        )
+        candidates = NimbusExperiment.objects.filter(id=other_experiment.id)
         self.assertEqual(
-            NimbusExperiment.audience_dimension_overlap(
-                self_items, self_exclude, other_items, other_exclude
-            ),
-            expected,
+            self_experiment.audience_overlapping_slugs(candidates),
+            ["other-exp"] if expected_overlap else [],
         )
 
     @parameterized.expand(
         [
-            ("locales_disjoint", LocaleFactory, "locales", "en-US", "fr", []),
-            ("countries_disjoint", CountryFactory, "countries", "US", "DE", []),
-            ("languages_disjoint", LanguageFactory, "languages", "en", "fr", []),
-            ("locales_overlap", LocaleFactory, "locales", "en-US", "en-US", ["peer"]),
+            ("locale", LocaleFactory, "locales", "en-US", "fr"),
+            ("country", CountryFactory, "countries", "US", "DE"),
+            ("language", LanguageFactory, "languages", "en", "fr"),
         ]
     )
-    def test_live_experiments_in_namespace_honors_audience(
-        self, _name, factory, field, live_code, draft_code, expected
+    def test_live_experiments_in_namespace_skips_disjoint_audience(
+        self, _name, factory, field, live_code, draft_code
     ):
         feature = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
@@ -4861,34 +4949,17 @@ class TestNimbusExperiment(TestCase):
             **self._namespace_base(feature),
             **{field: [factory.create(code=draft_code)]},
         )
-        self.assertEqual(list(experiment.live_experiments_in_namespace), expected)
-
-    def test_live_experiments_in_namespace_empty_draft_audience_overlaps(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        en = LocaleFactory.create(code="en-US")
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="peer",
-            locales=[en],
-            **self._namespace_base(feature),
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft",
-            **self._namespace_base(feature),
-        )
-        self.assertEqual(list(experiment.live_experiments_in_namespace), ["peer"])
+        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
 
     @parameterized.expand(
         [
-            ("disjoint", "fr", []),
-            ("overlap", "en-US", ["live-multi"]),
+            ("locale", LocaleFactory, "locales", "en-US", "fr"),
+            ("country", CountryFactory, "countries", "US", "DE"),
+            ("language", LanguageFactory, "languages", "en", "fr"),
         ]
     )
-    def test_feature_has_live_multifeature_experiments_honors_locales(
-        self, _name, draft_code, expected
+    def test_feature_has_live_multifeature_experiments_skips_disjoint_audience(
+        self, _name, factory, field, live_code, draft_code
     ):
         feature1 = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
@@ -4901,31 +4972,26 @@ class TestNimbusExperiment(TestCase):
             slug="live-multi",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature1, feature2],
-            locales=[LocaleFactory.create(code="en-US")],
+            **{field: [factory.create(code=live_code)]},
         )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="draft",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature1],
-            locales=[LocaleFactory.create(code=draft_code)],
+            **{field: [factory.create(code=draft_code)]},
         )
-        self.assertEqual(
-            list(experiment.feature_has_live_multifeature_experiments), expected
-        )
+        self.assertEqual(list(experiment.feature_has_live_multifeature_experiments), [])
 
     @parameterized.expand(
         [
-            ("locales_disjoint", LocaleFactory, "locales", "en-US", "fr", True),
-            ("countries_disjoint", CountryFactory, "countries", "US", "DE", True),
-            ("languages_disjoint", LanguageFactory, "languages", "en", "fr", True),
-            ("locales_overlap", LocaleFactory, "locales", "en-US", "en-US", False),
-            ("countries_overlap", CountryFactory, "countries", "US", "US", False),
-            ("languages_overlap", LanguageFactory, "languages", "en", "en", False),
+            ("locale", LocaleFactory, "locales", "en-US", "fr"),
+            ("country", CountryFactory, "countries", "US", "DE"),
+            ("language", LanguageFactory, "languages", "en", "fr"),
         ]
     )
-    def test_rollout_conflict_warning_honors_audience(
-        self, _name, factory, field, live_code, draft_code, expect_none
+    def test_rollout_conflict_warning_skips_disjoint_audience(
+        self, _name, factory, field, live_code, draft_code
     ):
         feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
@@ -4942,57 +5008,7 @@ class TestNimbusExperiment(TestCase):
             **self._rollout_base(feature),
             **{field: [factory.create(code=draft_code)]},
         )
-        if expect_none:
-            self.assertIsNone(experiment.rollout_conflict_warning)
-        else:
-            self.assertEqual(
-                experiment.rollout_conflict_warning["text"],
-                NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
-            )
-
-    def test_rollout_conflict_warning_empty_draft_audience_fires(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            **self._rollout_base(feature),
-            locales=[LocaleFactory.create(code="en-US")],
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            **self._rollout_base(feature),
-            locales=[],
-        )
-        self.assertIsNotNone(experiment.rollout_conflict_warning)
-
-    def test_rollout_conflict_warning_one_overlapping_of_many_fires(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        en = LocaleFactory.create(code="en-US")
-        fr = LocaleFactory.create(code="fr")
-        de = LocaleFactory.create(code="de")
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            **self._rollout_base(feature),
-            locales=[fr],
-        )
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            **self._rollout_base(feature),
-            locales=[en],
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            **self._rollout_base(feature),
-            locales=[en, de],
-        )
-        self.assertIsNotNone(experiment.rollout_conflict_warning)
+        self.assertIsNone(experiment.rollout_conflict_warning)
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4901,7 +4901,7 @@ class TestNimbusExperiment(TestCase):
         )
         candidates = NimbusExperiment.objects.filter(id=other_experiment.id)
         self.assertEqual(
-            self_experiment.audience_overlapping_slugs(candidates),
+            self_experiment.audience_targeting_overlap(candidates),
             ["other-exp"] if expected_overlap else [],
         )
 


### PR DESCRIPTION
Because

* Two experiments or rollouts with identical targeting except for region, language, or locale trigger audience-overlap warnings even though their target populations cannot overlap.
* This drives reviewers to adjust population sizing that does not actually need adjusting on the previous-namespace, multi-feature, and duplicate-rollout warnings.

This commit

* Adds `NimbusExperiment.audiences_overlap`, computing per-dimension intersection across locales, countries, and languages while honoring the `exclude_*` booleans.
* Uses it as a post-filter on `live_experiments_in_namespace`, `feature_has_live_multifeature_experiments`, and `rollout_conflict_warning` so disjoint audiences no longer raise the warning.
* Leaves `bucket_namespace` unchanged so allocation for live experiments does not shift.

Fixes #15405