### PR TITLE
feat(schemas): Add Firefox Labs fields to SDK experiment schemas

### DIFF
--- a/schemas/index.d.ts
+++ b/schemas/index.d.ts
@@ -153,23 +153,15 @@ export interface DesktopAllVersionsNimbusExperiment {
    */
   publishedDate?: string | null;
   /**
-   * Branch configuration for the experiment.
-   */
-  branches: DesktopAllVersionsExperimentBranch[];
-  /**
-   * When this property is set to true, treat this experiment as aFirefox Labs experiment
+   * When this property is set to true, treat this experiment as a Firefox Labs experiment
    */
   isFirefoxLabsOptIn?: boolean;
   /**
-   * The group this should appear under in Firefox Labs
-   */
-  firefoxLabsGroup?: string | null;
-  /**
-   * The title shown in Firefox Labs (Fluent ID)
+   * The title shown in Firefox Labs (Fluent ID or Resource ID)
    */
   firefoxLabsTitle?: string | null;
   /**
-   * The description shown in Firefox Labs (Fluent ID)
+   * The description shown in Firefox Labs (Fluent ID or Resource ID)
    */
   firefoxLabsDescription?: string | null;
   /**
@@ -179,15 +171,23 @@ export interface DesktopAllVersionsNimbusExperiment {
     [k: string]: string;
   } | null;
   /**
-   * Opt out of feature schema validation.
-   */
-  featureValidationOptOut?: boolean;
-  /**
    * Does the experiment require a restart to take effect?
    *
    * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
+  /**
+   * Branch configuration for the experiment.
+   */
+  branches: DesktopAllVersionsExperimentBranch[];
+  /**
+   * Opt out of feature schema validation.
+   */
+  featureValidationOptOut?: boolean;
+  /**
+   * The group this should appear under in Firefox Labs
+   */
+  firefoxLabsGroup?: string | null;
 }
 export interface ExperimentBucketConfig {
   randomizationUnit: RandomizationUnit;
@@ -399,23 +399,15 @@ export interface DesktopNimbusExperiment {
    */
   publishedDate?: string | null;
   /**
-   * Branch configuration for the experiment.
-   */
-  branches: DesktopExperimentBranch[];
-  /**
-   * When this property is set to true, treat this experiment as aFirefox Labs experiment
+   * When this property is set to true, treat this experiment as a Firefox Labs experiment
    */
   isFirefoxLabsOptIn?: boolean;
   /**
-   * The group this should appear under in Firefox Labs
-   */
-  firefoxLabsGroup?: string | null;
-  /**
-   * The title shown in Firefox Labs (Fluent ID)
+   * The title shown in Firefox Labs (Fluent ID or Resource ID)
    */
   firefoxLabsTitle?: string | null;
   /**
-   * The description shown in Firefox Labs (Fluent ID)
+   * The description shown in Firefox Labs (Fluent ID or Resource ID)
    */
   firefoxLabsDescription?: string | null;
   /**
@@ -425,15 +417,23 @@ export interface DesktopNimbusExperiment {
     [k: string]: string;
   } | null;
   /**
-   * Opt out of feature schema validation.
-   */
-  featureValidationOptOut?: boolean;
-  /**
    * Does the experiment require a restart to take effect?
    *
    * Only used by Firefox Labs Opt-Ins.
    */
   requiresRestart?: boolean;
+  /**
+   * Branch configuration for the experiment.
+   */
+  branches: DesktopExperimentBranch[];
+  /**
+   * Opt out of feature schema validation.
+   */
+  featureValidationOptOut?: boolean;
+  /**
+   * The group this should appear under in Firefox Labs
+   */
+  firefoxLabsGroup?: string | null;
 }
 /**
  * The branch definition supported on Firefox Desktop 95+.
@@ -577,6 +577,30 @@ export interface SdkNimbusExperiment {
    * If null, it has not yet been published.
    */
   publishedDate?: string | null;
+  /**
+   * When this property is set to true, treat this experiment as a Firefox Labs experiment
+   */
+  isFirefoxLabsOptIn?: boolean;
+  /**
+   * The title shown in Firefox Labs (Fluent ID or Resource ID)
+   */
+  firefoxLabsTitle?: string | null;
+  /**
+   * The description shown in Firefox Labs (Fluent ID or Resource ID)
+   */
+  firefoxLabsDescription?: string | null;
+  /**
+   * Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links.
+   */
+  firefoxLabsDescriptionLinks?: {
+    [k: string]: string;
+  } | null;
+  /**
+   * Does the experiment require a restart to take effect?
+   *
+   * Only used by Firefox Labs Opt-Ins.
+   */
+  requiresRestart?: boolean;
   /**
    * Branch configuration for the SDK experiment.
    */

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/common.py
@@ -2,8 +2,9 @@ import datetime
 from enum import Enum
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, RootModel, model_validator
 from pydantic.json_schema import SkipJsonSchema
+from typing_extensions import Self
 
 
 class RandomizationUnit(str, Enum):
@@ -26,9 +27,7 @@ class ExperimentBucketConfig(BaseModel):
     count: int = Field(description="Number of buckets in the range.")
     total: int = Field(
         description=(
-            "The total number of buckets.\n"
-            "\n"
-            "You can assume this will always be 10000."
+            "The total number of buckets.\n\nYou can assume this will always be 10000."
         )
     )
 
@@ -225,4 +224,73 @@ class BaseExperiment(BaseModel):
         default=None,
     )
 
