### PR TITLE
feat(nimbus): fetch and store enrollment funnel data alongside monitoring alerts (EXP-6872)

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -105,6 +105,12 @@ def get_monitoring_data():
     return load_data_from_gcs(str(path))
 
 
+def get_enrollment_funnel_data():
+    filename = "enrollment_funnel_v1_latest.json"
+    path = Path(ENROLLMENT_COUNTS_FOLDER, filename)
+    return load_data_from_gcs(str(path))
+
+
 def get_results_metrics_map(
     data: JetstreamData,
     primary_outcome_slugs: list[str],

--- a/experimenter/experimenter/jetstream/tasks.py
+++ b/experimenter/experimenter/jetstream/tasks.py
@@ -11,6 +11,7 @@ from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusChangeLog, NimbusExperiment
 from experimenter.jetstream.client import (
+    get_enrollment_funnel_data,
     get_experiment_data,
     get_monitoring_data,
     get_population_sizing_data,
@@ -144,6 +145,14 @@ def fetch_monitoring_data():
             return
 
         alert_data = data.get("v1")
+
+        try:
+            funnel_data = get_enrollment_funnel_data()
+            funnel_by_slug = funnel_data.get("v1", {}) if funnel_data else {}
+        except Exception as e:
+            logger.warning(f"Could not fetch enrollment funnel data: {e}")
+            funnel_by_slug = {}
+
         updated_count = 0
 
         for exp_slug, monitoring_data in alert_data.items():
@@ -153,9 +162,13 @@ def fetch_monitoring_data():
                     status=NimbusConstants.Status.LIVE,
                 )
 
-                # Only update if data has changed
-                if experiment.monitoring_data != monitoring_data:
-                    experiment.monitoring_data = monitoring_data
+                merged = {
+                    **monitoring_data,
+                    "enrollment_funnel": funnel_by_slug.get(exp_slug, []),
+                }
+
+                if experiment.monitoring_data != merged:
+                    experiment.monitoring_data = merged
                     experiment.monitoring_data_updated_at = timezone.now()
                     experiment.save()
                     generate_nimbus_changelog(

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -3441,6 +3441,26 @@ def mock_monitoring_data(request):
     return data
 
 
+SAMPLE_FUNNEL_ENTRIES = [
+    {
+        "app_name": "firefox_desktop",
+        "branch": "control",
+        "status": "Enrolled",
+        "reason": "Qualified",
+        "conflict_slug": None,
+        "client_count": 750000,
+    },
+    {
+        "app_name": "firefox_desktop",
+        "branch": None,
+        "status": "NotEnrolled",
+        "reason": "NotTargeted",
+        "conflict_slug": None,
+        "client_count": 5000000,
+    },
+]
+
+
 @pytest.mark.usefixtures("mock_monitoring_data")
 class TestFetchMonitoringDataTask(TestCase):
     def setUp(self):
@@ -3448,6 +3468,13 @@ class TestFetchMonitoringDataTask(TestCase):
         patcher = patch("experimenter.jetstream.tasks.get_monitoring_data")
         self.mock_get_monitoring_data = patcher.start()
         self.addCleanup(patcher.stop)
+
+        funnel_patcher = patch(
+            "experimenter.jetstream.tasks.get_enrollment_funnel_data"
+        )
+        self.mock_get_funnel_data = funnel_patcher.start()
+        self.mock_get_funnel_data.return_value = {"v1": {}}
+        self.addCleanup(funnel_patcher.stop)
 
     @parameterized.expand([(None,), ({},)])
     def test_fetch_monitoring_data_no_data(self, return_value):
@@ -3469,8 +3496,61 @@ class TestFetchMonitoringDataTask(TestCase):
         tasks.fetch_monitoring_data()
 
         experiment.refresh_from_db()
-        self.assertEqual(experiment.monitoring_data, self.monitoring_data)
+        self.assertEqual(
+            experiment.monitoring_data,
+            {**self.monitoring_data, "enrollment_funnel": []},
+        )
         self.assertIsNotNone(experiment.monitoring_data_updated_at)
+
+    def test_fetch_monitoring_data_merges_funnel_data(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            monitoring_data={},
+        )
+        self.mock_get_monitoring_data.return_value = {
+            "v1": {experiment.slug: self.monitoring_data}
+        }
+        self.mock_get_funnel_data.return_value = {
+            "v1": {experiment.slug: SAMPLE_FUNNEL_ENTRIES}
+        }
+
+        tasks.fetch_monitoring_data()
+
+        experiment.refresh_from_db()
+        self.assertEqual(
+            experiment.monitoring_data,
+            {**self.monitoring_data, "enrollment_funnel": SAMPLE_FUNNEL_ENTRIES},
+        )
+
+    def test_fetch_monitoring_data_funnel_defaults_to_empty_list_when_missing(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            monitoring_data={},
+        )
+        self.mock_get_monitoring_data.return_value = {
+            "v1": {experiment.slug: self.monitoring_data}
+        }
+        self.mock_get_funnel_data.return_value = {"v1": {}}
+
+        tasks.fetch_monitoring_data()
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.monitoring_data["enrollment_funnel"], [])
+
+    def test_fetch_monitoring_data_continues_if_funnel_fetch_fails(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            monitoring_data={},
+        )
+        self.mock_get_monitoring_data.return_value = {
+            "v1": {experiment.slug: self.monitoring_data}
+        }
+        self.mock_get_funnel_data.side_effect = Exception("GCS unavailable")
+
+        tasks.fetch_monitoring_data()
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.monitoring_data["enrollment_funnel"], [])
 
     @parameterized.expand(
         [
@@ -3558,8 +3638,8 @@ class TestFetchMonitoringDataTask(TestCase):
 
         exp1.refresh_from_db()
         exp2.refresh_from_db()
-        self.assertEqual(exp1.monitoring_data, data1)
-        self.assertEqual(exp2.monitoring_data, data2)
+        self.assertEqual(exp1.monitoring_data, {**data1, "enrollment_funnel": []})
+        self.assertEqual(exp2.monitoring_data, {**data2, "enrollment_funnel": []})
 
     def test_fetch_monitoring_data_fatal_error(self):
         self.mock_get_monitoring_data.side_effect = Exception("GCS connection failed")


### PR DESCRIPTION
## Summary

- Adds `get_enrollment_funnel_data()` to `jetstream/client.py` to load `enrollment_funnel_v1_latest.json` from GCS (produced by the bigquery-etl job merged in EXP-6871)
- Extends `fetch_monitoring_data()` in `jetstream/tasks.py` to fetch funnel data and merge it into `NimbusExperiment.monitoring_data` under the `enrollment_funnel` key alongside existing alert data
- Funnel fetch failures are handled gracefully — a warning is logged and `enrollment_funnel` defaults to `[]` so alert data continues to save

## Ticket

[EXP-6872](https://mozilla-hub.atlassian.net/browse/EXP-6872)

## Test plan

- [ ] Unit tests added/updated in `test_tasks.py` covering: funnel merge, missing slug defaulting to `[]`, GCS fetch failure fallback
- [ ] No new model or field — funnel data flows through the existing `monitoring_data` JSONField
- [ ] Existing monitoring tests updated to account for the added `enrollment_funnel` key