### PR TITLE
feat(nimbus): add advanced targeting for win10 eos hnt experiments

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4319,6 +4319,50 @@ FX_151_2_TRAINHOP_NEW_USERS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_151_3_TRAINHOP_WIN10_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
+    name=(
+        "Existing Windows 10 users with New Tab Fx151 Apr-19 Trainhop, "
+        "having default and needing pin",
+    ),
+    slug="newtab-151-0419-trainhop-win10-users-has-default-need-pin",
+    description=(
+        "Desktop Windows 10 users having default and needing pin, "
+        "with profiles older than 28 days, "
+        "having the New Tab 151.3.20260419.192959 train hop, "
+        "which includes users of Fx150"
+    ),
+    targeting=(
+        f"{PROFILE28DAYS} && {FX_151_3_TRAINHOP.targeting} && "
+        f"{WIN10_NOT_WIN11.targeting} && !{NEED_DEFAULT} && !{HAS_PIN}",
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FX_151_3_TRAINHOP_WIN10_NEED_DEFAULT_NEED_PIN = NimbusTargetingConfig(
+    name=(
+        "Existing Windows 10 users with New Tab Fx151 Apr-19 Trainhop, "
+        "needing default and pin",
+    ),
+    slug="newtab-151-0419-trainhop-win10-users-need-default-need-pin",
+    description=(
+        "Desktop Windows 10 users needing default and pin, "
+        "with profiles older than 28 days, "
+        "having the New Tab 151.3.20260419.192959 train hop, "
+        "which includes users of Fx150"
+    ),
+    targeting=(
+        f"{PROFILE28DAYS} && {FX_151_3_TRAINHOP.targeting} && "
+        f"{WIN10_NOT_WIN11.targeting} && {NEED_DEFAULT} && !{HAS_PIN}",
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4322,7 +4322,7 @@ FX_151_2_TRAINHOP_NEW_USERS = NimbusTargetingConfig(
 FX_151_3_TRAINHOP_WIN10_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     name=(
         "Existing Windows 10 users with New Tab Fx151 Apr-19 Trainhop, "
-        "having default and needing pin",
+        "having default and needing pin"
     ),
     slug="newtab-151-0419-trainhop-win10-users-has-default-need-pin",
     description=(
@@ -4333,7 +4333,7 @@ FX_151_3_TRAINHOP_WIN10_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     ),
     targeting=(
         f"{PROFILE28DAYS} && {FX_151_3_TRAINHOP.targeting} && "
-        f"{WIN10_NOT_WIN11.targeting} && !{NEED_DEFAULT} && !{HAS_PIN}",
+        f"{WIN10_NOT_WIN11.targeting} && !{NEED_DEFAULT} && !{HAS_PIN}"
     ),
     desktop_telemetry="",
     sticky_required=False,
@@ -4344,7 +4344,7 @@ FX_151_3_TRAINHOP_WIN10_HAS_DEFAULT_NEED_PIN = NimbusTargetingConfig(
 FX_151_3_TRAINHOP_WIN10_NEED_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     name=(
         "Existing Windows 10 users with New Tab Fx151 Apr-19 Trainhop, "
-        "needing default and pin",
+        "needing default and pin"
     ),
     slug="newtab-151-0419-trainhop-win10-users-need-default-need-pin",
     description=(
@@ -4355,7 +4355,7 @@ FX_151_3_TRAINHOP_WIN10_NEED_DEFAULT_NEED_PIN = NimbusTargetingConfig(
     ),
     targeting=(
         f"{PROFILE28DAYS} && {FX_151_3_TRAINHOP.targeting} && "
-        f"{WIN10_NOT_WIN11.targeting} && {NEED_DEFAULT} && !{HAS_PIN}",
+        f"{WIN10_NOT_WIN11.targeting} && {NEED_DEFAULT} && !{HAS_PIN}"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
To support the win10 EoS HNT differentiation/privacy experiments ([pin](https://docs.google.com/document/d/1aqBTR_Ia9fN1lci8XfWcsvxyoEVw-0KRYBgpQJt3b60/edit?tab=t.0) and [default](https://docs.google.com/document/d/1uuBOPg5FEENN-8w8bbIti02ffshTi-h2tOICetlRHtw/edit?tab=t.0)) this commit adds advanced targeting that covers:
- For the pin version:
    - Win10 users
    - Profile age 28 days and older
    - New Tab 151.3.20260419.192959 train hop
    - Is already set to default
    - Does NOT have Firefox pinned
- For the default version:
    - Win10 users
    - Profile age 28 days and older
    - New Tab 151.3.20260419.192959 train hop
    - Is NOT set to default
    - Does NOT have Firefox pinned