### PR TITLE
feat(schemas): Add support for setPref in SDK schemas

### DIFF
--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -758,6 +758,14 @@ export interface SdkFeatureVariable {
    * Only allowed when type is string.
    */
   enum?: string[];
+  setPref?: SetPref1;
+}
+export interface SetPref1 {
+  branch: PrefBranch;
+  /**
+   * The name of the pref to set.
+   */
+  pref: string;
 }
 export interface AnalysisError {
   analysis_basis?: AnalysisBasis | null;

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/feature_manifests.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/feature_manifests.py
@@ -57,6 +57,16 @@ class SdkFeatureVariable(BaseFeatureVariable):
         default=None,
     )
 
+    set_pref: SetPref | SkipJsonSchema[None] = Field(
+        alias="setPref",
+        description=(
+            "A pref that should be set to the value of this variable when enrolling.\n"
+            "\n"
+            "Only supported in Firefox for Android 152+.\n"
+        ),
+        default=None,
+    )
+
     model_config = ConfigDict(
         json_schema_extra={
             "dependentSchemas": {

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/sdk/sdk.yaml
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/feature_manifests/sdk/sdk.yaml
@@ -311,3 +311,27 @@ zoom-feature:
     status:
       type: boolean
       description: "Whether the page zoom feature is enabled or not\n"
+pref-feature:
+  description: A feature with prefs
+  hasExposure: false
+  variables:
+    foo:
+      type: boolean
+      description: bool variable
+      setPref:
+        pref: test.foo
+        branch: user
+
+    bar:
+      type: string
+      description: string variable
+      setPref:
+        pref: test.bar
+        branch: default
+
+    baz:
+      type: int
+      description: int variable
+      setPref:
+        pref: test.baz
+        branch: user

--- a/schemas/schemas/SdkFeatureManifest.schema.json
+++ b/schemas/schemas/SdkFeatureManifest.schema.json
@@ -16,6 +16,13 @@
       ],
       "type": "string"
     },
+    "PrefBranch": {
+      "enum": [
+        "default",
+        "user"
+      ],
+      "type": "string"
+    },
     "SdkFeature": {
       "description": "A feature.",
       "if": {
@@ -85,6 +92,10 @@
           },
           "type": "array"
         },
+        "setPref": {
+          "$ref": "#/$defs/SetPref",
+          "description": "A pref that should be set to the value of this variable when enrolling. Only supported in Firefox for Android 152+. "
+        },
         "type": {
           "$ref": "#/$defs/FeatureVariableType",
           "description": "The field type."
@@ -93,6 +104,23 @@
       "required": [
         "description",
         "type"
+      ],
+      "type": "object"
+    },
+    "SetPref": {
+      "properties": {
+        "branch": {
+          "$ref": "#/$defs/PrefBranch",
+          "description": "The branch the pref will be set on. Prefs set on the user branch persists through restarts."
+        },
+        "pref": {
+          "description": "The name of the pref to set.",
+          "type": "string"
+        }
+      },
+      "required": [
+        "branch",
+        "pref"
       ],
       "type": "object"
     }


### PR DESCRIPTION
Because:

- as of 152, Firefox for Android supports gecko prefs

this commit:

- adds support for setPref annotations in SDK manifests.

Fixes #15511