### PR TITLE
fix(nimbus): fix localizations reset by changes to audience form

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1035,11 +1035,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             key=lambda choice: choice[1].lower(),
         )
 
-    YES_NO_CHOICES = (
-        (True, "Yes"),
-        (False, "No"),
-    )
-
     channel = forms.ChoiceField(
         required=False,
         label="",
@@ -1108,7 +1103,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         required=False,
         widget=MultiSelectWidget(),
     )
-    localizations = forms.CharField(required=False, widget=forms.HiddenInput())
     is_sticky = forms.BooleanField(required=False)
     is_first_run = forms.BooleanField(required=False)
     population_percent = forms.DecimalField(
@@ -1144,7 +1138,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "is_sticky",
             "languages",
             "locales",
-            "localizations",
             "population_percent",
             "proposed_duration",
             "proposed_enrollment",
@@ -1155,9 +1148,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         ]
 
     def __init__(self, *args, **kwargs):
-        # Accept an optional keyword-only flag to render simple boolean radios.
-        rollout_card_view = kwargs.pop("rollout_card_view", False)
-
         super().__init__(*args, **kwargs)
         self.fields["targeting_config_slug"].choices = self.get_targeting_config_choices()
         self.setup_experiment_branch_choices()
@@ -1175,16 +1165,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 "hx-target": "#first-run-fields",
             }
         )
-
-        # We use a different widget for the is_sticky field when rendering this input
-        # as part of the new rollout form designs
-        if rollout_card_view and "is_sticky" in self.fields:
-            self.fields["is_sticky"] = forms.TypedChoiceField(
-                required=False,
-                choices=self.YES_NO_CHOICES,
-                widget=InlineRadioSelect,
-                coerce=lambda x: x == "True",
-            )
 
         # If this is a live rollout, restrict edits to only population_percent
         if self.instance.is_live_rollout:
@@ -1313,6 +1293,32 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def get_changelog_message(self):
         return f"{self.request.user} updated audience"
+
+
+class RolloutAudienceForm(AudienceForm):
+    YES_NO_CHOICES = (
+        (True, "Yes"),
+        (False, "No"),
+    )
+    localizations = forms.CharField(required=False, widget=forms.HiddenInput())
+
+    class Meta:
+        model = NimbusExperiment
+
+        fields = (
+            *AudienceForm.Meta.fields,
+            "localizations",
+        )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.fields["is_sticky"] = forms.TypedChoiceField(
+            required=False,
+            choices=self.YES_NO_CHOICES,
+            widget=InlineRadioSelect,
+            coerce=lambda x: x == "True",
+        )
 
 
 class SubscribeForm(NimbusChangeLogFormMixin, forms.ModelForm):

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3,7 +3,6 @@ import io
 import json
 from unittest.mock import patch
 
-from django import forms
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -3140,21 +3139,6 @@ class TestAudienceForm(RequestFormTestCase):
             expected_channels,
             msg="Channel choices did not match for desktop",
         )
-
-    def test_rollouts_audience_form_updated_is_sticky_widget(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            is_rollout=True,
-        )
-
-        form = AudienceForm(
-            instance=experiment, request=self.request, rollout_card_view=True
-        )
-
-        self.assertIn("is_sticky", form.fields)
-        is_sticky_field = form.fields["is_sticky"]
-        self.assertIsInstance(is_sticky_field, forms.TypedChoiceField)
 
 
 class TestNimbusBranchesForm(RequestFormTestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -3164,6 +3164,34 @@ class TestAudienceUpdateView(AuthTestCase):
         experiment.refresh_from_db()
         self.assertTrue(experiment.is_rollout_dirty)
 
+    def test_post_does_not_update_localizations(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            localizations=json.dumps({"localization-key": "localization-value"}),
+        )
+
+        response = self.client.post(
+            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug}),
+            {
+                "targeting_config_slug": NimbusExperiment.TargetingConfig.FIRST_RUN,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+
+        # Localizations should not be updated when an instance of AudienceForm is used
+        # in the view, so we check that the localizations field remains unchanged after
+        # the POST request.
+        self.assertEqual(
+            experiment.localizations,
+            json.dumps({"localization-key": "localization-value"}),
+        )
+        self.assertEqual(
+            experiment.targeting_config_slug, NimbusExperiment.TargetingConfig.FIRST_RUN
+        )
+
     def test_post_updates_overview_risks(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -73,6 +73,7 @@ from experimenter.nimbus_ui.forms import (
     QAStatusForm,
     ReviewToApproveForm,
     ReviewToDraftForm,
+    RolloutAudienceForm,
     SignoffForm,
     SubscribeForm,
     TagAssignForm,
@@ -1354,10 +1355,9 @@ class AudienceCardMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if not isinstance(kwargs.get("form"), AudienceForm):
-            context["form"] = AudienceForm(
+        if not isinstance(kwargs.get("form"), RolloutAudienceForm):
+            context["form"] = RolloutAudienceForm(
                 instance=self.object,
-                rollout_card_view=True,
             )
         context["cancel_url"] = reverse(
             self.cancel_url_name, kwargs={"slug": self.object.slug}
@@ -1388,13 +1388,8 @@ class NewRisksUpdateView(RisksCardMixin, NewCardUpdateView):
 
 
 class NewAudienceUpdateView(AudienceCardMixin, NewCardUpdateView):
-    form_class = AudienceForm
+    form_class = RolloutAudienceForm
     display_template = "nimbus_experiments/audience/card.html"
-
-    def get_form_kwargs(self):
-        kwargs = super().get_form_kwargs()
-        kwargs["rollout_card_view"] = True
-        return kwargs
 
 
 class NewQAUpdateView(QACardMixin, NewCardUpdateView):


### PR DESCRIPTION
Because

- The new rollouts audience form was recently created but worked by using the audience form class used in the current workflow despite requiring an additional input for localization which we added as a hidden form input
- This decision broke the existing audience form which would always submit an empty value for localizations thus resetting it each time it was saved  

This commit

- Creates a new standalone subclass `RolloutAudienceForm` which inherits from `AudienceForm` and adds any additional fields it requires to better separate the new design form logic
- This in turn fixes the above stated issue

Fixes #15867 