### PR TITLE
feat(nimbus): simplify collision warnings

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1873,6 +1873,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         deliveries_by_slug = {}
 
+        excluded_reason = {
+            "label": (
+                NimbusUIConstants.COLLISION_LABEL_EXCLUDED_BY_ROLLOUT
+                if self.is_rollout
+                else NimbusUIConstants.COLLISION_LABEL_EXCLUDED_BY_EXPERIMENT
+            ),
+            "detail": NimbusUIConstants.COLLISION_DETAIL_EXCLUDED,
+        }
         for slug in self.excluded_live_deliveries:
             entry = deliveries_by_slug.setdefault(
                 slug,
@@ -1881,21 +1889,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "reasons": [],
                 },
             )
-            entry["reasons"].append(
-                {
-                    "label": (
-                        "Excluded by this rollout"
-                        if self.is_rollout
-                        else "Excluded by this experiment"
-                    ),
-                    "detail": (
-                        "Clients enrolled in this delivery are filtered out of "
-                        "the eligible population, which may reduce statistical "
-                        "power and precision. Verify the configured population "
-                        "proportion accounts for this."
-                    ),
-                }
-            )
+            entry["reasons"].append(excluded_reason)
 
         for collision in self._slot_collisions():
             entry = deliveries_by_slug.setdefault(
@@ -1908,44 +1902,36 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
             entry["reasons"].append(
                 {
-                    "label_prefix": "Shares feature",
+                    "label_prefix": NimbusUIConstants.COLLISION_LABEL_SHARES_FEATURE,
                     "shared_features": [
                         _feature_link(f) for f in collision["shared_features"]
                     ],
-                    "detail": (
-                        "This live delivery already holds the feature slot "
-                        "for contested clients; this delivery will not "
-                        "enroll them."
-                    ),
+                    "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
                 }
             )
             if collision["same_namespace"]:
                 entry["reasons"].append(
                     {
-                        "label": "Shares an audience",
-                        "detail": (
-                            "This live delivery shares the same audience, so "
-                            "each client can only be enrolled in one of these. "
-                            "This reduces the eligible population and may reduce "
-                            "statistical power and precision. Verify the "
-                            "configured population proportion accounts for this."
-                        ),
+                        "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
+                        "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
                     }
                 )
             if collision["matching_configuration"]:
                 entry["reasons"].append(
                     {
-                        "label": "Has matching configuration",
+                        "label": (
+                            NimbusUIConstants.COLLISION_LABEL_MATCHING_CONFIGURATION
+                        ),
                         "detail": (
-                            "A live rollout already exists with the same "
-                            "application, feature, channel, and advanced "
-                            "targeting. Clients meeting the targeting will enroll "
-                            "in one or the other, and the sizing for this rollout "
-                            "cannot be adjusted."
+                            NimbusUIConstants.COLLISION_DETAIL_MATCHING_CONFIGURATION
                         ),
                     }
                 )
 
+        pref_reason = {
+            "label": NimbusUIConstants.COLLISION_LABEL_SETS_SAME_PREFERENCE,
+            "detail": NimbusUIConstants.COLLISION_DETAIL_SETS_SAME_PREFERENCE,
+        }
         for slug in self._pref_collision_slugs():
             entry = deliveries_by_slug.setdefault(
                 slug,
@@ -1954,17 +1940,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "reasons": [],
                 },
             )
-            entry["reasons"].append(
-                {
-                    "label": "Sets the same preference",
-                    "detail": (
-                        "This live rollout sets the same Firefox preference as "
-                        "this delivery. The collision may reduce the eligible "
-                        "population or prevent enrollment entirely. Verify the "
-                        "configured population proportion accounts for this."
-                    ),
-                }
-            )
+            entry["reasons"].append(pref_reason)
 
         deliveries = sorted(deliveries_by_slug.values(), key=lambda d: d["slug"])
         return {"deliveries": deliveries}
@@ -2199,7 +2175,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if version_warning := self.rollout_version_warning:
             self_issues.append(
                 {
-                    "label": "Firefox version below the rollout minimum",
+                    "label": (
+                        NimbusUIConstants.COLLISION_SELF_ISSUE_VERSION_BELOW_MINIMUM
+                    ),
                     "detail": version_warning["text"],
                 }
             )
@@ -2207,7 +2185,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
             self_issues.append(
                 {
-                    "label": "Targeting multiple channels",
+                    "label": NimbusUIConstants.COLLISION_SELF_ISSUE_MULTICHANNEL,
                     "detail": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
                 }
             )
@@ -2228,12 +2206,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def _collision_card_header(self, entries, self_issues):
         target = "rollout" if self.is_rollout else "experiment"
         if entries and self_issues:
-            return f"WARNING: Issues that may affect enrollment for this {target}:"
-        if entries:
-            return (
-                f"WARNING: The following live {target}s may conflict with this {target}:"
+            return NimbusUIConstants.COLLISION_CARD_HEADER_SELF_AND_COLLISIONS.format(
+                target=target
             )
-        return f"WARNING: Issues with this {target}:"
+        if entries:
+            return NimbusUIConstants.COLLISION_CARD_HEADER_COLLISIONS_ONLY.format(
+                target=target
+            )
+        return NimbusUIConstants.COLLISION_CARD_HEADER_SELF_ONLY.format(target=target)
 
     @property
     def has_results_errors(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1713,35 +1713,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         ]
 
     @property
-    def feature_has_live_overlapping_deliveries(self):
-        live_deliveries = NimbusExperiment.objects.filter(
-            status=self.Status.LIVE,
-            application=self.application,
-            is_rollout=self.is_rollout,
-        )
-        if not live_deliveries.exists():
-            return []
-
-        draft_feature_slugs = set(
-            self.feature_configs.all().values_list("slug", flat=True)
-        )
-        candidates = (
-            live_deliveries.filter(feature_configs__slug__in=draft_feature_slugs)
-            .exclude(id=self.id)
-            .order_by("slug")
-        )
-        overlapping_slugs = set(self.audience_overlap(candidates))
-        details = []
-        for candidate in candidates.filter(slug__in=overlapping_slugs).distinct():
-            shared = sorted(
-                draft_feature_slugs
-                & set(candidate.feature_configs.all().values_list("slug", flat=True))
-            )
-            details.append({"slug": candidate.slug, "shared_features": shared})
-        details.sort(key=lambda entry: entry["slug"])
-        return details
-
-    @property
     def excluded_live_deliveries(self):
         matching = []
         if self.excluded_experiments.exists():
@@ -1757,21 +1728,262 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
         return matching
 
-    @property
-    def live_experiments_in_namespace(self):
-        experiment_ids = NimbusBucketRange.objects.filter(
-            isolation_group__name=self.bucket_namespace,
-            isolation_group__application=self.application,
-        ).values_list("experiment_id", flat=True)
+    def _feature_allows_coenrollment(self, feature_config):
+        if not self.firefox_min_version:
+            return False
+        min_version = NimbusExperiment.Version.parse(self.firefox_min_version)
+        max_version = (
+            NimbusExperiment.Version.parse(self.firefox_max_version)
+            if self.firefox_max_version
+            else None
+        )
+        schemas = feature_config.get_versioned_schema_range(
+            min_version, max_version
+        ).schemas
+        return bool(schemas) and all(schema.allow_coenrollment for schema in schemas)
+
+    def _slot_collisions(self):
+        contesting_features = [
+            fc
+            for fc in self.feature_configs.all()
+            if not self._feature_allows_coenrollment(fc)
+        ]
+        if not contesting_features:
+            return []
+
+        contesting_ids = [fc.id for fc in contesting_features]
+        feature_by_id = {fc.id: fc for fc in contesting_features}
+
         candidates = (
             NimbusExperiment.objects.filter(
-                id__in=experiment_ids,
-                status=NimbusExperiment.Status.LIVE,
+                status=self.Status.LIVE,
+                application=self.application,
+                is_rollout=self.is_rollout,
+                feature_configs__id__in=contesting_ids,
             )
             .exclude(id=self.id)
+            .distinct()
             .order_by("slug")
         )
-        return self.audience_overlap(candidates)
+        overlapping_slugs = set(self.audience_overlap(candidates))
+        if not overlapping_slugs:
+            return []
+
+        self_namespace = self.bucket_namespace
+        collisions = []
+        for candidate in candidates.filter(slug__in=overlapping_slugs):
+            candidate_feature_ids = set(
+                candidate.feature_configs.values_list("id", flat=True)
+            )
+            shared_ids = sorted(set(contesting_ids) & candidate_feature_ids)
+            shared_features = [
+                {"slug": feature_by_id[fid].slug, "id": fid} for fid in shared_ids
+            ]
+
+            same_namespace = candidate.bucket_namespace == self_namespace
+            matching_configuration = bool(
+                self.is_rollout
+                and self.targeting_config_slug
+                and candidate.targeting_config_slug == self.targeting_config_slug
+                and candidate.channel == self.channel
+                and same_namespace
+            )
+
+            publish_date_relation = None
+            if self.is_rollout and candidate._start_date:
+                if not self._start_date or candidate._start_date < self._start_date:
+                    publish_date_relation = "blocked_by"
+                else:
+                    publish_date_relation = "would_block"
+
+            if self.is_rollout:
+                # Rollout slot is exclusive: an earlier-published rollout claims
+                # the entire overlapping audience.
+                estimated_loss = (
+                    Decimal(1) if publish_date_relation == "blocked_by" else Decimal(0)
+                )
+            else:
+                # Experiments contend by bucket fraction: each colliding live
+                # experiment claims roughly its population_percent of the shared
+                # bucket-eligible audience.
+                estimated_loss = (candidate.population_percent or Decimal(0)) / Decimal(
+                    100
+                )
+
+            collisions.append(
+                {
+                    "slug": candidate.slug,
+                    "shared_features": shared_features,
+                    "same_namespace": same_namespace,
+                    "matching_configuration": matching_configuration,
+                    "publish_date_relation": publish_date_relation,
+                    "estimated_loss": estimated_loss,
+                }
+            )
+
+        return collisions
+
+    def _pref_collision_slugs(self):
+        if not (self.is_desktop and not self.is_rollout and self.prevent_pref_conflicts):
+            return []
+        pref_setting_feature_ids = (
+            self.feature_configs.exclude(schemas__set_pref_vars={})
+            .distinct()
+            .values_list("id", flat=True)
+        )
+        if not pref_setting_feature_ids:
+            return []
+        return list(
+            NimbusExperiment.objects.filter(
+                status=self.Status.LIVE,
+                application=self.application,
+                channels__overlap=self.channels,
+                feature_configs__id__in=pref_setting_feature_ids,
+                is_rollout=True,
+            )
+            .exclude(id=self.id)
+            .distinct()
+            .order_by("slug")
+            .values_list("slug", flat=True)
+        )
+
+    @property
+    def collision_warnings(self):
+        if self.status not in (self.Status.DRAFT, self.Status.PREVIEW):
+            return {"deliveries": [], "estimated_loss_percent": 0}
+
+        features_url = reverse("nimbus-ui-features")
+
+        def _feature_link(feature):
+            return {
+                "slug": feature["slug"],
+                "url": (
+                    f"{features_url}?application={self.application}"
+                    f"&feature_configs={feature['id']}"
+                ),
+            }
+
+        deliveries_by_slug = {}
+
+        for slug in self.excluded_live_deliveries:
+            entry = deliveries_by_slug.setdefault(
+                slug,
+                {
+                    "slug": slug,
+                    "reasons": [],
+                    "publish_date_relation": None,
+                    "estimated_loss": Decimal(0),
+                },
+            )
+            entry["reasons"].append(
+                {
+                    "label": (
+                        "Excluded by this rollout"
+                        if self.is_rollout
+                        else "Excluded by this experiment"
+                    ),
+                    "detail": (
+                        "Clients enrolled in this delivery are filtered out of "
+                        "the eligible population, which may reduce statistical "
+                        "power and precision. Verify the configured population "
+                        "proportion accounts for this."
+                    ),
+                }
+            )
+
+        for collision in self._slot_collisions():
+            entry = deliveries_by_slug.setdefault(
+                collision["slug"],
+                {
+                    "slug": collision["slug"],
+                    "reasons": [],
+                    "publish_date_relation": None,
+                    "estimated_loss": Decimal(0),
+                },
+            )
+            entry["publish_date_relation"] = collision["publish_date_relation"]
+            entry["estimated_loss"] = max(
+                entry["estimated_loss"], collision["estimated_loss"]
+            )
+
+            entry["reasons"].append(
+                {
+                    "label_prefix": "Shares feature",
+                    "shared_features": [
+                        _feature_link(f) for f in collision["shared_features"]
+                    ],
+                    "detail": (
+                        "Rollouts share feature slots — the earliest-published "
+                        "rollout claims the slot, and this rollout will not enroll "
+                        "any clients eligible for both."
+                        if self.is_rollout
+                        else "Both deliveries use this feature, contending for the "
+                        "same eligible population, which may reduce statistical "
+                        "power and precision. Verify the configured population "
+                        "proportion accounts for this."
+                    ),
+                }
+            )
+            if collision["same_namespace"]:
+                entry["reasons"].append(
+                    {
+                        "label": "Shares an audience",
+                        "detail": (
+                            "This live delivery shares the same audience, so "
+                            "each client can only be enrolled in one of these. "
+                            "This reduces the eligible population and may reduce "
+                            "statistical power and precision. Verify the "
+                            "configured population proportion accounts for this."
+                        ),
+                    }
+                )
+            if collision["matching_configuration"]:
+                entry["reasons"].append(
+                    {
+                        "label": "Has matching configuration",
+                        "detail": (
+                            "A live rollout already exists with the same "
+                            "application, feature, channel, and advanced "
+                            "targeting. Clients meeting the targeting will enroll "
+                            "in one or the other, and the sizing for this rollout "
+                            "cannot be adjusted."
+                        ),
+                    }
+                )
+
+        for slug in self._pref_collision_slugs():
+            entry = deliveries_by_slug.setdefault(
+                slug,
+                {
+                    "slug": slug,
+                    "reasons": [],
+                    "publish_date_relation": None,
+                    "estimated_loss": Decimal(0),
+                },
+            )
+            entry["reasons"].append(
+                {
+                    "label": "Sets the same preference",
+                    "detail": (
+                        "This live rollout sets the same Firefox preference as "
+                        "this delivery. The collision may reduce the eligible "
+                        "population or prevent enrollment entirely. Verify the "
+                        "configured population proportion accounts for this."
+                    ),
+                }
+            )
+
+        deliveries = sorted(deliveries_by_slug.values(), key=lambda d: d["slug"])
+
+        total_loss = sum((d["estimated_loss"] for d in deliveries), start=Decimal(0))
+        if total_loss > Decimal(1):
+            total_loss = Decimal(1)
+        estimated_loss_percent = int((total_loss * Decimal(100)).to_integral_value())
+
+        return {
+            "deliveries": deliveries,
+            "estimated_loss_percent": estimated_loss_percent,
+        }
 
     @property
     def can_edit(self):
@@ -1961,28 +2173,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.publish_status == self.PublishStatus.WAITING and review_expired
 
     @property
-    def rollout_conflict_warning(self):
-        if not self.is_rollout:
-            return None
-
-        duplicate_rollouts = NimbusExperiment.objects.filter(
-            status=self.Status.LIVE,
-            channel=self.channel,
-            application=self.application,
-            targeting_config_slug=self.targeting_config_slug,
-            feature_configs__in=self.feature_configs.all(),
-            is_rollout=True,
-        ).exclude(id=self.id)
-
-        if self.audience_overlap(duplicate_rollouts):
-            return {
-                "text": NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS,
-                "variant": "danger",
-                "slugs": [],
-                "learn_more_link": NimbusUIConstants.ROLLOUT_BUCKET_WARNING,
-            }
-
-    @property
     def rollout_version_warning(self):
         if not self.is_rollout or not self.firefox_min_version:
             return None
@@ -2008,103 +2198,52 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             }
 
     @property
