### PR TITLE
chore(schemas): publish to npm via Trusted Publishing

### DIFF
--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -56,6 +56,10 @@ jobs:
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
         working-directory: schemas
         run: |
-          npm install -g npm@latest
-          npm version --allow-same-version --no-git-tag-version "$(cat VERSION)"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          FILE_VERSION="$(cat VERSION)"
+          if [ "$PKG_VERSION" != "$FILE_VERSION" ]; then
+            echo "package.json version ($PKG_VERSION) does not match VERSION ($FILE_VERSION); run 'make schemas_version' and commit" >&2
+            exit 1
+          fi
           npm publish --access public --provenance

--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,7 +47,15 @@ jobs:
         run: |
           make schemas_deploy_pypi SCHEMAS_ENV="-e TWINE_USERNAME=${{ secrets.TWINE_USERNAME }} -e TWINE_PASSWORD=${{ secrets.TWINE_PASSWORD }}"
 
+      - uses: actions/setup-node@v6
+        if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
+        with:
+          node-version: 24
+
       - name: Upload to NPM
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
+        working-directory: schemas
         run: |
-          make schemas_deploy_npm SCHEMAS_ENV="-e NPM_TOKEN=${{ secrets.NPM_TOKEN }}"
+          npm install -g npm@latest
+          npm version --allow-same-version --no-git-tag-version "$(cat VERSION)"
+          npm publish --access public --provenance


### PR DESCRIPTION
Because

* npm publishing was never finished after the CircleCI→GHA migration — `deploy-schemas.yml` referenced an `NPM_TOKEN` secret that was never added, so `@mozilla/nimbus-schemas` stopped publishing. The PyPI half works.
* npm now recommends [Trusted Publishing](https://docs.npmjs.com/trusted-publishers) (OIDC) over long-lived automation tokens for CI/CD.

This commit

* grants the deploy job `id-token: write`
* publishes from the runner with `npm publish --access public --provenance` on a recent npm, replacing the Dockerized `yarn publish` + `.npmrc` authToken (yarn classic can't do the OIDC exchange; the build step already produces the artifacts on the host)
* leaves PyPI publishing unchanged

Requires a one-time trusted-publisher config on npmjs.com for `@mozilla/nimbus-schemas` (repo `mozilla/experimenter`, workflow `deploy-schemas.yml`) before the next version bump merges.

Fixes #15896