### PR TITLE
fix(nimbus): add missing fenix targeting keys to preserved list

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/RecordedNimbusContext.kt
@@ -1,0 +1,6 @@
+val obj = JSONObject(
+    mapOf(
+        "knownField" to knownField,
+    ),
+)
+return obj

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v120.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v120.0.0/RecordedNimbusContext.kt
@@ -1,0 +1,6 @@
+val obj = JSONObject(
+    mapOf(
+        "knownField" to knownField,
+    ),
+)
+return obj

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v121.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v121.0.0/RecordedNimbusContext.kt
@@ -1,0 +1,6 @@
+val obj = JSONObject(
+    mapOf(
+        "knownField" to knownField,
+    ),
+)
+return obj

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v122.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v122.0.0/RecordedNimbusContext.kt
@@ -1,0 +1,6 @@
+val obj = JSONObject(
+    mapOf(
+        "knownField" to knownField,
+    ),
+)
+return obj

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v123.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v123.0.0/RecordedNimbusContext.kt
@@ -1,0 +1,6 @@
+val obj = JSONObject(
+    mapOf(
+        "knownField" to knownField,
+    ),
+)
+return obj

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/RecordedNimbusContext.swift
@@ -1,0 +1,3 @@
+guard let data = try? JSONSerialization.data(withJSONObject: [
+    "knownField": knownField,
+]),

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v120.0.0/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v120.0.0/RecordedNimbusContext.swift
@@ -1,0 +1,3 @@
+guard let data = try? JSONSerialization.data(withJSONObject: [
+    "knownField": knownField,
+]),

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v121.0.0/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v121.0.0/RecordedNimbusContext.swift
@@ -1,0 +1,3 @@
+guard let data = try? JSONSerialization.data(withJSONObject: [
+    "knownField": knownField,
+]),

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v122.0.0/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v122.0.0/RecordedNimbusContext.swift
@@ -1,0 +1,3 @@
+guard let data = try? JSONSerialization.data(withJSONObject: [
+    "knownField": knownField,
+]),

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v123.0.0/RecordedNimbusContext.swift
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/ios/v123.0.0/RecordedNimbusContext.swift
@@ -1,0 +1,3 @@
+guard let data = try? JSONSerialization.data(withJSONObject: [
+    "knownField": knownField,
+]),

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -4539,9 +4539,36 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         self.assertEqual(serializer.warnings, {})
 
-    def test_validate_targeting_config_uses_preserved_targeting_keys(self):
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+                {"knownField", "newtabAddonVersion", "defaultProfile", "userId"},
+            ),
+            (
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.TargetingConfig.MOBILE_FIRST_RUN,
+                {
+                    "knownField",
+                    "nimbus_id",
+                    "isFirstRun",
+                    "is_large_device",
+                    "number_of_app_launches",
+                },
+            ),
+            (
+                NimbusExperiment.Application.IOS,
+                NimbusExperiment.TargetingConfig.MOBILE_FIRST_RUN,
+                {"knownField", "current_date", "nimbus_id"},
+            ),
+        ]
+    )
+    def test_validate_targeting_config_uses_preserved_targeting_keys(
+        self, app, targeting_config, extracted_fields
+    ):
         NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP,
+            application=app,
             schemas=[
                 NimbusVersionedSchemaFactory.build(version=self.versions[(120, 0, 0)]),
                 NimbusVersionedSchemaFactory.build(version=self.versions[(121, 0, 0)]),
@@ -4550,10 +4577,11 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
+            application=app,
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_121,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
+            targeting_config_slug=targeting_config,
+            is_sticky=True,
         )
         serializer = NimbusReviewSerializer(
             experiment,
@@ -4563,7 +4591,7 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
 
         with patch(
             "experimenter.experiments.api.v5.serializers.extract_targeting_fields",
-            return_value={"knownField", "newtabAddonVersion", "defaultProfile", "userId"},
+            return_value=extracted_fields,
         ):
             self.assertTrue(serializer.is_valid(), serializer.errors)
 

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -38,7 +38,13 @@ PRESERVED_TARGETING_KEYS_BY_APPLICATION = {
         "localeLanguageCode",
         "attachedFxAOAuthClients",
     },
-    Application.FENIX: {"current_date", "nimbus_id"},
+    Application.FENIX: {
+        "current_date",
+        "nimbus_id",
+        "isFirstRun",
+        "is_large_device",
+        "number_of_app_launches",
+    },
     Application.IOS: {"current_date", "nimbus_id"},
 }
 


### PR DESCRIPTION
Because

- We discovered that targeting keys are being sourced from multiple locations where there is some overlap of keys with the same name but with different casing (e.g. `isFirstRun` vs `is_first_run`)
- These inconsistencies cause certain valid targeting fields to be missed during validation, since casing differences prevent them from matching expected keys causing some experiments to incorrectly surface validation errors despite technically using valid targeting fields

This commit

- Adds several missing keys to the persevered targeting field list
- Adds tests for mobile experiments using preserved keys

Fixes #15452 