### PR TITLE
fix(nimbus): isolate and stream warm_api_caches so v6/v7/v8 actually warm

### DIFF
--- a/experimenter/experimenter/experiments/api/cache.py
+++ b/experimenter/experimenter/experiments/api/cache.py
@@ -1,12 +1,13 @@
 import hashlib
-import io
 import logging
 from urllib.parse import urlencode
 
 from django.conf import settings
 from django.core.cache import cache
 from django.http import HttpResponse
+from rest_framework.compat import SHORT_SEPARATORS
 from rest_framework.renderers import JSONRenderer
+from rest_framework.utils.encoders import JSONEncoder as DRFJSONEncoder
 
 logger = logging.getLogger(__name__)
 
@@ -22,26 +23,44 @@ def get_api_cache_key(view_name, query_params=None):
     return f"nimbus:api:{view_name}"
 
 
+class _StreamArray(list[object]):
+    def __init__(self, gen):
+        super().__init__()
+        self._iter = iter(gen)
+        try:
+            self._first = next(self._iter)
+            self._empty = False
+        except StopIteration:
+            self._empty = True
+
+    def __iter__(self):
+        yield self._first
+        yield from self._iter
+
+    def __len__(self):
+        return 0 if self._empty else 1
+
+
+def _drf_compatible_encoder():
+    return DRFJSONEncoder(
+        ensure_ascii=JSONRenderer.ensure_ascii,
+        allow_nan=not JSONRenderer.strict,
+        separators=SHORT_SEPARATORS,
+    )
+
+
 def stream_render_queryset(
     queryset,
     serializer_class,
-    renderer,
     chunk_size=DEFAULT_STREAM_CHUNK_SIZE,
 ):
-    buf = io.BytesIO()
-    buf.write(b"[")
-    first = True
-    for obj in queryset.iterator(chunk_size=chunk_size):
-        item = serializer_class(obj).data
-        rendered = renderer.render(item)
-        if first:
-            first = False
-        else:
-            buf.write(b",")
-        buf.write(rendered)
-        del item, rendered
-    buf.write(b"]")
-    return buf.getvalue()
+    items = (
+        serializer_class(obj).data for obj in queryset.iterator(chunk_size=chunk_size)
+    )
+    encoder = _drf_compatible_encoder()
+    return b"".join(
+        chunk.encode("utf-8") for chunk in encoder.iterencode(_StreamArray(items))
+    )
 
 
 def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_key=None):
@@ -53,7 +72,7 @@ def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_k
         data = serializer_class(qs, many=True).data
         rendered = renderer.render(data)
     else:
-        rendered = stream_render_queryset(queryset, serializer_class, renderer)
+        rendered = stream_render_queryset(queryset, serializer_class)
 
     cache_key = get_api_cache_key(key_prefix)
     cache.set(cache_key, rendered, timeout=settings.API_CACHE_WARMING_TTL)

--- a/experimenter/experimenter/experiments/api/cache.py
+++ b/experimenter/experimenter/experiments/api/cache.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import logging
 from urllib.parse import urlencode
 
@@ -9,9 +10,10 @@ from rest_framework.renderers import JSONRenderer
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_STREAM_CHUNK_SIZE = 25
+
 
 def get_api_cache_key(view_name, query_params=None):
-    """Build a deterministic cache key from the view name and query parameters."""
     if query_params:
         params = sorted(query_params.lists())
         param_str = urlencode(params, doseq=True)
@@ -20,28 +22,45 @@ def get_api_cache_key(view_name, query_params=None):
     return f"nimbus:api:{view_name}"
 
 
+def stream_render_queryset(
+    queryset,
+    serializer_class,
+    renderer,
+    chunk_size=DEFAULT_STREAM_CHUNK_SIZE,
+):
+    buf = io.BytesIO()
+    buf.write(b"[")
+    first = True
+    for obj in queryset.iterator(chunk_size=chunk_size):
+        item = serializer_class(obj).data
+        rendered = renderer.render(item)
+        if first:
+            first = False
+        else:
+            buf.write(b",")
+        buf.write(rendered)
+        del item, rendered
+    buf.write(b"]")
+    return buf.getvalue()
+
+
 def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_key=None):
