### PR TITLE
Add targeting for PDF split view experiment

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1208,6 +1208,26 @@ WIN10_VPN_PROMOTION_ELIGIBLE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+EXISTING_USERS_PDF_PROMO_ELIGIBLE = NimbusTargetingConfig(
+    name="Windows 10+ users eligible for Split PDF promo",
+    slug="win10_pdf_split_promo",
+    description=(
+        "Windows 10 users at least 7 days old, not first run,"
+        "no enterprise, CFRs enabled"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && "
+        f"{NO_ENTERPRISE.targeting} && "
+        f"{PROFILEMORETHAN7DAYS} && "
+        "!isFirstStartup && "
+        "('browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue)"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIN10_EOS_SYNC_ELIGIBLE = NimbusTargetingConfig(
     name="Windows 10 users eligible for Windows 10 EoS Sync promotion",
     slug="win10_eos_sync_promotion_eligible",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1212,8 +1212,7 @@ EXISTING_USERS_PDF_PROMO_ELIGIBLE = NimbusTargetingConfig(
     name="Windows 10+ users eligible for Split PDF promo",
     slug="win10_pdf_split_promo",
     description=(
-        "Windows 10 users at least 7 days old, not first run,"
-        "no enterprise, CFRs enabled"
+        "Windows 10 users at least 7 days old, not first run,no enterprise, CFRs enabled"
     ),
     targeting=(
         "os.isWindows && os.windowsVersion >= 10 && "


### PR DESCRIPTION
Adds targeting needed for the ["Organize and Split" PDF experiment](https://docs.google.com/document/d/19za7cQtSI2GPBBpK_OV2uTnN9er3UdOnjNehL_AMijY/edit?tab=t.0).