### PR TITLE
fix(nimbus): fix disconnect between main page metric results and details modal

### DIFF
--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -571,10 +571,14 @@ class ExperimentResultsManager:
                     .get(window, {})
                 )
 
-                if (
-                    MetricSignificance.POSITIVE in significance_data.values()
-                    or MetricSignificance.NEGATIVE in significance_data.values()
-                ):
+                latest_window_index_significance = significance_data.get(
+                    str(len(significance_data.keys())), MetricSignificance.UNKNOWN
+                )
+
+                if latest_window_index_significance in [
+                    MetricSignificance.POSITIVE,
+                    MetricSignificance.NEGATIVE,
+                ]:
                     return True
             return False
 

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.test import TestCase
 from parameterized.parameterized import parameterized
 
@@ -1040,6 +1042,174 @@ class TestExperimentResultsManager(TestCase):
         self.assertIn("KPI Metrics", metric_areas)
         self.assertIn("Engagement", metric_areas)
         self.assertIn("Other Metrics", metric_areas)
+
+    @parameterized.expand(
+        [
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {"overall": {}},
+                                                        "branch-b": {
+                                                            "overall": {"1": "negative"}
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {"1": "positive"}
+                                                        },
+                                                        "branch-b": {"overall": {}},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                ["retained"],
+            ),
+            (
+                # This test case ensure that even if previous windows have significance,
+                # if the most recent window doesn't, the metric shouldn't be notable
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {"overall": {}},
+                                                        "branch-b": {
+                                                            "overall": {
+                                                                "1": "negative",
+                                                                "2": "negative",
+                                                                "3": "neutral",
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {
+                                                                "1": "negative",
+                                                                "2": "negative",
+                                                                "3": "neutral",
+                                                            }
+                                                        },
+                                                        "branch-b": {"overall": {}},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                [],
+            ),
+            # This test case ensures that if there are significant changes in the most
+            # recent window, the metric is notable, even if the significance is different
+            # across windows
+            (
+                {
+                    "v3": {
+                        "weekly": {
+                            "enrollments": {
+                                "all": {
+                                    "branch-a": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {"overall": {}},
+                                                        "branch-b": {
+                                                            "overall": {
+                                                                "1": "neutral",
+                                                                "2": "neutral",
+                                                                "3": "positive",
+                                                            }
+                                                        },
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "branch-b": {
+                                        "branch_data": {
+                                            "other_metrics": {
+                                                "retained": {
+                                                    "significance": {
+                                                        "branch-a": {
+                                                            "overall": {
+                                                                "1": "neutral",
+                                                                "2": "neutral",
+                                                                "3": "negative",
+                                                            }
+                                                        },
+                                                        "branch-b": {"overall": {}},
+                                                    },
+                                                }
+                                            }
+                                        }
+                                    },
+                                }
+                            }
+                        },
+                    }
+                },
+                ["retained"],
+            ),
+        ]
+    )
+    def test_notable_metrics_correctly_identified(
+        self, results_data, expected_notable_metrics
+    ):
+        self.experiment.results_data = results_data
+        self.experiment.save()
+
+        with mock.patch.object(
+            self.results_manager,
+            "metric_has_data",
+            side_effect=lambda metric_slug, *args, **kwargs: metric_slug == "retained",
+        ):
+            notable_metrics = (
+                self.results_manager.get_metric_areas("enrollments", "all", "branch-a")
+                .get("Notable Changes", {})
+                .get("metrics", [])
+            )
+
+        for notable_metric, metric_slug in zip(notable_metrics, expected_notable_metrics):
+            self.assertEqual(notable_metric.get("slug"), metric_slug)
 
     def test_get_branch_data_returns_correct_data(self):
         self.experiment.results_data = {

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -37,25 +37,29 @@
               <div class="col">
                 <p class="fw-bold text-center">Absolute count</p>
                 {% for branch_slug, branch_data in metric_data.items %}
-                  {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=branch_data.absolute.0.lower absolute_upper=branch_data.absolute.0.upper significance=branch_data.absolute.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
+                  {% with abs_last=branch_data.absolute|last %}
+                    {% include "common/metric_popout_card.html" with type="absolute" absolute_lower=abs_last.lower absolute_upper=abs_last.upper significance=abs_last.significance reference_branch=reference_branch branch_slug=branch_slug %}
 
+                  {% endwith %}
                 {% endfor %}
               </div>
               <div class="col">
                 <p class="fw-bold text-center">Relative change</p>
                 <div class="d-flex flex-column">
                   {% for branch_slug, branch_data in metric_data.items %}
-                    {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
-                      {% if branch_slug == branch_relative_ui %}
-                        {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=branch_data.relative.0.lower upper_relative=branch_data.relative.0.upper %}
+                    {% with rel_last=branch_data.relative|last %}
+                      {% for branch_relative_ui, branch_relative_ui_properties in ui_properties.items %}
+                        {% if branch_slug == branch_relative_ui %}
+                          {% include "common/metric_popout_card.html" with type="relative" lower_confidence=rel_last.lower upper_confidence=rel_last.upper significance=rel_last.significance reference_branch=reference_branch branch_slug=branch_slug branch_relative_ui_properties=branch_relative_ui_properties lower_relative=rel_last.lower upper_relative=rel_last.upper %}
+
+                        {% endif %}
+                      {% endfor %}
+                      {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
+                      {% if branch_slug == reference_branch %}
+                        {% include "common/metric_popout_card.html" with type="relative" lower_confidence=rel_last.lower upper_confidence=rel_last.upper significance=rel_last.significance reference_branch=reference_branch branch_slug=branch_slug %}
 
                       {% endif %}
-                    {% endfor %}
-                    {% comment %} the reference branch does not have relative comparision data therefore it must be separately rendered {% endcomment %}
-                    {% if branch_slug == reference_branch %}
-                      {% include "common/metric_popout_card.html" with type="relative" lower_confidence=branch_data.relative.0.lower upper_confidence=branch_data.relative.0.upper significance=branch_data.relative.0.significance reference_branch=reference_branch branch_slug=branch_slug %}
-
-                    {% endif %}
+                    {% endwith %}
                   {% endfor %}
                 </div>
               </div>


### PR DESCRIPTION
Because

- In the overview section of the metric details modal we were incorrectly showing data for the first window index whilst showing the latest on the main page
- Metrics were deemed notable as long as they had at least 1 window index with significant change  which would cause confusion if the latest index showed neutral change

This commit

- Fixes overview section in details modal so that it displays the last window point instead of the first
- Changes notable metric criteria to only display metrics whose latest window index shows significant change

Fixes #15696