### PR TITLE
fix(nimbus): hide sidebar toggle on pages without a sidebar

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -4,14 +4,16 @@
 
 <nav class="navbar navbar-expand-xl">
   <div class="container-fluid">
-    <button class="navbar-toggler"
-            type="button"
-            data-bs-toggle="offcanvas"
-            data-bs-target="#offcanvasSidebar"
-            aria-controls="offcanvasSidebar"
-            aria-label="Toggle sidebar">
-      <span class="navbar-toggler-icon"></span>
-    </button>
+    {% if has_sidebar %}
+      <button class="navbar-toggler"
+              type="button"
+              data-bs-toggle="offcanvas"
+              data-bs-target="#offcanvasSidebar"
+              aria-controls="offcanvasSidebar"
+              aria-label="Toggle sidebar">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+    {% endif %}
     <a class="navbar-brand align-items-center fs-3"
        href="{% url 'nimbus-ui-home' %}">
       <img src="{% static 'assets/logo.svg' %}"

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -5,23 +5,16 @@
 <nav class="navbar navbar-expand-xl">
   <div class="container-fluid">
     {% if has_sidebar %}
-      <button class="navbar-toggler"
-              type="button"
-              data-bs-toggle="offcanvas"
-              data-bs-target="#offcanvasSidebar"
-              aria-controls="offcanvasSidebar"
-              aria-label="Toggle sidebar">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-    {% else %}
-      <button class="navbar-toggler"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#navigation"
-              aria-controls="navigation"
-              aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
+      <div class="w-100 d-xl-none mb-2">
+        <button class="btn btn-outline-secondary"
+                type="button"
+                data-bs-toggle="offcanvas"
+                data-bs-target="#offcanvasSidebar"
+                aria-controls="offcanvasSidebar"
+                aria-label="Toggle sidebar">
+          <i class="fa-solid fa-bars"></i>
+        </button>
+      </div>
     {% endif %}
     <a class="navbar-brand align-items-center fs-3"
        href="{% url 'nimbus-ui-home' %}">
@@ -32,8 +25,9 @@
            class="me-2 mb-2">
       Nimbus Experiments
     </a>
-    <div class="collapse navbar-collapse" id="navigation">
-      <ul class="navbar-nav me-auto align-items-center">
+    <div class="navbar-collapse flex-column flex-xl-row gap-2 gap-xl-0"
+         id="navigation">
+      <ul class="navbar-nav me-auto align-items-xl-center gap-1 gap-xl-0">
         <li class="nav-item">
           <a href="{% url 'nimbus-ui-home' %}"
              class="nav-link link-primary py-0 mt-1 fw-semibold">
@@ -56,8 +50,8 @@
           </a>
         </li>
       </ul>
-      <ul class="navbar-nav ms-auto align-items-center">
-        <li class="nav-item me-2">
+      <ul class="navbar-nav ms-xl-auto align-items-xl-center gap-1 gap-xl-0 mt-3 mt-xl-0">
+        <li class="nav-item me-xl-2">
           <button id="create-new-button"
                   class="btn btn-primary"
                   data-bs-toggle="modal"

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -13,6 +13,15 @@
               aria-label="Toggle sidebar">
         <span class="navbar-toggler-icon"></span>
       </button>
+    {% else %}
+      <button class="navbar-toggler"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#navigation"
+              aria-controls="navigation"
+              aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
     {% endif %}
     <a class="navbar-brand align-items-center fs-3"
        href="{% url 'nimbus-ui-home' %}">
@@ -47,151 +56,151 @@
           </a>
         </li>
       </ul>
