### PR TITLE
feat(nimbus): send alert if the 25 percent clients have a feature conflict

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -828,6 +828,7 @@ class NimbusConstants:
         UNENROLLMENT_SPIKE = "unenrollment_spike", "Unenrollment Spike"
         SRM_MISMATCH = "srm_mismatch", "SRM Mismatch"
         ZERO_ENROLLMENT = "zero_enrollment", "Zero Enrollment"
+        FEATURE_CONFLICT = "feature_conflict", "Feature Conflict"
 
     # Error types from Jetstream that are expected for non-analysis reasons and
     # don't want alerting
@@ -1200,6 +1201,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     MONITORING_ALERT_MINIMUM_DAYS = 1
     ZERO_ENROLLMENT_DAYS_THRESHOLD = 3
     ZERO_ENROLLMENT_CLIENT_THRESHOLD = 1000
+    FEATURE_CONFLICT_THRESHOLD = 0.25
 
     OVERALL_WINDOW_INDEX = "1"
 

--- a/experimenter/experimenter/experiments/migrations/0331_alter_nimbusalert_alert_type.py
+++ b/experimenter/experimenter/experiments/migrations/0331_alter_nimbusalert_alert_type.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("experiments", "0330_alter_nimbusalert_alert_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="nimbusalert",
+            name="alert_type",
+            field=models.CharField(
+                choices=[
+                    ("analysis_error", "Analysis Error"),
+                    ("analysis_ready_daily", "Daily Analysis Ready"),
+                    ("analysis_ready_weekly", "Weekly Analysis Ready"),
+                    ("analysis_ready_overall", "Overall Analysis Ready"),
+                    ("experiment_launched", "Experiment Launched"),
+                    ("enrollment_healthy", "Enrollment Healthy"),
+                    ("launch_request", "Launch Request"),
+                    ("update_request", "Update Request"),
+                    ("end_enrollment_request", "End Enrollment Request"),
+                    ("end_experiment_request", "End Experiment Request"),
+                    ("unenrollment_spike", "Unenrollment Spike"),
+                    ("srm_mismatch", "SRM Mismatch"),
+                    ("zero_enrollment", "Zero Enrollment"),
+                    ("feature_conflict", "Feature Conflict"),
+                ],
+                help_text="Category of alert",
+                max_length=64,
+            ),
+        ),
+    ]

--- a/experimenter/experimenter/experiments/monitoring_utils.py
+++ b/experimenter/experimenter/experiments/monitoring_utils.py
@@ -1,5 +1,7 @@
 from scipy.stats import chisquare
 
+from experimenter.experiments.constants import NimbusConstants
+
 UNENROLLMENT_SPIKE_THRESHOLD = 0.10
 SRM_MISMATCH_P_VALUE_THRESHOLD = 0.001
 