-    def pref_targeting_rollout_collision_warning(self):
-        if self.is_desktop and not self.is_rollout and self.prevent_pref_conflicts:
-            colliding_experiments = NimbusExperiment.objects.filter(
-                status=self.Status.LIVE,
-                application=self.application,
-                channels__overlap=self.channels,
-                feature_configs__id__in=self.feature_configs.exclude(
-                    schemas__set_pref_vars={}
-                )
-                .distinct()
-                .values_list("id", flat=True),
-                is_rollout=True,
-            ).values_list("slug", flat=True)
-
-            if colliding_experiments:
-                return {
-                    "text": NimbusUIConstants.PREF_TARGETING_WARNING,
-                    "variant": "warning",
-                    "slugs": list(colliding_experiments),
-                    "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                }
-
-    @property
     def audience_overlap_warnings(self):
         warnings = []
-        excluded_live_deliveries = ""
-        if self.excluded_live_deliveries:
-            excluded_live_deliveries = ", ".join(self.excluded_live_deliveries)
 
-        feature_overlap_details = self.feature_has_live_overlapping_deliveries
-        feature_overlap_slugs = [entry["slug"] for entry in feature_overlap_details]
-        feature_has_live_overlapping_deliveries = ", ".join(feature_overlap_slugs)
+        if self.status not in [
+            NimbusConstants.Status.DRAFT,
+            NimbusConstants.Status.PREVIEW,
+        ]:
+            return warnings
 
-        live_experiments_in_namespace = ""
-        if self.live_experiments_in_namespace:
-            live_experiments_in_namespace = ", ".join(self.live_experiments_in_namespace)
+        collisions = self.collision_warnings
+        if collisions["deliveries"]:
+            text = (
+                "WARNING: The following live rollouts may conflict with this rollout:"
+                if self.is_rollout
+                else "WARNING: The following live experiments may conflict with "
+                "this experiment:"
+            )
+            warnings.append(
+                {
+                    "text": text,
+                    "entries": [
+                        {
+                            "slug": d["slug"],
+                            "reasons": d["reasons"],
+                            "publish_date_relation": d["publish_date_relation"],
+                        }
+                        for d in collisions["deliveries"]
+                    ],
+                    "estimated_loss_percent": collisions["estimated_loss_percent"],
+                    "variant": "warning",
+                    "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
+                }
+            )
 
-        overlapping_warnings = (
-            feature_has_live_overlapping_deliveries
-            and live_experiments_in_namespace
-            and feature_has_live_overlapping_deliveries in live_experiments_in_namespace
-        )
+        if rollout_version_warning := self.rollout_version_warning:
+            warnings.append(rollout_version_warning)
 
-        if self.status in [NimbusConstants.Status.DRAFT, NimbusConstants.Status.PREVIEW]:
-            if excluded_live_deliveries:
-                warnings.append(
-                    {
-                        "text": NimbusUIConstants.EXCLUDING_EXPERIMENTS_WARNING,
-                        "slugs": self.excluded_live_deliveries,
-                        "variant": "warning",
-                        "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                    }
-                )
-
-            if live_experiments_in_namespace and not overlapping_warnings:
-                warnings.append(
-                    {
-                        "text": NimbusUIConstants.LIVE_EXPERIMENTS_BUCKET_WARNING,
-                        "slugs": self.live_experiments_in_namespace,
-                        "variant": "warning",
-                        "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                    }
-                )
-
-            if feature_has_live_overlapping_deliveries:
-                warnings.append(
-                    {
-                        "text": (
-                            NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
-                            if self.is_rollout
-                            else NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
-                        ),
-                        "slugs": feature_overlap_slugs,
-                        "details": feature_overlap_details,
-                        "variant": "warning",
-                        "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                    }
-                )
-
-            if rollout_conflict_warning := self.rollout_conflict_warning:
-                warnings.append(rollout_conflict_warning)
-
-            if rollout_version_warning := self.rollout_version_warning:
-                warnings.append(rollout_version_warning)
-
-            if pref_collision_warning := self.pref_targeting_rollout_collision_warning:
-                warnings.append(pref_collision_warning)
-
-            if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
-                warnings.append(
-                    {
-                        "text": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
-                        "slugs": [],
-                        "variant": "warning",
-                        "learn_more_link": "",
-                    }
-                )
+        if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
+            warnings.append(
+                {
+                    "text": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
+                    "slugs": [],
+                    "variant": "warning",
+                    "learn_more_link": "",
+                }
+            )
 
         return warnings
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1754,6 +1754,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         contesting_ids = [fc.id for fc in contesting_features]
         feature_by_id = {fc.id: fc for fc in contesting_features}
 
+        # Same-polarity only: cross-polarity (rollout-vs-experiment) is a
+        # value-override case at value-resolution time
+        # (map_features_by_feature_id in enrollment.rs) and does not produce
+        # a FeatureConflict — both deliveries still enroll. We only warn on
+        # the case where one side fully refuses to enroll.
         candidates = (
             NimbusExperiment.objects.filter(
                 status=self.Status.LIVE,
@@ -1789,12 +1794,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 and same_namespace
             )
 
+            # Within polarity the SDK sorts by publish date and the earlier
+            # recipe claims the feature slot — the loser gets FeatureConflict.
+            # Applies identically to experiments and rollouts.
             publish_date_relation = None
-            if self.is_rollout and candidate._start_date:
-                if not self._start_date or candidate._start_date < self._start_date:
-                    publish_date_relation = "blocked_by"
-                else:
-                    publish_date_relation = "would_block"
+            if candidate._start_date and (
+                not self._start_date or candidate._start_date < self._start_date
+            ):
+                publish_date_relation = "blocked_by"
+            elif candidate._start_date:
+                publish_date_relation = "would_block"
 
             collisions.append(
                 {
@@ -1882,7 +1891,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "slug": collision["slug"],
                     "reasons": [],
                     "publish_date_relation": None,
-                    "estimated_loss": Decimal(0),
                 },
             )
             entry["publish_date_relation"] = collision["publish_date_relation"]
@@ -1894,14 +1902,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         _feature_link(f) for f in collision["shared_features"]
                     ],
                     "detail": (
-                        "Rollouts share feature slots — the earliest-published "
-                        "rollout claims the slot, and this rollout will not enroll "
-                        "any clients eligible for both."
-                        if self.is_rollout
-                        else "Both deliveries use this feature, contending for the "
-                        "same eligible population, which may reduce statistical "
-                        "power and precision. Verify the configured population "
-                        "proportion accounts for this."
+                        "Both deliveries use this feature. The earlier-"
+                        "published delivery claims the feature slot for "
+                        "any contested client; the later one will not "
+                        "enroll those clients."
                     ),
                 }
             )

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1714,21 +1714,32 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def feature_has_live_overlapping_deliveries(self):
-        matching = []
         live_deliveries = NimbusExperiment.objects.filter(
             status=self.Status.LIVE,
             application=self.application,
             is_rollout=self.is_rollout,
         )
-        if live_deliveries.exists():
-            feature_slugs = self.feature_configs.all().values_list("slug", flat=True)
-            candidates = (
-                live_deliveries.filter(feature_configs__slug__in=feature_slugs)
-                .exclude(id=self.id)
-                .order_by("slug")
+        if not live_deliveries.exists():
+            return []
+
+        draft_feature_slugs = set(
+            self.feature_configs.all().values_list("slug", flat=True)
+        )
+        candidates = (
+            live_deliveries.filter(feature_configs__slug__in=draft_feature_slugs)
+            .exclude(id=self.id)
+            .order_by("slug")
+        )
+        overlapping_slugs = set(self.audience_overlap(candidates))
+        details = []
+        for candidate in candidates.filter(slug__in=overlapping_slugs).distinct():
+            shared = sorted(
+                draft_feature_slugs
+                & set(candidate.feature_configs.all().values_list("slug", flat=True))
             )
-            matching = self.audience_overlap(candidates)
-        return matching
+            details.append({"slug": candidate.slug, "shared_features": shared})
+        details.sort(key=lambda entry: entry["slug"])
+        return details
 
     @property
     def excluded_live_deliveries(self):
@@ -2026,11 +2037,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.excluded_live_deliveries:
             excluded_live_deliveries = ", ".join(self.excluded_live_deliveries)
 
-        feature_has_live_overlapping_deliveries = ""
-        if self.feature_has_live_overlapping_deliveries:
-            feature_has_live_overlapping_deliveries = ", ".join(
-                self.feature_has_live_overlapping_deliveries
-            )
+        feature_overlap_details = self.feature_has_live_overlapping_deliveries
+        feature_overlap_slugs = [entry["slug"] for entry in feature_overlap_details]
+        feature_has_live_overlapping_deliveries = ", ".join(feature_overlap_slugs)
 
         live_experiments_in_namespace = ""
         if self.live_experiments_in_namespace:
@@ -2071,7 +2080,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                             if self.is_rollout
                             else NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
                         ),
-                        "slugs": self.feature_has_live_overlapping_deliveries,
+                        "slugs": feature_overlap_slugs,
+                        "details": feature_overlap_details,
                         "variant": "warning",
                         "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
                     }

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -21,7 +21,7 @@ from django.core.files.base import ContentFile
 from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MaxValueValidator
 from django.db import models
-from django.db.models import Case, Count, F, Prefetch, Q, QuerySet, When
+from django.db.models import Case, F, Prefetch, Q, QuerySet, When
 from django.db.models.constraints import UniqueConstraint
 from django.urls import reverse
 from django.utils import timezone
@@ -1713,13 +1713,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         ]
 
     def channels_overlap(self, candidate):
-        no_channel = NimbusExperiment.Channel.NO_CHANNEL
+        matches_all = {"", NimbusExperiment.Channel.NO_CHANNEL}
         if self.is_desktop:
-            self_channels = set(self.channels) - {"", no_channel}
-            candidate_channels = set(candidate.channels) - {"", no_channel}
+            self_channels = set(self.channels) - matches_all
+            candidate_channels = set(candidate.channels) - matches_all
         else:
-            self_channels = {self.channel} - {"", no_channel}
-            candidate_channels = {candidate.channel} - {"", no_channel}
+            self_channels = {self.channel} - matches_all
+            candidate_channels = {candidate.channel} - matches_all
         if not self_channels or not candidate_channels:
             return True
         return bool(self_channels & candidate_channels)

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1908,9 +1908,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         _feature_link(f) for f in collision["shared_features"]
                     ],
                     "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
-                    "learn_more_url": (
-                        NimbusUIConstants.COLLISION_LEARN_MORE_SHARES_FEATURE
-                    ),
                 }
             )
             if collision["same_namespace"]:
@@ -1918,9 +1915,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     {
                         "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
                         "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
-                        "learn_more_url": (
-                            NimbusUIConstants.COLLISION_LEARN_MORE_SHARES_AUDIENCE
-                        ),
                     }
                 )
             if collision["matching_configuration"]:
@@ -2201,9 +2195,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 {
                     "label": NimbusUIConstants.COLLISION_SELF_ISSUE_MULTICHANNEL,
                     "detail": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
-                    "learn_more_url": (
-                        NimbusUIConstants.COLLISION_LEARN_MORE_MULTICHANNEL
-                    ),
                 }
             )
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1712,7 +1712,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
         ]
 
-    def _channels_overlap(self, candidate):
+    def channels_overlap(self, candidate):
         no_channel = NimbusExperiment.Channel.NO_CHANNEL
         if self.is_desktop:
             self_channels = set(self.channels) - {"", no_channel}
@@ -1724,15 +1724,13 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return True
         return bool(self_channels & candidate_channels)
 
-    def _targeting_configs_overlap(self, candidate):
-        no_targeting = NimbusExperiment.TargetingConfig.NO_TARGETING
-        self_slug = self.targeting_config_slug
-        candidate_slug = candidate.targeting_config_slug
-        self_has = self_slug and self_slug != no_targeting
-        candidate_has = candidate_slug and candidate_slug != no_targeting
-        if not self_has or not candidate_has:
-            return True
-        return self_slug == candidate_slug
+    def targeting_configs_overlap(self, candidate):
+        matches_all = {"", NimbusExperiment.TargetingConfig.NO_TARGETING}
+        return (
+            self.targeting_config_slug in matches_all
+            or candidate.targeting_config_slug in matches_all
+            or self.targeting_config_slug == candidate.targeting_config_slug
+        )
 
     @property
     def excluded_live_deliveries(self):
@@ -1750,7 +1748,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
         return matching
 
-    def _feature_allows_coenrollment(self, feature_config):
+    def feature_allows_coenrollment(self, feature_config):
         if not self.firefox_min_version:
             return False
         min_version = NimbusExperiment.Version.parse(self.firefox_min_version)
@@ -1764,11 +1762,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         ).schemas
         return bool(schemas) and all(schema.allow_coenrollment for schema in schemas)
 
-    def _slot_collisions(self):
+    def slot_collisions(self):
         contesting_features = [
             fc
             for fc in self.feature_configs.all()
-            if not self._feature_allows_coenrollment(fc)
+            if not self.feature_allows_coenrollment(fc)
         ]
         if not contesting_features:
             return []
@@ -1799,9 +1797,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         self_namespace = self.bucket_namespace
         collisions = []
         for candidate in candidates.filter(slug__in=overlapping_slugs):
-            if not self._channels_overlap(candidate):
+            if not self.channels_overlap(candidate):
                 continue
