### PR TITLE
fix(schemas): Check all schemas packages for diffs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,8 +325,18 @@ SCHEMAS_RUN = docker run --rm $(DOCKER_RUN_INTERACTIVE) $(SCHEMAS_ENV) -v ./sche
 SCHEMAS_BLACK = black --check --diff .
 SCHEMAS_RUFF = ruff check .
 SCHEMAS_DIFF_PYDANTIC = \
-	poetry run python generate_json_schema.py --output /tmp/test_index.d.ts &&\
-	diff /tmp/test_index.d.ts index.d.ts || (echo nimbus-schemas typescript package is out of sync please run make schemas_build;exit 1) &&\
+	mkdir -p /tmp/schemas-diff/ && \
+	poetry run python generate_json_schema.py \
+		--output /tmp/schemas-diff/index.d.ts \
+		--json-schemas /tmp/schemas-diff/schemas/ \
+		--python-package-dir /tmp/schemas-diff/mozilla_nimbus_schemas/ && \
+	( \
+		diff index.d.ts /tmp/schemas-diff/index.d.ts && \
+		diff -r ./schemas /tmp/schemas-diff/schemas/ \
+	) || ( \
+		echo schemas packages are out of out of sync\: run make schemas_build; \
+		exit 1 \
+	) && \
 	echo 'Done. No problems found in schemas.'
 SCHEMAS_TEST = pytest
 SCHEMAS_FORMAT = ruff check --fix . && black .
@@ -350,7 +360,7 @@ schemas_format: schemas_docker_build  ## Format schemas source tree
 	$(SCHEMAS_RUN) "$(SCHEMAS_FORMAT)"
 
 schemas_lint: schemas_docker_build  ## Lint schemas source tree
-	$(SCHEMAS_RUN) "$(SCHEMAS_BLACK)&&$(SCHEMAS_RUFF)&&$(SCHEMAS_DIFF_PYDANTIC)&&$(SCHEMAS_TEST)"
+	$(SCHEMAS_RUN) "$(SCHEMAS_BLACK) && $(SCHEMAS_RUFF) && $(SCHEMAS_DIFF_PYDANTIC) && $(SCHEMAS_GENERATE) && $(SCHEMAS_TEST)"
 
 schemas_check: schemas_lint
 

--- a/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
@@ -342,6 +342,7 @@
           "type": "string"
         },
         "value": {
+          "additionalProperties": true,
           "type": "object"
         },
         "enabled": {
@@ -394,6 +395,7 @@
           "type": "string"
         },
         "value": {
+          "additionalProperties": true,
           "description": "The values that define the feature configuration. This should be validated against a schema.",
           "type": "object"
         }

--- a/schemas/schemas/DesktopNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopNimbusExperiment.schema.json
@@ -368,6 +368,7 @@
           "type": "string"
         },
         "value": {
+          "additionalProperties": true,
           "description": "The values that define the feature configuration. This should be validated against a schema.",
           "type": "object"
         }

--- a/schemas/schemas/ExperimentFeatureConfig.schema.json
+++ b/schemas/schemas/ExperimentFeatureConfig.schema.json
@@ -8,6 +8,7 @@
       "type": "string"
     },
     "value": {
+      "additionalProperties": true,
       "description": "The values that define the feature configuration. This should be validated against a schema.",
       "type": "object"
     }

--- a/schemas/schemas/NimbusExperimentV7.schema.json
+++ b/schemas/schemas/NimbusExperimentV7.schema.json
@@ -280,6 +280,7 @@
           "type": "string"
         },
         "value": {
+          "additionalProperties": true,
           "description": "The values that define the feature configuration. This should be validated against a schema.",
           "type": "object"
         }

--- a/schemas/schemas/SdkNimbusExperiment.schema.json
+++ b/schemas/schemas/SdkNimbusExperiment.schema.json
@@ -230,6 +230,7 @@
           "type": "string"
         },
         "value": {
+          "additionalProperties": true,
           "description": "The values that define the feature configuration. This should be validated against a schema.",
           "type": "object"
         }


### PR DESCRIPTION
Because:

- our `schemas_check` target only diffed `index.d.ts` with the generated `test_index.d.ts`, resulting in changing being missed in the generated JSON schemas

this commit:

- also recursively diffs the JSON schemas in `schemas_check`; and
- includes the missing changes from `make schemas_generate`.

Fixes #15876