@@ -67,3 +69,26 @@ def check_zero_enrollment(
 
     total_enrollments = monitoring_data.get("total_enrollments", 0)
     return total_enrollments < client_threshold
+
+
+def check_feature_conflict(monitoring_data, threshold):
+    funnel = monitoring_data.get("enrollment_funnel", [])
+    if not funnel:
+        return False, 0.0, []
+
+    total = sum(row.get("client_count", 0) for row in funnel)
+    if total == 0:
+        return False, 0.0, []
+
+    conflict_count = 0
+    conflict_slugs = set()
+
+    for row in funnel:
+        if row.get("reason") == NimbusConstants.FunnelReason.FEATURE_CONFLICT:
+            conflict_count += row.get("client_count", 0)
+            slug = row.get("conflict_slug")
+            if slug:
+                conflict_slugs.add(slug)
+
+    rate = conflict_count / total
+    return rate >= threshold, rate, sorted(conflict_slugs)

--- a/experimenter/experimenter/experiments/monitoring_utils.py
+++ b/experimenter/experimenter/experiments/monitoring_utils.py
@@ -1,6 +1,16 @@
+from dataclasses import dataclass, field
+
 from scipy.stats import chisquare
 
 from experimenter.experiments.constants import NimbusConstants
+
+
+@dataclass
+class FeatureConflictResult:
+    is_conflict: bool
+    rate: float
+    slugs: list[str] = field(default_factory=list)
+
 
 UNENROLLMENT_SPIKE_THRESHOLD = 0.10
 SRM_MISMATCH_P_VALUE_THRESHOLD = 0.001
@@ -74,11 +84,11 @@ def check_zero_enrollment(
 def check_feature_conflict(monitoring_data, threshold):
     funnel = monitoring_data.get("enrollment_funnel", [])
     if not funnel:
-        return False, 0.0, []
+        return FeatureConflictResult(is_conflict=False, rate=0.0, slugs=[])
 
     total = sum(row.get("client_count", 0) for row in funnel)
     if total == 0:
-        return False, 0.0, []
+        return FeatureConflictResult(is_conflict=False, rate=0.0, slugs=[])
 
     conflict_count = 0
     conflict_slugs = set()
@@ -91,4 +101,8 @@ def check_feature_conflict(monitoring_data, threshold):
                 conflict_slugs.add(slug)
 
     rate = conflict_count / total
-    return rate >= threshold, rate, sorted(conflict_slugs)
+    return FeatureConflictResult(
+        is_conflict=rate >= threshold,
+        rate=rate,
+        slugs=sorted(conflict_slugs),
+    )

--- a/experimenter/experimenter/slack/constants.py
+++ b/experimenter/experimenter/slack/constants.py
@@ -91,7 +91,12 @@ class SlackConstants:
     SLACK_ZERO_ENROLLMENT_MESSAGE = (
         "⚠️ *{experiment}* has enrolled fewer than {client_threshold:,} clients "
         "after {days} days (current: {total_enrollments:,}).\n"
-        "Please review targeting, rollout percentage, and feature conflicts."
+        "Please review targeting, percentage, and feature conflicts."
+    )
+    SLACK_FEATURE_CONFLICT_MESSAGE = (
+        "⚠️ *{experiment}* has a feature conflict affecting {rate:.1%} of the "
+        "evaluated population.\n"
+        "Blocking recipe: {conflict_slugs}"
     )
 
     # Slack notification log messages
@@ -171,6 +176,12 @@ class SlackConstants:
     )
     SLACK_LOG_FAILED_SEND_ZERO_ENROLLMENT = (
         "Failed to send zero enrollment alert for experiment {experiment}"
+    )
+    SLACK_LOG_FEATURE_CONFLICT_SENT = (
+        "Sent feature conflict alert for experiment {experiment}"
+    )
+    SLACK_LOG_FAILED_SEND_FEATURE_CONFLICT = (
+        "Failed to send feature conflict alert for experiment {experiment}"
     )
     SLACK_LOG_MONITORING_ALERTS_ERROR = (
         "Error checking monitoring alerts for experiment {experiment}"

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -464,12 +464,12 @@ def _check_monitoring_alerts(experiment):
                 experiment, experiment.monitoring_data, days_since_start
             )
 
-        is_conflict, conflict_rate, conflict_slugs = check_feature_conflict(
+        result = check_feature_conflict(
             experiment.monitoring_data,
             NimbusConstants.FEATURE_CONFLICT_THRESHOLD,
         )
-        if is_conflict:
-            _send_feature_conflict_alert(experiment, conflict_rate, conflict_slugs)
+        if result.is_conflict:
+            _send_feature_conflict_alert(experiment, result.rate, result.slugs)
 
     except Exception as e:
         msg = SlackConstants.SLACK_LOG_MONITORING_ALERTS_ERROR.format(

--- a/experimenter/experimenter/slack/tasks.py
+++ b/experimenter/experimenter/slack/tasks.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import NimbusAlert, NimbusExperiment
 from experimenter.experiments.monitoring_utils import (
+    check_feature_conflict,
     check_srm_mismatch,
     check_unenrollment_spike,
     check_zero_enrollment,
@@ -407,6 +408,26 @@ def _send_zero_enrollment_alert(experiment, monitoring_data, days):
     )
 
 
+def _send_feature_conflict_alert(experiment, rate, conflict_slugs):
+    slug_links = ", ".join(
+        f"<{experiment.experiment_url.replace(experiment.slug, slug)}|{slug}>"
+        for slug in conflict_slugs
+    )
+    message = SlackConstants.SLACK_FEATURE_CONFLICT_MESSAGE.format(
+        experiment=experiment.name,
+        rate=rate,
+        conflict_slugs=slug_links,
+    )
+    _send_monitoring_alert(
+        experiment,
+        NimbusConstants.AlertType.FEATURE_CONFLICT,
+        message,
+        SlackConstants.SLACK_LOG_FEATURE_CONFLICT_SENT,
+        SlackConstants.SLACK_LOG_FAILED_SEND_FEATURE_CONFLICT,
+        "feature_conflict_alert",
+    )
+
+
 def _check_monitoring_alerts(experiment):
     if experiment.status != NimbusConstants.Status.LIVE:
         return
@@ -442,6 +463,13 @@ def _check_monitoring_alerts(experiment):
             _send_zero_enrollment_alert(
                 experiment, experiment.monitoring_data, days_since_start
             )
+
+        is_conflict, conflict_rate, conflict_slugs = check_feature_conflict(
+            experiment.monitoring_data,
+            NimbusConstants.FEATURE_CONFLICT_THRESHOLD,
+        )
+        if is_conflict:
+            _send_feature_conflict_alert(experiment, conflict_rate, conflict_slugs)
 
     except Exception as e:
         msg = SlackConstants.SLACK_LOG_MONITORING_ALERTS_ERROR.format(

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -6,9 +6,14 @@ from django.test import TestCase
 from django.utils import timezone
 from parameterized import parameterized
 
-from experimenter.experiments.constants import NimbusConstants
+from experimenter.experiments.constants import (
+    APPLICATION_CONFIG_DESKTOP,
+    APPLICATION_CONFIG_FENIX,
+    NimbusConstants,
+)
 from experimenter.experiments.models import NimbusAlert
 from experimenter.experiments.monitoring_utils import (
+    check_feature_conflict,
     check_srm_mismatch,
     check_unenrollment_spike,
     check_zero_enrollment,
@@ -63,6 +68,33 @@ _ZERO_ENROLLMENT_MONITORING_DATA = {
         "treatment": {"enrollments": 0},
     },
     "reasons_by_branch": {},
+}
+
+_FEATURE_CONFLICT_MONITORING_DATA = {
+    "total_enrollments": 1000,
+    "total_unenrollments": 0,
+    "branches": {
+        "control": {"enrollments": 1000},
+    },
+    "reasons_by_branch": {},
+    "enrollment_funnel": [
+        {
+            "status": NimbusConstants.FunnelStatus.NOT_ENROLLED,
+            "reason": NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+            "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
+            "branch": "control",
+            "conflict_slug": "blocking-recipe-slug",
+            "client_count": 800,
+        },
+        {
+            "status": NimbusConstants.FunnelStatus.ENROLLED,
+            "reason": NimbusConstants.FunnelReason.QUALIFIED,
+            "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
+            "branch": "control",
+            "conflict_slug": None,
+            "client_count": 200,
+        },
+    ],
 }
 
 
@@ -1063,6 +1095,129 @@ class TestCheckZeroEnrollment(TestCase):
         )
 
 
+class TestCheckFeatureConflict(TestCase):
+    def _check(self, monitoring_data):
+        return check_feature_conflict(
+            monitoring_data,
+            threshold=NimbusConstants.FEATURE_CONFLICT_THRESHOLD,
+        )
+
+    def _funnel_row(self, status, reason, app_name, client_count, conflict_slug=None):
+        return {
+            "status": status,
+            "reason": reason,
+            "app_name": app_name,
+            "branch": "control",
+            "conflict_slug": conflict_slug,
+            "client_count": client_count,
+        }
+
+    def test_returns_true_when_conflict_rate_exceeds_threshold(self):
+        is_conflict, rate, slugs = self._check(_FEATURE_CONFLICT_MONITORING_DATA)
+        self.assertTrue(is_conflict)
+        self.assertAlmostEqual(rate, 0.80)
+        self.assertEqual(slugs, ["blocking-recipe-slug"])
+
+    def test_returns_false_when_conflict_rate_below_threshold(self):
+        monitoring_data = {
+            "enrollment_funnel": [
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                    NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                    APPLICATION_CONFIG_DESKTOP.app_name,
+                    100,
+                    conflict_slug="some-slug",
+                ),
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.ENROLLED,
+                    NimbusConstants.FunnelReason.QUALIFIED,
+                    APPLICATION_CONFIG_DESKTOP.app_name,
+                    900,
+                ),
+            ]
+        }
+        is_conflict, rate, _ = self._check(monitoring_data)
+        self.assertFalse(is_conflict)
+        self.assertAlmostEqual(rate, 0.10)
+
+    @parameterized.expand(
+        [
+            ("no_funnel_key", {}),
+            ("empty_funnel", {"enrollment_funnel": []}),
+            (
+                "all_zero_counts",
+                {
+                    "enrollment_funnel": [
+                        {
+                            "status": NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                            "reason": NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                            "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
+                            "branch": "control",
+                            "conflict_slug": "some-slug",
+                            "client_count": 0,
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+    def test_returns_false_for_empty_or_zero_population(self, _, monitoring_data):
+        is_conflict, rate, slugs = self._check(monitoring_data)
+        self.assertFalse(is_conflict)
+        self.assertEqual(rate, 0.0)
+        self.assertEqual(slugs, [])
+
+    def test_collects_conflict_slugs(self):
+        monitoring_data = {
+            "enrollment_funnel": [
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                    NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                    APPLICATION_CONFIG_DESKTOP.app_name,
+                    400,
+                    conflict_slug="recipe-a",
+                ),
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                    NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                    APPLICATION_CONFIG_DESKTOP.app_name,
+                    200,
+                    conflict_slug="recipe-b",
+                ),
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.ENROLLED,
+                    NimbusConstants.FunnelReason.QUALIFIED,
+                    APPLICATION_CONFIG_DESKTOP.app_name,
+                    100,
+                ),
+            ]
+        }
+        is_conflict, _, slugs = self._check(monitoring_data)
+        self.assertTrue(is_conflict)
+        self.assertEqual(slugs, ["recipe-a", "recipe-b"])
+
+    def test_no_conflict_slug_for_mobile(self):
+        monitoring_data = {
+            "enrollment_funnel": [
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                    NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                    APPLICATION_CONFIG_FENIX.app_name,
+                    800,
+                ),
+                self._funnel_row(
+                    NimbusConstants.FunnelStatus.ENROLLED,
+                    NimbusConstants.FunnelReason.QUALIFIED,
+                    APPLICATION_CONFIG_FENIX.app_name,
+                    200,
+                ),
+            ]
+        }
+        is_conflict, _, slugs = self._check(monitoring_data)
+        self.assertTrue(is_conflict)
+        self.assertEqual(slugs, [])
+
+
 class TestCheckMonitoringAlerts(TestCase):
     def test_skips_non_live_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1241,6 +1396,11 @@ class TestCheckMonitoringAlerts(TestCase):
                 _ZERO_ENROLLMENT_MONITORING_DATA,
                 NimbusConstants.AlertType.ZERO_ENROLLMENT,
             ),
+            (
+                "feature_conflict",
+                _FEATURE_CONFLICT_MONITORING_DATA,
+                NimbusConstants.AlertType.FEATURE_CONFLICT,
+            ),
         ]
     )
     def test_does_not_create_duplicate_alert(self, _, monitoring_data, alert_type):
