### PR TITLE
refactor(nimbus): use active_experiments for sticky enrollment

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,7 +555,7 @@ To test a targeting expression, first add an app context named `app_context.json
 You can then invoke the script with the `--targeting-string` flag:
 
 ```bash
-python sdk_eval_check.py --targeting-string "(app_version|versionCompare('106.*') <= 0) && (is_already_enrolled)"
+python sdk_eval_check.py --targeting-string "(app_version|versionCompare('106.*') <= 0) && ('my-experiment-slug' in active_experiments)"
 ```
 
 The script should return the results, either `True`, `False`, or an error.

--- a/cirrus/server/tests/test_feature_manifest.py
+++ b/cirrus/server/tests/test_feature_manifest.py
@@ -148,7 +148,8 @@ def test_compute_feature_configurations_targeting_doesnt_match(fml_setup):
         "appId": "test_app_id",
         "appName": "test_app_name",
         "channel": "developer",
-        "targeting": '(is_already_enrolled) || (username in ["test", "test2"])',
+        "targeting": "('experiment-slug' in active_experiments) "
+        "|| (username in ['test', 'test2'])",
         "bucketConfig": bucket_config,
         "isRollout": False,
         "isEnrollmentPaused": False,

--- a/cirrus/server/tests/test_feature_manifest.py
+++ b/cirrus/server/tests/test_feature_manifest.py
@@ -148,8 +148,9 @@ def test_compute_feature_configurations_targeting_doesnt_match(fml_setup):
         "appId": "test_app_id",
         "appName": "test_app_name",
         "channel": "developer",
-        "targeting": "('experiment-slug' in active_experiments) "
-        "|| (username in ['test', 'test2'])",
+        "targeting": (
+            "('experiment-slug' in active_experiments) || (username in ['test', 'test2'])"
+        ),
         "bucketConfig": bucket_config,
         "isRollout": False,
         "isEnrollmentPaused": False,

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -781,7 +781,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.is_sticky and sticky_expressions:
             expressions.append(
                 make_sticky_targeting_expression(
-                    self.is_desktop, self.is_rollout, sticky_expressions
+                    self.is_desktop, self.is_rollout, sticky_expressions, self.slug
                 )
             )
         else:
@@ -793,6 +793,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     self.is_desktop,
                     self.is_rollout,
                     (f"!('{pref}'|preferenceIsUserSet)" for pref in sorted(prefs)),
+                    self.slug,
                 )
             )
 
@@ -3301,14 +3302,14 @@ class NimbusAlert(models.Model):
         ).exists()
 
 
-def make_sticky_targeting_expression(is_desktop, is_rollout, expressions):
+def make_sticky_targeting_expression(is_desktop, is_rollout, expressions, slug):
     if is_desktop:
         if is_rollout:
             sticky_clause = "experiment.slug in activeRollouts"
         else:
             sticky_clause = "experiment.slug in activeExperiments"
     else:
-        sticky_clause = "is_already_enrolled"
+        sticky_clause = f"'{slug}' in active_experiments"
 
     expressions_joined = " && ".join(f"({expression})" for expression in expressions)
 

--- a/experimenter/experimenter/experiments/tests/jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/jexl_utils.py
@@ -52,7 +52,6 @@ def validate_jexl_expr(expression, application):
 
         custom_targeting_attributes = json.dumps(
             {
-                "is_already_enrolled": True,
                 "days_since_update": 1,
                 "days_since_install": 1,
                 "isFirstRun": "true",

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -1137,7 +1137,7 @@ class TestNimbusExperiment(TestCase):
 
         sticky_expression = (
             "("
-            "(is_already_enrolled) "
+            f"('{experiment.slug}' in active_experiments) "
             "|| "
             "("
             "(days_since_install < 7) "

--- a/experimenter/tests/integration/nimbus/test_mobile_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_mobile_targeting.py
@@ -93,7 +93,6 @@ def test_check_mobile_targeting(
     # and must be encoded as JSON before being passed to the evaluator
     custom_targeting_attributes = json.dumps(
         {
-            "is_already_enrolled": True,
             "days_since_update": 1,
             "days_since_install": 1,
             "isFirstRun": "true",

--- a/experimenter/tests/tools/example_app_context.json
+++ b/experimenter/tests/tools/example_app_context.json
@@ -17,7 +17,6 @@
     "installation_date": 1612674000,
     "custom_targeting_attributes": {},
     "additional_targeting": {
-        "is_already_enrolled": true,
         "days_since_install": 5,
         "days_since_update": 2
     }

--- a/experimenter/tests/tools/sdk_eval_check.py
+++ b/experimenter/tests/tools/sdk_eval_check.py
@@ -80,7 +80,6 @@ if __name__ == "__main__":
     )
     custom_targeting_attributes = json.dumps(
         {
-            "is_already_enrolled": True,
             "days_since_update": 1,
             "days_since_install": 1,
             "isFirstRun": "true",


### PR DESCRIPTION
Because

* mozilla/application-services#5374 changed how enrollments are calculated
* experimenter needs to express sticky enrollment using the SDK-supported <slug> in active_experiments format

This commit

* updates sticky enrollment targeting to use <slug> in active_experiments

Fixes #8661