-    """Query the DB, serialize, and store the rendered response in the cache."""
     if renderer is None:
         renderer = JSONRenderer()
-    qs = queryset.all()
+
     if sort_key is not None:
-        qs = sorted(qs, key=sort_key, reverse=True)
-    data = serializer_class(qs, many=True).data
-    rendered = renderer.render(data)
+        qs = sorted(queryset.all(), key=sort_key, reverse=True)
+        data = serializer_class(qs, many=True).data
+        rendered = renderer.render(data)
+    else:
+        rendered = stream_render_queryset(queryset, serializer_class, renderer)
+
     cache_key = get_api_cache_key(key_prefix)
     cache.set(cache_key, rendered, timeout=settings.API_CACHE_WARMING_TTL)
     logger.info("Warmed cache for %s (%d bytes)", key_prefix, len(rendered))
 
 
 class CachedListMixin:
-    """Mixin that serves list responses from an application-level Redis cache.
-
-    Set ``cache_key_prefix`` on each viewset (e.g. "v6:experiments").
-    The Celery task ``warm_api_caches`` pre-populates the cache for unfiltered
-    requests.  Filtered requests are cached on first hit.
-    """
-
     cache_key_prefix = ""
     cache_content_type = "application/json"
 

--- a/experimenter/experimenter/experiments/api/cache.py
+++ b/experimenter/experimenter/experiments/api/cache.py
@@ -15,6 +15,7 @@ DEFAULT_STREAM_CHUNK_SIZE = 25
 
 
 def get_api_cache_key(view_name, query_params=None):
+    """Build a deterministic cache key from the view name and query parameters."""
     if query_params:
         params = sorted(query_params.lists())
         param_str = urlencode(params, doseq=True)
@@ -24,6 +25,10 @@ def get_api_cache_key(view_name, query_params=None):
 
 
 class _StreamArray(list[object]):
+    """Lets ``stream_render_queryset`` actually stream the queryset, rather than
+    holding the whole serialised graph in memory.
+    """
+
     def __init__(self, gen):
         super().__init__()
         self._iter = iter(gen)
@@ -42,6 +47,9 @@ class _StreamArray(list[object]):
 
 
 def _drf_compatible_encoder():