@@ -1281,6 +1441,11 @@ class TestCheckMonitoringAlerts(TestCase):
                 "zero_enrollment",
                 _ZERO_ENROLLMENT_MONITORING_DATA,
                 NimbusConstants.AlertType.ZERO_ENROLLMENT,
+            ),
+            (
+                "feature_conflict",
+                _FEATURE_CONFLICT_MONITORING_DATA,
+                NimbusConstants.AlertType.FEATURE_CONFLICT,
             ),
         ]
     )
@@ -1380,11 +1545,78 @@ class TestCheckMonitoringAlerts(TestCase):
             ).exists()
         )
 
+    def test_sends_feature_conflict_alert_with_slug_when_available(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            monitoring_data=_FEATURE_CONFLICT_MONITORING_DATA,
+        )
+        with mock.patch(
+            "experimenter.slack.tasks.send_slack_notification",
+            return_value=("1234567890.123456", "C123456"),
+        ) as mock_send_slack:
+            tasks._check_monitoring_alerts(experiment)
+            mock_send_slack.assert_called_once()
+            action_text = mock_send_slack.call_args[1]["action_text"]
+            self.assertIn("feature conflict", action_text)
+            self.assertIn("blocking-recipe-slug", action_text)
+
+        self.assertTrue(
+            NimbusAlert.objects.filter(
+                experiment=experiment,
+                alert_type=NimbusConstants.AlertType.FEATURE_CONFLICT,
+            ).exists()
+        )
+
+    def test_sends_feature_conflict_alert_with_empty_slug_when_unavailable(self):
+        mobile_funnel = [
+            {
+                "status": NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                "reason": NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                "app_name": APPLICATION_CONFIG_FENIX.app_name,
+                "branch": "control",
+                "conflict_slug": None,
+                "client_count": 800,
+            },
+            {
+                "status": NimbusConstants.FunnelStatus.ENROLLED,
+                "reason": NimbusConstants.FunnelReason.QUALIFIED,
+                "app_name": APPLICATION_CONFIG_FENIX.app_name,
+                "branch": "control",
+                "conflict_slug": None,
+                "client_count": 200,
+            },
+        ]
+        monitoring_data = {
+            **_FEATURE_CONFLICT_MONITORING_DATA,
+            "enrollment_funnel": mobile_funnel,
+        }
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            monitoring_data=monitoring_data,
+        )
+        with mock.patch(
+            "experimenter.slack.tasks.send_slack_notification",
+            return_value=("1234567890.123456", "C123456"),
+        ) as mock_send_slack:
+            tasks._check_monitoring_alerts(experiment)
+            mock_send_slack.assert_called_once()
+            action_text = mock_send_slack.call_args[1]["action_text"]
+            self.assertIn("feature conflict", action_text)
+            self.assertIn("Blocking recipe:", action_text)
+
+        self.assertTrue(
+            NimbusAlert.objects.filter(
+                experiment=experiment,
+                alert_type=NimbusConstants.AlertType.FEATURE_CONFLICT,
+            ).exists()
+        )
+
     @parameterized.expand(
         [
             ("unenrollment_spike", _SPIKE_MONITORING_DATA),
             ("srm_mismatch", _SRM_MONITORING_DATA),
             ("zero_enrollment", _ZERO_ENROLLMENT_MONITORING_DATA),
+            ("feature_conflict", _FEATURE_CONFLICT_MONITORING_DATA),
         ]
     )
     def test_handles_slack_failure_gracefully(self, _, monitoring_data):

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -1113,10 +1113,10 @@ class TestCheckFeatureConflict(TestCase):
         }
 
     def test_returns_true_when_conflict_rate_exceeds_threshold(self):