-            if not self._targeting_configs_overlap(candidate):
+            if not self.targeting_configs_overlap(candidate):
                 continue
             candidate_feature_ids = set(
                 candidate.feature_configs.values_list("id", flat=True)
@@ -1831,7 +1829,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         return collisions
 
-    def _pref_collision_slugs(self):
+    def pref_collision_slugs(self):
         if not (self.is_desktop and not self.is_rollout and self.prevent_pref_conflicts):
             return []
         pref_setting_feature_ids = (
@@ -1855,25 +1853,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             .values_list("slug", flat=True)
         )
 
-    @property
-    def collision_warnings(self):
-        if self.status not in (self.Status.DRAFT, self.Status.PREVIEW):
-            return {"deliveries": []}
-
-        features_url = reverse("nimbus-ui-features")
-
-        def _feature_link(feature):
-            return {
-                "slug": feature["slug"],
-                "url": (
-                    f"{features_url}?application={self.application}"
-                    f"&feature_configs={feature['id']}"
-                ),
-            }
-
-        deliveries_by_slug = {}
-
-        excluded_reason = {
+    def excluded_collision_reasons(self):
+        reason = {
             "label": (
                 NimbusUIConstants.COLLISION_LABEL_EXCLUDED_BY_ROLLOUT
                 if self.is_rollout
@@ -1882,72 +1863,87 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             "detail": NimbusUIConstants.COLLISION_DETAIL_EXCLUDED,
             "learn_more_url": NimbusUIConstants.COLLISION_LEARN_MORE_EXCLUDED,
         }
-        for slug in self.excluded_live_deliveries:
-            entry = deliveries_by_slug.setdefault(
-                slug,
-                {
-                    "slug": slug,
-                    "reasons": [],
-                },
-            )
-            entry["reasons"].append(excluded_reason)
+        return [(slug, reason) for slug in self.excluded_live_deliveries]
 
-        for collision in self._slot_collisions():
-            entry = deliveries_by_slug.setdefault(
-                collision["slug"],
-                {
-                    "slug": collision["slug"],
-                    "reasons": [],
-                },
-            )
+    def slot_collision_reasons(self):
+        features_url = reverse("nimbus-ui-features")
 
-            entry["reasons"].append(
-                {
-                    "label_prefix": NimbusUIConstants.COLLISION_LABEL_SHARES_FEATURE,
-                    "shared_features": [
-                        _feature_link(f) for f in collision["shared_features"]
-                    ],
-                    "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
-                    "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                }
+        def feature_link(feature):
+            return {
+                "slug": feature["slug"],
+                "url": (
+                    f"{features_url}?application={self.application}"
+                    f"&feature_configs={feature['id']}"
+                ),
+            }
+
+        pairs = []
+        for collision in self.slot_collisions():
+            slug = collision["slug"]
+            pairs.append(
+                (
+                    slug,
+                    {
+                        "label_prefix": NimbusUIConstants.COLLISION_LABEL_SHARES_FEATURE,
+                        "shared_features": [
+                            feature_link(f) for f in collision["shared_features"]
+                        ],
+                        "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
+                        "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
+                    },
+                )
             )
             if collision["same_namespace"]:
-                entry["reasons"].append(
-                    {
-                        "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
-                        "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
-                        "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
-                    }
+                pairs.append(
+                    (
+                        slug,
+                        {
+                            "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
+                            "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
+                            "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
+                        },
+                    )
                 )
             if collision["matching_configuration"]:
-                entry["reasons"].append(
-                    {
-                        "label": (
-                            NimbusUIConstants.COLLISION_LABEL_MATCHING_CONFIGURATION
-                        ),
-                        "detail": (
-                            NimbusUIConstants.COLLISION_DETAIL_MATCHING_CONFIGURATION
-                        ),
-                        "learn_more_url": (
-                            NimbusUIConstants.COLLISION_LEARN_MORE_MATCHING_CONFIGURATION
-                        ),
-                    }
+                pairs.append(
+                    (
+                        slug,
+                        {
+                            "label": (
+                                NimbusUIConstants.COLLISION_LABEL_MATCHING_CONFIGURATION
+                            ),
+                            "detail": (
+                                NimbusUIConstants.COLLISION_DETAIL_MATCHING_CONFIGURATION
+                            ),
+                            "learn_more_url": (
+                                NimbusUIConstants.COLLISION_LEARN_MORE_MATCHING_CONFIGURATION
+                            ),
+                        },
+                    )
                 )
+        return pairs
 
-        pref_reason = {
+    def pref_collision_reasons(self):
+        reason = {
             "label": NimbusUIConstants.COLLISION_LABEL_SETS_SAME_PREFERENCE,
             "detail": NimbusUIConstants.COLLISION_DETAIL_SETS_SAME_PREFERENCE,
             "learn_more_url": NimbusUIConstants.COLLISION_LEARN_MORE_SETS_SAME_PREFERENCE,
         }
-        for slug in self._pref_collision_slugs():
-            entry = deliveries_by_slug.setdefault(
-                slug,
-                {
-                    "slug": slug,
-                    "reasons": [],
-                },
-            )
-            entry["reasons"].append(pref_reason)
+        return [(slug, reason) for slug in self.pref_collision_slugs()]
+
+    @property
+    def collision_warnings(self):
+        if self.status not in (self.Status.DRAFT, self.Status.PREVIEW):
+            return {"deliveries": []}
+
+        deliveries_by_slug = {}
+        for slug, reason in (
+            *self.excluded_collision_reasons(),
+            *self.slot_collision_reasons(),
+            *self.pref_collision_reasons(),
+        ):
+            entry = deliveries_by_slug.setdefault(slug, {"slug": slug, "reasons": []})
+            entry["reasons"].append(reason)
 
         deliveries = sorted(deliveries_by_slug.values(), key=lambda d: d["slug"])
         return {"deliveries": deliveries}
@@ -2205,7 +2201,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         return [
             {
-                "text": self._collision_card_header(entries, self_issues),
+                "text": self.collision_card_header(entries, self_issues),
                 "entries": entries,
                 "self_issues": self_issues,
                 "variant": "warning",
@@ -2213,7 +2209,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             }
         ]
 
-    def _collision_card_header(self, entries, self_issues):
+    def collision_card_header(self, entries, self_issues):
         target = "rollout" if self.is_rollout else "experiment"
         if entries and self_issues:
             return NimbusUIConstants.COLLISION_CARD_HEADER_SELF_AND_COLLISIONS.format(

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1713,18 +1713,17 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         ]
 
     @property
-    def feature_has_live_multifeature_experiments(self):
+    def feature_has_live_overlapping_deliveries(self):
         matching = []
-        live_experiments = NimbusExperiment.objects.filter(
+        live_deliveries = NimbusExperiment.objects.filter(
             status=self.Status.LIVE,
             application=self.application,
+            is_rollout=self.is_rollout,
         )
-        if live_experiments.exists():
+        if live_deliveries.exists():
             feature_slugs = self.feature_configs.all().values_list("slug", flat=True)
             candidates = (
-                live_experiments.annotate(n_feature_configs=Count("feature_configs"))
-                .filter(n_feature_configs__gt=1)
-                .filter(feature_configs__slug__in=feature_slugs)
+                live_deliveries.filter(feature_configs__slug__in=feature_slugs)
                 .exclude(id=self.id)
                 .order_by("slug")
             )
@@ -2027,10 +2026,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.excluded_live_deliveries:
             excluded_live_deliveries = ", ".join(self.excluded_live_deliveries)
 
-        feature_has_live_multifeature_experiments = ""
-        if self.feature_has_live_multifeature_experiments:
-            feature_has_live_multifeature_experiments = ", ".join(
-                self.feature_has_live_multifeature_experiments
+        feature_has_live_overlapping_deliveries = ""
+        if self.feature_has_live_overlapping_deliveries:
+            feature_has_live_overlapping_deliveries = ", ".join(
+                self.feature_has_live_overlapping_deliveries
             )
 
         live_experiments_in_namespace = ""
@@ -2038,9 +2037,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             live_experiments_in_namespace = ", ".join(self.live_experiments_in_namespace)
 
         overlapping_warnings = (
-            feature_has_live_multifeature_experiments
+            feature_has_live_overlapping_deliveries
             and live_experiments_in_namespace
-            and feature_has_live_multifeature_experiments in live_experiments_in_namespace
+            and feature_has_live_overlapping_deliveries in live_experiments_in_namespace
         )
 
         if self.status in [NimbusConstants.Status.DRAFT, NimbusConstants.Status.PREVIEW]:
@@ -2064,11 +2063,15 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     }
                 )
 
-            if feature_has_live_multifeature_experiments:
+            if feature_has_live_overlapping_deliveries:
                 warnings.append(
                     {
-                        "text": NimbusUIConstants.LIVE_MULTIFEATURE_WARNING,
-                        "slugs": self.feature_has_live_multifeature_experiments,
+                        "text": (
+                            NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
+                            if self.is_rollout
+                            else NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
+                        ),
+                        "slugs": self.feature_has_live_overlapping_deliveries,
                         "variant": "warning",
                         "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
                     }

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1712,6 +1712,28 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
         ]
 
+    def _channels_overlap(self, candidate):
+        no_channel = NimbusExperiment.Channel.NO_CHANNEL
+        if self.is_desktop:
+            self_channels = set(self.channels) - {"", no_channel}
+            candidate_channels = set(candidate.channels) - {"", no_channel}
+        else:
+            self_channels = {self.channel} - {"", no_channel}
+            candidate_channels = {candidate.channel} - {"", no_channel}
+        if not self_channels or not candidate_channels:
+            return True
+        return bool(self_channels & candidate_channels)
+
+    def _targeting_configs_overlap(self, candidate):
+        no_targeting = NimbusExperiment.TargetingConfig.NO_TARGETING
+        self_slug = self.targeting_config_slug
+        candidate_slug = candidate.targeting_config_slug
+        self_has = self_slug and self_slug != no_targeting
+        candidate_has = candidate_slug and candidate_slug != no_targeting
+        if not self_has or not candidate_has:
+            return True
+        return self_slug == candidate_slug
+
     @property
     def excluded_live_deliveries(self):
         matching = []
@@ -1777,6 +1799,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         self_namespace = self.bucket_namespace
         collisions = []
         for candidate in candidates.filter(slug__in=overlapping_slugs):
+            if not self._channels_overlap(candidate):
+                continue
+            if not self._targeting_configs_overlap(candidate):
+                continue
             candidate_feature_ids = set(
                 candidate.feature_configs.values_list("id", flat=True)
             )

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1794,24 +1794,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 and same_namespace
             )
 
-            # Within polarity the SDK sorts by publish date and the earlier
-            # recipe claims the feature slot — the loser gets FeatureConflict.
-            # Applies identically to experiments and rollouts.
-            publish_date_relation = None
-            if candidate._start_date and (
-                not self._start_date or candidate._start_date < self._start_date
-            ):
-                publish_date_relation = "blocked_by"
-            elif candidate._start_date:
-                publish_date_relation = "would_block"
-
             collisions.append(
                 {
                     "slug": candidate.slug,
                     "shared_features": shared_features,
                     "same_namespace": same_namespace,
                     "matching_configuration": matching_configuration,
-                    "publish_date_relation": publish_date_relation,
                 }
             )
 
@@ -1865,7 +1853,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 {
                     "slug": slug,
                     "reasons": [],
-                    "publish_date_relation": None,
                 },
             )
             entry["reasons"].append(
@@ -1890,10 +1877,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 {
                     "slug": collision["slug"],
                     "reasons": [],
-                    "publish_date_relation": None,
                 },
             )
-            entry["publish_date_relation"] = collision["publish_date_relation"]
 
             entry["reasons"].append(
                 {
@@ -1902,10 +1887,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         _feature_link(f) for f in collision["shared_features"]
                     ],
                     "detail": (
-                        "Both deliveries use this feature. The earlier-"
-                        "published delivery claims the feature slot for "
-                        "any contested client; the later one will not "
-                        "enroll those clients."
+                        "This live delivery already holds the feature slot "
+                        "for contested clients; this delivery will not "
+                        "enroll them."
                     ),
                 }
             )
@@ -1942,7 +1926,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 {
                     "slug": slug,
                     "reasons": [],
-                    "publish_date_relation": None,
                 },
             )
             entry["reasons"].append(
@@ -2182,12 +2165,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         collisions = self.collision_warnings
         entries = [
-            {
-                "slug": d["slug"],
-                "reasons": d["reasons"],
-                "publish_date_relation": d["publish_date_relation"],
-            }
-            for d in collisions["deliveries"]
+            {"slug": d["slug"], "reasons": d["reasons"]} for d in collisions["deliveries"]
         ]
 
         self_issues = []

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1796,20 +1796,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 else:
                     publish_date_relation = "would_block"
 
-            if self.is_rollout:
-                # Rollout slot is exclusive: an earlier-published rollout claims
-                # the entire overlapping audience.
-                estimated_loss = (
-                    Decimal(1) if publish_date_relation == "blocked_by" else Decimal(0)
-                )
-            else:
-                # Experiments contend by bucket fraction: each colliding live
-                # experiment claims roughly its population_percent of the shared
-                # bucket-eligible audience.
-                estimated_loss = (candidate.population_percent or Decimal(0)) / Decimal(
-                    100
-                )
-
             collisions.append(
                 {
                     "slug": candidate.slug,
@@ -1817,7 +1803,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "same_namespace": same_namespace,
                     "matching_configuration": matching_configuration,
                     "publish_date_relation": publish_date_relation,
-                    "estimated_loss": estimated_loss,
                 }
             )
 
@@ -1850,7 +1835,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def collision_warnings(self):
         if self.status not in (self.Status.DRAFT, self.Status.PREVIEW):
-            return {"deliveries": [], "estimated_loss_percent": 0}
+            return {"deliveries": []}
 
         features_url = reverse("nimbus-ui-features")
 
@@ -1872,7 +1857,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "slug": slug,
                     "reasons": [],
                     "publish_date_relation": None,
-                    "estimated_loss": Decimal(0),
                 },
             )
             entry["reasons"].append(
@@ -1902,9 +1886,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 },
             )
             entry["publish_date_relation"] = collision["publish_date_relation"]
-            entry["estimated_loss"] = max(
-                entry["estimated_loss"], collision["estimated_loss"]
-            )
 
             entry["reasons"].append(
                 {
@@ -1958,7 +1939,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     "slug": slug,
                     "reasons": [],
                     "publish_date_relation": None,
-                    "estimated_loss": Decimal(0),
                 },
             )
             entry["reasons"].append(
@@ -1974,16 +1954,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             )
 
         deliveries = sorted(deliveries_by_slug.values(), key=lambda d: d["slug"])
-
-        total_loss = sum((d["estimated_loss"] for d in deliveries), start=Decimal(0))
-        if total_loss > Decimal(1):
-            total_loss = Decimal(1)
-        estimated_loss_percent = int((total_loss * Decimal(100)).to_integral_value())
-
-        return {
-            "deliveries": deliveries,
-            "estimated_loss_percent": estimated_loss_percent,
-        }
+        return {"deliveries": deliveries}
 
     @property
     def can_edit(self):
@@ -2241,7 +2212,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 "text": self._collision_card_header(entries, self_issues),
                 "entries": entries,
                 "self_issues": self_issues,
-                "estimated_loss_percent": collisions["estimated_loss_percent"],
                 "variant": "warning",
                 "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
             }

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1908,6 +1908,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         _feature_link(f) for f in collision["shared_features"]
                     ],
                     "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
+                    "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
                 }
             )
             if collision["same_namespace"]:
@@ -1915,6 +1916,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     {
                         "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
                         "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
+                        "learn_more_url": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
                     }
                 )
             if collision["matching_configuration"]:

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2199,53 +2199,63 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def audience_overlap_warnings(self):
-        warnings = []
-
         if self.status not in [
             NimbusConstants.Status.DRAFT,
             NimbusConstants.Status.PREVIEW,
         ]:
-            return warnings
+            return []
 
         collisions = self.collision_warnings