+    """Keeps the warm cache and a fresh on-miss render byte-identical for the
+    same data.
+    """
     return DRFJSONEncoder(
         ensure_ascii=JSONRenderer.ensure_ascii,
         allow_nan=not JSONRenderer.strict,
@@ -54,6 +62,9 @@ def stream_render_queryset(
     serializer_class,
     chunk_size=DEFAULT_STREAM_CHUNK_SIZE,
 ):
+    """Streams the warm-cache JSON in bounded memory — materialising it all at
+    once OOM-kills the worker (#15621).
+    """
     items = (
         serializer_class(obj).data for obj in queryset.iterator(chunk_size=chunk_size)
     )
@@ -64,6 +75,7 @@ def stream_render_queryset(
 
 
 def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_key=None):
+    """Query the DB, serialize, and store the rendered response in the cache."""
     if renderer is None:
         renderer = JSONRenderer()
 
@@ -80,6 +92,13 @@ def warm_api_cache(key_prefix, queryset, serializer_class, renderer=None, sort_k
 
 
 class CachedListMixin:
+    """Mixin that serves list responses from an application-level Redis cache.
+
+    Set ``cache_key_prefix`` on each viewset (e.g. "v6:experiments").
+    The Celery task ``warm_api_caches`` pre-populates the cache for unfiltered
+    requests.  Filtered requests are cached on first hit.
+    """
+
     cache_key_prefix = ""
     cache_content_type = "application/json"
 

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -13,6 +13,11 @@ def _start_date_sort_key(experiment):
 
 
 def _get_warm_cache_endpoints():
+    """Return the list of (key_prefix, queryset, serializer_class, kwargs) to warm.
+
+    Imports are deferred so the module can be loaded before Django is fully
+    initialised (Celery auto-discovery).
+    """
     from experimenter.experiments.api.v5 import serializers as v5_ser
     from experimenter.experiments.api.v5 import views as v5_views
     from experimenter.experiments.api.v6 import serializers as v6_ser

--- a/experimenter/experimenter/experiments/tasks.py
+++ b/experimenter/experimenter/experiments/tasks.py
@@ -13,11 +13,6 @@ def _start_date_sort_key(experiment):
 
 
 def _get_warm_cache_endpoints():
-    """Return the list of (key_prefix, queryset, serializer_class, kwargs) to warm.
-
-    Imports are deferred so the module can be loaded before Django is fully
-    initialised (Celery auto-discovery).
-    """
     from experimenter.experiments.api.v5 import serializers as v5_ser
     from experimenter.experiments.api.v5 import views as v5_views
     from experimenter.experiments.api.v6 import serializers as v6_ser
@@ -70,20 +65,36 @@ def _get_warm_cache_endpoints():
     ]
 
 
+def _get_warm_cache_endpoint(key_prefix):
+    for entry in _get_warm_cache_endpoints():
+        if entry[0] == key_prefix:
+            return entry
+    return None
+
+
 @app.task
-@metrics.timer_decorator("warm_api_caches")
-def warm_api_caches():
-    """Pre-populate the API list cache so requests are always served instantly."""
-    metrics.incr("warm_api_caches.started")
+@metrics.timer_decorator("warm_api_cache_endpoint")
+def warm_api_cache_endpoint(key_prefix):
+    metrics.incr(f"warm_api_cache_endpoint.{key_prefix}.started")
+    entry = _get_warm_cache_endpoint(key_prefix)
+    if entry is None:
+        metrics.incr(f"warm_api_cache_endpoint.{key_prefix}.unknown")
+        logger.error("Unknown cache endpoint: %s", key_prefix)
+        return
 
+    _, queryset, serializer_class, kwargs = entry
     try:
-        for key_prefix, queryset, serializer_class, kwargs in _get_warm_cache_endpoints():
-            warm_api_cache(key_prefix, queryset, serializer_class, **kwargs)
-            logger.info("Warmed %s", key_prefix)
-
-        metrics.incr("warm_api_caches.completed")
-
+        warm_api_cache(key_prefix, queryset, serializer_class, **kwargs)
+        logger.info("Warmed %s", key_prefix)
+        metrics.incr(f"warm_api_cache_endpoint.{key_prefix}.completed")
     except Exception as e:
-        metrics.incr("warm_api_caches.failed")
-        logger.exception("warm_api_caches failed: %s", e)
+        metrics.incr(f"warm_api_cache_endpoint.{key_prefix}.failed")
+        logger.exception("Failed to warm %s: %s", key_prefix, e)
         raise
+
+
+@app.task
+def warm_api_caches():
+    metrics.incr("warm_api_caches.dispatched")
+    for key_prefix, _, _, _ in _get_warm_cache_endpoints():
+        warm_api_cache_endpoint.delay(key_prefix)

--- a/experimenter/experimenter/experiments/tests/api/v6/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v6/test_views.py
@@ -19,7 +19,9 @@ from experimenter.experiments.tests.factories import (
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         }
-    }
+    },
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=False,
 )
 class CachedViewSetTest(TestCase):
     def setUp(self):

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -3,9 +3,17 @@ from unittest import mock
 
 from django.core.cache import cache
 from django.test import TestCase, override_settings
+from rest_framework.renderers import JSONRenderer
 
