### PR TITLE
feat(nimbus): Reset slack notification state when cloning

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2094,6 +2094,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         cloned._computed_end_date = None
         cloned.qa_status = NimbusExperiment.QAStatus.NOT_SET
         cloned.qa_comment = None
+        cloned.enable_review_slack_notifications = True
         cloned.risk_ai = None
         cloned.risk_brand = None
         cloned.risk_message = None

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4197,6 +4197,13 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertFalse(child.is_rollout_dirty)
 
+    def test_clone_resets_enable_review_slack_notifications(self):
+        parent = NimbusExperimentFactory.create(
+            enable_review_slack_notifications=False,
+        )
+        child = parent.clone("Child Experiment", parent.owner)
+        self.assertTrue(child.enable_review_slack_notifications)
+
     def _clone_experiment_and_assert_common_expectations(
         self, parent, rollout_branch_slug=None
     ):
@@ -4226,6 +4233,7 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(child.conclusion_recommendations, [])
         self.assertEqual(child.qa_status, NimbusExperiment.QAStatus.NOT_SET)
         self.assertEqual(child.qa_comment, None)
+        self.assertEqual(child.enable_review_slack_notifications, True)
         self.assertEqual(child.qa_run_date, None)
         self.assertEqual(child.qa_run_test_plan_url, None)
         self.assertEqual(child.qa_run_testrail_url, None)


### PR DESCRIPTION
Because

- By default we keep the slack notification state enabled, but when we clone the experiment we are copying the state from the parent, whereas we should reset the state and turned the slack notification by default.

This commit
-  Turns on the default state for the newly cloned experiment

Fixes #15412 