### PR TITLE
fix(nimbus): re-issue log-state in the fenix enrollment poll loop

### DIFF
--- a/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
+++ b/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
@@ -9,8 +9,8 @@ from nimbus.models.base_dataclass import BaseExperimentApplications
 
 FENIX_APP = BaseExperimentApplications.FIREFOX_FENIX.value
 APP_APPLY_WAIT = 15
-LOG_STATE_TIMEOUT = 60
-LOG_STATE_POLL_INTERVAL = 1
+LOG_STATE_TIMEOUT = 120
+LOG_STATE_POLL_INTERVAL = 5
 
 
 @pytest.mark.fenix_enrollment
@@ -57,10 +57,6 @@ def test_fenix_enrollment(
     )
     time.sleep(APP_APPLY_WAIT)
 
-    subprocess.check_call(
-        ["nimbus-cli", "--app", FENIX_APP, "--channel", fenix_channel, "log-state"]
-    )
-
     pattern = re.compile(
         rf"nimbus_client:\s*{re.escape(experiment_slug)}\s+\|\s*\S+\s+\|\s*(\S+)"
     )
@@ -69,11 +65,15 @@ def test_fenix_enrollment(
     match = None
     deadline = time.monotonic() + LOG_STATE_TIMEOUT
     while time.monotonic() < deadline:
+        subprocess.check_call(["adb", "logcat", "-c"])
+        subprocess.check_call(
+            ["nimbus-cli", "--app", FENIX_APP, "--channel", fenix_channel, "log-state"]
+        )
+        time.sleep(LOG_STATE_POLL_INTERVAL)
         logcat = subprocess.check_output(["adb", "logcat", "-d"], text=True)
         match = pattern.search(logcat)
         if match is not None:
             break
-        time.sleep(LOG_STATE_POLL_INTERVAL)
 
     nimbus_lines = [line for line in logcat.splitlines() if "nimbus_client" in line]
     assert match is not None, (


### PR DESCRIPTION
Because

* The single `log-state` launch can read an empty DB before the enroll's enrollment persists on a loaded CI emulator, and the poll loop only re-dumps logcat — it never re-issues `log-state` — so an early empty read can never recover.

This commit

* Re-issues `log-state` inside the poll loop (clear logcat, relaunch, dump, match) and raises the timeout, so a late-persisted enrollment still surfaces.

Refs #15845

---

Scoped to the `No log-state row found` flake. The separate `5554 / SeekableByteChannel` SDK-download flake tracked in #15845 needs a different approach (pre-download required cmdline-tools that aren't present pre-action on these runners) and is deferred to a follow-up.