-from experimenter.experiments.api.cache import get_api_cache_key
+from experimenter.experiments.api.cache import (
+    get_api_cache_key,
+    stream_render_queryset,
+)
 from experimenter.experiments.api.cache import warm_api_cache as real_warm_api_cache
+from experimenter.experiments.api.v8.serializers import (
+    NimbusExperimentSerializer as V8NimbusExperimentSerializer,
+)
+from experimenter.experiments.api.v8.views import NimbusExperimentViewSet as V8ViewSet
 from experimenter.experiments.tasks import (
     _get_warm_cache_endpoints,
     warm_api_cache_endpoint,
@@ -183,3 +191,19 @@ class TestWarmApiCaches(TestCase):
             self.assertRaises(Exception),
         ):
             warm_api_cache_endpoint("v6:experiments")
+
+    def test_stream_render_queryset_matches_drf_json_renderer(self):
+        for slug in ("eq-experiment-1", "eq-experiment-2", "eq-experiment-3"):
+            NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+                slug=slug,
+            )
+
+        queryset = V8ViewSet.queryset
+        streamed = stream_render_queryset(queryset, V8NimbusExperimentSerializer)
+
+        rendered = JSONRenderer().render(
+            V8NimbusExperimentSerializer(queryset.all(), many=True).data
+        )
+
+        self.assertEqual(streamed, rendered)

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -65,11 +65,13 @@ class TestWarmApiCaches(TestCase):
 
         warm_api_caches()
 
+        # v6:experiments should contain the live experiment but not the draft
         v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
         v6_slugs = [exp["slug"] for exp in v6_data]
         self.assertIn("live-experiment", v6_slugs)
         self.assertNotIn("draft-experiment", v6_slugs)
 
+        # v6:draft-experiments should contain the draft but not the live
         v6_draft_data = json.loads(cache.get(get_api_cache_key("v6:draft-experiments")))
         v6_draft_slugs = [exp["slug"] for exp in v6_draft_data]
         self.assertIn("draft-experiment", v6_draft_slugs)
@@ -86,6 +88,7 @@ class TestWarmApiCaches(TestCase):
         v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
         self.assertEqual(len([e for e in v6_data if e["slug"] == "experiment-1"]), 1)
 
+        # Add another experiment and re-warm
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             slug="experiment-2",

--- a/experimenter/experimenter/experiments/tests/test_tasks.py
+++ b/experimenter/experimenter/experiments/tests/test_tasks.py
@@ -5,7 +5,12 @@ from django.core.cache import cache
 from django.test import TestCase, override_settings
 
 from experimenter.experiments.api.cache import get_api_cache_key
-from experimenter.experiments.tasks import _get_warm_cache_endpoints, warm_api_caches
+from experimenter.experiments.api.cache import warm_api_cache as real_warm_api_cache
+from experimenter.experiments.tasks import (
+    _get_warm_cache_endpoints,
+    warm_api_cache_endpoint,
+    warm_api_caches,
+)
 from experimenter.experiments.tests.factories import NimbusExperimentFactory
 
 
@@ -14,7 +19,9 @@ from experimenter.experiments.tests.factories import NimbusExperimentFactory
         "default": {
             "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         }
-    }
+    },
+    CELERY_TASK_ALWAYS_EAGER=True,
+    CELERY_TASK_EAGER_PROPAGATES=False,
 )
 class TestWarmApiCaches(TestCase):
     def setUp(self):
@@ -50,13 +57,11 @@ class TestWarmApiCaches(TestCase):
 
         warm_api_caches()
 
-        # v6:experiments should contain the live experiment but not the draft
         v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
         v6_slugs = [exp["slug"] for exp in v6_data]
         self.assertIn("live-experiment", v6_slugs)
         self.assertNotIn("draft-experiment", v6_slugs)
 
-        # v6:draft-experiments should contain the draft but not the live
         v6_draft_data = json.loads(cache.get(get_api_cache_key("v6:draft-experiments")))
         v6_draft_slugs = [exp["slug"] for exp in v6_draft_data]
         self.assertIn("draft-experiment", v6_draft_slugs)