-        if collisions["deliveries"]:
-            text = (
-                "WARNING: The following live rollouts may conflict with this rollout:"
-                if self.is_rollout
-                else "WARNING: The following live experiments may conflict with "
-                "this experiment:"
-            )
-            warnings.append(
+        entries = [
+            {
+                "slug": d["slug"],
+                "reasons": d["reasons"],
+                "publish_date_relation": d["publish_date_relation"],
+            }
+            for d in collisions["deliveries"]
+        ]
+
+        self_issues = []
+
+        if version_warning := self.rollout_version_warning:
+            self_issues.append(
                 {
-                    "text": text,
-                    "entries": [
-                        {
-                            "slug": d["slug"],
-                            "reasons": d["reasons"],
-                            "publish_date_relation": d["publish_date_relation"],
-                        }
-                        for d in collisions["deliveries"]
-                    ],
-                    "estimated_loss_percent": collisions["estimated_loss_percent"],
-                    "variant": "warning",
-                    "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
+                    "label": "Firefox version below the rollout minimum",
+                    "detail": version_warning["text"],
                 }
             )
-
-        if rollout_version_warning := self.rollout_version_warning:
-            warnings.append(rollout_version_warning)
 
         if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
-            warnings.append(
+            self_issues.append(
                 {
-                    "text": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
-                    "slugs": [],
-                    "variant": "warning",
-                    "learn_more_link": "",
+                    "label": "Targeting multiple channels",
+                    "detail": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
                 }
             )
 
-        return warnings
+        if not entries and not self_issues:
+            return []
+
+        return [
+            {
+                "text": self._collision_card_header(entries, self_issues),
+                "entries": entries,
+                "self_issues": self_issues,
+                "estimated_loss_percent": collisions["estimated_loss_percent"],
+                "variant": "warning",
+                "learn_more_link": NimbusUIConstants.AUDIENCE_OVERLAP_WARNING,
+            }
+        ]
+
+    def _collision_card_header(self, entries, self_issues):
+        target = "rollout" if self.is_rollout else "experiment"
+        if entries and self_issues:
+            return f"WARNING: Issues that may affect enrollment for this {target}:"
+        if entries:
+            return (
+                f"WARNING: The following live {target}s may conflict with this {target}:"
+            )
+        return f"WARNING: Issues with this {target}:"
 
     @property
     def has_results_errors(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1880,6 +1880,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 else NimbusUIConstants.COLLISION_LABEL_EXCLUDED_BY_EXPERIMENT
             ),
             "detail": NimbusUIConstants.COLLISION_DETAIL_EXCLUDED,
+            "learn_more_url": NimbusUIConstants.COLLISION_LEARN_MORE_EXCLUDED,
         }
         for slug in self.excluded_live_deliveries:
             entry = deliveries_by_slug.setdefault(
@@ -1907,6 +1908,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         _feature_link(f) for f in collision["shared_features"]
                     ],
                     "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_FEATURE,
+                    "learn_more_url": (
+                        NimbusUIConstants.COLLISION_LEARN_MORE_SHARES_FEATURE
+                    ),
                 }
             )
             if collision["same_namespace"]:
@@ -1914,6 +1918,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     {
                         "label": NimbusUIConstants.COLLISION_LABEL_SHARES_AUDIENCE,
                         "detail": NimbusUIConstants.COLLISION_DETAIL_SHARES_AUDIENCE,
+                        "learn_more_url": (
+                            NimbusUIConstants.COLLISION_LEARN_MORE_SHARES_AUDIENCE
+                        ),
                     }
                 )
             if collision["matching_configuration"]:
@@ -1925,12 +1932,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         "detail": (
                             NimbusUIConstants.COLLISION_DETAIL_MATCHING_CONFIGURATION
                         ),
+                        "learn_more_url": (
+                            NimbusUIConstants.COLLISION_LEARN_MORE_MATCHING_CONFIGURATION
+                        ),
                     }
                 )
 
         pref_reason = {
             "label": NimbusUIConstants.COLLISION_LABEL_SETS_SAME_PREFERENCE,
             "detail": NimbusUIConstants.COLLISION_DETAIL_SETS_SAME_PREFERENCE,
+            "learn_more_url": NimbusUIConstants.COLLISION_LEARN_MORE_SETS_SAME_PREFERENCE,
         }
         for slug in self._pref_collision_slugs():
             entry = deliveries_by_slug.setdefault(
@@ -2179,6 +2190,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                         NimbusUIConstants.COLLISION_SELF_ISSUE_VERSION_BELOW_MINIMUM
                     ),
                     "detail": version_warning["text"],
+                    "learn_more_url": (
+                        NimbusUIConstants.COLLISION_LEARN_MORE_VERSION_BELOW_MINIMUM
+                    ),
                 }
             )
 
@@ -2187,6 +2201,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 {
                     "label": NimbusUIConstants.COLLISION_SELF_ISSUE_MULTICHANNEL,
                     "detail": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
+                    "learn_more_url": (
+                        NimbusUIConstants.COLLISION_LEARN_MORE_MULTICHANNEL
+                    ),
                 }
             )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2675,7 +2675,7 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
-    def test_excluding_experiments_warning(self):
+    def test_collision_warnings_excluded(self):
         draft_feature = NimbusFeatureConfigFactory.create(
             slug="draft-only-feature",
             application=NimbusExperiment.Application.DESKTOP,
@@ -2710,16 +2710,17 @@ class TestNimbusExperiment(TestCase):
                 branch_slug=None,
             )
 
-        warnings = draft.audience_overlap_warnings
-        self.assertEqual(len(warnings), 1)
+        deliveries = draft.collision_warnings["deliveries"]
         self.assertEqual(
-            warnings[0]["text"], NimbusUIConstants.EXCLUDING_EXPERIMENTS_WARNING
+            [d["slug"] for d in deliveries], [excluded_one.slug, excluded_two.slug]
         )
-        self.assertEqual(
-            list(warnings[0]["slugs"]), [excluded_one.slug, excluded_two.slug]
-        )
+        for delivery in deliveries:
+            self.assertEqual(len(delivery["reasons"]), 1)
+            self.assertEqual(
+                delivery["reasons"][0]["label"], "Excluded by this experiment"
+            )
 
-    def test_live_feature_overlap_warning(self):
+    def test_collision_warnings_shares_feature_experiment(self):
         feature_a = NimbusFeatureConfigFactory.create(
             slug="feature-a",
             application=NimbusExperiment.Application.DESKTOP,
@@ -2736,6 +2737,7 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
             feature_configs=[feature_a, feature_b],
+            population_percent=Decimal("50"),
         )
         draft = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
@@ -2746,61 +2748,310 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[feature_a],
         )
 
-        warnings = draft.audience_overlap_warnings
-        feature_overlap_warning = next(
-            (
-                w
-                for w in warnings
-                if w["text"] == NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
-            ),
-            None,
+        result = draft.collision_warnings
+        self.assertEqual(len(result["deliveries"]), 1)
+        delivery = result["deliveries"][0]
+        self.assertEqual(delivery["slug"], live_experiment.slug)
+        feature_reason = next(
+            (r for r in delivery["reasons"] if r.get("shared_features")), None
         )
-        self.assertIsNotNone(feature_overlap_warning)
-        self.assertEqual(feature_overlap_warning["slugs"], [live_experiment.slug])
+        self.assertIsNotNone(feature_reason)
         self.assertEqual(
-            feature_overlap_warning["details"],
-            [{"slug": live_experiment.slug, "shared_features": ["feature-a"]}],
+            [f["slug"] for f in feature_reason["shared_features"]], [feature_a.slug]
+        )
+        self.assertIsNone(delivery["publish_date_relation"])
+        # Single live experiment at 50% → 50% loss
+        self.assertEqual(result["estimated_loss_percent"], 50)
+
+    def test_collision_warnings_shares_feature_rollout_blocked_by(self):
+        shared_feature = NimbusFeatureConfigFactory.create(
+            slug="shared-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live_blocker = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-blocker",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[shared_feature],
+        )
+        draft_rollout = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-rollout",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            feature_configs=[shared_feature],
         )
 
-    def test_multiple_warnings(self):
+        result = draft_rollout.collision_warnings
+        self.assertEqual(len(result["deliveries"]), 1)
+        delivery = result["deliveries"][0]
+        self.assertEqual(delivery["slug"], live_blocker.slug)
+        self.assertEqual(delivery["publish_date_relation"], "blocked_by")
+        # Single colliding rollout that published earlier → draft loses entire overlap
+        self.assertEqual(result["estimated_loss_percent"], 100)
+
+    def test_collision_warnings_includes_same_namespace(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="shared-namespace-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live_peer = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-peer",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+
+        deliveries = draft.collision_warnings["deliveries"]
+        self.assertEqual(len(deliveries), 1)
+        labels = [r["label"] for r in deliveries[0]["reasons"] if r.get("label")]
+        self.assertIn("Shares an audience", labels)
+        self.assertEqual(deliveries[0]["slug"], live_peer.slug)
+
+    def test_collision_warnings_includes_matching_configuration(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="rollout-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-duplicate",
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-duplicate",
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.BETA],
+            application=NimbusExperiment.Application.DESKTOP,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+        )
+
+        deliveries = draft.collision_warnings["deliveries"]
+        self.assertEqual(len(deliveries), 1)
+        labels = [r["label"] for r in deliveries[0]["reasons"] if r.get("label")]
+        self.assertIn("Has matching configuration", labels)
+
+    @mock_valid_features
+    def test_collision_warnings_sets_same_preference(self):
+        Features.clear_cache()
+        call_command("load_feature_configs")
+
+        feature = NimbusFeatureConfig.objects.get(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="setPrefFeature",
+        )
+        rollout = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+            is_rollout=False,
+            prevent_pref_conflicts=True,
+        )
+
+        deliveries = experiment.collision_warnings["deliveries"]
+        slugs = [d["slug"] for d in deliveries]
+        self.assertIn(rollout.slug, slugs)
+        rollout_entry = next(d for d in deliveries if d["slug"] == rollout.slug)
+        labels = [r["label"] for r in rollout_entry["reasons"] if r.get("label")]
+        self.assertIn("Sets the same preference", labels)
+
+    def test_collision_warnings_skips_features_allowing_coenrollment(self):
+        coenroll_feature = NimbusFeatureConfigFactory.create(
+            slug="coenroll-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+            schemas=[
+                NimbusVersionedSchemaFactory.create(version=None, allow_coenrollment=True)
+            ],
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-coenroll",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[coenroll_feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-coenroll",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[coenroll_feature],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+        )
+
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
+
+    def test_collision_warnings_excludes_self(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="self-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="self-live",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="self-draft",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        slugs = [d["slug"] for d in draft.collision_warnings["deliveries"]]
+        self.assertNotIn(draft.slug, slugs)
+        self.assertIn(live.slug, slugs)
+
+    def test_collision_warnings_experiment_does_not_collide_with_rollout(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="cross-polarity-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-rollout",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+
+        self.assertEqual(draft_experiment.collision_warnings["deliveries"], [])
+
+    def test_collision_warnings_estimated_loss_caps_at_100_percent(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="cap-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        for slug, pop in (("live-a", "60"), ("live-b", "60")):
+            NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+                slug=slug,
+                is_rollout=False,
+                application=NimbusExperiment.Application.DESKTOP,
+                channels=[NimbusExperiment.Channel.RELEASE],
+                feature_configs=[feature],
+                population_percent=Decimal(pop),
+            )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-cap",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        # 60% + 60% would be 120%; capped at 100%
+        self.assertEqual(draft.collision_warnings["estimated_loss_percent"], 100)
+
+    def test_collision_warnings_returns_empty_for_complete_experiment(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="complete-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-conflict",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        complete = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            slug="complete-experiment",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+
+        self.assertEqual(complete.collision_warnings["deliveries"], [])
+
+    def test_audience_overlap_warnings_aggregates_collision_warnings(self):
         feature_a = NimbusFeatureConfigFactory.create(
-            slug="feature-a",
+            slug="agg-feature-a",
             application=NimbusExperiment.Application.DESKTOP,
         )
         feature_b = NimbusFeatureConfigFactory.create(
-            slug="feature-b",
+            slug="agg-feature-b",
             application=NimbusExperiment.Application.DESKTOP,
         )
         feature_c = NimbusFeatureConfigFactory.create(
-            slug="feature-c",
+            slug="agg-feature-c",
             application=NimbusExperiment.Application.DESKTOP,
         )
 
         excluded_live = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="excluded-live",
+            slug="agg-excluded-live",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature_c],
         )
         same_namespace_live = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="same-namespace-live",
+            slug="agg-same-namespace-live",
             is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
             feature_configs=[feature_a, feature_b],
+            population_percent=Decimal("25"),
         )
         feature_overlap_live = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="feature-overlap-live",
+            slug="agg-feature-overlap-live",
             is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
             feature_configs=[feature_a],
+            population_percent=Decimal("25"),
         )
         draft = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft",
+            slug="agg-draft",
             is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
@@ -2813,199 +3064,108 @@ class TestNimbusExperiment(TestCase):
         )
 
         warnings = draft.audience_overlap_warnings
-        self.assertEqual(len(warnings), 3)
-
+        self.assertEqual(len(warnings), 1)
+        warning = warnings[0]
+        self.assertIn("WARNING:", warning["text"])
+        self.assertEqual(warning["variant"], "warning")
+        entry_slugs = [e["slug"] for e in warning["entries"]]
         self.assertEqual(
-            warnings[0]["text"], NimbusUIConstants.EXCLUDING_EXPERIMENTS_WARNING
+            entry_slugs,
+            [
+                excluded_live.slug,
+                feature_overlap_live.slug,
+                same_namespace_live.slug,
+            ],
         )
-        self.assertEqual(list(warnings[0]["slugs"]), [excluded_live.slug])
+        # 25% + 25% = 50% estimated loss
+        self.assertEqual(warning["estimated_loss_percent"], 50)
 
-        self.assertEqual(
-            warnings[1]["text"], NimbusUIConstants.LIVE_EXPERIMENTS_BUCKET_WARNING
-        )
-        self.assertEqual(list(warnings[1]["slugs"]), [same_namespace_live.slug])
-
-        self.assertEqual(
-            warnings[2]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
-        )
-        self.assertEqual(
-            warnings[2]["slugs"],
-            [feature_overlap_live.slug, same_namespace_live.slug],
-        )
-
-    def test_rollout_conflict_warning(self):
-        test_feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
+    def test_collision_warnings_no_min_version_treats_feature_as_contesting(self):
+        # Without firefox_min_version we can't resolve coenrollment schemas, so the
+        # feature is treated as contesting (collision still surfaces).
+        feature = NimbusFeatureConfigFactory.create(
+            slug="no-version-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[test_feature],
-        )
-
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[test_feature],
-        )
-
-        warnings = experiment.audience_overlap_warnings
-        rollout_warning = next(
-            (
-                w
-                for w in warnings
-                if w["text"] == NimbusUIConstants.ERROR_ROLLOUT_BUCKET_EXISTS
-            ),
-            None,
-        )
-
-        self.assertIsNotNone(rollout_warning)
-        self.assertEqual(rollout_warning["variant"], "danger")
-        self.assertEqual(rollout_warning["slugs"], [])
-        self.assertEqual(
-            rollout_warning["learn_more_link"], NimbusUIConstants.ROLLOUT_BUCKET_WARNING
-        )
-
-    def test_rollout_conflict_warning_returns_none_when_no_conflict(self):
-        test_feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.BETA],
-            application=NimbusExperiment.Application.DESKTOP,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[test_feature],
-        )
-
-        self.assertIsNone(experiment.rollout_conflict_warning)
-
-    def test_rollout_feature_overlap_with_live_rollout_different_targeting(self):
-        shared_feature = NimbusFeatureConfigFactory.create(
-            slug="shared-feature",
-            name="shared-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        extra_feature = NimbusFeatureConfigFactory.create(
-            slug="extra-feature",
-            name="extra-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-
-        live_blocker = NimbusExperimentFactory.create_with_lifecycle(
+        live = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-blocker",
-            is_rollout=True,
+            slug="no-version-live",
+            is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[shared_feature],
+            feature_configs=[feature],
         )
-
-        draft_rollout = NimbusExperimentFactory.create_with_lifecycle(
+        draft = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft-rollout",
+            slug="no-version-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        slugs = [d["slug"] for d in draft.collision_warnings["deliveries"]]
+        self.assertEqual(slugs, [live.slug])
+
+    def test_collision_warnings_publish_date_would_block(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="would-block-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        # Self started before the live competitor, so self would block it.
+        self_rollout = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="self-rollout",
             is_rollout=True,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
-            feature_configs=[shared_feature, extra_feature],
+            feature_configs=[feature],
         )
+        self_rollout._start_date = datetime.date(2026, 1, 1)
+        self_rollout.status = NimbusExperiment.Status.DRAFT
+        self_rollout.save()
+        newer_live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="newer-live",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        newer_live._start_date = datetime.date(2026, 4, 1)
+        newer_live.save()
 
-        warnings = draft_rollout.audience_overlap_warnings
-        feature_overlap_warning = next(
-            (
-                w
-                for w in warnings
-                if w["text"] == NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
-            ),
-            None,
-        )
+        deliveries = self_rollout.collision_warnings["deliveries"]
+        newer_entry = next(d for d in deliveries if d["slug"] == newer_live.slug)
+        self.assertEqual(newer_entry["publish_date_relation"], "would_block")
+        # would_block contributes 0 estimated loss (the live one loses)
+        self.assertEqual(newer_entry["estimated_loss"], Decimal(0))
 
-        self.assertIsNotNone(
-            feature_overlap_warning,
-            "Expected a warning naming the live single-feature rollout that holds "
-            "the shared feature slot",
-        )
-        self.assertEqual(feature_overlap_warning["variant"], "warning")
-        self.assertEqual(list(feature_overlap_warning["slugs"]), [live_blocker.slug])
-        self.assertEqual(
-            feature_overlap_warning["details"],
-            [{"slug": live_blocker.slug, "shared_features": [shared_feature.slug]}],
-        )
-
-    def test_experiment_does_not_warn_on_live_rollout_sharing_feature(self):
-        shared_feature = NimbusFeatureConfigFactory.create(
-            slug="shared-feature",
-            name="shared-feature",
+    def test_collision_warnings_pref_no_set_pref_features_returns_empty(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="non-pref-feature",
             application=NimbusExperiment.Application.DESKTOP,
         )
-
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-rollout",
+            slug="non-pref-live-rollout",
             is_rollout=True,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[shared_feature],
+            feature_configs=[feature],
         )
-
-        draft_experiment = NimbusExperimentFactory.create_with_lifecycle(
+        draft = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft-experiment",
+            slug="non-pref-draft",
             is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[shared_feature],
-        )
-
-        self.assertEqual(
-            list(draft_experiment.feature_has_live_overlapping_deliveries), []
-        )
-
-    @mock_valid_features
-    def test_pref_targeting_rollout_collision_warning(self):
-        Features.clear_cache()
-        call_command("load_feature_configs")
-
-        feature = NimbusFeatureConfig.objects.get(
-            application=NimbusExperiment.Application.DESKTOP,
-            slug="setPrefFeature",
-        )
-
-        rollout = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=NimbusExperiment.Application.DESKTOP,
-            is_rollout=True,
-            channels=[NimbusExperiment.Channel.RELEASE],
             feature_configs=[feature],
-        )
-
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-            is_rollout=False,
             prevent_pref_conflicts=True,
         )
