### PR TITLE
feat(schemas): Sort properties of generated JSON schemas

### DIFF
--- a/schemas/generate_json_schema.py
+++ b/schemas/generate_json_schema.py
@@ -173,6 +173,11 @@ def prettify_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
         match obj.get("type"):
             case "object":
                 if properties := obj.get("properties"):
+                    # Sort the properties of generated schemas. This will make
+                    # schema changes easier to review.
+                    properties = obj["properties"] = {
+                        key: properties[key] for key in sorted(properties)
+                    }
                     _walk_objects(properties.values())
 
             case "array":
@@ -183,9 +188,10 @@ def prettify_json_schema(schema: dict[str, Any]) -> dict[str, Any]:
             if group := obj.get(group_key):
                 _walk_objects(group)
 
+        if defs := obj.get("$defs"):
+            _walk_objects(defs.values())
+
     _walk_object(pretty_schema, top_level=True)
-    if defs := pretty_schema.get("$defs"):
-        _walk_objects(defs.values())
 
     return pretty_schema
 

--- a/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
@@ -4,98 +4,28 @@
   "description": "A Nimbus experiment for Firefox Desktop. This schema is more strict than DesktopNimbusExperiment and is backwards comaptible with Firefox Desktop versions less than 95. It is intended for use inside Experimenter itself.",
   "type": "object",
   "properties": {
-    "schemaVersion": {
-      "description": "Version of the NimbusExperiment schema this experiment refers to",
-      "type": "string"
-    },
-    "slug": {
-      "description": "Unique identifier for the experiment",
-      "type": "string"
-    },
-    "id": {
-      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+    "appId": {
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "appName": {
       "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
-    "appId": {
-      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
-      "type": "string"
-    },
-    "channel": {
-      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
-      "type": "string"
-    },
-    "userFacingName": {
-      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "userFacingDescription": {
-      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
-      "type": "boolean"
-    },
-    "isRollout": {
-      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
-      "type": "boolean"
+    "branches": {
+      "description": "Branch configuration for the experiment.",
+      "items": {
+        "$ref": "#/$defs/DesktopAllVersionsExperimentBranch"
+      },
+      "type": "array"
     },
     "bucketConfig": {
       "$ref": "#/$defs/ExperimentBucketConfig",
       "description": "Bucketing configuration."
     },
-    "outcomes": {
-      "description": "A list of outcomes relevant to the experiment analysis.",
-      "items": {
-        "$ref": "#/$defs/ExperimentOutcome"
-      },
-      "type": "array"
-    },
-    "featureIds": {
-      "description": "A list of featureIds the experiment contains configurations for.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "targeting": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A JEXL targeting expression used to filter out experiments."
-    },
-    "startDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
-    },
-    "enrollmentEndDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
+    "channel": {
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
+      "type": "string"
     },
     "endDate": {
       "anyOf": [
@@ -109,93 +39,28 @@
       ],
       "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
-    "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "referenceBranch": {
+    "enrollmentEndDate": {
       "anyOf": [
         {
+          "format": "date",
           "type": "string"
         },
         {
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
-    "locales": {
-      "anyOf": [
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
-    },
-    "localizations": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ExperimentLocalizations"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "publishedDate": {
-      "anyOf": [
-        {
-          "format": "date-time",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
-    },
-    "branches": {
-      "description": "Branch configuration for the experiment.",
+    "featureIds": {
+      "description": "A list of featureIds the experiment contains configurations for.",
       "items": {
-        "$ref": "#/$defs/DesktopAllVersionsExperimentBranch"
+        "type": "string"
       },
       "type": "array"
     },
-    "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+    "featureValidationOptOut": {
+      "description": "Opt out of feature schema validation.",
       "type": "boolean"
-    },
-    "firefoxLabsGroup": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The group this should appear under in Firefox Labs"
-    },
-    "firefoxLabsTitle": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The title shown in Firefox Labs (Fluent ID)"
     },
     "firefoxLabsDescription": {
       "anyOf": [
@@ -225,13 +90,148 @@
       ],
       "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
     },
-    "featureValidationOptOut": {
-      "description": "Opt out of feature schema validation.",
+    "firefoxLabsGroup": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The group this should appear under in Firefox Labs"
+    },
+    "firefoxLabsTitle": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The title shown in Firefox Labs (Fluent ID)"
+    },
+    "id": {
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+      "type": "string"
+    },
+    "isEnrollmentPaused": {
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
+    },
+    "isFirefoxLabsOptIn": {
+      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+      "type": "boolean"
+    },
+    "isRollout": {
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "type": "boolean"
+    },
+    "locales": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
+    },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "outcomes": {
+      "description": "A list of outcomes relevant to the experiment analysis.",
+      "items": {
+        "$ref": "#/$defs/ExperimentOutcome"
+      },
+      "type": "array"
+    },
+    "proposedDuration": {
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "proposedEnrollment": {
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "publishedDate": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
+    },
+    "referenceBranch": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "requiresRestart": {
       "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
+    },
+    "schemaVersion": {
+      "description": "Version of the NimbusExperiment schema this experiment refers to",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Unique identifier for the experiment",
+      "type": "string"
+    },
+    "startDate": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "targeting": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A JEXL targeting expression used to filter out experiments."
+    },
+    "userFacingDescription": {
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
+    },
+    "userFacingName": {
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
     }
   },
   "required": [
@@ -296,13 +296,9 @@
     "DesktopAllVersionsExperimentBranch": {
       "description": "The branch definition supported on all Firefox Desktop versions. This version requires the feature field to be present to support older Firefox Desktop clients.",
       "properties": {
-        "slug": {
-          "description": "Identifier for the branch.",
-          "type": "string"
-        },
-        "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
-          "type": "integer"
+        "feature": {
+          "$ref": "#/$defs/DesktopPre95FeatureConfig",
+          "description": "The feature key must be provided with values to prevent crashes if the experiment is encountered by Desktop clients earlier than version 95."
         },
         "features": {
           "description": "An array of feature configurations.",
@@ -322,9 +318,13 @@
           ],
           "description": "The branch title shown in Firefox Labs (Fluent ID)"
         },
-        "feature": {
-          "$ref": "#/$defs/DesktopPre95FeatureConfig",
-          "description": "The feature key must be provided with values to prevent crashes if the experiment is encountered by Desktop clients earlier than version 95."
+        "ratio": {
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
+          "type": "integer"
+        },
+        "slug": {
+          "description": "Identifier for the branch.",
+          "type": "string"
         }
       },
       "required": [
@@ -337,6 +337,10 @@
     },
     "DesktopPre95FeatureConfig": {
       "properties": {
+        "enabled": {
+          "const": false,
+          "type": "boolean"
+        },
         "featureId": {
           "const": "this-is-included-for-desktop-pre-95-support",
           "type": "string"
@@ -344,10 +348,6 @@
         "value": {
           "additionalProperties": true,
           "type": "object"
-        },
-        "enabled": {
-          "const": false,
-          "type": "boolean"
         }
       },
       "required": [
@@ -359,19 +359,19 @@
     },
     "ExperimentBucketConfig": {
       "properties": {
-        "randomizationUnit": {
-          "$ref": "#/$defs/RandomizationUnit"
+        "count": {
+          "description": "Number of buckets in the range.",
+          "type": "integer"
         },
         "namespace": {
           "description": "Additional inputs to the hashing function.",
           "type": "string"
         },
+        "randomizationUnit": {
+          "$ref": "#/$defs/RandomizationUnit"
+        },
         "start": {
           "description": "Index of the starting bucket of the range.",
-          "type": "integer"
-        },
-        "count": {
-          "description": "Number of buckets in the range.",
           "type": "integer"
         },
         "total": {
@@ -418,12 +418,12 @@
     },
     "ExperimentOutcome": {
       "properties": {
-        "slug": {
-          "description": "Identifier for the outcome.",
-          "type": "string"
-        },
         "priority": {
           "description": "e.g., \"primary\" or \"secondary\".",
+          "type": "string"
+        },
+        "slug": {
+          "description": "Identifier for the outcome.",
           "type": "string"
         }
       },

--- a/schemas/schemas/DesktopFeature.schema.json
+++ b/schemas/schemas/DesktopFeature.schema.json
@@ -4,24 +4,8 @@
   "description": "A feature.",
   "type": "object",
   "properties": {
-    "description": {
-      "description": "The description of the feature.",
-      "type": "string"
-    },
-    "hasExposure": {
-      "description": "Whether or not this feature records exposure telemetry.",
-      "type": "boolean"
-    },
-    "exposureDescription": {
-      "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
-      "type": "string"
-    },
-    "owner": {
-      "description": "The owner of the feature.",
-      "type": "string"
-    },
-    "isEarlyStartup": {
-      "description": "If true, the feature values will be cached in prefs so that they can be read before Nimbus is initialized during Firefox startup.",
+    "allowCoenrollment": {
+      "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
       "type": "boolean"
     },
     "applications": {
@@ -32,20 +16,36 @@
       "minLength": 1,
       "type": "array"
     },
+    "description": {
+      "description": "The description of the feature.",
+      "type": "string"
+    },
+    "exposureDescription": {
+      "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
+      "type": "string"
+    },
+    "hasExposure": {
+      "description": "Whether or not this feature records exposure telemetry.",
+      "type": "boolean"
+    },
+    "isEarlyStartup": {
+      "description": "If true, the feature values will be cached in prefs so that they can be read before Nimbus is initialized during Firefox startup.",
+      "type": "boolean"
+    },
+    "owner": {
+      "description": "The owner of the feature.",
+      "type": "string"
+    },
+    "schema": {
+      "$ref": "#/$defs/NimbusFeatureSchema",
+      "description": "An optional JSON schema that describes the feature variables."
+    },
     "variables": {
       "additionalProperties": {
         "$ref": "#/$defs/DesktopFeatureVariable"
       },
       "description": "The variables that this feature can set.",
       "type": "object"
-    },
-    "schema": {
-      "$ref": "#/$defs/NimbusFeatureSchema",
-      "description": "An optional JSON schema that describes the feature variables."
-    },
-    "allowCoenrollment": {
-      "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
-      "type": "boolean"
     }
   },
   "required": [
@@ -171,10 +171,6 @@
           "description": "A description of the feature.",
           "type": "string"
         },
-        "type": {
-          "$ref": "#/$defs/FeatureVariableType",
-          "description": "The field type."
-        },
         "enum": {
           "anyOf": [
             {
@@ -206,6 +202,10 @@
             }
           ],
           "description": "A pref that should be set to the value of this variable when enrolling in experiments. Using a string is deprecated and unsupported in Firefox 124+."
+        },
+        "type": {
+          "$ref": "#/$defs/FeatureVariableType",
+          "description": "The field type."
         }
       },
       "required": [
@@ -226,12 +226,12 @@
     "NimbusFeatureSchema": {
       "description": "Information about a JSON schema.",
       "properties": {
-        "uri": {
-          "description": "The resource:// or chrome:// URI that can be loaded at runtime within Firefox. Required by Firefox so that Nimbus can import the schema for validation.",
-          "type": "string"
-        },
         "path": {
           "description": "The path to the schema file in the source checkout. Required by Experimenter so that it can find schema files in source checkouts.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The resource:// or chrome:// URI that can be loaded at runtime within Firefox. Required by Firefox so that Nimbus can import the schema for validation.",
           "type": "string"
         }
       },

--- a/schemas/schemas/DesktopFeatureManifest.schema.json
+++ b/schemas/schemas/DesktopFeatureManifest.schema.json
@@ -24,24 +24,8 @@
         }
       },
       "properties": {
-        "description": {
-          "description": "The description of the feature.",
-          "type": "string"
-        },
-        "hasExposure": {
-          "description": "Whether or not this feature records exposure telemetry.",
-          "type": "boolean"
-        },
-        "exposureDescription": {
-          "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
-          "type": "string"
-        },
-        "owner": {
-          "description": "The owner of the feature.",
-          "type": "string"
-        },
-        "isEarlyStartup": {
-          "description": "If true, the feature values will be cached in prefs so that they can be read before Nimbus is initialized during Firefox startup.",
+        "allowCoenrollment": {
+          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
           "type": "boolean"
         },
         "applications": {
@@ -52,20 +36,36 @@
           "minLength": 1,
           "type": "array"
         },
+        "description": {
+          "description": "The description of the feature.",
+          "type": "string"
+        },
+        "exposureDescription": {
+          "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
+          "type": "string"
+        },
+        "hasExposure": {
+          "description": "Whether or not this feature records exposure telemetry.",
+          "type": "boolean"
+        },
+        "isEarlyStartup": {
+          "description": "If true, the feature values will be cached in prefs so that they can be read before Nimbus is initialized during Firefox startup.",
+          "type": "boolean"
+        },
+        "owner": {
+          "description": "The owner of the feature.",
+          "type": "string"
+        },
+        "schema": {
+          "$ref": "#/$defs/NimbusFeatureSchema",
+          "description": "An optional JSON schema that describes the feature variables."
+        },
         "variables": {
           "additionalProperties": {
             "$ref": "#/$defs/DesktopFeatureVariable"
           },
           "description": "The variables that this feature can set.",
           "type": "object"
-        },
-        "schema": {
-          "$ref": "#/$defs/NimbusFeatureSchema",
-          "description": "An optional JSON schema that describes the feature variables."
-        },
-        "allowCoenrollment": {
-          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
-          "type": "boolean"
         }
       },
       "required": [
@@ -178,10 +178,6 @@
           "description": "A description of the feature.",
           "type": "string"
         },
-        "type": {
-          "$ref": "#/$defs/FeatureVariableType",
-          "description": "The field type."
-        },
         "enum": {
           "anyOf": [
             {
@@ -213,6 +209,10 @@
             }
           ],
           "description": "A pref that should be set to the value of this variable when enrolling in experiments. Using a string is deprecated and unsupported in Firefox 124+."
+        },
+        "type": {
+          "$ref": "#/$defs/FeatureVariableType",
+          "description": "The field type."
         }
       },
       "required": [
@@ -233,12 +233,12 @@
     "NimbusFeatureSchema": {
       "description": "Information about a JSON schema.",
       "properties": {
-        "uri": {
-          "description": "The resource:// or chrome:// URI that can be loaded at runtime within Firefox. Required by Firefox so that Nimbus can import the schema for validation.",
-          "type": "string"
-        },
         "path": {
           "description": "The path to the schema file in the source checkout. Required by Experimenter so that it can find schema files in source checkouts.",
+          "type": "string"
+        },
+        "uri": {
+          "description": "The resource:// or chrome:// URI that can be loaded at runtime within Firefox. Required by Firefox so that Nimbus can import the schema for validation.",
           "type": "string"
         }
       },

--- a/schemas/schemas/DesktopNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopNimbusExperiment.schema.json
@@ -4,98 +4,28 @@
   "description": "A Nimbus experiment for Firefox Desktop. This schema is less strict than DesktopAllVersionsNimbusExperiment and is intended for use in Firefox Desktop.",
   "type": "object",
   "properties": {
-    "schemaVersion": {
-      "description": "Version of the NimbusExperiment schema this experiment refers to",
-      "type": "string"
-    },
-    "slug": {
-      "description": "Unique identifier for the experiment",
-      "type": "string"
-    },
-    "id": {
-      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+    "appId": {
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "appName": {
       "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
-    "appId": {
-      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
-      "type": "string"
-    },
-    "channel": {
-      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
-      "type": "string"
-    },
-    "userFacingName": {
-      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "userFacingDescription": {
-      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
-      "type": "boolean"
-    },
-    "isRollout": {
-      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
-      "type": "boolean"
+    "branches": {
+      "description": "Branch configuration for the experiment.",
+      "items": {
+        "$ref": "#/$defs/DesktopExperimentBranch"
+      },
+      "type": "array"
     },
     "bucketConfig": {
       "$ref": "#/$defs/ExperimentBucketConfig",
       "description": "Bucketing configuration."
     },
-    "outcomes": {
-      "description": "A list of outcomes relevant to the experiment analysis.",
-      "items": {
-        "$ref": "#/$defs/ExperimentOutcome"
-      },
-      "type": "array"
-    },
-    "featureIds": {
-      "description": "A list of featureIds the experiment contains configurations for.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "targeting": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A JEXL targeting expression used to filter out experiments."
-    },
-    "startDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
-    },
-    "enrollmentEndDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
+    "channel": {
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
+      "type": "string"
     },
     "endDate": {
       "anyOf": [
@@ -109,93 +39,28 @@
       ],
       "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
-    "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "referenceBranch": {
+    "enrollmentEndDate": {
       "anyOf": [
         {
+          "format": "date",
           "type": "string"
         },
         {
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
-    "locales": {
-      "anyOf": [
-        {
-          "items": {
-            "type": "string"
-          },
-          "type": "array"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
-    },
-    "localizations": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/ExperimentLocalizations"
-        },
-        {
-          "type": "null"
-        }
-      ]
-    },
-    "publishedDate": {
-      "anyOf": [
-        {
-          "format": "date-time",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
-    },
-    "branches": {
-      "description": "Branch configuration for the experiment.",
+    "featureIds": {
+      "description": "A list of featureIds the experiment contains configurations for.",
       "items": {
-        "$ref": "#/$defs/DesktopExperimentBranch"
+        "type": "string"
       },
       "type": "array"
     },
-    "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+    "featureValidationOptOut": {
+      "description": "Opt out of feature schema validation.",
       "type": "boolean"
-    },
-    "firefoxLabsGroup": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The group this should appear under in Firefox Labs"
-    },
-    "firefoxLabsTitle": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "The title shown in Firefox Labs (Fluent ID)"
     },
     "firefoxLabsDescription": {
       "anyOf": [
@@ -225,13 +90,148 @@
       ],
       "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
     },
-    "featureValidationOptOut": {
-      "description": "Opt out of feature schema validation.",
+    "firefoxLabsGroup": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The group this should appear under in Firefox Labs"
+    },
+    "firefoxLabsTitle": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The title shown in Firefox Labs (Fluent ID)"
+    },
+    "id": {
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+      "type": "string"
+    },
+    "isEnrollmentPaused": {
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
       "type": "boolean"
+    },
+    "isFirefoxLabsOptIn": {
+      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+      "type": "boolean"
+    },
+    "isRollout": {
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "type": "boolean"
+    },
+    "locales": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The list of locale codes (e.g., \"en-US\" or \"fr\") that this experiment is targeting. If null, all locales are targeted."
+    },
+    "localizations": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/ExperimentLocalizations"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "outcomes": {
+      "description": "A list of outcomes relevant to the experiment analysis.",
+      "items": {
+        "$ref": "#/$defs/ExperimentOutcome"
+      },
+      "type": "array"
+    },
+    "proposedDuration": {
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "proposedEnrollment": {
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "publishedDate": {
+      "anyOf": [
+        {
+          "format": "date-time",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
+    },
+    "referenceBranch": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
     "requiresRestart": {
       "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
       "type": "boolean"
+    },
+    "schemaVersion": {
+      "description": "Version of the NimbusExperiment schema this experiment refers to",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Unique identifier for the experiment",
+      "type": "string"
+    },
+    "startDate": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "targeting": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A JEXL targeting expression used to filter out experiments."
+    },
+    "userFacingDescription": {
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
+    },
+    "userFacingName": {
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
     }
   },
   "required": [
@@ -296,14 +296,6 @@
     "DesktopExperimentBranch": {
       "description": "The branch definition supported on Firefox Desktop 95+.",
       "properties": {
-        "slug": {
-          "description": "Identifier for the branch.",
-          "type": "string"
-        },
-        "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
-          "type": "integer"
-        },
         "features": {
           "description": "An array of feature configurations.",
           "items": {
@@ -321,6 +313,14 @@
             }
           ],
           "description": "The branch title shown in Firefox Labs (Fluent ID)"
+        },
+        "ratio": {
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
+          "type": "integer"
+        },
+        "slug": {
+          "description": "Identifier for the branch.",
+          "type": "string"
         }
       },
       "required": [
@@ -332,19 +332,19 @@
     },
     "ExperimentBucketConfig": {
       "properties": {
-        "randomizationUnit": {
-          "$ref": "#/$defs/RandomizationUnit"
+        "count": {
+          "description": "Number of buckets in the range.",
+          "type": "integer"
         },
         "namespace": {
           "description": "Additional inputs to the hashing function.",
           "type": "string"
         },
+        "randomizationUnit": {
+          "$ref": "#/$defs/RandomizationUnit"
+        },
         "start": {
           "description": "Index of the starting bucket of the range.",
-          "type": "integer"
-        },
-        "count": {
-          "description": "Number of buckets in the range.",
           "type": "integer"
         },
         "total": {
@@ -391,12 +391,12 @@
     },
     "ExperimentOutcome": {
       "properties": {
-        "slug": {
-          "description": "Identifier for the outcome.",
-          "type": "string"
-        },
         "priority": {
           "description": "e.g., \"primary\" or \"secondary\".",
+          "type": "string"
+        },
+        "slug": {
+          "description": "Identifier for the outcome.",
           "type": "string"
         }
       },

--- a/schemas/schemas/ExperimentBucketConfig.schema.json
+++ b/schemas/schemas/ExperimentBucketConfig.schema.json
@@ -3,19 +3,19 @@
   "title": "ExperimentBucketConfig",
   "type": "object",
   "properties": {
-    "randomizationUnit": {
-      "$ref": "#/$defs/RandomizationUnit"
+    "count": {
+      "description": "Number of buckets in the range.",
+      "type": "integer"
     },
     "namespace": {
       "description": "Additional inputs to the hashing function.",
       "type": "string"
     },
+    "randomizationUnit": {
+      "$ref": "#/$defs/RandomizationUnit"
+    },
     "start": {
       "description": "Index of the starting bucket of the range.",
-      "type": "integer"
-    },
-    "count": {
-      "description": "Number of buckets in the range.",
       "type": "integer"
     },
     "total": {

--- a/schemas/schemas/ExperimentOutcome.schema.json
+++ b/schemas/schemas/ExperimentOutcome.schema.json
@@ -3,12 +3,12 @@
   "title": "ExperimentOutcome",
   "type": "object",
   "properties": {
-    "slug": {
-      "description": "Identifier for the outcome.",
-      "type": "string"
-    },
     "priority": {
       "description": "e.g., \"primary\" or \"secondary\".",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Identifier for the outcome.",
       "type": "string"
     }
   },

--- a/schemas/schemas/NimbusExperimentV7.schema.json
+++ b/schemas/schemas/NimbusExperimentV7.schema.json
@@ -4,98 +4,35 @@
   "description": "A Nimbus experiment for V7.",
   "type": "object",
   "properties": {
-    "schemaVersion": {
-      "description": "Version of the NimbusExperiment schema this experiment refers to",
-      "type": "string"
-    },
-    "slug": {
-      "description": "Unique identifier for the experiment",
-      "type": "string"
-    },
-    "id": {
-      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+    "appId": {
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "appName": {
       "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
-    "appId": {
-      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
-      "type": "string"
-    },
-    "channel": {
-      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
-      "type": "string"
-    },
-    "userFacingName": {
-      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "userFacingDescription": {
-      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
-      "type": "boolean"
-    },
-    "isRollout": {
-      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
-      "type": "boolean"
+    "branches": {
+      "description": "Branch configuration for the experiment.",
+      "items": {
+        "$ref": "#/$defs/BaseExperimentBranch"
+      },
+      "type": "array"
     },
     "bucketConfig": {
       "$ref": "#/$defs/ExperimentBucketConfig",
       "description": "Bucketing configuration."
     },
-    "outcomes": {
-      "description": "A list of outcomes relevant to the experiment analysis.",
+    "channel": {
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
+      "type": "string"
+    },
+    "documentationLinks": {
+      "description": "All documentation links associated with this experiment.",
       "items": {
-        "$ref": "#/$defs/ExperimentOutcome"
+        "$ref": "#/$defs/DocumentationLink"
       },
       "type": "array"
-    },
-    "featureIds": {
-      "description": "A list of featureIds the experiment contains configurations for.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "targeting": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A JEXL targeting expression used to filter out experiments."
-    },
-    "startDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
-    },
-    "enrollmentEndDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
     },
     "endDate": {
       "anyOf": [
@@ -109,24 +46,36 @@
       ],
       "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
-    "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "referenceBranch": {
+    "enrollmentEndDate": {
       "anyOf": [
         {
+          "format": "date",
           "type": "string"
         },
         {
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "featureIds": {
+      "description": "A list of featureIds the experiment contains configurations for.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "id": {
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+      "type": "string"
+    },
+    "isEnrollmentPaused": {
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
+      "type": "boolean"
+    },
+    "isRollout": {
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "type": "boolean"
     },
     "locales": {
       "anyOf": [
@@ -153,6 +102,21 @@
       ],
       "description": "Per-locale localization substitutions."
     },
+    "outcomes": {
+      "description": "A list of outcomes relevant to the experiment analysis.",
+      "items": {
+        "$ref": "#/$defs/ExperimentOutcome"
+      },
+      "type": "array"
+    },
+    "proposedDuration": {
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "proposedEnrollment": {
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -165,19 +129,55 @@
       ],
       "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
-    "branches": {
-      "description": "Branch configuration for the experiment.",
-      "items": {
-        "$ref": "#/$defs/BaseExperimentBranch"
-      },
-      "type": "array"
+    "referenceBranch": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
-    "documentationLinks": {
-      "description": "All documentation links associated with this experiment.",
-      "items": {
-        "$ref": "#/$defs/DocumentationLink"
-      },
-      "type": "array"
+    "schemaVersion": {
+      "description": "Version of the NimbusExperiment schema this experiment refers to",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Unique identifier for the experiment",
+      "type": "string"
+    },
+    "startDate": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "targeting": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A JEXL targeting expression used to filter out experiments."
+    },
+    "userFacingDescription": {
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
+    },
+    "userFacingName": {
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
     }
   },
   "required": [
@@ -202,20 +202,20 @@
   "$defs": {
     "BaseExperimentBranch": {
       "properties": {
-        "slug": {
-          "description": "Identifier for the branch.",
-          "type": "string"
-        },
-        "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
-          "type": "integer"
-        },
         "features": {
           "description": "An array of feature configurations.",
           "items": {
             "$ref": "#/$defs/ExperimentFeatureConfig"
           },
           "type": "array"
+        },
+        "ratio": {
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
+          "type": "integer"
+        },
+        "slug": {
+          "description": "Identifier for the branch.",
+          "type": "string"
         }
       },
       "required": [
@@ -227,12 +227,12 @@
     },
     "DocumentationLink": {
       "properties": {
-        "title": {
-          "description": "The name associated with the link.",
-          "type": "string"
-        },
         "link": {
           "description": "The URL associated with the link.",
+          "type": "string"
+        },
+        "title": {
+          "description": "The name associated with the link.",
           "type": "string"
         }
       },
@@ -244,19 +244,19 @@
     },
     "ExperimentBucketConfig": {
       "properties": {
-        "randomizationUnit": {
-          "$ref": "#/$defs/RandomizationUnit"
+        "count": {
+          "description": "Number of buckets in the range.",
+          "type": "integer"
         },
         "namespace": {
           "description": "Additional inputs to the hashing function.",
           "type": "string"
         },
+        "randomizationUnit": {
+          "$ref": "#/$defs/RandomizationUnit"
+        },
         "start": {
           "description": "Index of the starting bucket of the range.",
-          "type": "integer"
-        },
-        "count": {
-          "description": "Number of buckets in the range.",
           "type": "integer"
         },
         "total": {
@@ -303,12 +303,12 @@
     },
     "ExperimentOutcome": {
       "properties": {
-        "slug": {
-          "description": "Identifier for the outcome.",
-          "type": "string"
-        },
         "priority": {
           "description": "e.g., \"primary\" or \"secondary\".",
+          "type": "string"
+        },
+        "slug": {
+          "description": "Identifier for the outcome.",
           "type": "string"
         }
       },

--- a/schemas/schemas/SdkFeatureManifest.schema.json
+++ b/schemas/schemas/SdkFeatureManifest.schema.json
@@ -26,17 +26,21 @@
         }
       },
       "properties": {
+        "allow-coenrollment": {
+          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
+          "type": "boolean"
+        },
         "description": {
           "description": "The description of the feature.",
+          "type": "string"
+        },
+        "exposureDescription": {
+          "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
           "type": "string"
         },
         "hasExposure": {
           "description": "Whether or not this feature records exposure telemetry.",
           "type": "boolean"
-        },
-        "exposureDescription": {
-          "description": "A description of the exposure telemetry collected by this feature. Only required if hasExposure is true.",
-          "type": "string"
         },
         "variables": {
           "additionalProperties": {
@@ -44,10 +48,6 @@
           },
           "description": "The variables that this feature can set.",
           "type": "object"
-        },
-        "allow-coenrollment": {
-          "description": "If true, clients can enroll in multiple experiments and rollouts that use this feature.",
-          "type": "boolean"
         }
       },
       "required": [
@@ -78,16 +78,16 @@
           "description": "A description of the feature.",
           "type": "string"
         },
-        "type": {
-          "$ref": "#/$defs/FeatureVariableType",
-          "description": "The field type."
-        },
         "enum": {
           "description": "An optional list of possible string values. Only allowed when type is string.",
           "items": {
             "type": "string"
           },
           "type": "array"
+        },
+        "type": {
+          "$ref": "#/$defs/FeatureVariableType",
+          "description": "The field type."
         }
       },
       "required": [

--- a/schemas/schemas/SdkNimbusExperiment.schema.json
+++ b/schemas/schemas/SdkNimbusExperiment.schema.json
@@ -4,98 +4,28 @@
   "description": "A Nimbus experiment for Nimbus SDK-based applications.",
   "type": "object",
   "properties": {
-    "schemaVersion": {
-      "description": "Version of the NimbusExperiment schema this experiment refers to",
-      "type": "string"
-    },
-    "slug": {
-      "description": "Unique identifier for the experiment",
-      "type": "string"
-    },
-    "id": {
-      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+    "appId": {
+      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
       "type": "string"
     },
     "appName": {
       "description": "A slug identifying the targeted product of this experiment. It should be a lowercased_with_underscores name that is short and unambiguous and it should match the app_name found in https://probeinfo.telemetry.mozilla.org/glean/repositories. Examples are \"fenix\" and \"firefox_desktop\".",
       "type": "string"
     },
-    "appId": {
-      "description": "The platform identifier for the targeted app. This should match app's identifier exactly as it appears in the relevant app store listing (for relevant platforms) or the app's Glean initialization (for other platforms). Examples are \"org.mozilla.firefox_beta\" and \"firefox-desktop\".",
-      "type": "string"
-    },
-    "channel": {
-      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
-      "type": "string"
-    },
-    "userFacingName": {
-      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "userFacingDescription": {
-      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
-      "type": "string"
-    },
-    "isEnrollmentPaused": {
-      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
-      "type": "boolean"
-    },
-    "isRollout": {
-      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
-      "type": "boolean"
+    "branches": {
+      "description": "Branch configuration for the SDK experiment.",
+      "items": {
+        "$ref": "#/$defs/SdkExperimentBranch"
+      },
+      "type": "array"
     },
     "bucketConfig": {
       "$ref": "#/$defs/ExperimentBucketConfig",
       "description": "Bucketing configuration."
     },
-    "outcomes": {
-      "description": "A list of outcomes relevant to the experiment analysis.",
-      "items": {
-        "$ref": "#/$defs/ExperimentOutcome"
-      },
-      "type": "array"
-    },
-    "featureIds": {
-      "description": "A list of featureIds the experiment contains configurations for.",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "targeting": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "A JEXL targeting expression used to filter out experiments."
-    },
-    "startDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
-    },
-    "enrollmentEndDate": {
-      "anyOf": [
-        {
-          "format": "date",
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
+    "channel": {
+      "description": "A specific channel of an application such as \"nightly\", \"beta\", or \"release\".",
+      "type": "string"
     },
     "endDate": {
       "anyOf": [
@@ -109,24 +39,36 @@
       ],
       "description": "Actual end date of this experiment. Note that this field is expected to be null in Remote Settings."
     },
-    "proposedDuration": {
-      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "proposedEnrollment": {
-      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
-      "type": "integer"
-    },
-    "referenceBranch": {
+    "enrollmentEndDate": {
       "anyOf": [
         {
+          "format": "date",
           "type": "string"
         },
         {
           "type": "null"
         }
       ],
-      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
+      "description": "Actual enrollment end date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "featureIds": {
+      "description": "A list of featureIds the experiment contains configurations for.",
+      "items": {
+        "type": "string"
+      },
+      "type": "array"
+    },
+    "id": {
+      "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
+      "type": "string"
+    },
+    "isEnrollmentPaused": {
+      "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
+      "type": "boolean"
+    },
+    "isRollout": {
+      "description": "When this property is set to true, treat this experiment as a rollout. Rollouts are currently handled as single-branch experiments separated from the bucketing namespace for normal experiments. See-also: https://mozilla-hub.atlassian.net/browse/SDK-405",
+      "type": "boolean"
     },
     "locales": {
       "anyOf": [
@@ -153,6 +95,21 @@
       ],
       "description": "Per-locale localization substitutions."
     },
+    "outcomes": {
+      "description": "A list of outcomes relevant to the experiment analysis.",
+      "items": {
+        "$ref": "#/$defs/ExperimentOutcome"
+      },
+      "type": "array"
+    },
+    "proposedDuration": {
+      "description": "Duration of the experiment from the start date in days. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
+    "proposedEnrollment": {
+      "description": "This represents the number of days that we expect to enroll new users. Note that this property is only used during the analysis phase (i.e., not by the SDK).",
+      "type": "integer"
+    },
     "publishedDate": {
       "anyOf": [
         {
@@ -165,12 +122,55 @@
       ],
       "description": "The date that this experiment was first published to Remote Settings. If null, it has not yet been published."
     },
-    "branches": {
-      "description": "Branch configuration for the SDK experiment.",
-      "items": {
-        "$ref": "#/$defs/SdkExperimentBranch"
-      },
-      "type": "array"
+    "referenceBranch": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
+    },
+    "schemaVersion": {
+      "description": "Version of the NimbusExperiment schema this experiment refers to",
+      "type": "string"
+    },
+    "slug": {
+      "description": "Unique identifier for the experiment",
+      "type": "string"
+    },
+    "startDate": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Actual publish date of the experiment. Note that this value is expected to be null in Remote Settings."
+    },
+    "targeting": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "A JEXL targeting expression used to filter out experiments."
+    },
+    "userFacingDescription": {
+      "description": "Short public description of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
+    },
+    "userFacingName": {
+      "description": "Public name of the experiment that will be displayed on \"about:studies\".",
+      "type": "string"
     }
   },
   "required": [
@@ -194,19 +194,19 @@
   "$defs": {
     "ExperimentBucketConfig": {
       "properties": {
-        "randomizationUnit": {
-          "$ref": "#/$defs/RandomizationUnit"
+        "count": {
+          "description": "Number of buckets in the range.",
+          "type": "integer"
         },
         "namespace": {
           "description": "Additional inputs to the hashing function.",
           "type": "string"
         },
+        "randomizationUnit": {
+          "$ref": "#/$defs/RandomizationUnit"
+        },
         "start": {
           "description": "Index of the starting bucket of the range.",
-          "type": "integer"
-        },
-        "count": {
-          "description": "Number of buckets in the range.",
           "type": "integer"
         },
         "total": {
@@ -253,12 +253,12 @@
     },
     "ExperimentOutcome": {
       "properties": {
-        "slug": {
-          "description": "Identifier for the outcome.",
-          "type": "string"
-        },
         "priority": {
           "description": "e.g., \"primary\" or \"secondary\".",
+          "type": "string"
+        },
+        "slug": {
+          "description": "Identifier for the outcome.",
           "type": "string"
         }
       },
@@ -281,20 +281,20 @@
     "SdkExperimentBranch": {
       "description": "The branch definition for SDK-based applications. Supported on Firefox for Android 96+, Firefox for iOS 39+, and all versions of Cirrus.",
       "properties": {
-        "slug": {
-          "description": "Identifier for the branch.",
-          "type": "string"
-        },
-        "ratio": {
-          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
-          "type": "integer"
-        },
         "features": {
           "description": "An array of feature configurations.",
           "items": {
             "$ref": "#/$defs/ExperimentFeatureConfig"
           },
           "type": "array"
+        },
+        "ratio": {
+          "description": "Relative ratio of population for the branch. e.g., if branch A=1 and branch B=3, then branch A would get 25% of the population.",
+          "type": "integer"
+        },
+        "slug": {
+          "description": "Identifier for the branch.",
+          "type": "string"
         }
       },
       "required": [


### PR DESCRIPTION
Because:

- declaration order defines the order of properties in the generated schemas; and
- this order can change drastically when refactoring (e.g., a field into a base class)

this commit:

- sorts all properties of the top level schema and any definitions in "$defs".

Fixes #15868
