### PR TITLE
fix(nimbus): hide weekly and daily data for desktop 3dr

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -308,6 +308,15 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     MISSING_METRIC_DATA_MESSAGE = """Results for this metric are unavailable because
     some or all of the required metric data is missing."""
 
+    HIDDEN_DAILY_METRICS = [
+        NimbusConstants.RETENTION_3_DAYS,
+        NimbusConstants.RETENTION_3_DAYS_DESKTOP,
+    ]
+    HIDDEN_WEEKLY_METRICS = [
+        NimbusConstants.RETENTION_3_DAYS,
+        NimbusConstants.RETENTION_3_DAYS_DESKTOP,
+    ]
+
     class MetricAreaType:
         PRIMARY = {
             "label": "Primary Metric",

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -106,7 +106,7 @@
             </div>
           </div>
           {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
-            {% if weekly_metric_data.has_weekly_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
+            {% if weekly_metric_data.has_weekly_data and not metric_info.slug in NimbusUIConstants.HIDDEN_WEEKLY_METRICS %}
               <div class="border border-1 rounded py-4 px-5 rounded-4">
                 <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
                 <div class="d-flex mt-3">
@@ -168,7 +168,7 @@
             {% endif %}
           {% endwith %}
           {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
-            {% if daily_metric_data.has_daily_data and not metric_info.slug == experiment.RETENTION_3_DAYS %}
+            {% if daily_metric_data.has_daily_data and not metric_info.slug in NimbusUIConstants.HIDDEN_DAILY_METRICS %}
               <div class="border border-1 rounded py-4 px-5 rounded-4">
                 <h2 class="fs-6 fw-bold">Daily breakdown</h2>
                 <div class="d-flex mt-3">


### PR DESCRIPTION
Because

- The name of the desktop 3dr constant for was [recently changed](https://github.com/mozilla/experimenter/pull/15480/changes#diff-c6282c236676f5c4a949c4fe94a917e8e3392b634f04f5c00d3c5a315a468903R919) causing the weekly + daily data cards to incorrectly render for the desktop 3dr metric

This commit

- Updates the weekly + daily data cards to conditionally render as long as the metric is not within an exception list currently containing the metric slugs for both mobile and desktop 3dr 

Fixes #15736 