-    </div>
-    <ul class="navbar-nav ms-auto align-items-center">
-      <li class="nav-item me-2">
-        <button id="create-new-button"
-                class="btn btn-primary"
-                data-bs-toggle="modal"
-                data-bs-target="#createModal">
-          <i class="fa-regular fa-pen-to-square me-1"></i>
-          Create Experiment
-        </button>
-      </li>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle"
-           href="#"
-           role="button"
-           data-bs-toggle="dropdown"
-           aria-expanded="false">Links</a>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li>
-            <a href="https://experimenter.info/"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-book me-2"></i>
-              Docs
-            </a>
-          </li>
-          <li>
-            <a href="https://github.com/mozilla-extensions/nimbus-devtools/releases/tag/release%2Fv0.3.0"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-wrench me-2"></i>
-              Nimbus Devtools
-            </a>
-          </li>
-          <li>
-            <a href="{% url "nimbus-experiments-csv" %}"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-file-arrow-down me-2"></i>
-              Reports
-            </a>
-          </li>
-          <li>
-            <a href="{% url "nimbus-experiments-csv-usage" %}"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-chart-line me-2"></i>
-              Usage Stats
-            </a>
-          </li>
-          <li>
-            <a href="{% url "nimbus-experiments-yaml" %}"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-file-lines me-2"></i>
-              YAML Export
-            </a>
-          </li>
-          <li>
-            <a id="legacy_page_link"
-               href="/legacy/"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-ghost me-2"></i>
-              Legacy
-            </a>
-          </li>
-          <li>
-            <hr class="dropdown-divider">
-          </li>
-          <li>
-            <a href="https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&issuetype=10097"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-comment-dots me-2"></i>
-              Feedback
-            </a>
-          </li>
-          <li>
-            <a href="https://mozilla.slack.com/?redir=%2Farchives%2FCF94YGE03"
-               class="dropdown-item link-primary"
-               target="_blank"
-               rel="noreferrer">
-              <i class="fa-solid fa-circle-question me-2"></i>
-              Help
-            </a>
-          </li>
-        </ul>
-      </li>
-      <li class="nav-item dropdown">
-        <a class="nav-link dropdown-toggle"
-           href="#"
-           role="button"
-           data-bs-toggle="dropdown"
-           aria-expanded="false">
-          <i class="fa-regular fa-circle-user"></i>
-        </a>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllOwned#my-deliveries"
-               class="dropdown-item link-primary">
-              <i class="fa-solid fa-user me-2"></i>
-              My Deliveries
-            </a>
-          </li>
-          <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllSubscribed#my-deliveries"
-               class="dropdown-item link-primary">
-              <i class="fa-solid fa-bell me-2"></i>
-              My Subscribed Deliveries
-            </a>
-          </li>
-          <li>
-            <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=FeatureSubscribed#my-deliveries"
-               class="dropdown-item link-primary">
-              <i class="fa-solid fa-boxes-stacked me-2"></i>
-              My Subscribed Features
-            </a>
-          </li>
-          <li>
-            <hr class="dropdown-divider">
-          </li>
-          <li class="dropdown-item">
-            <div class="form-check form-switch">
-              <label class="form-check-label" for="theme-selector">Light Mode</label>
-              <input id="theme-selector"
-                     class="form-check-input"
-                     type="checkbox"
-                     role="switch">
-            </div>
-          </li>
-          <li>
-            {% include 'glean/opt_out_button.html' %}
+      <ul class="navbar-nav ms-auto align-items-center">
+        <li class="nav-item me-2">
+          <button id="create-new-button"
+                  class="btn btn-primary"
+                  data-bs-toggle="modal"
+                  data-bs-target="#createModal">
+            <i class="fa-regular fa-pen-to-square me-1"></i>
+            Create Experiment
+          </button>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle"
+             href="#"
+             role="button"
+             data-bs-toggle="dropdown"
+             aria-expanded="false">Links</a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li>
+              <a href="https://experimenter.info/"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-book me-2"></i>
+                Docs
+              </a>
+            </li>
+            <li>
+              <a href="https://github.com/mozilla-extensions/nimbus-devtools/releases/tag/release%2Fv0.3.0"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-wrench me-2"></i>
+                Nimbus Devtools
+              </a>
+            </li>
+            <li>
+              <a href="{% url "nimbus-experiments-csv" %}"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-file-arrow-down me-2"></i>
+                Reports
+              </a>
+            </li>
+            <li>
+              <a href="{% url "nimbus-experiments-csv-usage" %}"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-chart-line me-2"></i>
+                Usage Stats
+              </a>
+            </li>
+            <li>
+              <a href="{% url "nimbus-experiments-yaml" %}"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-file-lines me-2"></i>
+                YAML Export
+              </a>
+            </li>
+            <li>
+              <a id="legacy_page_link"
+                 href="/legacy/"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-ghost me-2"></i>
+                Legacy
+              </a>
+            </li>
+            <li>
+              <hr class="dropdown-divider">
+            </li>
+            <li>
+              <a href="https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10203&issuetype=10097"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-comment-dots me-2"></i>
+                Feedback
+              </a>
+            </li>
+            <li>
+              <a href="https://mozilla.slack.com/?redir=%2Farchives%2FCF94YGE03"
+                 class="dropdown-item link-primary"
+                 target="_blank"
+                 rel="noreferrer">
+                <i class="fa-solid fa-circle-question me-2"></i>
+                Help
+              </a>
+            </li>
+          </ul>
+        </li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle"
+             href="#"
+             role="button"
+             data-bs-toggle="dropdown"
+             aria-expanded="false">
+            <i class="fa-regular fa-circle-user"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end">
+            <li>
+              <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllOwned#my-deliveries"
+                 class="dropdown-item link-primary">
+                <i class="fa-solid fa-user me-2"></i>
+                My Deliveries
+              </a>
+            </li>
+            <li>
+              <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=AllSubscribed#my-deliveries"
+                 class="dropdown-item link-primary">
+                <i class="fa-solid fa-bell me-2"></i>
+                My Subscribed Deliveries
+              </a>
+            </li>
+            <li>
+              <a href="{% url 'nimbus-ui-home' %}?my_deliveries_status=FeatureSubscribed#my-deliveries"
+                 class="dropdown-item link-primary">
+                <i class="fa-solid fa-boxes-stacked me-2"></i>
+                My Subscribed Features
+              </a>
+            </li>
+            <li>
+              <hr class="dropdown-divider">
+            </li>
+            <li class="dropdown-item">
+              <div class="form-check form-switch">
+                <label class="form-check-label" for="theme-selector">Light Mode</label>
+                <input id="theme-selector"
+                       class="form-check-input"
+                       type="checkbox"
+                       role="switch">
+              </div>
+            </li>
+            <li>
+              {% include 'glean/opt_out_button.html' %}
 
