### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/cirrus/server/cirrus/experiment_recipes.py
+++ b/cirrus/server/cirrus/experiment_recipes.py
@@ -51,7 +51,7 @@ class RemoteSettings:
         self.sdk.set_experiments(json.dumps(self.recipes))
 
     def fetch_recipes(self) -> None:
-        response = self.session.get(self.url)
+        response = self.session.get(self.url, timeout=(2, 10))
         response.raise_for_status()
         response_json = response.json()
         data = response_json.get("changes")

--- a/cirrus/server/cirrus/experiment_recipes.py
+++ b/cirrus/server/cirrus/experiment_recipes.py
@@ -51,7 +51,7 @@ class RemoteSettings:
         self.sdk.set_experiments(json.dumps(self.recipes))
 
     def fetch_recipes(self) -> None:
-        response = self.session.get(self.url, timeout=(2, 10))
+        response = self.session.get(self.url, timeout=(5, 10))
         response.raise_for_status()
         response_json = response.json()
         data = response_json.get("changes")

--- a/experimenter/experimenter/cirrus/middleware.py
+++ b/experimenter/experimenter/cirrus/middleware.py
@@ -54,6 +54,7 @@ class CirrusMiddleware:
                         "context": {},
                     },
                     params=params,
+                    timeout=(2, 5),
                 )
                 cirrus_response.raise_for_status()
                 response_json = cirrus_response.json()
@@ -61,6 +62,8 @@ class CirrusMiddleware:
                     enrollments=response_json["Enrollments"],
                     features=CirrusFeatures(response_json["Features"]),
                 )
+            except requests.exceptions.Timeout as e:
+                sentry_sdk.capture_exception(e)
             except (KeyError, requests.exceptions.RequestException) as e:
                 sentry_sdk.capture_exception(e)
         return self.get_response(request)

--- a/experimenter/experimenter/cirrus/middleware.py
+++ b/experimenter/experimenter/cirrus/middleware.py
@@ -54,7 +54,7 @@ class CirrusMiddleware:
                         "context": {},
                     },
                     params=params,
-                    timeout=(2, 5),
+                    timeout=(5, 10),
                 )
                 cirrus_response.raise_for_status()
                 response_json = cirrus_response.json()


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `High` | **File**: `experimenter/experimenter/cirrus/middleware.py:L52`

The middleware performs a blocking `requests.post()` to `CIRRUS_URL` without a timeout. A slow or unresponsive Cirrus service can tie up Django worker threads/processes, enabling denial-of-service through request pileups.

## Solution

Set explicit connect/read timeouts (for example, `timeout=(2, 5)`) and handle timeout exceptions separately. Consider circuit-breaking/fallback behavior (e.g., skip Cirrus enrichment on timeout) to preserve application availability.

## Changes

- `experimenter/experimenter/cirrus/middleware.py` (modified)
- `cirrus/server/cirrus/experiment_recipes.py` (modified)