-        is_conflict, rate, slugs = self._check(_FEATURE_CONFLICT_MONITORING_DATA)
-        self.assertTrue(is_conflict)
-        self.assertAlmostEqual(rate, 0.80)
-        self.assertEqual(slugs, ["blocking-recipe-slug"])
+        result = self._check(_FEATURE_CONFLICT_MONITORING_DATA)
+        self.assertTrue(result.is_conflict)
+        self.assertAlmostEqual(result.rate, 0.80)
+        self.assertEqual(result.slugs, ["blocking-recipe-slug"])
 
     def test_returns_false_when_conflict_rate_below_threshold(self):
         monitoring_data = {
@@ -1136,9 +1136,9 @@ class TestCheckFeatureConflict(TestCase):
                 ),
             ]
         }
-        is_conflict, rate, _ = self._check(monitoring_data)
-        self.assertFalse(is_conflict)
-        self.assertAlmostEqual(rate, 0.10)
+        result = self._check(monitoring_data)
+        self.assertFalse(result.is_conflict)
+        self.assertAlmostEqual(result.rate, 0.10)
 
     @parameterized.expand(
         [
@@ -1162,10 +1162,10 @@ class TestCheckFeatureConflict(TestCase):
         ]
     )
     def test_returns_false_for_empty_or_zero_population(self, _, monitoring_data):