-          </li>
-        </ul>
-      </li>
-    </ul>
+            </li>
+          </ul>
+        </li>
+      </ul>
+    </div>
   </div>
 </nav>
 <!-- Modal -->

--- a/experimenter/experimenter/nimbus_ui/templates/common/with_sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/with_sidebar.html
@@ -2,6 +2,10 @@
 
 {% load static %}
 
+{% block header %}
+  {% include "common/header.html" with has_sidebar=True %}
+
+{% endblock header %}
 {% block content %}
   <div id="content" class="container-fluid">
     <div id="content-with-sidebar" class="row">

--- a/experimenter/experimenter/nimbus_ui/templates/experimenter_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/experimenter_base.html
@@ -22,8 +22,10 @@
   {# djlint:on #}
   class="bg-body-tertiary">
   <div class="container-fluid bg-body border-bottom border-1 py-1">
-    {% include "common/header.html" %}
+    {% block header %}
+      {% include "common/header.html" %}
 
+    {% endblock header %}
   </div>
   <div class="container-fluid">
     {% block content %}


### PR DESCRIPTION
Because

* The header nav was inaccessible at narrow viewports — the hamburger toggle errored on click (it targeted an offcanvas that only existed on sidebar pages), and the right-side ul stacked badly outside the collapse.

This commit

* Drops the navbar's `.collapse` wrapper so nav items stack vertically at narrow viewports and lay out horizontally at xl+.
* Moves the right-side ul inside the navbar-collapse so both groups flow together.
* Renders the sidebar toggle only on pages that have a sidebar.

Fixes #14875