### PR TITLE
feat(nimbus): Add advanced targeting for new users in New Tab 151.2.20260328.211913 train hop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -47,6 +47,7 @@ NEED_DEFAULT = "!isDefaultBrowser"
 PROFILE28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"
 PROFILELESSTHAN28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 < 28"
 PROFILELESSTHAN1HOUR = "(currentDate|date - profileAgeCreated|date) / 3600000 < 1"
+PROFILELESSTHAN2DAYS = "(currentDate|date - profileAgeCreated|date) / 3600000 < 48"
 PROFILEMORETHAN7DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 > 7"
 NEW_PROFILE = "(currentDate|date - profileAgeCreated|date) / 3600000 <= 24"
 NEW_NON_SELECTABLE_PROFILE = f"({NEW_PROFILE}) && profileGroupProfileCount == 0"
@@ -4282,6 +4283,24 @@ FX_151_3_TRAINHOP = NimbusTargetingConfig(
     targeting="newtabAddonVersion|versionCompare('151.3.20260419.192959') >= 0",
     desktop_telemetry="",
     sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FX_151_2_TRAINHOP_NEW_USERS = NimbusTargetingConfig(
+    name="New users with New Tab Fx151 Mar-28 Trainhop",
+    slug="newtab-151-0328-trainhop-new-users",
+    description=(
+        "Desktop new users with profile age less than 48 hours "
+        "having the New Tab 151.2.20260328.211913 train hop, "
+        "which includes users of Fx149"
+    ),
+    targeting=(
+        f"{PROFILELESSTHAN2DAYS} && "
+        f"{FX_151_2_TRAINHOP.targeting}"
+    )
+    desktop_telemetry="",
+    sticky_required=True,
     is_first_run_required=False,
     application_choice_names=(Application.DESKTOP.name,),
 )

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4295,10 +4295,7 @@ FX_151_2_TRAINHOP_NEW_USERS = NimbusTargetingConfig(
         "having the New Tab 151.2.20260328.211913 train hop, "
         "which includes users of Fx149"
     ),
-    targeting=(
-        f"{PROFILELESSTHAN2DAYS} && "
-        f"{FX_151_2_TRAINHOP.targeting}"
-    )
+    targeting=f"{PROFILELESSTHAN2DAYS} && {FX_151_2_TRAINHOP.targeting}",
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,


### PR DESCRIPTION
To support the [Kitified value prop on new tab experiment](https://docs.google.com/document/d/1TfMktdm5MFNrg15AYlIE6dOqpXGWvDhM8GQrsmrW3Jk/edit?tab=t.0) this commit adds advanced targeting that covers:
- New users (profile age less than 48 hours)
- New Tab 151.2.20260328.211913 train hop