-        is_conflict, rate, slugs = self._check(monitoring_data)
-        self.assertFalse(is_conflict)
-        self.assertEqual(rate, 0.0)
-        self.assertEqual(slugs, [])
+        result = self._check(monitoring_data)
+        self.assertFalse(result.is_conflict)
+        self.assertEqual(result.rate, 0.0)
+        self.assertEqual(result.slugs, [])
 
     def test_collects_conflict_slugs(self):
         monitoring_data = {
@@ -1192,9 +1192,9 @@ class TestCheckFeatureConflict(TestCase):
                 ),
             ]
         }
-        is_conflict, _, slugs = self._check(monitoring_data)
-        self.assertTrue(is_conflict)
-        self.assertEqual(slugs, ["recipe-a", "recipe-b"])
+        result = self._check(monitoring_data)
+        self.assertTrue(result.is_conflict)
+        self.assertEqual(result.slugs, ["recipe-a", "recipe-b"])
 
     def test_no_conflict_slug_for_mobile(self):
         monitoring_data = {
@@ -1213,9 +1213,9 @@ class TestCheckFeatureConflict(TestCase):
                 ),
             ]
         }
-        is_conflict, _, slugs = self._check(monitoring_data)
-        self.assertTrue(is_conflict)
-        self.assertEqual(slugs, [])
+        result = self._check(monitoring_data)
+        self.assertTrue(result.is_conflict)
+        self.assertEqual(result.slugs, [])
 
 
 class TestCheckMonitoringAlerts(TestCase):


### PR DESCRIPTION
Because

- It is possible due to feature conflict with the other recipe, users might not get enrolled in the experiment

This commit

- Sends the alert in the slack if more than 25% of the client are not enrolled due to a feature conflict

Fixes #15520 