-
-        warnings = experiment.audience_overlap_warnings
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["text"], NimbusUIConstants.PREF_TARGETING_WARNING)
-        self.assertEqual(warnings[0]["slugs"], [rollout.slug])
+        # Cross-polarity collision is not surfaced because the shared feature
+        # doesn't set a pref.
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
 
     def test_multichannel_experiments_warning(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -4668,118 +4828,6 @@ class TestNimbusExperiment(TestCase):
             ],
         )
 
-    @parameterized.expand(
-        [
-            (NimbusExperiment.Application.FENIX, NimbusExperiment.Application.FENIX, 3),
-            (
-                NimbusExperiment.Application.FENIX,
-                NimbusExperiment.Application.DESKTOP,
-                0,
-            ),
-        ]
-    )
-    def test_get_live_overlapping_deliveries_for_feature(
-        self,
-        application1,
-        application2,
-        expected_matches,
-    ):
-        feature1 = NimbusFeatureConfigFactory.create()
-        feature2 = NimbusFeatureConfigFactory.create()
-
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=application1,
-            feature_configs=[feature1, feature2],
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=application1,
-            feature_configs=[feature1, feature2],
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=application1,
-            feature_configs=[feature1, feature2],
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=application1,
-            feature_configs=[feature1, feature2],
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=application2,
-            feature_configs=[feature1],
-        )
-
-        experiments = experiment.feature_has_live_overlapping_deliveries
-        self.assertEqual(len(experiments), expected_matches)
-
-    def test_get_live_overlapping_deliveries_for_feature_no_live(self):
-        feature1 = NimbusFeatureConfigFactory.create()
-        feature2 = NimbusFeatureConfigFactory.create()
-
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
-            feature_configs=[feature1, feature2],
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            feature_configs=[feature1, feature2],
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            feature_configs=[feature1, feature2],
-        )
-
-        experiments = experiment.feature_has_live_overlapping_deliveries
-        self.assertEqual(len(experiments), 0)
-
-    def test_get_live_overlapping_deliveries_for_feature_single_feature_live(self):
-        feature1 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        feature2 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-
-        live_single_feature = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-single-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1],
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1, feature2],
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1],
-        )
-
-        self.assertEqual(
-            list(experiment.feature_has_live_overlapping_deliveries),
-            [{"slug": live_single_feature.slug, "shared_features": [feature1.slug]}],
-        )
-
-    def test_get_live_overlapping_deliveries_none(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[
-                NimbusFeatureConfigFactory.create(
-                    application=NimbusExperiment.Application.DESKTOP
-                )
-            ],
-        )
-
-        experiments = experiment.feature_has_live_overlapping_deliveries
-        self.assertEqual(len(experiments), 0)
-
     def test_get_live_excluded_experiments(self):
         experiments = {
             slug: NimbusExperimentFactory.create_with_lifecycle(
@@ -4825,123 +4873,6 @@ class TestNimbusExperiment(TestCase):
         excluded_live_experiments = experiment.excluded_live_deliveries
         self.assertEqual(len(excluded_live_experiments), 0)
         self.assertEqual(excluded_live_experiments, [])
-
-    def test_get_live_experiments_in_previous_namespaces(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        experiments = {
-            slug: NimbusExperimentFactory.create_with_lifecycle(
-                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-                slug=slug,
-                application=NimbusExperiment.Application.DESKTOP,
-                channels=[NimbusExperiment.Channel.RELEASE],
-                firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-                firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-                feature_configs=[feature],
-            )
-            for slug in ("foo", "bar", "baz")
-        }
-
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-            feature_configs=[feature],
-        )
-
-        self.assertEqual(
-            list(experiment.live_experiments_in_namespace),
-            [
-                experiments["bar"].slug,
-                experiments["baz"].slug,
-                experiments["foo"].slug,
-            ],
-        )
-
-    def test_get_live_experiments_do_not_exist_in_previous_namespaces(self):
-        feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-
-        for slug in ("foo", "bar", "baz"):
-            NimbusExperimentFactory.create_with_lifecycle(
-                NimbusExperimentFactory.Lifecycles.CREATED,
-                slug=slug,
-                application=NimbusExperiment.Application.DESKTOP,
-                channels=[NimbusExperiment.Channel.RELEASE],
-                firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-                firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-                feature_configs=[feature],
-            )
-
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            slug="slug2",
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-
-        matching_experiments = experiment.live_experiments_in_namespace
-        self.assertEqual(len(matching_experiments), 0)
-
-    def test_get_live_experiments_in_different_namespaces(self):
-        feature1 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        feature2 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-
-        for slug in ("foo", "bar", "baz"):
-            NimbusExperimentFactory.create_with_lifecycle(
-                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-                slug=slug,
-                application=NimbusExperiment.Application.DESKTOP,
-                channels=[NimbusExperiment.Channel.RELEASE],
-                firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-                firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-                targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-                feature_configs=[feature1],
-            )
-
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            slug="slug2",
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature2],
-        )
-
-        matching_experiments = experiment.live_experiments_in_namespace
-        self.assertEqual(len(matching_experiments), 0)
-
-    def test_get_live_experiments_in_different_namespaces_excludes_self(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=NimbusExperiment.Application.DESKTOP,
-            slug="slug2",
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[NimbusFeatureConfigFactory.create()],
-        )
-
-        matching_experiments = experiment.live_experiments_in_namespace
-        self.assertEqual(len(matching_experiments), 0)
 
     @parameterized.expand(
         [
@@ -5062,102 +4993,34 @@ class TestNimbusExperiment(TestCase):
             ("language", LanguageFactory, "languages", "en", "fr"),
         ]
     )
-    def test_live_experiments_in_namespace_skips_disjoint_audience(
+    def test_collision_warnings_skips_disjoint_audience(
         self, _name, factory, field, live_code, draft_code
     ):
         feature = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
+            slug="disjoint-audience-feature",
+            application=NimbusExperiment.Application.DESKTOP,
         )
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
             slug="peer",
+            is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             feature_configs=[feature],
             **{field: [factory.create(code=live_code)]},
         )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
+        draft = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             slug="draft",
+            is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
-            firefox_max_version=NimbusExperiment.Version.FIREFOX_130,
-            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
             feature_configs=[feature],
             **{field: [factory.create(code=draft_code)]},
         )
-        self.assertEqual(list(experiment.live_experiments_in_namespace), [])
-
-    @parameterized.expand(
-        [
-            ("locale", LocaleFactory, "locales", "en-US", "fr"),
-            ("country", CountryFactory, "countries", "US", "DE"),
-            ("language", LanguageFactory, "languages", "en", "fr"),
-        ]
-    )
-    def test_feature_has_live_overlapping_deliveries_skips_disjoint_audience(
-        self, _name, factory, field, live_code, draft_code
-    ):
-        feature1 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        feature2 = NimbusFeatureConfigFactory.create(
-            application=NimbusExperiment.Application.DESKTOP
-        )
-        NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-multi",
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1, feature2],
-            **{field: [factory.create(code=live_code)]},
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft",
-            application=NimbusExperiment.Application.DESKTOP,
-            feature_configs=[feature1],
-            **{field: [factory.create(code=draft_code)]},
-        )
-        self.assertEqual(list(experiment.feature_has_live_overlapping_deliveries), [])
-
-    @parameterized.expand(
-        [
-            ("locale", LocaleFactory, "locales", "en-US", "fr"),
-            ("country", CountryFactory, "countries", "US", "DE"),
-            ("language", LanguageFactory, "languages", "en", "fr"),
-        ]
-    )
-    def test_rollout_conflict_warning_skips_disjoint_audience(
-        self, _name, factory, field, live_code, draft_code
-    ):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="test-feature",
-            name="test-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.LIVE,
-            is_rollout=True,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.BETA],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            **{field: [factory.create(code=live_code)]},
-        )
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.BETA],
-            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
-            feature_configs=[feature],
-            **{field: [factory.create(code=draft_code)]},
-        )
-        self.assertIsNone(experiment.rollout_conflict_warning)
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3080,6 +3080,38 @@ class TestNimbusExperiment(TestCase):
         # 25% + 25% = 50% estimated loss
         self.assertEqual(warning["estimated_loss_percent"], 50)
 
+    def test_audience_overlap_warnings_combines_collisions_and_self_issues(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="combo-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="combo-live",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="combo-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+
+        warnings = draft.audience_overlap_warnings
+        self.assertEqual(len(warnings), 1)
+        warning = warnings[0]
+        self.assertEqual([e["slug"] for e in warning["entries"]], [live.slug])
+        labels = [issue["label"] for issue in warning["self_issues"]]
+        self.assertIn("Targeting multiple channels", labels)
+        self.assertIn(
+            "Issues that may affect enrollment for this experiment", warning["text"]
+        )
+
     def test_collision_warnings_no_min_version_treats_feature_as_contesting(self):
         # Without firefox_min_version we can't resolve coenrollment schemas, so the
         # feature is treated as contesting (collision still surfaces).
@@ -3177,10 +3209,9 @@ class TestNimbusExperiment(TestCase):
 
         warnings = experiment.audience_overlap_warnings
         self.assertEqual(len(warnings), 1)
-        self.assertEqual(
-            warnings[0]["text"], NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING
-        )
-        self.assertEqual(warnings[0]["slugs"], [])
+        self.assertEqual(warnings[0]["entries"], [])
+        labels = [issue["label"] for issue in warnings[0]["self_issues"]]
+        self.assertIn("Targeting multiple channels", labels)
 
     def test_clear_branches_deletes_branches_without_deleting_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -3266,16 +3297,14 @@ class TestNimbusExperiment(TestCase):
         )
 
         warnings = experiment.audience_overlap_warnings
-        version_warning = next(
-            (
-                w
-                for w in warnings
-                if NimbusExperiment.Application(application).label in w["text"]
-            ),
-            None,
-        )
-        self.assertIsNotNone(version_warning)
-        self.assertEqual(version_warning["variant"], "warning")
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["variant"], "warning")
+        version_issues = [
+            issue
+            for issue in warnings[0]["self_issues"]
+            if NimbusExperiment.Application(application).label in issue["detail"]
+        ]
+        self.assertEqual(len(version_issues), 1)
 
     def test_allocate_buckets_generates_bucket_range(self):
         feature = NimbusFeatureConfigFactory(slug="feature")

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2675,157 +2675,163 @@ class TestNimbusExperiment(TestCase):
             ),
         )
 
-    @mock.patch.object(
-        NimbusExperiment, "excluded_live_deliveries", new_callable=mock.PropertyMock
-    )
-    def test_excluding_experiments_warning(self, mock_excluded_live_deliveries):
-        mock_excluded_live_deliveries.return_value = ["experiment1", "experiment2"]
-
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
+    def test_excluding_experiments_warning(self):
+        draft_feature = NimbusFeatureConfigFactory.create(
+            slug="draft-only-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        excluded_feature = NimbusFeatureConfigFactory.create(
+            slug="excluded-only-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        excluded_one = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="excluded-one",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[excluded_feature],
+        )
+        excluded_two = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="excluded-two",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[excluded_feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[draft_feature],
         )
+        for excluded in (excluded_one, excluded_two):
+            NimbusExperimentBranchThroughExcluded.objects.create(
+                parent_experiment=draft,
+                child_experiment=excluded,
+                branch_slug=None,
+            )
 
-        warnings = experiment.audience_overlap_warnings
+        warnings = draft.audience_overlap_warnings
         self.assertEqual(len(warnings), 1)
         self.assertEqual(
             warnings[0]["text"], NimbusUIConstants.EXCLUDING_EXPERIMENTS_WARNING
         )
-        self.assertEqual(warnings[0]["slugs"], ["experiment1", "experiment2"])
-
-    @mock.patch.object(
-        NimbusExperiment, "live_experiments_in_namespace", new_callable=mock.PropertyMock
-    )
-    def test_live_experiments_bucket_warning(self, mock_live_experiments_in_namespace):
-        mock_live_experiments_in_namespace.return_value = ["experiment3"]
-
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-        )
-
-        warnings = experiment.audience_overlap_warnings
-        self.assertEqual(len(warnings), 1)
         self.assertEqual(
-            warnings[0]["text"], NimbusUIConstants.LIVE_EXPERIMENTS_BUCKET_WARNING
+            list(warnings[0]["slugs"]), [excluded_one.slug, excluded_two.slug]
         )
-        self.assertEqual(warnings[0]["slugs"], ["experiment3"])
 
