### PR TITLE
feat(nimbus): show metric details modal for metrics without results

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -17,167 +17,169 @@
                 data-bs-dismiss="modal"
                 aria-label="Close"></button>
       </div>
-      <div class="modal-body d-flex flex-column gap-4"
-           id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">
-        <div class="border border-1 rounded py-4 px-5 rounded-4">
-          <h2 class="fs-6 fw-bold">Overview</h2>
-          <div class="row row-cols-3 g-3">
-            <div class="col">
-              <p class="fw-bold text-center">Branches</p>
-              {% for branch in branch_data %}
-                <div class="p-3 mb-3 d-flex flex-column justify-content-center text-start text-center align-items-center"
-                     style="height: 75px">
-                  {% if branch.slug == reference_branch %}<small class="text-muted">Baseline</small>{% endif %}
-                  <p class="mb-0 text-truncate w-100 text-center"
-                     title="{{ branch.name }}">{{ branch.name }}</p>
-                </div>
-              {% endfor %}
-            </div>
-            <div class="col">
-              <p class="fw-bold text-center">Absolute count</p>
-              {% for branch_slug, branch_data in metric_data.items %}
-                {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
-
-              {% endfor %}
-            </div>
-            <div class="col">
-              <p class="fw-bold text-center">Relative change</p>
-              <div class="d-flex flex-column">
+      {% if metric_info.has_data %}
+        <div class="modal-body d-flex flex-column gap-4"
+             id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">
+          <div class="border border-1 rounded py-4 px-5 rounded-4">
+            <h2 class="fs-6 fw-bold">Overview</h2>
+            <div class="row row-cols-3 g-3">
+              <div class="col">
+                <p class="fw-bold text-center">Branches</p>
+                {% for branch in branch_data %}
+                  <div class="p-3 mb-3 d-flex flex-column justify-content-center text-start text-center align-items-center"
+                       style="height: 75px">
+                    {% if branch.slug == reference_branch %}<small class="text-muted">Baseline</small>{% endif %}
+                    <p class="mb-0 text-truncate w-100 text-center"
+                       title="{{ branch.name }}">{{ branch.name }}</p>
+                  </div>
+                {% endfor %}
+              </div>
+              <div class="col">
+                <p class="fw-bold text-center">Absolute count</p>
                 {% for branch_slug, branch_data in metric_data.items %}
-                  {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
-                    {% if branch_slug == branch_relative_ui %}
-                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
+                  {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+
+                {% endfor %}
+              </div>
+              <div class="col">
+                <p class="fw-bold text-center">Relative change</p>
+                <div class="d-flex flex-column">
+                  {% for branch_slug, branch_data in metric_data.items %}
+                    {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
+                      {% if branch_slug == branch_relative_ui %}
+                        {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
+
+                      {% endif %}
+                    {% endfor %}
+                    {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
+                    {% if branch_slug == reference_branch %}
+                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
 
                     {% endif %}
                   {% endfor %}
-                  {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
-                  {% if branch_slug == reference_branch %}
-                    {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
-
-                  {% endif %}
-                {% endfor %}
+                </div>
               </div>
             </div>
           </div>
-        </div>
-        {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
-          {% if weekly_metric_data.has_weekly_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
-            <div class="border border-1 rounded py-4 px-5 rounded-4">
-              <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
-              <div class="d-flex mt-3">
-                <div class="col-2">
-                  <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-                  {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
-                    {% for branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
-                      {% if forloop.first %}
-                        {% for week in branch_weekly_metric_data %}
-                          <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
-                               style="height: 100px">
-                            <small class="text-muted">Week {{ forloop.counter }}</small>
-                          </div>
-                        {% endfor %}
+          {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
+            {% if weekly_metric_data.has_weekly_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
+              <div class="border border-1 rounded py-4 px-5 rounded-4">
+                <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
+                <div class="d-flex mt-3">
+                  <div class="col-2">
+                    <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+                    {% with reference_branch_weekly=weekly_metric_data.data|dict_get:reference_branch %}
+                      {% for branch_slug, branch_weekly_metric_data in weekly_metric_data.data.items %}
+                        {% if forloop.first %}
+                          {% for week in branch_weekly_metric_data %}
+                            <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                                 style="height: 100px">
+                              <small class="text-muted">Week {{ forloop.counter }}</small>
+                            </div>
+                          {% endfor %}
+                        {% endif %}
+                      {% endfor %}
+                    {% endwith %}
+                  </div>
+                  <div class="col position-relative w-25">
+                    <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
+                      {% if branch_data|length > 3 %}
+                        <div class="branch-fade branch-fade-left"></div>
+                        <div class="branch-fade branch-fade-right"></div>
                       {% endif %}
-                    {% endfor %}
-                  {% endwith %}
-                </div>
-                <div class="col position-relative w-25">
-                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
-                    {% if branch_data|length > 3 %}
-                      <div class="branch-fade branch-fade-left"></div>
-                      <div class="branch-fade branch-fade-right"></div>
-                    {% endif %}
-                    {% for branch in branch_data %}
-                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                        <p class="fs-5 text-truncate w-100 text-center"
-                           title="{{ branch.name }}">{{ branch.name }}</p>
-                        <div class="d-flex flex-column gap-3 w-100 h-100">
-                          {% for weekly_data_point in weekly_metric_data.data|dict_get:branch.slug %}
-                            {% if not weekly_data_point.0.lower and not weekly_data_point.1.lower %}
-                              <div class="d-flex align-items-center" style="height: 100px;">
-                                <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
-                                  <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-                                  <p class="mb-0 fw-semibold">Week unavailable</p>
-                                  <p class="mb-0">Other weeks may not be affected.</p>
-                                  <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
-                                     target="_blank"
-                                     href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+                      {% for branch in branch_data %}
+                        <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                          <p class="fs-5 text-truncate w-100 text-center"
+                             title="{{ branch.name }}">{{ branch.name }}</p>
+                          <div class="d-flex flex-column gap-3 w-100 h-100">
+                            {% for weekly_data_point in weekly_metric_data.data|dict_get:branch.slug %}
+                              {% if not weekly_data_point.0.lower and not weekly_data_point.1.lower %}
+                                <div class="d-flex align-items-center" style="height: 100px;">
+                                  <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                    <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                    <p class="mb-0 fw-semibold">Week unavailable</p>
+                                    <p class="mb-0">Other weeks may not be affected.</p>
+                                    <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                       target="_blank"
+                                       href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+                                  </div>
                                 </div>
-                              </div>
-                            {% else %}
-                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change lower_percent=weekly_data_point.1.lower upper_percent=weekly_data_point.1.upper %}
+                              {% else %}
+                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=weekly_data_point.0.lower absolute_upper=weekly_data_point.0.upper significance=weekly_data_point.1.significance percentage=weekly_data_point.1.avg_rel_change lower_percent=weekly_data_point.1.lower upper_percent=weekly_data_point.1.upper %}
 
-                            {% endif %}
-                          {% empty %}
-                            {% comment %} DAU edge case: reference branch lacks both absolute and relative weekly data, so render a standalone baseline column. {% endcomment %}
-                            <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
-                              <div>Baseline</div>
-                            </div>
-                          {% endfor %}
+                              {% endif %}
+                            {% empty %}
+                              {% comment %} DAU edge case: reference branch lacks both absolute and relative weekly data, so render a standalone baseline column. {% endcomment %}
+                              <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
+                                <div>Baseline</div>
+                              </div>
+                            {% endfor %}
+                          </div>
                         </div>
-                      </div>
-                    {% endfor %}
-                  </div>
-                </div>
-              </div>
-            </div>
-          {% endif %}
-        {% endwith %}
-        {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
-          {% if daily_metric_data.has_daily_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
-            <div class="border border-1 rounded py-4 px-5 rounded-4">
-              <h2 class="fs-6 fw-bold">Daily breakdown</h2>
-              <div class="d-flex mt-3">
-                <div class="col-2">
-                  <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
-                  {% for i in '0123456'|make_list %}
-                    <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
-                         style="height: 100px">
-                      <small class="text-muted">Day {{ forloop.counter }}</small>
+                      {% endfor %}
                     </div>
-                  {% endfor %}
-                </div>
-                <div class="col position-relative w-25">
-                  <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
-                    {% if branch_data|length > 3 %}
-                      <div class="branch-fade branch-fade-left"></div>
-                      <div class="branch-fade branch-fade-right"></div>
-                    {% endif %}
-                    {% for branch in branch_data %}
-                      <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
-                        <p class="fs-5 text-truncate w-100 text-center"
-                           title="{{ branch.name }}">{{ branch.name }}</p>
-                        <div class="d-flex flex-column gap-3 w-100 h-100">
-                          {% for daily_data_point in daily_metric_data.data|dict_get:branch.slug|slice:":7" %}
-                            {% if not daily_data_point.0.lower and not daily_data_point.1.lower %}
-                              <div class="d-flex align-items-center" style="height: 100px;">
-                                <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
-                                  <i class="fa-solid fa-triangle-exclamation fs-5"></i>
-                                  <p class="mb-0 fw-semibold">Day unavailable</p>
-                                  <p class="mb-0">Other days may not be affected.</p>
-                                  <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
-                                     target="_blank"
-                                     href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
-                                </div>
-                              </div>
-                            {% else %}
-                              {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=daily_data_point.0.lower absolute_upper=daily_data_point.0.upper significance=daily_data_point.1.significance percentage=daily_data_point.1.avg_rel_change lower_percent=daily_data_point.1.lower upper_percent=daily_data_point.1.upper %}
-
-                            {% endif %}
-                          {% empty %}
-                            <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
-                              <div>Baseline</div>
-                            </div>
-                          {% endfor %}
-                        </div>
-                      </div>
-                    {% endfor %}
                   </div>
                 </div>
               </div>
-            </div>
-          {% endif %}
-        {% endwith %}
-      </div>
+            {% endif %}
+          {% endwith %}
+          {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
+            {% if daily_metric_data.has_daily_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
+              <div class="border border-1 rounded py-4 px-5 rounded-4">
+                <h2 class="fs-6 fw-bold">Daily breakdown</h2>
+                <div class="d-flex mt-3">
+                  <div class="col-2">
+                    <p class="fs-5 mb-3 invisible" aria-hidden="true">Baseline</p>
+                    {% for i in '0123456'|make_list %}
+                      <div class="{% if forloop.last %}mb-4{% endif %} mb-3 d-flex text-center rounded-4 w-100 text-start position-relative d-flex flex-column align-items-center justify-content-center"
+                           style="height: 100px">
+                        <small class="text-muted">Day {{ forloop.counter }}</small>
+                      </div>
+                    {% endfor %}
+                  </div>
+                  <div class="col position-relative w-25">
+                    <div class="row flex-row flex-nowrap overflow-auto mx-2 pb-3 {% if branch_data|length > 3 %}mx-4{% endif %}">
+                      {% if branch_data|length > 3 %}
+                        <div class="branch-fade branch-fade-left"></div>
+                        <div class="branch-fade branch-fade-right"></div>
+                      {% endif %}
+                      {% for branch in branch_data %}
+                        <div class="{% if branch.slug == selected_reference_branch %}col-2{% elif branch_data|length > 3 %}col-4{% else %}col{% endif %} d-flex flex-column align-items-center">
+                          <p class="fs-5 text-truncate w-100 text-center"
+                             title="{{ branch.name }}">{{ branch.name }}</p>
+                          <div class="d-flex flex-column gap-3 w-100 h-100">
+                            {% for daily_data_point in daily_metric_data.data|dict_get:branch.slug|slice:":7" %}
+                              {% if not daily_data_point.0.lower and not daily_data_point.1.lower %}
+                                <div class="d-flex align-items-center" style="height: 100px;">
+                                  <div class="position-absolute alert alert-warning d-flex align-items-center justify-content-center gap-2 end-0 start-0 {% if branch_data|length > 4 %}mx-5{% else %}mx-3{% endif %} mb-0">
+                                    <i class="fa-solid fa-triangle-exclamation fs-5"></i>
+                                    <p class="mb-0 fw-semibold">Day unavailable</p>
+                                    <p class="mb-0">Other days may not be affected.</p>
+                                    <a class="btn btn-secondary bg-secondary-subtle border-0 text-body fw-semibold"
+                                       target="_blank"
+                                       href="{{ ask_experimenter_slack_link }}">Contact Experimenter Support</a>
+                                  </div>
+                                </div>
+                              {% else %}
+                                {% include "common/metric_card.html" with slug=branch.slug reference_branch=selected_reference_branch absolute_lower=daily_data_point.0.lower absolute_upper=daily_data_point.0.upper significance=daily_data_point.1.significance percentage=daily_data_point.1.avg_rel_change lower_percent=daily_data_point.1.lower upper_percent=daily_data_point.1.upper %}
+
+                              {% endif %}
+                            {% empty %}
+                              <div class="text-center text-muted w-100 py-4 h-100 d-flex flex-column align-items-center justify-content-center rounded-3 bg-body-tertiary">
+                                <div>Baseline</div>
+                              </div>
+                            {% endfor %}
+                          </div>
+                        </div>
+                      {% endfor %}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            {% endif %}
+          {% endwith %}
+        </div>
+      {% endif %}
     </div>
   </div>
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -348,6 +348,7 @@
                       {% endfor %}
                     {% else %}
                       {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric %}
+
                     {% endif %}
                   {% endfor %}
                 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -331,23 +331,24 @@
                             type="button"
                             data-bs-toggle="modal"
                             data-bs-target="#{{ experiment.slug }}-{{ metric.slug }}-{{ area|slugify }}"
-                            style="height: 100px;
-                                   {% if not metric.has_data %}cursor: default;{% endif %}">
-                      {% if metric.has_data %}
-                        <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
-                      {% endif %}
+                            style="height: 100px">
+                      <i class="fa-solid fa-arrow-up-right-from-square text-secondary fa-sm position-absolute top-0 end-0 p-3 px-2"></i>
                       <p class=" metric-text mb-0">{{ metric.friendly_name }}</p>
                     </button>
-                    {% for curr_metric_slug, metric_data in metric_data.items %}
-                      {% if curr_metric_slug == metric.slug %}
-                        {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
-                          {% if metric_ui_properties == curr_metric_slug %}
-                            {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
+                    {% if metric.has_data %}
+                      {% for curr_metric_slug, metric_data in metric_data.items %}
+                        {% if curr_metric_slug == metric.slug %}
+                          {% for metric_ui_properties, ui_properties in relative_metric_changes.items %}
+                            {% if metric_ui_properties == curr_metric_slug %}
+                              {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric metric_data=metric_data branches=branch_data reference_branch=selected_reference_branch ui_properties=ui_properties display_type=metric.display_type %}
 
-                          {% endif %}
-                        {% endfor %}
-                      {% endif %}
-                    {% endfor %}
+                            {% endif %}
+                          {% endfor %}
+                        {% endif %}
+                      {% endfor %}
+                    {% else %}
+                      {% include "common/metric_popout.html" with experiment_slug=experiment.slug metric_info=metric %}
+                    {% endif %}
                   {% endfor %}
                 </div>
                 <div class="col position-relative w-25 d-flex flex-column">


### PR DESCRIPTION
Because

* users cannot open the metric details modal when a metric has no results
* metric descriptions can still be useful even without data

This commit

* makes the metric clickable even when metric data is unavailable and shows metric description

Fixes #15668

<img width="1707" height="698" alt="Screenshot 2026-05-20 at 4 10 39 PM" src="https://github.com/user-attachments/assets/9f479893-91b4-4e98-bc0f-b6feb696dbc2" />
<img width="1716" height="746" alt="Screenshot 2026-05-20 at 4 10 50 PM" src="https://github.com/user-attachments/assets/74fa58f6-9f67-4135-9533-843c133ad2f1" />
