### PR TITLE
fix(project): make xz-utils install non-interactive

### DIFF
--- a/experimenter/tests/nimbus_integration_tests.sh
+++ b/experimenter/tests/nimbus_integration_tests.sh
@@ -12,7 +12,7 @@ install_firefox() {
     local firefox_version="$1"
     echo $firefox_version
     sudo apt-get update -qqy
-    sudo apt-get install xz-utils
+    sudo apt-get install -qqy xz-utils
     sudo rm -rf /var/lib/apt/lists/* /var/cache/apt/*
     sudo wget --no-verbose -O /tmp/firefox $firefox_version
     sudo rm -rf /opt/firefox-latest


### PR DESCRIPTION
Because

* Integration tests fail when apt-get prompts for confirmation

This commit

* Add the non-interactive yes flag when installing xz-utils

Fixes #15800 