### PR TITLE
chore(schemas): publish to PyPI via Trusted Publishing

### DIFF
--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -44,8 +44,10 @@ jobs:
 
       - name: Upload to PyPI
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
-        run: |
-          make schemas_deploy_pypi SCHEMAS_ENV="-e TWINE_USERNAME=${{ secrets.TWINE_USERNAME }} -e TWINE_PASSWORD=${{ secrets.TWINE_PASSWORD }}"
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: schemas/dist/
+          skip-existing: true
 
       - uses: actions/setup-node@v6
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'


### PR DESCRIPTION
Because

* the PyPI publish in `deploy-schemas.yml` still used long-lived `TWINE_USERNAME`/`TWINE_PASSWORD` credentials. PyPI supports [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC), which removes the stored token — mirroring the npm change in #15896.

This commit

* replaces the Dockerized `twine upload` with the official `pypa/gh-action-pypi-publish` action, run on the runner against the `schemas/dist/` artifacts the build step already produces
* reuses the job's existing `id-token: write`; no stored credentials, PEP 740 attestations generated automatically
* leaves npm publishing unchanged

Requires a one-time trusted-publisher config on pypi.org for `mozilla-nimbus-schemas` (repo `mozilla/experimenter`, workflow `deploy-schemas.yml`). The `TWINE_*` secrets and the underlying PyPI token can be removed afterward.

Fixes #15931