-    model_config = ConfigDict(use_enum_values=True)
+    # Firefox Labs-related fields.
+
+    isFirefoxLabsOptIn: bool = Field(
+        description=(
+            "When this property is set to true, treat this experiment as a "
+            "Firefox Labs experiment"
+        ),
+        default=None,
+    )
+    firefoxLabsTitle: str | None = Field(
+        description="The title shown in Firefox Labs (Fluent ID or Resource ID)",
+        default=None,
+    )
+    firefoxLabsDescription: str | None = Field(
+        description="The description shown in Firefox Labs (Fluent ID or Resource ID)",
+        default=None,
+    )
+    firefoxLabsDescriptionLinks: dict[str, HttpUrl] | None = Field(
+        description=(
+            "Links that will be used with the firefoxLabsDescription Fluent ID. May be "
+            "null for Firefox Labs Opt-In recipes that do not use links."
+        ),
+        default=None,
+    )
+    requiresRestart: bool | SkipJsonSchema[None] = Field(
+        description=(
+            "Does the experiment require a restart to take effect?\n"
+            "\n"
+            "Only used by Firefox Labs Opt-Ins."
+        ),
+        default=False,
+    )
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_firefox_labs_base(cls, data: Self) -> Self:
+        if data.isFirefoxLabsOptIn:
+            if data.firefoxLabsTitle is None:
+                raise ValueError(
+                    "missing field firefoxLabsTitle (required because isFirefoxLabsOptIn "
+                    "is True)"
+                )
+            if data.firefoxLabsDescription is None:
+                raise ValueError(
+                    "missing field firefoxLabsDescription (required because "
+                    "isFirefoxLabsOptIn is True)"
+                )
+
+        return data
+
+    model_config = ConfigDict(
+        use_enum_values=True,
+        json_schema_extra={
+            "dependentSchemas": {
+                "isFirefoxLabsOptIn": {
+                    "if": {
+                        "properties": {
+                            "isFirefoxLabsOptIn": {"const": True},
+                        },
+                    },
+                    "then": {
+                        "required": [
+                            "firefoxLabsDescription",
+                            "firefoxLabsTitle",
+                        ],
+                    },
+                }
+            }
+        },
+    )

--- a/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/experiments.py
+++ b/schemas/mozilla_nimbus_schemas/experimenter_apis/experiments/experiments.py
@@ -1,6 +1,7 @@
+from copy import deepcopy
 from typing import Any, Literal
 
-from pydantic import ConfigDict, Field, HttpUrl, model_validator
+from pydantic import ConfigDict, Field, model_validator
 from pydantic.json_schema import SkipJsonSchema
 from typing_extensions import Self
 
@@ -54,6 +55,41 @@ class DesktopAllVersionsExperimentBranch(DesktopExperimentBranch):
     )
 
 