-    @mock.patch.object(
-        NimbusExperiment,
-        "feature_has_live_overlapping_deliveries",
-        new_callable=mock.PropertyMock,
-    )
-    def test_live_feature_overlap_warning(
-        self, mock_feature_has_live_overlapping_deliveries
-    ):
-        mock_feature_has_live_overlapping_deliveries.return_value = [
-            {"slug": "experiment5", "shared_features": ["feature-a"]},
-            {"slug": "experiment6", "shared_features": ["feature-a", "feature-b"]},
-        ]
-
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.PREVIEW,
-            channels=[NimbusExperiment.Channel.RELEASE],
+    def test_live_feature_overlap_warning(self):
+        feature_a = NimbusFeatureConfigFactory.create(
+            slug="feature-a",
             application=NimbusExperiment.Application.DESKTOP,
+        )
+        feature_b = NimbusFeatureConfigFactory.create(
+            slug="feature-b",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        live_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-experiment",
             is_rollout=False,
-        )
-
-        warnings = experiment.audience_overlap_warnings
-        self.assertEqual(len(warnings), 1)
-        self.assertEqual(
-            warnings[0]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
-        )
-        self.assertEqual(warnings[0]["slugs"], ["experiment5", "experiment6"])
-        self.assertEqual(
-            warnings[0]["details"],
-            [
-                {"slug": "experiment5", "shared_features": ["feature-a"]},
-                {"slug": "experiment6", "shared_features": ["feature-a", "feature-b"]},
-            ],
-        )
-
-    @mock.patch.object(
-        NimbusExperiment,
-        "feature_has_live_overlapping_deliveries",
-        new_callable=mock.PropertyMock,
-    )
-    def test_live_rollout_feature_overlap_warning(
-        self, mock_feature_has_live_overlapping_deliveries
-    ):
-        mock_feature_has_live_overlapping_deliveries.return_value = [
-            {"slug": "rollout-blocker", "shared_features": ["fxms-message-2"]},
-        ]
-
-        rollout = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            channels=[NimbusExperiment.Channel.RELEASE],
             application=NimbusExperiment.Application.DESKTOP,
-            is_rollout=True,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature_a, feature_b],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature_a],
         )
 
-        warnings = rollout.audience_overlap_warnings
+        warnings = draft.audience_overlap_warnings
         feature_overlap_warning = next(
             (
                 w
                 for w in warnings
-                if w["text"] == NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
+                if w["text"] == NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
             ),
             None,
         )
         self.assertIsNotNone(feature_overlap_warning)
-        self.assertEqual(feature_overlap_warning["slugs"], ["rollout-blocker"])
+        self.assertEqual(feature_overlap_warning["slugs"], [live_experiment.slug])
         self.assertEqual(
             feature_overlap_warning["details"],
-            [{"slug": "rollout-blocker", "shared_features": ["fxms-message-2"]}],
+            [{"slug": live_experiment.slug, "shared_features": ["feature-a"]}],
         )
 
-    @mock.patch.object(
-        NimbusExperiment, "excluded_live_deliveries", new_callable=mock.PropertyMock
-    )
-    @mock.patch.object(
-        NimbusExperiment, "live_experiments_in_namespace", new_callable=mock.PropertyMock
-    )
-    @mock.patch.object(
-        NimbusExperiment,
-        "feature_has_live_overlapping_deliveries",
-        new_callable=mock.PropertyMock,
-    )
-    def test_multiple_warnings(
-        self,
-        mock_feature_has_live_overlapping_deliveries,
-        mock_live_experiments_in_namespace,
-        mock_excluded_live_deliveries,
-    ):
-        mock_excluded_live_deliveries.return_value = ["experiment1", "experiment2"]
-        mock_live_experiments_in_namespace.return_value = ["experiment3"]
-        mock_feature_has_live_overlapping_deliveries.return_value = [
-            {"slug": "experiment4", "shared_features": ["feature-a"]},
-        ]
+    def test_multiple_warnings(self):
+        feature_a = NimbusFeatureConfigFactory.create(
+            slug="feature-a",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        feature_b = NimbusFeatureConfigFactory.create(
+            slug="feature-b",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        feature_c = NimbusFeatureConfigFactory.create(
+            slug="feature-c",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
 
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
+        excluded_live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="excluded-live",
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_c],
+        )
+        same_namespace_live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="same-namespace-live",
+            is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature_a, feature_b],
+        )
+        feature_overlap_live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="feature-overlap-live",
             is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature_a],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature_a, feature_b],
+        )
+        NimbusExperimentBranchThroughExcluded.objects.create(
+            parent_experiment=draft,
+            child_experiment=excluded_live,
+            branch_slug=None,
         )
 
-        warnings = experiment.audience_overlap_warnings
+        warnings = draft.audience_overlap_warnings
         self.assertEqual(len(warnings), 3)
+
         self.assertEqual(
             warnings[0]["text"], NimbusUIConstants.EXCLUDING_EXPERIMENTS_WARNING
         )
-        self.assertEqual(warnings[0]["slugs"], ["experiment1", "experiment2"])
+        self.assertEqual(list(warnings[0]["slugs"]), [excluded_live.slug])
+
         self.assertEqual(
             warnings[1]["text"], NimbusUIConstants.LIVE_EXPERIMENTS_BUCKET_WARNING
         )
-        self.assertEqual(warnings[1]["slugs"], ["experiment3"])
+        self.assertEqual(list(warnings[1]["slugs"]), [same_namespace_live.slug])
+
         self.assertEqual(
             warnings[2]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
         )
-        self.assertEqual(warnings[2]["slugs"], ["experiment4"])
+        self.assertEqual(
+            warnings[2]["slugs"],
+            [feature_overlap_live.slug, same_namespace_live.slug],
+        )
 
     def test_rollout_conflict_warning(self):
         test_feature = NimbusFeatureConfigFactory.create(
@@ -2920,7 +2926,11 @@ class TestNimbusExperiment(TestCase):
 
         warnings = draft_rollout.audience_overlap_warnings
         feature_overlap_warning = next(
-            (w for w in warnings if live_blocker.slug in (w.get("slugs") or [])),
+            (
+                w
+                for w in warnings
+                if w["text"] == NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
+            ),
             None,
         )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2722,8 +2722,8 @@ class TestNimbusExperiment(TestCase):
         self, mock_feature_has_live_overlapping_deliveries
     ):
         mock_feature_has_live_overlapping_deliveries.return_value = [
-            "experiment5",
-            "experiment6",
+            {"slug": "experiment5", "shared_features": ["feature-a"]},
+            {"slug": "experiment6", "shared_features": ["feature-a", "feature-b"]},
         ]
 
         experiment = NimbusExperimentFactory.create(
@@ -2739,6 +2739,13 @@ class TestNimbusExperiment(TestCase):
             warnings[0]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
         )
         self.assertEqual(warnings[0]["slugs"], ["experiment5", "experiment6"])
+        self.assertEqual(
+            warnings[0]["details"],
+            [
+                {"slug": "experiment5", "shared_features": ["feature-a"]},
+                {"slug": "experiment6", "shared_features": ["feature-a", "feature-b"]},
+            ],
+        )
 
     @mock.patch.object(
         NimbusExperiment,
@@ -2749,7 +2756,7 @@ class TestNimbusExperiment(TestCase):
         self, mock_feature_has_live_overlapping_deliveries
     ):
         mock_feature_has_live_overlapping_deliveries.return_value = [
-            "rollout-blocker",
+            {"slug": "rollout-blocker", "shared_features": ["fxms-message-2"]},
         ]
 
         rollout = NimbusExperimentFactory.create(
@@ -2770,6 +2777,10 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertIsNotNone(feature_overlap_warning)
         self.assertEqual(feature_overlap_warning["slugs"], ["rollout-blocker"])
+        self.assertEqual(
+            feature_overlap_warning["details"],
+            [{"slug": "rollout-blocker", "shared_features": ["fxms-message-2"]}],
+        )
 
     @mock.patch.object(
         NimbusExperiment, "excluded_live_deliveries", new_callable=mock.PropertyMock
@@ -2790,7 +2801,9 @@ class TestNimbusExperiment(TestCase):
     ):
         mock_excluded_live_deliveries.return_value = ["experiment1", "experiment2"]
         mock_live_experiments_in_namespace.return_value = ["experiment3"]
-        mock_feature_has_live_overlapping_deliveries.return_value = ["experiment4"]
+        mock_feature_has_live_overlapping_deliveries.return_value = [
+            {"slug": "experiment4", "shared_features": ["feature-a"]},
+        ]
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
@@ -2918,6 +2931,10 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(feature_overlap_warning["variant"], "warning")
         self.assertEqual(list(feature_overlap_warning["slugs"]), [live_blocker.slug])
+        self.assertEqual(
+            feature_overlap_warning["details"],
+            [{"slug": live_blocker.slug, "shared_features": [shared_feature.slug]}],
+        )
 
     def test_experiment_does_not_warn_on_live_rollout_sharing_feature(self):
         shared_feature = NimbusFeatureConfigFactory.create(
@@ -4736,7 +4753,7 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(
             list(experiment.feature_has_live_overlapping_deliveries),
-            [live_single_feature.slug],
+            [{"slug": live_single_feature.slug, "shared_features": [feature1.slug]}],
         )
 
     def test_get_live_overlapping_deliveries_none(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2715,13 +2715,13 @@ class TestNimbusExperiment(TestCase):
 
     @mock.patch.object(
         NimbusExperiment,
-        "feature_has_live_multifeature_experiments",
+        "feature_has_live_overlapping_deliveries",
         new_callable=mock.PropertyMock,
     )
-    def test_live_multifeature_warning(
-        self, mock_feature_has_live_multifeature_experiments
+    def test_live_feature_overlap_warning(
+        self, mock_feature_has_live_overlapping_deliveries
     ):
-        mock_feature_has_live_multifeature_experiments.return_value = [
+        mock_feature_has_live_overlapping_deliveries.return_value = [
             "experiment5",
             "experiment6",
         ]
@@ -2730,12 +2730,46 @@ class TestNimbusExperiment(TestCase):
             status=NimbusExperiment.Status.PREVIEW,
             channels=[NimbusExperiment.Channel.RELEASE],
             application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=False,
         )
 
         warnings = experiment.audience_overlap_warnings
         self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["text"], NimbusUIConstants.LIVE_MULTIFEATURE_WARNING)
+        self.assertEqual(
+            warnings[0]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
+        )
         self.assertEqual(warnings[0]["slugs"], ["experiment5", "experiment6"])
+
+    @mock.patch.object(
+        NimbusExperiment,
+        "feature_has_live_overlapping_deliveries",
+        new_callable=mock.PropertyMock,
+    )
+    def test_live_rollout_feature_overlap_warning(
+        self, mock_feature_has_live_overlapping_deliveries
+    ):
+        mock_feature_has_live_overlapping_deliveries.return_value = [
+            "rollout-blocker",
+        ]
+
+        rollout = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+
+        warnings = rollout.audience_overlap_warnings
+        feature_overlap_warning = next(
+            (
+                w
+                for w in warnings
+                if w["text"] == NimbusUIConstants.LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING
+            ),
+            None,
+        )
+        self.assertIsNotNone(feature_overlap_warning)
+        self.assertEqual(feature_overlap_warning["slugs"], ["rollout-blocker"])
 
     @mock.patch.object(
         NimbusExperiment, "excluded_live_deliveries", new_callable=mock.PropertyMock
@@ -2745,23 +2779,24 @@ class TestNimbusExperiment(TestCase):
     )
     @mock.patch.object(
         NimbusExperiment,
-        "feature_has_live_multifeature_experiments",
+        "feature_has_live_overlapping_deliveries",
         new_callable=mock.PropertyMock,
     )
     def test_multiple_warnings(
         self,
-        mock_feature_has_live_multifeature_experiments,
+        mock_feature_has_live_overlapping_deliveries,
         mock_live_experiments_in_namespace,
         mock_excluded_live_deliveries,
     ):
         mock_excluded_live_deliveries.return_value = ["experiment1", "experiment2"]
         mock_live_experiments_in_namespace.return_value = ["experiment3"]
-        mock_feature_has_live_multifeature_experiments.return_value = ["experiment4"]
+        mock_feature_has_live_overlapping_deliveries.return_value = ["experiment4"]
 
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channels=[NimbusExperiment.Channel.RELEASE],
+            is_rollout=False,
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -2774,7 +2809,9 @@ class TestNimbusExperiment(TestCase):
             warnings[1]["text"], NimbusUIConstants.LIVE_EXPERIMENTS_BUCKET_WARNING
         )
         self.assertEqual(warnings[1]["slugs"], ["experiment3"])
-        self.assertEqual(warnings[2]["text"], NimbusUIConstants.LIVE_MULTIFEATURE_WARNING)
+        self.assertEqual(
+            warnings[2]["text"], NimbusUIConstants.LIVE_FEATURE_OVERLAP_WARNING
+        )
         self.assertEqual(warnings[2]["slugs"], ["experiment4"])
 
     def test_rollout_conflict_warning(self):
@@ -2835,6 +2872,81 @@ class TestNimbusExperiment(TestCase):
         )
 
         self.assertIsNone(experiment.rollout_conflict_warning)
+
+    def test_rollout_feature_overlap_with_live_rollout_different_targeting(self):
+        shared_feature = NimbusFeatureConfigFactory.create(
+            slug="shared-feature",
+            name="shared-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        extra_feature = NimbusFeatureConfigFactory.create(
+            slug="extra-feature",
+            name="extra-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        live_blocker = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-blocker",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[shared_feature],
+        )
+
+        draft_rollout = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-rollout",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            feature_configs=[shared_feature, extra_feature],
+        )
+
+        warnings = draft_rollout.audience_overlap_warnings
+        feature_overlap_warning = next(
+            (w for w in warnings if live_blocker.slug in (w.get("slugs") or [])),
+            None,
+        )
+
+        self.assertIsNotNone(
+            feature_overlap_warning,
+            "Expected a warning naming the live single-feature rollout that holds "
+            "the shared feature slot",
+        )
+        self.assertEqual(feature_overlap_warning["variant"], "warning")
+        self.assertEqual(list(feature_overlap_warning["slugs"]), [live_blocker.slug])
+
+    def test_experiment_does_not_warn_on_live_rollout_sharing_feature(self):
+        shared_feature = NimbusFeatureConfigFactory.create(
+            slug="shared-feature",
+            name="shared-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-rollout",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[shared_feature],
+        )
+
+        draft_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[shared_feature],
+        )
+
+        self.assertEqual(
+            list(draft_experiment.feature_has_live_overlapping_deliveries), []
+        )
 
     @mock_valid_features
     def test_pref_targeting_rollout_collision_warning(self):
@@ -4539,7 +4651,7 @@ class TestNimbusExperiment(TestCase):
             ),
         ]
     )
-    def test_get_live_multifeature_experiments_for_feature(
+    def test_get_live_overlapping_deliveries_for_feature(
         self,
         application1,
         application2,
@@ -4574,10 +4686,10 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[feature1],
         )
 
-        experiments = experiment.feature_has_live_multifeature_experiments
+        experiments = experiment.feature_has_live_overlapping_deliveries
         self.assertEqual(len(experiments), expected_matches)
 
-    def test_get_live_multifeature_experiments_for_feature_no_live(self):
+    def test_get_live_overlapping_deliveries_for_feature_no_live(self):
         feature1 = NimbusFeatureConfigFactory.create()
         feature2 = NimbusFeatureConfigFactory.create()
 
@@ -4594,10 +4706,10 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[feature1, feature2],
         )
 
-        experiments = experiment.feature_has_live_multifeature_experiments
+        experiments = experiment.feature_has_live_overlapping_deliveries
         self.assertEqual(len(experiments), 0)
 
