### PR TITLE
fix(nimbus): use airplane mode for fenix integration test network disable

### DIFF
--- a/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
+++ b/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
@@ -31,8 +31,9 @@ def test_fenix_enrollment(
     # Prevent the real Nimbus RS fetch from overwriting our local enrollment
     # (without this, Nimbus evolves against the fresh fetch — which does not
     # contain our test experiment — and unenrolls us).
-    subprocess.check_call(["adb", "shell", "svc", "wifi", "disable"])
-    subprocess.check_call(["adb", "shell", "svc", "data", "disable"])
+    subprocess.check_call(
+        ["adb", "shell", "cmd", "connectivity", "airplane-mode", "enable"]
+    )
 
     subprocess.check_call(
         [


### PR DESCRIPTION
Because

* `adb shell svc wifi disable` + `adb shell svc data disable` return before the emulator's network stack has actually torn down. Fenix can start in that window, open a socket to production Remote Settings, and complete the background `maybeFetchExperiments` fetch before our enroll intent finishes — which causes Nimbus to evolve against the fresh prod-RS list, unenroll our local test experiment, and enroll a real production experiment on the same feature slot. The release matrix job fails with `No log-state row found for fenix-release-integration-test` and the logcat dump shows e.g. `long-term-holdback-2025-h1-growth-android` instead.

This commit

* Replaces the two `svc` commands with a single `adb shell cmd connectivity airplane-mode enable`. `cmd connectivity` returns after the airplane-mode broadcast has propagated and all radios are down, so Fenix cannot reach prod RS by the time `nimbus-cli enroll` launches the app.

Fixes #15417