### PR TITLE
feat(nimbus): Show metric errors in details modal

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -305,6 +305,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     monitoring period is complete.
     <a href="https://experimenter.info/workflow/monitoring">Learn more</a>"""
 
+    MISSING_METRIC_DATA_MESSAGE = """Results for this metric are unavailable because
+    some or all of the required metric data is missing."""
+
     class MetricAreaType:
         PRIMARY = {
             "label": "Primary Metric",

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -17,6 +17,36 @@
                 data-bs-dismiss="modal"
                 aria-label="Close"></button>
       </div>
+      {% if experiment.results_data.v3.errors %}
+        {% for error_group, error_list in experiment.results_data.v3.errors.items %}
+          {% with error=error_list|last %}
+            {% if error.metric == metric_info.slug %}
+              <div class="modal-body pt-0">
+                <div class="alert alert-warning rounded-4 mb-0 text-start small">
+                  <div class="d-flex align-items-center gap-2 mb-1">
+                    <i class="fa-solid fa-triangle-exclamation"></i>
+                    <strong>Metric error</strong>
+                  </div>
+                  <dl class="row mb-0">
+                    <dt class="col-sm-4 mb-1">Type</dt>
+                    <dd class="col-sm-8 mb-1">
+                      {{ error.exception_type|default:"Unknown error" }}
+                    </dd>
+                    <dt class="col-sm-4 mb-1">Timestamp</dt>
+                    <dd class="col-sm-8 mb-1">
+                      {{ error.timestamp|parse_date|date:"N j, Y g:i A"|default:"N/A" }}
+                    </dd>
+                    <dt class="col-sm-4 mb-0">Message</dt>
+                    <dd class="col-sm-8 mb-0 text-break">
+                      {{ error.message|default:"N/A" }}
+                    </dd>
+                  </dl>
+                </div>
+              </div>
+            {% endif %}
+          {% endwith %}
+        {% endfor %}
+      {% endif %}
       {% if metric_info.has_data %}
         <div class="modal-body d-flex flex-column gap-4"
              id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -52,7 +52,7 @@
           <div class="alert alert-warning rounded-4 mb-0 text-start small">
             <div class="d-flex align-items-center gap-2 mb-1">
               <i class="fa-solid fa-triangle-exclamation"></i>
-              <strong>Results for this metric are unavailable because some or all of the required metric data is missing.</strong>
+              <strong>{{ NimbusUIConstants.MISSING_METRIC_DATA_MESSAGE }}</strong>
             </div>
           </div>
         </div>

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -47,6 +47,16 @@
           {% endwith %}
         {% endfor %}
       {% endif %}
+      {% if not metric_info.has_data %}
+        <div class="modal-body pt-0">
+          <div class="alert alert-warning rounded-4 mb-0 text-start small">
+            <div class="d-flex align-items-center gap-2 mb-1">
+              <i class="fa-solid fa-triangle-exclamation"></i>
+              <strong>Results for this metric are unavailable because some or all of the required metric data is missing.</strong>
+            </div>
+          </div>
+        </div>
+      {% endif %}
       {% if metric_info.has_data %}
         <div class="modal-body d-flex flex-column gap-4"
              id="{{ experiment_slug }}-{{ metric_info.slug }}-accordion">


### PR DESCRIPTION
Because

* we cannot currently see metric-specific errors from details modal

This commit

* shows metric errors in the details modal when errors exist for the specific metric
* displays the latest metric error type, timestamp, and message

Fixes #15669

<img width="1707" height="674" alt="Screenshot 2026-05-29 at 2 48 26 PM" src="https://github.com/user-attachments/assets/a437d93f-ebc2-4457-80f1-f0034622f653" />

<img width="3430" height="1460" alt="image" src="https://github.com/user-attachments/assets/c1e2db45-46b2-47ea-87dc-c8ee2febcff3" />