-    def test_get_live_multifeature_experiments_for_feature_no_live_multifeature(self):
+    def test_get_live_overlapping_deliveries_for_feature_single_feature_live(self):
         feature1 = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP
         )
@@ -4605,8 +4717,9 @@ class TestNimbusExperiment(TestCase):
             application=NimbusExperiment.Application.DESKTOP
         )
 
-        NimbusExperimentFactory.create_with_lifecycle(
+        live_single_feature = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-single-feature",
             application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[feature1],
         )
@@ -4621,10 +4734,12 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[feature1],
         )
 
-        experiments = experiment.feature_has_live_multifeature_experiments
-        self.assertEqual(len(experiments), 0)
+        self.assertEqual(
+            list(experiment.feature_has_live_overlapping_deliveries),
+            [live_single_feature.slug],
+        )
 
-    def test_get_live_multifeature_experiments_none(self):
+    def test_get_live_overlapping_deliveries_none(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
@@ -4635,7 +4750,7 @@ class TestNimbusExperiment(TestCase):
             ],
         )
 
-        experiments = experiment.feature_has_live_multifeature_experiments
+        experiments = experiment.feature_has_live_overlapping_deliveries
         self.assertEqual(len(experiments), 0)
 
     def test_get_live_excluded_experiments(self):
@@ -4957,7 +5072,7 @@ class TestNimbusExperiment(TestCase):
             ("language", LanguageFactory, "languages", "en", "fr"),
         ]
     )
-    def test_feature_has_live_multifeature_experiments_skips_disjoint_audience(
+    def test_feature_has_live_overlapping_deliveries_skips_disjoint_audience(
         self, _name, factory, field, live_code, draft_code
     ):
         feature1 = NimbusFeatureConfigFactory.create(
@@ -4980,7 +5095,7 @@ class TestNimbusExperiment(TestCase):
             feature_configs=[feature1],
             **{field: [factory.create(code=draft_code)]},
         )
-        self.assertEqual(list(experiment.feature_has_live_multifeature_experiments), [])
+        self.assertEqual(list(experiment.feature_has_live_overlapping_deliveries), [])
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2759,7 +2759,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             [f["slug"] for f in feature_reason["shared_features"]], [feature_a.slug]
         )
