### PR TITLE
fix(nimbus): skip data points with None bounds in get_max_metric_value

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -100,6 +100,9 @@ class ExperimentResultsManager:
                     lower = data_point.get("lower")
                     upper = data_point.get("upper")
 
+                    if lower is None or upper is None:
+                        continue
+
                     max_value = max(max_value, abs(lower), abs(upper))
 
         return max_value

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -1547,6 +1547,74 @@ class TestExperimentResultsManager(TestCase):
                 },
                 0,
             ),
+            (
+                {
+                    "v3": {
+                        "overall": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": []},
+                                                        "branch-b": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": None,
+                                                                    "upper": None,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        },
+                                                        "branch-c": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.5,
+                                                                    "upper": 0.7,
+                                                                    "point": 0.1,
+                                                                }
+                                                            ]
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": [{}]},
+                                                        "branch-b": {"all": []},
+                                                        "branch-c": {"all": [{}]},
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-c": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "relative_uplift": {
+                                                        "branch-a": {"all": [{}]},
+                                                        "branch-b": {"all": [{}]},
+                                                        "branch-c": {"all": []},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        }
+                    }
+                },
+                0.7,
+            ),
         ]
     )
     def test_get_max_metric_value(self, results_data, expected_max_value):

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -1559,24 +1559,8 @@ class TestExperimentResultsManager(TestCase):
                                                 "retained": {
                                                     "relative_uplift": {
                                                         "branch-a": {"all": []},
-                                                        "branch-b": {
-                                                            "all": [
-                                                                {
-                                                                    "lower": None,
-                                                                    "upper": None,
-                                                                    "point": 0.02,
-                                                                }
-                                                            ]
-                                                        },
-                                                        "branch-c": {
-                                                            "all": [
-                                                                {
-                                                                    "lower": -0.5,
-                                                                    "upper": 0.7,
-                                                                    "point": 0.1,
-                                                                }
-                                                            ]
-                                                        },
+                                                        "branch-b": {"all": [{}]},
+                                                        "branch-c": {"all": [{}]},
                                                     },
                                                 }
                                             }
@@ -1587,7 +1571,15 @@ class TestExperimentResultsManager(TestCase):
                                             "other_metrics": {
                                                 "retained": {
                                                     "relative_uplift": {
-                                                        "branch-a": {"all": [{}]},
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": None,
+                                                                    "upper": None,
+                                                                    "point": 0.02,
+                                                                }
+                                                            ]
+                                                        },
                                                         "branch-b": {"all": []},
                                                         "branch-c": {"all": [{}]},
                                                     }
@@ -1600,7 +1592,15 @@ class TestExperimentResultsManager(TestCase):
                                             "other_metrics": {
                                                 "retained": {
                                                     "relative_uplift": {
-                                                        "branch-a": {"all": [{}]},
+                                                        "branch-a": {
+                                                            "all": [
+                                                                {
+                                                                    "lower": -0.5,
+                                                                    "upper": 0.7,
+                                                                    "point": 0.1,
+                                                                }
+                                                            ]
+                                                        },
                                                         "branch-b": {"all": [{}]},
                                                         "branch-c": {"all": []},
                                                     },


### PR DESCRIPTION
Because

- A data point in `relative_uplift` results can have explicit `null` (or missing) `lower`/`upper` while still being a non-empty dict (e.g. only `point` is set). The existing `if not data_point: continue` guard treats these as truthy and proceeds, then `abs(None)` raises `TypeError: bad operand type for abs(): 'NoneType'` (Sentry EXPERIMENTER-PROD-16X).

This commit

- Skips the data point when either bound is `None` before calling `abs()` in `ResultsManager.get_max_metric_value`.
- Adds a parameterized test case covering a data point with `None` lower/upper alongside a sibling branch with valid bounds, asserting the valid bounds still drive the max.

Fixes #15396