### PR TITLE
feat(nimbus): add advanced targeting for win10 existing users needing…

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1165,6 +1165,19 @@ WIN10_NEED_DEFAULT = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WIN10_EXISTING_USERS_NEED_DEFAULT = NimbusTargetingConfig(
+    name="Windows 10 existing users needing default",
+    slug="win10_existing_users_need_default",
+    description=(
+        "Windows 10 users with profiles older than 28 days needing default"
+    ),
+    targeting=f"{PROFILE28DAYS} && {WIN10_NEED_DEFAULT.targeting}",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 GUIDANCE_NOTIFICATION_GIF_EXPERIMENT = NimbusTargetingConfig(
     name="Guidance notification GIF experiment",
     slug="guidance_notification_gif_experiment",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1168,9 +1168,7 @@ WIN10_NEED_DEFAULT = NimbusTargetingConfig(
 WIN10_EXISTING_USERS_NEED_DEFAULT = NimbusTargetingConfig(
     name="Windows 10 existing users needing default",
     slug="win10_existing_users_need_default",
-    description=(
-        "Windows 10 users with profiles older than 28 days needing default"
-    ),
+    description=("Windows 10 users with profiles older than 28 days needing default"),
     targeting=f"{PROFILE28DAYS} && {WIN10_NEED_DEFAULT.targeting}",
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
To support the [Win10 EoS communicate privacy value experiment](https://docs.google.com/document/d/1A43ptw9LQlhF2pR7mcbt_mCrJx9zuaNEHYs1PhJBT2A/edit?tab=t.0) this commit adds advanced targeting that covers:
- Win10 users
- Profile age 28 days and older
- Is NOT set to default