-        self.assertIsNone(delivery["publish_date_relation"])
+        # Live experiment published before this draft → draft is blocked.
+        self.assertEqual(delivery["publish_date_relation"], "blocked_by")
 
     def test_collision_warnings_shares_feature_rollout_blocked_by(self):
         shared_feature = NimbusFeatureConfigFactory.create(
@@ -3138,6 +3139,34 @@ class TestNimbusExperiment(TestCase):
         deliveries = self_rollout.collision_warnings["deliveries"]
         newer_entry = next(d for d in deliveries if d["slug"] == newer_live.slug)
         self.assertEqual(newer_entry["publish_date_relation"], "would_block")
+
+    def test_collision_warnings_publish_date_directionality_for_experiments(self):
+        # Publish-date ordering applies to experiments, not just rollouts —
+        # the SDK uses the same machinery for both polarities.
+        feature = NimbusFeatureConfigFactory.create(
+            slug="exp-pubdate-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live_blocker = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-experiment-blocker",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-experiment",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+
+        deliveries = draft.collision_warnings["deliveries"]
+        entry = next(d for d in deliveries if d["slug"] == live_blocker.slug)
+        self.assertEqual(entry["publish_date_relation"], "blocked_by")
 
     def test_collision_warnings_pref_no_set_pref_features_returns_empty(self):
         feature = NimbusFeatureConfigFactory.create(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -4983,6 +4983,130 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(draft.collision_warnings["deliveries"], [])
 
+    def test_collision_warnings_skips_disjoint_channels_non_desktop(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="fenix-disjoint-channels-feature",
+            application=NimbusExperiment.Application.FENIX,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="fenix-nightly-live",
+            is_rollout=False,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.NIGHTLY,
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="fenix-release-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.RELEASE,
+            feature_configs=[feature],
+        )
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
+
+    def test_collision_warnings_empty_channels_intersects_anything(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="empty-channels-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="release-only-live",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="all-channels-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[],
+            feature_configs=[feature],
+        )
+        slugs = [d["slug"] for d in draft.collision_warnings["deliveries"]]
+        self.assertIn(live.slug, slugs)
+
+    def test_collision_warnings_skips_disjoint_channels(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="disjoint-channels-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="release-only-live",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="nightly-only-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
+            feature_configs=[feature],
+        )
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
+
+    def test_collision_warnings_skips_disjoint_targeting_configs(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="disjoint-targeting-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="mac-only-live",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="first-run-draft",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+        )
+        # Different non-empty targeting_config_slug — treated as disjoint.
+        self.assertEqual(draft.collision_warnings["deliveries"], [])
+
+    def test_collision_warnings_targeting_config_no_targeting_intersects_anything(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="no-targeting-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        live = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="mac-only-live",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.MAC_ONLY,
+            feature_configs=[feature],
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="no-targeting-draft",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            feature_configs=[feature],
+        )
+        # Draft has no targeting constraint → its audience is a superset, so
+        # the live recipe's audience is wholly contained.
+        slugs = [d["slug"] for d in draft.collision_warnings["deliveries"]]
+        self.assertIn(live.slug, slugs)
+
     @parameterized.expand(
         [
             (

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2979,6 +2979,23 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(complete.collision_warnings["deliveries"], [])
 
+    def test_audience_overlap_warnings_empty_when_no_collisions_or_self_issues(self):
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="clean-draft",
+            is_rollout=False,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    slug="clean-feature",
+                    application=NimbusExperiment.Application.DESKTOP,
+                )
+            ],
+        )
+
+        self.assertEqual(draft.audience_overlap_warnings, [])
+
     def test_audience_overlap_warnings_aggregates_collision_warnings(self):
         feature_a = NimbusFeatureConfigFactory.create(
             slug="agg-feature-a",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2760,8 +2760,6 @@ class TestNimbusExperiment(TestCase):
             [f["slug"] for f in feature_reason["shared_features"]], [feature_a.slug]
         )
         self.assertIsNone(delivery["publish_date_relation"])
-        # Single live experiment at 50% → 50% loss
-        self.assertEqual(result["estimated_loss_percent"], 50)
 
     def test_collision_warnings_shares_feature_rollout_blocked_by(self):
         shared_feature = NimbusFeatureConfigFactory.create(
@@ -2792,8 +2790,6 @@ class TestNimbusExperiment(TestCase):
         delivery = result["deliveries"][0]
         self.assertEqual(delivery["slug"], live_blocker.slug)
         self.assertEqual(delivery["publish_date_relation"], "blocked_by")
-        # Single colliding rollout that published earlier → draft loses entire overlap
-        self.assertEqual(result["estimated_loss_percent"], 100)
 
     def test_collision_warnings_includes_same_namespace(self):
         feature = NimbusFeatureConfigFactory.create(
@@ -2961,32 +2957,6 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(draft_experiment.collision_warnings["deliveries"], [])
 
-    def test_collision_warnings_estimated_loss_caps_at_100_percent(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="cap-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        for slug, pop in (("live-a", "60"), ("live-b", "60")):
-            NimbusExperimentFactory.create_with_lifecycle(
-                NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-                slug=slug,
-                is_rollout=False,
-                application=NimbusExperiment.Application.DESKTOP,
-                channels=[NimbusExperiment.Channel.RELEASE],
-                feature_configs=[feature],
-                population_percent=Decimal(pop),
-            )
-        draft = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft-cap",
-            is_rollout=False,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-        # 60% + 60% would be 120%; capped at 100%
-        self.assertEqual(draft.collision_warnings["estimated_loss_percent"], 100)
-
     def test_collision_warnings_returns_empty_for_complete_experiment(self):
         feature = NimbusFeatureConfigFactory.create(
             slug="complete-feature",
@@ -3077,8 +3047,6 @@ class TestNimbusExperiment(TestCase):
                 same_namespace_live.slug,
             ],
         )
-        # 25% + 25% = 50% estimated loss
-        self.assertEqual(warning["estimated_loss_percent"], 50)
 
     def test_audience_overlap_warnings_combines_collisions_and_self_issues(self):
         feature = NimbusFeatureConfigFactory.create(
@@ -3170,8 +3138,6 @@ class TestNimbusExperiment(TestCase):
         deliveries = self_rollout.collision_warnings["deliveries"]
         newer_entry = next(d for d in deliveries if d["slug"] == newer_live.slug)
         self.assertEqual(newer_entry["publish_date_relation"], "would_block")
-        # would_block contributes 0 estimated loss (the live one loses)
-        self.assertEqual(newer_entry["estimated_loss"], Decimal(0))
 
     def test_collision_warnings_pref_no_set_pref_features_returns_empty(self):
         feature = NimbusFeatureConfigFactory.create(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -2759,10 +2759,8 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(
             [f["slug"] for f in feature_reason["shared_features"]], [feature_a.slug]
         )
-        # Live experiment published before this draft → draft is blocked.
-        self.assertEqual(delivery["publish_date_relation"], "blocked_by")
 
-    def test_collision_warnings_shares_feature_rollout_blocked_by(self):
+    def test_collision_warnings_shares_feature_rollout(self):
         shared_feature = NimbusFeatureConfigFactory.create(
             slug="shared-feature",
             application=NimbusExperiment.Application.DESKTOP,
@@ -2790,7 +2788,6 @@ class TestNimbusExperiment(TestCase):
         self.assertEqual(len(result["deliveries"]), 1)
         delivery = result["deliveries"][0]
         self.assertEqual(delivery["slug"], live_blocker.slug)
-        self.assertEqual(delivery["publish_date_relation"], "blocked_by")
 
     def test_collision_warnings_includes_same_namespace(self):
         feature = NimbusFeatureConfigFactory.create(
@@ -3107,66 +3104,6 @@ class TestNimbusExperiment(TestCase):
         )
         slugs = [d["slug"] for d in draft.collision_warnings["deliveries"]]
         self.assertEqual(slugs, [live.slug])
-
-    def test_collision_warnings_publish_date_would_block(self):
-        feature = NimbusFeatureConfigFactory.create(
-            slug="would-block-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        # Self started before the live competitor, so self would block it.
-        self_rollout = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="self-rollout",
-            is_rollout=True,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-        self_rollout._start_date = datetime.date(2026, 1, 1)
-        self_rollout.status = NimbusExperiment.Status.DRAFT
-        self_rollout.save()
-        newer_live = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="newer-live",
-            is_rollout=True,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-        newer_live._start_date = datetime.date(2026, 4, 1)
-        newer_live.save()
-
-        deliveries = self_rollout.collision_warnings["deliveries"]
-        newer_entry = next(d for d in deliveries if d["slug"] == newer_live.slug)
-        self.assertEqual(newer_entry["publish_date_relation"], "would_block")
-
-    def test_collision_warnings_publish_date_directionality_for_experiments(self):
-        # Publish-date ordering applies to experiments, not just rollouts —
-        # the SDK uses the same machinery for both polarities.
-        feature = NimbusFeatureConfigFactory.create(
-            slug="exp-pubdate-feature",
-            application=NimbusExperiment.Application.DESKTOP,
-        )
-        live_blocker = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            slug="live-experiment-blocker",
-            is_rollout=False,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-        draft = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            slug="draft-experiment",
-            is_rollout=False,
-            application=NimbusExperiment.Application.DESKTOP,
-            channels=[NimbusExperiment.Channel.RELEASE],
-            feature_configs=[feature],
-        )
-
-        deliveries = draft.collision_warnings["deliveries"]
-        entry = next(d for d in deliveries if d["slug"] == live_blocker.slug)
-        self.assertEqual(entry["publish_date_relation"], "blocked_by")
 
     def test_collision_warnings_pref_no_set_pref_features_returns_empty(self):
         feature = NimbusFeatureConfigFactory.create(

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -48,33 +48,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "within a healthy range — below the alert threshold."
     )
 
-    EXCLUDING_EXPERIMENTS_WARNING = """The following experiments are being excluded by
-    your experiment and may reduce the eligible population for your experiment which
-    may result in reduced statistical power and precision. Please check that the
-    configured population proportion has accounted for this:"""
-    LIVE_EXPERIMENTS_BUCKET_WARNING = """The following experiments are LIVE on a
-    previous namespace and may reduce the eligible population for your experiment
-    which may result in reduced statistical power and precision. Please check that
-    the configured population proportion has accounted for this:"""
-    LIVE_FEATURE_OVERLAP_WARNING = """The following experiments are LIVE on a feature
-    this experiment also uses, and may reduce the eligible population which may result
-    in reduced statistical power and precision. Please check that the configured
-    population proportion has accounted for this:"""
-    LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING = """The following rollouts are LIVE on a
-    feature this rollout also uses. Rollouts share feature slots, and the rollout
-    published earliest will claim each contested slot — clients eligible for both will
-    only enroll in the earlier one. Please check that the configured population
-    proportion has accounted for this:"""
-    ERROR_ROLLOUT_BUCKET_EXISTS = """WARNING: A rollout already exists for this
-    combination of application, feature, channel, and advanced targeting!
-        If this rollout is launched, a client meeting the advanced
-        targeting criteria will be enrolled in one and not the other and
-        you will not be able to adjust the sizing for this rollout."""
-    PREF_TARGETING_WARNING = """WARNING: The following rollouts are LIVE
-    that set the same prefs and may reduce the eligible population for your experiment
-    which may result in reduced statistical power and precision or prevent enrollment
-    entirely. Please check that the configured population proportion has accounted for
-    this:"""
     EXPERIMENT_MULTICHANNEL_WARNING = """WARNING: This experiment is targeting multiple
     channels.  Each channel has significantly different population sizes and user
     behaviour.  Running an experiment on multiple channels can create misleading or
@@ -82,9 +55,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     AUDIENCE_OVERLAP_WARNING = (
         "https://experimenter.info/advanced/warnings#audience-overlap"
-    )
-    ROLLOUT_BUCKET_WARNING = (
-        "https://experimenter.info/advanced/warnings#rollout-bucketing-warning"
     )
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -56,9 +56,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     previous namespace and may reduce the eligible population for your experiment
     which may result in reduced statistical power and precision. Please check that
     the configured population proportion has accounted for this:"""
-    LIVE_MULTIFEATURE_WARNING = """The following multi-feature experiments are LIVE
-    and may reduce the eligible population for your experiment which may result in
-    reduced statistical power and precision. Please check that the configured population
+    LIVE_FEATURE_OVERLAP_WARNING = """The following experiments are LIVE on a feature
+    this experiment also uses, and may reduce the eligible population which may result
+    in reduced statistical power and precision. Please check that the configured
+    population proportion has accounted for this:"""
+    LIVE_ROLLOUT_FEATURE_OVERLAP_WARNING = """The following rollouts are LIVE on a
+    feature this rollout also uses. Rollouts share feature slots, and the rollout
+    published earliest will claim each contested slot — clients eligible for both will
+    only enroll in the earlier one. Please check that the configured population
     proportion has accounted for this:"""
     ERROR_ROLLOUT_BUCKET_EXISTS = """WARNING: A rollout already exists for this
     combination of application, feature, channel, and advanced targeting!

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -108,6 +108,30 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Firefox version below the rollout minimum"
     )
     COLLISION_SELF_ISSUE_MULTICHANNEL = "Targeting multiple channels"
+
+    # --- collision_warnings per-reason learn-more URLs ---
+    COLLISION_LEARN_MORE_EXCLUDED = (
+        "https://experimenter.info/advanced/warnings"
+        "#an-experiment-excludes-other-live-deliveries"
+    )
+    COLLISION_LEARN_MORE_SHARES_FEATURE = (
+        "https://experimenter.info/advanced/enrollment-state-machine#feature-conflict"
+    )
+    COLLISION_LEARN_MORE_SHARES_AUDIENCE = (
+        "https://experimenter.info/data-analysis/data-topics/bucketing"
+    )
+    COLLISION_LEARN_MORE_MATCHING_CONFIGURATION = (
+        "https://experimenter.info/advanced/warnings#rollout-bucketing-warning"
+    )
+    COLLISION_LEARN_MORE_SETS_SAME_PREFERENCE = (
+        "https://experimenter.info/advanced/warnings"
+        "#rollouts-and-setpref-interaction-(desktop)"
+    )
+    COLLISION_LEARN_MORE_VERSION_BELOW_MINIMUM = (
+        "https://experimenter.info/advanced/rollouts"
+        "#supported-platforms-and-minimum-versions"
+    )
+    COLLISION_LEARN_MORE_MULTICHANNEL = "https://experimenter.info/workflow/experiments"
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created
     request with either your feature engineering team or in #ask-experimenter

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -56,6 +56,58 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     AUDIENCE_OVERLAP_WARNING = (
         "https://experimenter.info/advanced/warnings#audience-overlap"
     )
+
+    # --- collision_warnings card headers ---
+    COLLISION_CARD_HEADER_COLLISIONS_ONLY = (
+        "WARNING: The following live {target}s may conflict with this {target}:"
+    )
+    COLLISION_CARD_HEADER_SELF_AND_COLLISIONS = (
+        "WARNING: Issues that may affect enrollment for this {target}:"
+    )
+    COLLISION_CARD_HEADER_SELF_ONLY = "WARNING: Issues with this {target}:"
+
+    # --- collision_warnings reason labels ---
+    COLLISION_LABEL_EXCLUDED_BY_ROLLOUT = "Excluded by this rollout"
+    COLLISION_LABEL_EXCLUDED_BY_EXPERIMENT = "Excluded by this experiment"
+    COLLISION_LABEL_SHARES_FEATURE = "Shares feature"
+    COLLISION_LABEL_SHARES_AUDIENCE = "Shares an audience"
+    COLLISION_LABEL_MATCHING_CONFIGURATION = "Has matching configuration"
+    COLLISION_LABEL_SETS_SAME_PREFERENCE = "Sets the same preference"
+
+    # --- collision_warnings reason detail tooltips ---
+    COLLISION_DETAIL_EXCLUDED = (
+        "Clients enrolled in this delivery are filtered out of the eligible "
+        "population, which may reduce statistical power and precision. Verify "
+        "the configured population proportion accounts for this."
+    )
+    COLLISION_DETAIL_SHARES_FEATURE = (
+        "This live delivery already holds the feature slot for contested "
+        "clients; this delivery will not enroll them."
+    )
+    COLLISION_DETAIL_SHARES_AUDIENCE = (
+        "This live delivery shares the same audience, so each client can only "
+        "be enrolled in one of these. This reduces the eligible population "
+        "and may reduce statistical power and precision. Verify the "
+        "configured population proportion accounts for this."
+    )
+    COLLISION_DETAIL_MATCHING_CONFIGURATION = (
+        "A live rollout already exists with the same application, feature, "
+        "channel, and advanced targeting. Clients meeting the targeting will "
+        "enroll in one or the other, and the sizing for this rollout cannot "
+        "be adjusted."
+    )
+    COLLISION_DETAIL_SETS_SAME_PREFERENCE = (
+        "This live rollout sets the same Firefox preference as this "
+        "delivery. The collision may reduce the eligible population or "
+        "prevent enrollment entirely. Verify the configured population "
+        "proportion accounts for this."
+    )
+
+    # --- collision_warnings self-issue labels ---
+    COLLISION_SELF_ISSUE_VERSION_BELOW_MINIMUM = (
+        "Firefox version below the rollout minimum"
+    )
+    COLLISION_SELF_ISSUE_MULTICHANNEL = "Targeting multiple channels"
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created
     request with either your feature engineering team or in #ask-experimenter

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -110,15 +110,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     COLLISION_SELF_ISSUE_MULTICHANNEL = "Targeting multiple channels"
 
     # --- collision_warnings per-reason learn-more URLs ---
+    # Only set where the doc page directly addresses the warning. Reasons
+    # without a tight-fit doc page (Shares feature, Shares an audience,
+    # Targeting multiple channels) have no link until the docs are updated.
     COLLISION_LEARN_MORE_EXCLUDED = (
         "https://experimenter.info/advanced/warnings"
         "#an-experiment-excludes-other-live-deliveries"
-    )
-    COLLISION_LEARN_MORE_SHARES_FEATURE = (
-        "https://experimenter.info/advanced/enrollment-state-machine#feature-conflict"
-    )
-    COLLISION_LEARN_MORE_SHARES_AUDIENCE = (
-        "https://experimenter.info/data-analysis/data-topics/bucketing"
     )
     COLLISION_LEARN_MORE_MATCHING_CONFIGURATION = (
         "https://experimenter.info/advanced/warnings#rollout-bucketing-warning"
@@ -131,7 +128,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "https://experimenter.info/advanced/rollouts"
         "#supported-platforms-and-minimum-versions"
     )
-    COLLISION_LEARN_MORE_MULTICHANNEL = "https://experimenter.info/workflow/experiments"
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created
     request with either your feature engineering team or in #ask-experimenter

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -4,11 +4,20 @@
          role="alert">
       <p class="mb-1">{{ warning.text }}</p>
       <ul class="mb-1">
-        {% for slug in warning.slugs %}
-          <li>
-            <a target="_blank" href="{% url "nimbus-ui-detail" slug=slug %}">{{ slug }}</a>
-          </li>
-        {% endfor %}
+        {% if warning.details %}
+          {% for entry in warning.details %}
+            <li>
+              <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
+              (Shares {{ entry.shared_features|join:", " }})
+            </li>
+          {% endfor %}
+        {% else %}
+          {% for slug in warning.slugs %}
+            <li>
+              <a target="_blank" href="{% url "nimbus-ui-detail" slug=slug %}">{{ slug }}</a>
+            </li>
+          {% endfor %}
+        {% endif %}
       </ul>
       {% if warning.learn_more_link %}
         <a href="{{ warning.learn_more_link }}"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -2,13 +2,45 @@
   {% for warning in experiment.audience_overlap_warnings %}
     <div class="alert alert-{{ warning.variant|default:'warning' }}"
          role="alert">
-      <p class="mb-1">{{ warning.text }}</p>
+      <p class="mb-1">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        {{ warning.text }}
+        {% if warning.estimated_loss_percent %}
+          <span class="fw-semibold">Estimated loss: up to {{ warning.estimated_loss_percent }}% of eligible audience.</span>
+        {% endif %}
+      </p>
       <ul class="mb-1">
-        {% if warning.details %}
-          {% for entry in warning.details %}
+        {% if warning.entries %}
+          {% for entry in warning.entries %}
             <li>
+              {% if entry.publish_date_relation == "blocked_by" %}
+                <span class="text-muted me-1"
+                      title="This live delivery published earlier and will claim contested clients first.">↳ blocked by</span>
+              {% elif entry.publish_date_relation == "would_block" %}
+                <span class="text-muted me-1"
+                      title="This live delivery published later; clients eligible for both will enroll here instead.">↰ would block</span>
+              {% endif %}
               <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
-              (Shares {{ entry.shared_features|join:", " }})
+              <span class="text-muted">
+                (
+                {% for reason in entry.reasons %}
+                  {% if reason.shared_features %}
+                    {{ reason.label_prefix }}
+                    {% for feature in reason.shared_features %}
+                      <a target="_blank" href="{{ feature.url }}">{{ feature.slug }}</a>
+                      {% if not forloop.last %},{% endif %}
+                    {% endfor %}
+                  {% else %}
+                    {{ reason.label }}
+                  {% endif %}
+                  <i class="fa-regular fa-circle-question fa-sm"
+                     data-bs-toggle="tooltip"
+                     data-bs-placement="top"
+                     title="{{ reason.detail }}"></i>
+                  {% if not forloop.last %},{% endif %}
+                {% endfor %}
+                )
+              </span>
             </li>
           {% endfor %}
         {% else %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -10,46 +10,47 @@
         {% endif %}
       </p>
       <ul class="mb-1">
-        {% if warning.entries %}
-          {% for entry in warning.entries %}
-            <li>
-              {% if entry.publish_date_relation == "blocked_by" %}
-                <span class="text-muted me-1"
-                      title="This live delivery published earlier and will claim contested clients first.">↳ blocked by</span>
-              {% elif entry.publish_date_relation == "would_block" %}
-                <span class="text-muted me-1"
-                      title="This live delivery published later; clients eligible for both will enroll here instead.">↰ would block</span>
-              {% endif %}
-              <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
-              <span class="text-muted">
-                (
-                {% for reason in entry.reasons %}
-                  {% if reason.shared_features %}
-                    {{ reason.label_prefix }}
-                    {% for feature in reason.shared_features %}
-                      <a target="_blank" href="{{ feature.url }}">{{ feature.slug }}</a>
-                      {% if not forloop.last %},{% endif %}
-                    {% endfor %}
-                  {% else %}
-                    {{ reason.label }}
-                  {% endif %}
-                  <i class="fa-regular fa-circle-question fa-sm"
-                     data-bs-toggle="tooltip"
-                     data-bs-placement="top"
-                     title="{{ reason.detail }}"></i>
-                  {% if not forloop.last %},{% endif %}
-                {% endfor %}
-                )
-              </span>
-            </li>
-          {% endfor %}
-        {% else %}
-          {% for slug in warning.slugs %}
-            <li>
-              <a target="_blank" href="{% url "nimbus-ui-detail" slug=slug %}">{{ slug }}</a>
-            </li>
-          {% endfor %}
-        {% endif %}
+        {% for entry in warning.entries %}
+          <li>
+            {% if entry.publish_date_relation == "blocked_by" %}
+              <span class="text-muted me-1"
+                    title="This live delivery published earlier and will claim contested clients first.">↳ blocked by</span>
+            {% elif entry.publish_date_relation == "would_block" %}
+              <span class="text-muted me-1"
+                    title="This live delivery published later; clients eligible for both will enroll here instead.">↰ would block</span>
+            {% endif %}
+            <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
+            <span class="text-muted">
+              (
+              {% for reason in entry.reasons %}
+                {% if reason.shared_features %}
+                  {{ reason.label_prefix }}
+                  {% for feature in reason.shared_features %}
+                    <a target="_blank" href="{{ feature.url }}">{{ feature.slug }}</a>
+                    {% if not forloop.last %},{% endif %}
+                  {% endfor %}
+                {% else %}
+                  {{ reason.label }}
+                {% endif %}
+                <i class="fa-regular fa-circle-question fa-sm"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="top"
+                   title="{{ reason.detail }}"></i>
+                {% if not forloop.last %},{% endif %}
+              {% endfor %}
+              )
+            </span>
+          </li>
+        {% endfor %}
+        {% for issue in warning.self_issues %}
+          <li>
+            <span>{{ issue.label }}</span>
+            <i class="fa-regular fa-circle-question fa-sm"
+               data-bs-toggle="tooltip"
+               data-bs-placement="top"
+               title="{{ issue.detail }}"></i>
+          </li>
+        {% endfor %}
       </ul>
       {% if warning.learn_more_link %}
         <a href="{{ warning.learn_more_link }}"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -26,6 +26,13 @@
                    data-bs-toggle="tooltip"
                    data-bs-placement="top"
                    title="{{ reason.detail }}"></i>
+                {% if reason.learn_more_url %}
+                  <a href="{{ reason.learn_more_url }}"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     class="text-decoration-none"
+                     title="Learn more">↗</a>
+                {% endif %}
                 {% if not forloop.last %},{% endif %}
               {% endfor %}
               )
@@ -39,6 +46,13 @@
                data-bs-toggle="tooltip"
                data-bs-placement="top"
                title="{{ issue.detail }}"></i>
+            {% if issue.learn_more_url %}
+              <a href="{{ issue.learn_more_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="text-decoration-none"
+                 title="Learn more">↗</a>
+            {% endif %}
           </li>
         {% endfor %}
       </ul>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -5,9 +5,6 @@
       <p class="mb-1">
         <i class="fa-solid fa-triangle-exclamation me-1"></i>
         {{ warning.text }}
-        {% if warning.estimated_loss_percent %}
-          <span class="fw-semibold">Estimated loss: up to {{ warning.estimated_loss_percent }}% of eligible audience.</span>
-        {% endif %}
       </p>
       <ul class="mb-1">
         {% for entry in warning.entries %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -9,13 +9,6 @@
       <ul class="mb-1">
         {% for entry in warning.entries %}
           <li>
-            {% if entry.publish_date_relation == "blocked_by" %}
-              <span class="text-muted me-1"
-                    title="This live delivery published earlier and claims the feature slot for contested clients first.">↳ blocked by</span>
-            {% elif entry.publish_date_relation == "would_block" %}
-              <span class="text-muted me-1"
-                    title="This delivery published earlier than the live one; it claims the feature slot for contested clients.">↰ would block</span>
-            {% endif %}
             <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
             <span class="text-muted">
               (

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -11,10 +11,10 @@
           <li>
             {% if entry.publish_date_relation == "blocked_by" %}
               <span class="text-muted me-1"
-                    title="This live delivery published earlier and will claim contested clients first.">↳ blocked by</span>
+                    title="This live delivery published earlier and claims the feature slot for contested clients first.">↳ blocked by</span>
             {% elif entry.publish_date_relation == "would_block" %}
               <span class="text-muted me-1"
-                    title="This live delivery published later; clients eligible for both will enroll here instead.">↰ would block</span>
+                    title="This delivery published earlier than the live one; it claims the feature slot for contested clients.">↰ would block</span>
             {% endif %}
             <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
             <span class="text-muted">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/audience_overlap_warnings.html
@@ -30,8 +30,7 @@
                   <a href="{{ reason.learn_more_url }}"
                      target="_blank"
                      rel="noopener noreferrer"
-                     class="text-decoration-none"
-                     title="Learn more">↗</a>
+                     class="ms-1">Learn more</a>
                 {% endif %}
                 {% if not forloop.last %},{% endif %}
               {% endfor %}
@@ -50,8 +49,7 @@
               <a href="{{ issue.learn_more_url }}"
                  target="_blank"
                  rel="noopener noreferrer"
-                 class="text-decoration-none"
-                 title="Learn more">↗</a>
+                 class="ms-1">Learn more</a>
             {% endif %}
           </li>
         {% endfor %}


### PR DESCRIPTION
Because

* Seven separate audience-overlap warnings, each rendering its own card with its own verbose text, plus a fragile substring-based dedup between two of them.
* Real detection gaps (single-feature rollout blocking a multi-feature draft, rollout-vs-rollout on different targeting) that the narrow predicates missed.
* Real false positives — coenrolling features, disjoint channels, and disjoint advanced-targeting configs all triggered warnings they shouldn't.

This PR

* Replaces all seven with one `collision_warnings` primitive: same-polarity live recipes sharing a non-coenrolling feature with overlapping locale/country/language/channel/targeting.
* Renders one unified card. Each colliding delivery is a row with its applicable reasons inline; self-issues fold in as additional rows.
* Compact reason labels with `?` tooltips replace the verbose warning-text constants.

Validated against last week's SDK `FeatureConflict` telemetry: 100% recall on top-200 pairs by client volume.

Fixes #15467