### PR TITLE
fix(nimbus): skip Swift macro validation in iOS integration build

### DIFF
--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -121,6 +121,7 @@ jobs:
             -scheme Fennec \
             -destination "platform=iOS Simulator,name=${IOS_SIMULATOR},OS=${IOS_VERSION}" \
             -derivedDataPath ./DerivedData \
+            -skipMacroValidation \
             COMPILER_INDEX_STORE_ENABLE=NO \
             CODE_SIGN_IDENTITY= CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO \
             ENABLE_USER_SCRIPT_SANDBOXING=NO \


### PR DESCRIPTION
Because

* A newer firefox-ios main pulled in the ModifiedCopy Swift macro package, and xcodebuild rejects untrusted compile-time macros non-interactively, failing the Fennec build before the enrollment test runs.
* Every new compile-time macro package in firefox-ios will break the automated iOS-SHA bump the same way until CI trusts macros.

This commit

* Adds -skipMacroValidation to the xcodebuild build invocation in the iOS integration workflow.

Fixes #15906