+def desktop_nimbus_experiment_json_schema_extras():
+    extras = deepcopy(BaseExperiment.model_config["json_schema_extra"])
+
+    firefox_labs_schema = extras["dependentSchemas"]["isFirefoxLabsOptIn"]
+    firefox_labs_schema["then"].update(
+        {
+            # On Desktop, firefoxLabsGroup is also required.
+            "required": sorted(
+                [
+                    *firefox_labs_schema["then"]["required"],
+                    "firefoxLabsGroup",
+                ]
+            ),
+            # Additionally, Desktop validates multi-branch Firefox Labs opt-ins.
+            "if": {
+                "properties": {
+                    "isRollout": {"const": False},
+                },
+                "required": ["isRollout"],
+            },
+            "then": {
+                "properties": {
+                    "branches": {
+                        "items": {
+                            "required": ["firefoxLabsTitle"],
+                        },
+                    },
+                },
+            },
+        }
+    )
+
+    return extras
+
+
 class DesktopNimbusExperiment(BaseExperiment):
     """A Nimbus experiment for Firefox Desktop.
 
@@ -68,65 +104,29 @@ class DesktopNimbusExperiment(BaseExperiment):
         description="Branch configuration for the experiment."
     )
 
-    isFirefoxLabsOptIn: bool = Field(
-        description=(
-            "When this property is set to true, treat this experiment as a"
-            "Firefox Labs experiment"
-        ),
-        default=None,
-    )
-    firefoxLabsGroup: str | None = Field(
-        description="The group this should appear under in Firefox Labs",
-        default=None,
-    )
-    firefoxLabsTitle: str | None = Field(
-        description="The title shown in Firefox Labs (Fluent ID)",
-        default=None,
-    )
-    firefoxLabsDescription: str | None = Field(
-        description="The description shown in Firefox Labs (Fluent ID)",
-        default=None,
-    )
-    firefoxLabsDescriptionLinks: dict[str, HttpUrl] | None = Field(
-        description=(
-            "Links that will be used with the firefoxLabsDescription Fluent ID. May be "
-            "null for Firefox Labs Opt-In recipes that do not use links."
-        ),
-        default=None,
-    )
     featureValidationOptOut: bool | SkipJsonSchema[None] = Field(
         description="Opt out of feature schema validation.",
         default=None,
     )
-    requiresRestart: bool | SkipJsonSchema[None] = Field(
-        description=(
-            "Does the experiment require a restart to take effect?\n"
-            "\n"
-            "Only used by Firefox Labs Opt-Ins."
-        ),
-        default=False,
-    )
+
     localizations: ExperimentLocalizations | None = Field(default=None)
+
+    # Only Desktop labs supports groups.
+    firefoxLabsGroup: str | None = Field(
+        description="The group this should appear under in Firefox Labs",
+        default=None,
+    )
 
     @model_validator(mode="after")
     @classmethod
-    def validate_firefox_labs(cls, data: Self) -> Self:
+    def validate_firefox_labs_desktop(cls, data: Self) -> Self:
         if data.isFirefoxLabsOptIn:
-            if data.firefoxLabsTitle is None:
-                raise ValueError(
-                    "missing field firefoxLabsTitle (required because isFirefoxLabsOptIn "
-                    "is True)"
-                )
-            if data.firefoxLabsDescription is None:
-                raise ValueError(
-                    "missing field firefoxLabsDescription (required because "
-                    "isFirefoxLabsOptIn is True)"
-                )
             if data.firefoxLabsGroup is None:
                 raise ValueError(
                     "missing field firefoxLabsGroup (required because isFirefoxLabsOptIn "
                     "is True)"
                 )
+
             if not data.isRollout:
                 for branch in data.branches:
                     if branch.firefoxLabsTitle is None:
@@ -139,40 +139,8 @@ class DesktopNimbusExperiment(BaseExperiment):
         return data
 
     model_config = ConfigDict(
-        json_schema_extra={
-            "dependentSchemas": {
-                "isFirefoxLabsOptIn": {
-                    "if": {
-                        "properties": {
-                            "isFirefoxLabsOptIn": {"const": True},
-                        },
-                    },
-                    "then": {
-                        "required": [
-                            "firefoxLabsDescription",
-                            "firefoxLabsDescriptionLinks",
-                            "firefoxLabsGroup",
-                            "firefoxLabsTitle",
-                        ],
-                        "if": {
-                            "properties": {
-                                "isRollout": {"const": False},
-                            },
-                            "required": ["isRollout"],
-                        },
-                        "then": {
-                            "properties": {
-                                "branches": {
-                                    "items": {
-                                        "required": ["firefoxLabsTitle"],
-                                    },
-                                },
-                            },
-                        },
-                    },
-                }
-            }
-        }
+        use_enum_values=True,
+        json_schema_extra=desktop_nimbus_experiment_json_schema_extras(),
     )
 
 
@@ -192,9 +160,42 @@ class DesktopAllVersionsNimbusExperiment(DesktopNimbusExperiment):
     )
 
 
+def sdk_nimbus_experiment_json_schema_extras():
+    extras = deepcopy(BaseExperiment.model_config["json_schema_extra"])
+
+    firefox_labs_schema = extras["dependentSchemas"]["isFirefoxLabsOptIn"]
+    firefox_labs_schema["then"].update(
+        {
+            # For the SDK, isRollout is also required and must be true
+            "required": sorted(
+                [
+                    *firefox_labs_schema["then"]["required"],
+                    "isRollout",
+                ]
+            ),
+            "type": "object",
+            "properties": {"isRollout": {"const": True}},
+        }
+    )
+
+    return extras
+
+
 class SdkNimbusExperiment(BaseExperiment):
     """A Nimbus experiment for Nimbus SDK-based applications."""
 
     branches: list[SdkExperimentBranch] = Field(
         description="Branch configuration for the SDK experiment."
+    )
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_firefox_labs_desktop(cls, data: Self) -> Self:
+        if data.isFirefoxLabsOptIn and not data.isRollout:
+            raise ValueError("isFirefoxLabsOptIn requires isRollout")
+
+        return data
+
+    model_config = ConfigDict(
+        use_enum_values=True, json_schema_extra=sdk_nimbus_experiment_json_schema_extras()
     )

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/experiments/sdk/android-153-fxLabsOptIn-is-null.json
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/experiments/sdk/android-153-fxLabsOptIn-is-null.json
@@ -1,0 +1,57 @@
+{
+  "appId": "org.mozilla.firefox",
+  "appName": "fenix",
+  "application": "org.mozilla.fenix",
+  "arguments": {},
+  "branches": [
+    {
+      "features": [
+        {
+          "featureId": "no-feature-fenix",
+          "value": {}
+        }
+      ],
+      "ratio": 1,
+      "slug": "control"
+    },
+    {
+      "features": [
+        {
+          "featureId": "no-feature-fenix",
+          "value": {}
+        }
+      ],
+      "ratio": 1,
+      "slug": "treatment"
+    }
+  ],
+  "bucketConfig": {
+    "count": 10000,
+    "namespace": "firefox-android-fxlabsoptin-is-null",
+    "randomizationUnit": "nimbus_id",
+    "start": 0,
+    "total": 10000
+  },
+  "channel": "nightly",
+  "endDate": null,
+  "featureIds": ["no-feature-fenix"],
+  "id": "firefox-android-multifeature-test",
+  "isEnrollmentPaused": false,
+  "outcomes": [
+    {
+      "priority": "secondary",
+      "slug": "default-browser"
+    }
+  ],
+  "probeSets": [],
+  "proposedDuration": 28,
+  "proposedEnrollment": 7,
+  "referenceBranch": "control",
+  "schemaVersion": "1.6.2",
+  "slug": "firefox-android-multifeature-test",
+  "startDate": "2021-11-01",
+  "targeting": "true",
+  "userFacingDescription": "firefox-android-fxLabsOptIn-is-null",
+  "userFacingName": "firefox-android-fxLabsOptIn-is-null",
+  "firefoxLabsOptIn": null
+}

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/experiments/sdk/android-153-fxLabsOptIn-is-rollout.json
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/fixtures/experiments/sdk/android-153-fxLabsOptIn-is-rollout.json
@@ -1,0 +1,48 @@
+{
+  "appId": "org.mozilla.firefox",
+  "appName": "fenix",
+  "application": "org.mozilla.fenix",
+  "arguments": {},
+  "branches": [
+    {
+      "features": [
+        {
+          "featureId": "no-feature-fenix",
+          "value": {}
+        }
+      ],
+      "ratio": 1,
+      "slug": "control"
+    }
+  ],
+  "bucketConfig": {
+    "count": 10000,
+    "namespace": "firefox-android-fxLabsOptIn-is-rollout",
+    "randomizationUnit": "nimbus_id",
+    "start": 0,
+    "total": 10000
+  },
+  "channel": "nightly",
+  "endDate": null,
+  "featureIds": ["no-feature-fenix"],
+  "id": "firefox-android-fxLabsOptIn-is-rollout",
+  "isEnrollmentPaused": false,
+  "outcomes": [
+    {
+      "priority": "secondary",
+      "slug": "default-browser"
+    }
+  ],
+  "probeSets": [],
+  "proposedDuration": 28,
+  "proposedEnrollment": 7,
+  "referenceBranch": "control",
+  "schemaVersion": "1.6.2",
+  "slug": "firefox-android-fxLabsOptIn-is-rollout",
+  "startDate": "2021-11-01",
+  "targeting": "true",
+  "userFacingDescription": "firefox-android-fxLabsOptIn-is-null",
+  "userFacingName": "firefox-android-fxLabsOptIn-is-null",
+  "isRollout": true,
+  "firefoxLabsOptIn": true
+}

--- a/schemas/mozilla_nimbus_schemas/tests/experiments/test_experiments.py
+++ b/schemas/mozilla_nimbus_schemas/tests/experiments/test_experiments.py
@@ -128,28 +128,10 @@ def test_sdk_experiment_fixtures_are_valid(
     sdk_nimbus_experiment_schema_validator.validate(experiment_json)
 
 
-def test_desktop_nimbus_expirement_with_fxlabs_opt_in_is_not_rollout(
-    validate_desktop_experiment,
-):
-    experiment_json = _desktop_nimbus_experiment(isRollout=False)
-    experiment_json.update(
-        {
-            "isFirefoxLabsOptIn": True,
-            "firefoxLabsTitle": "test-title",
-            "firefoxLabsDescription": "test-desc",
-            "firefoxLabsDescriptionLinks": None,
-            "firefoxLabsGroup": "test-group",
-        }
-    )
-    experiment_json["branches"][0]["firefoxLabsTitle"] = "branch-one-fx-labs-title"
-    experiment_json["branches"][1]["firefoxLabsTitle"] = "branch-two-fx-labs-title"
-    validate_desktop_experiment(experiment_json)
-
-
 def test_desktop_nimbus_experiment_with_fxlabs_opt_in_is_rollout(
     validate_desktop_experiment,
 ):
-    experiment_json = _desktop_nimbus_experiment(isRollout=True)
+    experiment_json = _desktop_nimbus_experiment(is_rollout=True)
     experiment_json.update(
         {
             "isFirefoxLabsOptIn": True,
@@ -163,7 +145,7 @@ def test_desktop_nimbus_experiment_with_fxlabs_opt_in_is_rollout(
 
 
 def test_desktop_nimbus_experiment_without_fxlabs_opt_in(validate_desktop_experiment):
-    experiment_json = _desktop_nimbus_experiment(isRollout=False)
+    experiment_json = _desktop_nimbus_experiment()
     experiment_json["isFirefoxLabsOptIn"] = False
     validate_desktop_experiment(experiment_json)
 
@@ -172,7 +154,7 @@ def test_desktop_nimbus_experiment_with_fxlabs_opt_in_but_missing_required_field
     validate_desktop_experiment,
     desktop_all_versions_nimbus_experiment_schema_validator,
 ):
-    experiment_json = _desktop_nimbus_experiment(isRollout=False)
+    experiment_json = _desktop_nimbus_experiment()
     experiment_json["isFirefoxLabsOptIn"] = True
     validate_desktop_experiment(experiment_json, valid=False, valid_all_versions=False)
 
@@ -183,12 +165,9 @@ def test_desktop_nimbus_experiment_with_fxlabs_opt_in_but_missing_required_field
         )
     ]
 
-    assert len(error_messages) == 6
+    assert len(error_messages) == 5
     assert error_messages.count("'firefoxLabsTitle' is a required property") == 3
     assert error_messages.count("'firefoxLabsDescription' is a required property") == 1
-    assert (
-        error_messages.count("'firefoxLabsDescriptionLinks' is a required property") == 1
-    )
     assert error_messages.count("'firefoxLabsGroup' is a required property") == 1
 
 
@@ -196,7 +175,7 @@ def test_desktop_nimbus_experiment_with_fxlabs_opt_in_invalid_description_links(
     validate_desktop_experiment,
     desktop_all_versions_nimbus_experiment_schema_validator,
 ):
-    experiment_json = _desktop_nimbus_experiment(isRollout=True)
+    experiment_json = _desktop_nimbus_experiment(is_rollout=True)
     experiment_json.update(
         {
             "isFirefoxLabsOptIn": True,
@@ -224,14 +203,102 @@ def test_desktop_experiment_feature_ids_required(
     validate_desktop_experiment,
 ):
     """Testing the featureIds field is required."""
-    experiment_json = _desktop_nimbus_experiment(False)
+    experiment_json = _desktop_nimbus_experiment(is_rollout=False)
     del experiment_json["featureIds"]
 
     validate_desktop_experiment(experiment_json, valid=False, valid_all_versions=False)
 
 
-def _desktop_nimbus_experiment(isRollout: bool) -> dict[str, Any]:
-    return {
+def test_sdk_nimbus_experiment_with_fxlabs_optin_is_not_rollout(
+    sdk_nimbus_experiment_schema_validator,
+):
+    experiment_json = {
+        **_sdk_nimbus_experiment(),
+        "isFirefoxLabsOptIn": True,
+        "firefoxLabsTitle": "test-title",
+        "firefoxLabsDescription": "test-desc",
+        "firefoxLabsDescriptionLinks": None,
+    }
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        SdkNimbusExperiment.model_validate(experiment_json)
+
+    pydantic_errors = [str(e["ctx"]["error"]) for e in exc_info.value.errors()]
+
+    assert len(pydantic_errors) == 1
+    assert "isFirefoxLabsOptIn requires isRollout" in pydantic_errors
+
+    schema_errors = list(
+        sdk_nimbus_experiment_schema_validator.iter_errors(experiment_json)
+    )
+
+    assert len(schema_errors) == 1
+    assert list(schema_errors[0].path) == ["isRollout"]
+    assert schema_errors[0].message == "True was expected"
+
+
+def test_sdk_nimbus_experiment_with_fxlabs_optin_but_missing_required_title(
+    sdk_nimbus_experiment_schema_validator,
+):
+    experiment_json = {
+        **_sdk_nimbus_experiment(is_rollout=True),
+        "isFirefoxLabsOptIn": True,
+        "firefoxLabsDescription": "description",
+        "firefoxLabsDescriptionLinks": None,
+    }
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        SdkNimbusExperiment.model_validate(experiment_json)
+
+    pydantic_errors = [str(e["ctx"]["error"]) for e in exc_info.value.errors()]
+
+    assert len(pydantic_errors) == 1
+    assert (
+        "missing field firefoxLabsTitle (required because isFirefoxLabsOptIn is True)"
+        in pydantic_errors
+    )
+
+    schema_errors = [
+        e.message
+        for e in sdk_nimbus_experiment_schema_validator.iter_errors(experiment_json)
+    ]
+
+    assert len(schema_errors) == 1
+    assert "'firefoxLabsTitle' is a required property" in schema_errors
+
+
+def test_sdk_nimbus_experiment_with_fxlabs_optin_but_missing_required_description(
+    sdk_nimbus_experiment_schema_validator,
+):
+    experiment_json = {
+        **_sdk_nimbus_experiment(is_rollout=True),
+        "isFirefoxLabsOptIn": True,
+        "firefoxLabsTitle": "description",
+        "firefoxLabsDescriptionLinks": None,
+    }
+
+    with pytest.raises(pydantic.ValidationError) as exc_info:
+        SdkNimbusExperiment.model_validate(experiment_json)
+
+    pydantic_errors = [str(e["ctx"]["error"]) for e in exc_info.value.errors()]
+
+    assert len(pydantic_errors) == 1
+    assert (
+        "missing field firefoxLabsDescription (required because isFirefoxLabsOptIn "
+        "is True)"
+    ) in pydantic_errors
+
+    schema_errors = [
+        e.message
+        for e in sdk_nimbus_experiment_schema_validator.iter_errors(experiment_json)
+    ]
+
+    assert len(schema_errors) == 1
+    assert "'firefoxLabsDescription' is a required property" in schema_errors
+
+
+def _desktop_nimbus_experiment(*, is_rollout: bool = False) -> dict[str, Any]:
+    recipe = {
         "appId": "firefox-desktop",
         "appName": "firefox_desktop",
         "application": "firefox-desktop",
@@ -296,5 +363,50 @@ def _desktop_nimbus_experiment(isRollout: bool) -> dict[str, Any]:
         "targeting": "true",
         "userFacingDescription": "Test user facing description",
         "userFacingName": "MR2 Upgrade Spotlight Holdback",
-        "isRollout": bool(isRollout),
+        "isRollout": bool(is_rollout),
+    }
+
+    if is_rollout:
+        recipe["branches"] = [recipe["branches"][0]]
+
+    return recipe
+
+
+def _sdk_nimbus_experiment(*, is_rollout: bool = False) -> dict[str, Any]:
+    return {
+        "appId": "org.mozilla.firefox",
+        "appName": "fenix",
+        "application": "org.mozilla.fenix",
+        "branches": [
+            {
+                "features": [{"featureId": "no-feature-fenix", "value": {}}],
+                "ratio": 1,
+                "slug": "control",
+            }
+        ],
+        "bucketConfig": {
+            "count": 10000,
+            "namespace": "firefox-android-test",
+            "randomizationUnit": "nimbus_id",
+            "start": 0,
+            "total": 10000,
+        },
+        "channel": "nightly",
+        "endDate": None,
+        "featureIds": ["no-feature-fenix"],
+        "id": "firefox-android-test",
+        "isEnrollmentPaused": False,
+        "outcomes": [{"priority": "secondary", "slug": "default-browser"}],
+        "probeSets": [],
+        "proposedDuration": 28,
+        "proposedEnrollment": 7,
+        "referenceBranch": "control",
+        "schemaVersion": "1.6.2",
+        "slug": "firefox-android-test",
+        "startDate": "2021-11-01",
+        "targeting": "true",
+        "userFacingDescription": "firefox-android-test",
+        "userFacingName": "firefox-android-test",
+        "isRollout": is_rollout,
+        "firefoxLabsOptIn": True,
     }

--- a/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopAllVersionsNimbusExperiment.schema.json
@@ -71,7 +71,7 @@
           "type": "null"
         }
       ],
-      "description": "The description shown in Firefox Labs (Fluent ID)"
+      "description": "The description shown in Firefox Labs (Fluent ID or Resource ID)"
     },
     "firefoxLabsDescriptionLinks": {
       "anyOf": [
@@ -110,7 +110,7 @@
           "type": "null"
         }
       ],
-      "description": "The title shown in Firefox Labs (Fluent ID)"
+      "description": "The title shown in Firefox Labs (Fluent ID or Resource ID)"
     },
     "id": {
       "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
@@ -121,7 +121,7 @@
       "type": "boolean"
     },
     "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+      "description": "When this property is set to true, treat this experiment as a Firefox Labs experiment",
       "type": "boolean"
     },
     "isRollout": {
@@ -274,7 +274,6 @@
         },
         "required": [
           "firefoxLabsDescription",
-          "firefoxLabsDescriptionLinks",
           "firefoxLabsGroup",
           "firefoxLabsTitle"
         ],

--- a/schemas/schemas/DesktopNimbusExperiment.schema.json
+++ b/schemas/schemas/DesktopNimbusExperiment.schema.json
@@ -71,7 +71,7 @@
           "type": "null"
         }
       ],
-      "description": "The description shown in Firefox Labs (Fluent ID)"
+      "description": "The description shown in Firefox Labs (Fluent ID or Resource ID)"
     },
     "firefoxLabsDescriptionLinks": {
       "anyOf": [
@@ -110,7 +110,7 @@
           "type": "null"
         }
       ],
-      "description": "The title shown in Firefox Labs (Fluent ID)"
+      "description": "The title shown in Firefox Labs (Fluent ID or Resource ID)"
     },
     "id": {
       "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
@@ -121,7 +121,7 @@
       "type": "boolean"
     },
     "isFirefoxLabsOptIn": {
-      "description": "When this property is set to true, treat this experiment as aFirefox Labs experiment",
+      "description": "When this property is set to true, treat this experiment as a Firefox Labs experiment",
       "type": "boolean"
     },
     "isRollout": {
@@ -274,7 +274,6 @@
         },
         "required": [
           "firefoxLabsDescription",
-          "firefoxLabsDescriptionLinks",
           "firefoxLabsGroup",
           "firefoxLabsTitle"
         ],

--- a/schemas/schemas/NimbusExperimentV7.schema.json
+++ b/schemas/schemas/NimbusExperimentV7.schema.json
@@ -65,12 +65,55 @@
       },
       "type": "array"
     },
+    "firefoxLabsDescription": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The description shown in Firefox Labs (Fluent ID or Resource ID)"
+    },
+    "firefoxLabsDescriptionLinks": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "format": "uri",
+            "maxLength": 2083,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
+    },
+    "firefoxLabsTitle": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The title shown in Firefox Labs (Fluent ID or Resource ID)"
+    },
     "id": {
       "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "isEnrollmentPaused": {
       "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
+      "type": "boolean"
+    },
+    "isFirefoxLabsOptIn": {
+      "description": "When this property is set to true, treat this experiment as a Firefox Labs experiment",
       "type": "boolean"
     },
     "isRollout": {
@@ -140,6 +183,10 @@
       ],
       "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
+    "requiresRestart": {
+      "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
+      "type": "boolean"
+    },
     "schemaVersion": {
       "description": "Version of the NimbusExperiment schema this experiment refers to",
       "type": "string"
@@ -199,6 +246,23 @@
     "branches",
     "documentationLinks"
   ],
+  "dependentSchemas": {
+    "isFirefoxLabsOptIn": {
+      "if": {
+        "properties": {
+          "isFirefoxLabsOptIn": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "required": [
+          "firefoxLabsDescription",
+          "firefoxLabsTitle"
+        ]
+      }
+    }
+  },
   "$defs": {
     "BaseExperimentBranch": {
       "properties": {

--- a/schemas/schemas/SdkNimbusExperiment.schema.json
+++ b/schemas/schemas/SdkNimbusExperiment.schema.json
@@ -58,12 +58,55 @@
       },
       "type": "array"
     },
+    "firefoxLabsDescription": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The description shown in Firefox Labs (Fluent ID or Resource ID)"
+    },
+    "firefoxLabsDescriptionLinks": {
+      "anyOf": [
+        {
+          "additionalProperties": {
+            "format": "uri",
+            "maxLength": 2083,
+            "minLength": 1,
+            "type": "string"
+          },
+          "type": "object"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "Links that will be used with the firefoxLabsDescription Fluent ID. May be null for Firefox Labs Opt-In recipes that do not use links."
+    },
+    "firefoxLabsTitle": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "description": "The title shown in Firefox Labs (Fluent ID or Resource ID)"
+    },
     "id": {
       "description": "Unique identifier for the experiiment. This is a duplicate of slug, but is required field for all Remote Settings records.",
       "type": "string"
     },
     "isEnrollmentPaused": {
       "description": "When this property is set to true, the SDK should not enroll new users into the experiment that have not already been enrolled.",
+      "type": "boolean"
+    },
+    "isFirefoxLabsOptIn": {
+      "description": "When this property is set to true, treat this experiment as a Firefox Labs experiment",
       "type": "boolean"
     },
     "isRollout": {
@@ -133,6 +176,10 @@
       ],
       "description": "The slug of the reference branch (i.e., the branch we consider \"control\")."
     },
+    "requiresRestart": {
+      "description": "Does the experiment require a restart to take effect? Only used by Firefox Labs Opt-Ins.",
+      "type": "boolean"
+    },
     "schemaVersion": {
       "description": "Version of the NimbusExperiment schema this experiment refers to",
       "type": "string"
@@ -191,6 +238,30 @@
     "referenceBranch",
     "branches"
   ],
+  "dependentSchemas": {
+    "isFirefoxLabsOptIn": {
+      "if": {
+        "properties": {
+          "isFirefoxLabsOptIn": {
+            "const": true
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "isRollout": {
+            "const": true
+          }
+        },
+        "required": [
+          "firefoxLabsDescription",
+          "firefoxLabsTitle",
+          "isRollout"
+        ],
+        "type": "object"
+      }
+    }
+  },
   "$defs": {
     "ExperimentBucketConfig": {
       "properties": {


### PR DESCRIPTION
This commit is a breaking change.

Because:

- we are bringing Firefox Labs to the SDK; and
- our Pydantic models cannot distinguish between the
  firefoxLabsDescriptionLinks field being absent or null

This commit:

- adds most Firefox Labs fields (no firefoxLabsGroup) to the SDK
  experiment schemas; and
- removes the hard requirement for the presence of the
  firefoxLabsDescriptionLinks field in order to align the validation
  behaviour between the Pydantic model and the generated JSON schema.

Fixes #15865