### PR TITLE
fix(nimbus): filter targeting config versions by application 

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1850,7 +1850,8 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         versions = (
             NimbusFeatureVersion.objects.filter(
-                NimbusFeatureVersion.objects.between_versions_q(min_version, max_version)
+                NimbusFeatureVersion.objects.between_versions_q(min_version, max_version),
+                schemas__feature_config__application=data.get("application"),
             )
             .order_by("-major", "-minor", "-patch")
             .distinct()

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -4421,6 +4421,14 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         warn_feature_schema,
         expected_valid,
     ):
+        NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.build(version=self.versions[(120, 0, 0)]),
+                NimbusVersionedSchemaFactory.build(version=self.versions[(121, 0, 0)]),
+            ],
+        )
+
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -4469,6 +4477,15 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         min_version,
         max_version,
     ):
+        NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.build(version=self.versions[(120, 0, 0)]),
+                NimbusVersionedSchemaFactory.build(version=self.versions[(121, 0, 0)]),
+                NimbusVersionedSchemaFactory.build(version=self.versions[(122, 0, 0)]),
+            ],
+        )
+
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -4493,6 +4510,14 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         self.assertEqual(serializer.warnings, {})
 
     def test_validate_targeting_configs_assume_unversioned_uses_unversioned_context(self):
+        NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.build(version=self.versions[(120, 0, 0)]),
+                NimbusVersionedSchemaFactory.build(version=self.versions[(121, 0, 0)]),
+            ],
+        )
+
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -4515,6 +4540,14 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         self.assertEqual(serializer.warnings, {})
 
     def test_validate_targeting_config_uses_preserved_targeting_keys(self):
+        NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.build(version=self.versions[(120, 0, 0)]),
+                NimbusVersionedSchemaFactory.build(version=self.versions[(121, 0, 0)]),
+            ],
+        )
+
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,


### PR DESCRIPTION
Because

- The targeting config validation was querying all `NimbusFeatureVersion` records globally without filtering by application, causing versions from other apps (e.g., desktop 152.0.0) to appear in ios validation and fail

This commit

- Adds `schemas__feature_config__application` filter to the version query so we only include versions that have schemas defined for the specific application

Fixes #15432