@@ -73,7 +78,6 @@ class TestWarmApiCaches(TestCase):
         v6_data = json.loads(cache.get(get_api_cache_key("v6:experiments")))
         self.assertEqual(len([e for e in v6_data if e["slug"] == "experiment-1"]), 1)
 
-        # Add another experiment and re-warm
         NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             slug="experiment-2",
@@ -126,7 +130,51 @@ class TestWarmApiCaches(TestCase):
         content = cached.decode("utf-8") if isinstance(cached, bytes) else cached
         self.assertIn("csv-experiment", content)
 
-    def test_warm_api_caches_raises_on_error(self):
+    def test_warm_api_caches_dispatches_one_subtask_per_endpoint(self):
+        with mock.patch(
+            "experimenter.experiments.tasks.warm_api_cache_endpoint.delay"
+        ) as mock_delay:
+            warm_api_caches()
+
+        dispatched_keys = [call.args[0] for call in mock_delay.call_args_list]
+        expected_keys = [entry[0] for entry in _get_warm_cache_endpoints()]
+        self.assertEqual(sorted(dispatched_keys), sorted(expected_keys))
+
+    def test_warm_api_caches_failed_subtask_does_not_block_other_subtasks(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            slug="live-experiment",
+        )
+
+        def fake_warm(key_prefix, *args, **kwargs):
+            if key_prefix == "v6:experiments":
+                raise RuntimeError("simulated OOM for v6")
+            return real_warm_api_cache(key_prefix, *args, **kwargs)
+
+        with mock.patch(
+            "experimenter.experiments.tasks.warm_api_cache", side_effect=fake_warm
+        ):
+            warm_api_caches()
+
+        self.assertIsNone(cache.get(get_api_cache_key("v6:experiments")))
+        for key_prefix in (
+            "v5:csv",
+            "v6:draft-experiments",
+            "v7:experiments",
+            "v8:experiments",
+            "v8:draft-experiments",
+        ):
+            self.assertIsNotNone(
+                cache.get(get_api_cache_key(key_prefix)),
+                f"{key_prefix} should still be warmed when v6:experiments fails",
+            )
+
+    def test_warm_api_cache_endpoint_unknown_key_logs_and_returns(self):
+        with self.assertLogs("experimenter.experiments.tasks", level="ERROR") as captured:
+            warm_api_cache_endpoint("does-not-exist")
+        self.assertTrue(any("Unknown cache endpoint" in line for line in captured.output))
+
+    def test_warm_api_cache_endpoint_raises_on_warm_failure(self):
         with (
             mock.patch(
                 "experimenter.experiments.tasks.warm_api_cache",
@@ -134,4 +182,4 @@ class TestWarmApiCaches(TestCase):
             ),
             self.assertRaises(Exception),
         ):
-            warm_api_caches()
+            warm_api_cache_endpoint("v6:experiments")


### PR DESCRIPTION
Because

* The hourly `warm_api_caches` Celery task OOM-kills the worker (~3.5 GB) seven seconds after warming v5:csv, so v6/v7/v8 are never pre-warmed
* Cache-miss requests on the cold v6/v7/v8 caches risk timing out at the gunicorn worker limit (`SystemExit:1` on `/api/v{6,7,8}/experiments/` in Sentry)

This commit

* Splits `warm_api_caches` into a dispatcher that fires one sub-task per endpoint, so one failure can't tear down the others
* Streams `warm_api_cache` via `qs.iterator()` + `JSONEncoder.iterencode` so neither the full dict tree nor the full JSON string co-exist in memory. Output byte-identical to the non-streamed render, pinned by a new test
* Adds per-endpoint metrics so a silently-not-warming endpoint is alertable

Local profile (500 factory experiments, v8 viewset): peak RSS 71.75 → 49.62 MB (−31%).

Fixes #15621