### PR TITLE
fix(nimbus): update targeting field validation to use additional preserved fields

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -37,6 +37,7 @@ from experimenter.experiments.models import (
     NimbusVersionedSchema,
 )
 from experimenter.features.manifests.nimbus_fml_loader import NimbusFmlLoader
+from experimenter.targeting.constants import PRESERVED_TARGETING_KEYS_BY_APPLICATION
 from experimenter.targeting.targeting_context_parser import TargetingContextFields
 
 logger = logging.getLogger()
@@ -1861,6 +1862,11 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             fields = set(
                 TargetingContextFields.for_application(
                     data.get("application"), targeting_context_version
+                )
+            )
+            fields.update(
+                PRESERVED_TARGETING_KEYS_BY_APPLICATION.get(
+                    data.get("application"), set()
                 )
             )
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -4514,6 +4514,28 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         self.assertEqual(serializer.warnings, {})
 
+    def test_validate_targeting_config_uses_preserved_targeting_keys(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            firefox_max_version=NimbusExperiment.Version.FIREFOX_121,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+        )
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        with patch(
+            "experimenter.experiments.api.v5.serializers.extract_targeting_fields",
+            return_value={"knownField", "newtabAddonVersion", "defaultProfile", "userId"},
+        ):
+            self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        self.assertEqual(serializer.warnings, {})
+
 
 class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
     def setUp(self):


### PR DESCRIPTION
Because

- When we added validation for targeting configs against targeting context fields within the experiment version range, we didn’t include preserved targeting fields in the set of fields being validated
- This caused some experiments to incorrectly show errors during review

This commit

- Adds preserved targeting fields to the set of fields validated per application

Fixes #15429 