### PR TITLE
feat(nimbus): Improve funnel diagram

### DIFF
--- a/docs/proposals/pre-launch-population-sizing.md
+++ b/docs/proposals/pre-launch-population-sizing.md
@@ -1,0 +1,115 @@
+# Pre-Launch Population Sizing: Proposal
+
+## Background
+
+Experimenter currently fetches a pre-computed, globally-aggregated sizing dataset from GCS once per week (Monday 06:00 UTC via `fetch_population_sizing_data`). That dataset is keyed by `app_id / SizingUserType / channel / country` and reports `number_of_clients_targeted`, `sample_size_per_branch`, and `population_percent_per_branch` for a handful of canonical targeting recipes. The data is stored in Redis under `SIZING_DATA_KEY` but is not yet surfaced in any Experimenter view or API response.
+
+The goal of this proposal is to extend that foundation with:
+
+1. A per-experiment estimated eligible population count, derived from the experiment's JEXL targeting expression.
+2. Validation of JEXL-to-SQL translations against real SDK enrollment decisions via `enrollment_status` telemetry.
+
+---
+
+## How enrollment_status Helps Pre-Launch Sizing
+
+### Status: enrollment_status is ON BY DEFAULT (no gating)
+
+As of the current Firefox Desktop release cycle, the `enrollment_status` Glean event (`nimbus_events / enrollment_status`) is **enabled for all Firefox Desktop clients by default**. The earlier feature-flag gate (`enable-enrollment-status-telemetry-for-firefox-desktop-via-nimbustelemetry`) has been removed. There is no longer a gated sub-population — every eligible Desktop client fires this event on every Nimbus evaluation cycle.
+
+This has two important consequences for pre-launch sizing:
+
+#### 1. Full-population JEXL validation (before launch)
+
+Because `enrollment_status` fires for all clients (both `Enrolled` and `NotEnrolled`), the `NotEnrolled` rows tell us, for any live or paused experiment, exactly how many clients the SDK evaluated against the targeting JEXL and decided were not eligible. This gives us a ground-truth reference against which to compare our JEXL-to-SQL estimates.
+
+Workflow:
+```
+Write JEXL → Translate to SQL → Run SQL on nimbus_targeting_context → Compare count
+                                                                         against enrollment_status
+                                                                         NotEnrolled/Enrolled split
+```
+
+If the SQL count matches the enrollment_status eligible count (within a few percent), the translation is correct.
+
+#### 2. Historical sizing for re-run experiments
+
+If an experiment with identical or nearly identical targeting has been run before, its `enrollment_status` history in BigQuery gives a direct empirical estimate of the eligible population — no SQL translation needed. This is the highest-confidence sizing signal available.
+
+### What enrollment_status provides
+
+| Field | BigQuery location |
+|---|---|
+| Event category | `e.category = 'nimbus_events'` |
+| Event name | `e.name = 'enrollment_status'` |
+| Experiment slug | `e.extra.experiment` (or `e.extra.slug`) |
+| Status | `e.extra.status` — `Enrolled`, `NotEnrolled`, `WasEnrolled`, `Disqualified`, `ErrorEnrolling` |
+| Branch | `e.extra.branch` |
+| Reason | `e.extra.reason` |
+
+The relevant table is `mozdata.firefox_desktop.nimbus_events` (Glean events ping). For population sizing the most useful statuses are `Enrolled` and `NotEnrolled`; the ratio `Enrolled / (Enrolled + NotEnrolled)` is the targeting hit rate.
+
+### Updated "Gotchas" section
+
+**Previously documented gotcha (now historical):**
+
+> enrollment_status data is only available for the sub-population that has the
+> `enable-enrollment-status-telemetry-for-firefox-desktop-via-nimbustelemetry`
+> Nimbus feature enabled — do not treat it as fully representative.
+
+**Current status:** This gate has been removed. `enrollment_status` is representative of the full Firefox Desktop population and can be used without any population-coverage correction.
+
+---
+
+## Corrected SQL Template: nimbus_targeting_context
+
+The SQL template for estimating the eligible population from `nimbus_targeting_context` had several column-name and logic bugs. The corrected version is maintained at:
+
+```
+experimenter/experimenter/experiments/sql/pre_launch_population_sizing_desktop.sql
+```
+
+Key fixes:
+
+| Bug | Wrong | Correct |
+|---|---|---|
+| Table | `moz-fx-data-shared-prod.firefox_desktop.metrics` | `mozdata.firefox_desktop.nimbus_targeting_context` |
+| Channel column | `nimbus_targeting_context_update_channel` | `JSON_VALUE(metrics.object.nimbus_targeting_context_browser_settings, '$.update.channel')` |
+| Profile age column | `nimbus_targeting_context_profile_age_in_days` | Derived via `DATE_DIFF` from `profile_age_created` (stored as epoch milliseconds INT64) |
+| Windows OS detection | `JSON_VALUE(..., '$.isWindows')` | `NOT JSON_VALUE(..., '$.isMac') = 'true' AND NOT JSON_VALUE(..., '$.isLinux') = 'true'` |
+| client_id | top-level `client_id` | `client_info.client_id` |
+
+---
+
+## Validation Query: enrollment_status vs. SQL estimate
+
+See the validation query section at the bottom of `pre_launch_population_sizing_desktop.sql` for a ready-to-run template that compares the JEXL-to-SQL count against the observed `enrollment_status` counts for a named experiment.
+
+---
+
+## Implementation Plan (Phased)
+
+### Phase 1: Expose existing GCS data in the Experimenter API (already computed, not yet surfaced)
+
+- Add a GraphQL field `populationSizing` to the `NimbusExperimentType` that reads from `cache.get(settings.SIZING_DATA_KEY)` and matches on `app_id` + `channel` + `country`.
+- Render the matched `number_of_clients_targeted` on the Audience tab in the UI.
+
+### Phase 2: Per-experiment JEXL-to-SQL estimates (new)
+
+- Implement a `jexl_to_sql` converter for the subset of JEXL constructs used in Nimbus targeting (version comparisons, locale/country string matches, OS booleans, profile age).
+- Run the corrected SQL template against `mozdata.firefox_desktop.nimbus_targeting_context` with the translated WHERE clause.
+- Store the result as `estimated_eligible` on `NimbusExperiment` (or in the GCS output file).
+- Schedule via a new Celery task running daily, limited to experiments in Draft/Preview/Review status.
+
+### Phase 3: enrollment_status validation (new)
+
+- For any experiment that has previously run (status Complete) or is currently live, compare the Phase 2 SQL estimate against the observed `enrollment_status` counts.
+- Surface the comparison in the Experimenter UI as a confidence indicator for the estimate.
+
+---
+
+## Open Questions
+
+1. Should `estimated_eligible` be re-computed on every recipe change, or only on-demand?
+2. What JEXL constructs are out of scope for the SQL translator (e.g. `regExpMatch`, nested `||` on non-primitive fields)?
+3. For mobile apps (Fenix, iOS), `nimbus_targeting_context` is not available — what is the equivalent table?

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1497,7 +1497,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def monitoring_health_warnings(self):
-        """Returns a list of active health warnings for display in the features page."""
         warnings = []
         if not self.monitoring_data:
             return warnings

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1516,7 +1516,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if conflict.is_conflict:
             warnings.append(
                 {
-                    "type": "feature_conflict",
+                    "type": NimbusConstants.AlertType.FEATURE_CONFLICT,
                     "label": f"Feature Conflict {conflict.rate:.0%}",
                 }
             )
@@ -1530,7 +1530,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             total = self.monitoring_data.get("total_enrollments", 0)
             warnings.append(
                 {
-                    "type": "low_enrollment",
+                    "type": NimbusConstants.AlertType.ZERO_ENROLLMENT,
                     "label": f"Low Enrollment ({total:,})",
                 }
             )

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1527,10 +1527,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD,
             NimbusConstants.ZERO_ENROLLMENT_CLIENT_THRESHOLD,
         ):
+            total = self.monitoring_data.get("total_enrollments", 0)
             warnings.append(
                 {
                     "type": "low_enrollment",
-                    "label": f"Low Enrollment ({self.monitoring_data.get('total_enrollments', 0):,})",
+                    "label": f"Low Enrollment ({total:,})",
                 }
             )
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1496,6 +1496,48 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return {"total": total, "stages": stages}
 
     @property
+    def monitoring_health_warnings(self):
+        """Returns a list of active health warnings for display in the features page."""
+        warnings = []
+        if not self.monitoring_data:
+            return warnings
+
+        from experimenter.experiments.monitoring_utils import (
+            check_feature_conflict,
+            check_zero_enrollment,
+        )
+
+        days_live = (
+            (datetime.date.today() - self.start_date).days if self.start_date else 0
+        )
+
+        is_conflict, conflict_rate, _ = check_feature_conflict(
+            self.monitoring_data, NimbusConstants.FEATURE_CONFLICT_THRESHOLD
+        )
+        if is_conflict:
+            warnings.append(
+                {
+                    "type": "feature_conflict",
+                    "label": f"Feature Conflict {conflict_rate:.0%}",
+                }
+            )
+
+        if check_zero_enrollment(
+            self.monitoring_data,
+            days_live,
+            NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD,
+            NimbusConstants.ZERO_ENROLLMENT_CLIENT_THRESHOLD,
+        ):
+            warnings.append(
+                {
+                    "type": "low_enrollment",
+                    "label": f"Low Enrollment ({self.monitoring_data.get('total_enrollments', 0):,})",
+                }
+            )
+
+        return warnings
+
+    @property
     def monitoring_summary(self):
         if not self.monitoring_data:
             return None

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1510,14 +1510,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             (datetime.date.today() - self.start_date).days if self.start_date else 0
         )
 
-        is_conflict, conflict_rate, _ = check_feature_conflict(
+        conflict = check_feature_conflict(
             self.monitoring_data, NimbusConstants.FEATURE_CONFLICT_THRESHOLD
         )
-        if is_conflict:
+        if conflict.is_conflict:
             warnings.append(
                 {
                     "type": "feature_conflict",
-                    "label": f"Feature Conflict {conflict_rate:.0%}",
+                    "label": f"Feature Conflict {conflict.rate:.0%}",
                 }
             )
 

--- a/experimenter/experimenter/experiments/sql/pre_launch_population_sizing_desktop.sql
+++ b/experimenter/experimenter/experiments/sql/pre_launch_population_sizing_desktop.sql
@@ -1,0 +1,158 @@
+-- Pre-launch population sizing for Firefox Desktop
+--
+-- Estimates the number of clients that would match a given set of targeting
+-- criteria BEFORE the experiment launches, using the daily
+-- mozdata.firefox_desktop.nimbus_targeting_context table.
+--
+-- Table facts (confirmed from live BQ schema):
+--   client_id:            client_info.client_id  (nested)
+--   sample_id:            top-level INT64 (0-99)
+--   partition:            submission_timestamp  (use DATE(submission_timestamp))
+--   channel:              JSON_VALUE(metrics.object.nimbus_targeting_context_browser_settings, '$.update.channel')
+--   locale:               metrics.string.nimbus_targeting_context_locale
+--   profile_age_created:  metrics.quantity.nimbus_targeting_context_profile_age_created  (epoch ms INT64)
+--   os JSON:              metrics.object.nimbus_targeting_context_os
+--                           keys: isMac, isLinux, windowsBuildNumber, windowsVersion
+--                           NO isWindows key — derive as: NOT isMac AND NOT isLinux
+--
+-- Usage:
+--   Set the DECLARE variables below to match the experiment's targeting,
+--   then run. Output: eligible_clients_sample, eligible_clients_full (x10), pct_of_dau.
+
+DECLARE param_channel STRING DEFAULT 'release';
+DECLARE param_min_profile_age_days INT64 DEFAULT 0;
+DECLARE param_windows_only BOOL DEFAULT FALSE;
+DECLARE param_country STRING DEFAULT NULL;        -- NULL = all countries
+DECLARE param_locale_prefix STRING DEFAULT NULL;  -- e.g. 'en' matches 'en-US','en-GB'. NULL = all
+DECLARE param_date DATE DEFAULT DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY);
+
+WITH base AS (
+  SELECT
+    client_info.client_id                                                         AS client_id,
+
+    -- Channel: from browserSettings JSON object (no flat column exists)
+    JSON_VALUE(
+      metrics.object.nimbus_targeting_context_browser_settings, '$.update.channel'
+    )                                                                             AS channel,
+
+    -- OS detection: $.isWindows does not exist in the JSON
+    -- Windows = NOT isMac AND NOT isLinux
+    JSON_VALUE(metrics.object.nimbus_targeting_context_os, '$.isMac')            AS os_is_mac,
+    JSON_VALUE(metrics.object.nimbus_targeting_context_os, '$.isLinux')          AS os_is_linux,
+
+    -- Profile age: epoch ms INT64, convert to days
+    DATE_DIFF(
+      CURRENT_DATE(),
+      DATE(TIMESTAMP_MILLIS(
+        CAST(metrics.quantity.nimbus_targeting_context_profile_age_created AS INT64)
+      )),
+      DAY
+    )                                                                             AS profile_age_days,
+
+    -- Locale: flat string column
+    metrics.string.nimbus_targeting_context_locale                               AS locale,
+
+    -- Country from Glean geo enrichment
+    normalized_country_code                                                       AS country
+
+  FROM `mozdata.firefox_desktop.nimbus_targeting_context`
+  WHERE DATE(submission_timestamp) = param_date
+    AND sample_id < 10  -- 10% sample; multiply final counts by 10
+),
+
+filtered AS (
+  SELECT client_id
+  FROM base
+  WHERE
+    channel = param_channel
+
+    AND profile_age_days >= param_min_profile_age_days
+
+    -- Windows: NOT isMac AND NOT isLinux
+    AND (
+      NOT param_windows_only
+      OR (
+        COALESCE(os_is_mac,   'false') != 'true'
+        AND COALESCE(os_is_linux, 'false') != 'true'
+      )
+    )
+
+    AND (param_country IS NULL OR country = param_country)
+
+    AND (
+      param_locale_prefix IS NULL
+      OR STARTS_WITH(LOWER(locale), LOWER(param_locale_prefix))
+    )
+
+  GROUP BY client_id  -- deduplicate to one row per client
+),
+
+channel_dau AS (
+  SELECT COUNT(DISTINCT client_info.client_id) AS total_channel_sample
+  FROM `mozdata.firefox_desktop.nimbus_targeting_context`
+  WHERE DATE(submission_timestamp) = param_date
+    AND sample_id < 10
+    AND JSON_VALUE(
+      metrics.object.nimbus_targeting_context_browser_settings, '$.update.channel'
+    ) = param_channel
+)
+
+SELECT
+  COUNT(f.client_id)                                    AS eligible_clients_sample,
+  COUNT(f.client_id) * 10                               AS eligible_clients_full,
+  ROUND(
+    SAFE_DIVIDE(COUNT(f.client_id), ANY_VALUE(dau.total_channel_sample)),
+    4
+  )                                                     AS pct_of_channel_dau,
+  param_date                                            AS sizing_date,
+  param_channel                                         AS channel,
+  param_country                                         AS country,
+  param_locale_prefix                                   AS locale_prefix,
+  param_min_profile_age_days                            AS min_profile_age_days,
+  param_windows_only                                    AS windows_only
+
+FROM filtered f
+CROSS JOIN channel_dau dau;
+
+
+-- =============================================================================
+-- VALIDATION QUERY: Compare SQL estimate vs. enrollment_status ground truth
+--
+-- enrollment_status is ON BY DEFAULT for all Firefox Desktop clients as of 2026.
+-- The old gating rollout (enable-enrollment-status-telemetry-for-firefox-desktop-
+-- via-nimbustelemetry) has been removed. Counts are fully representative.
+--
+-- Run this after the sizing query above for an experiment with similar targeting.
+-- If agreement_pct is within ±10%, the JEXL→SQL translation is correct.
+-- =============================================================================
+
+DECLARE experiment_slug STRING DEFAULT 'your-experiment-slug-here';
+DECLARE validation_date DATE DEFAULT DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY);
+
+WITH sdk_counts AS (
+  SELECT
+    (SELECT value FROM UNNEST(e.extra) WHERE key = 'status') AS status,
+    COUNT(DISTINCT client_info.client_id)                     AS clients
+  FROM `mozdata.firefox_desktop.nimbus_targeting_context`,
+    UNNEST(events) AS e
+  WHERE DATE(submission_timestamp) = validation_date
+    AND sample_id < 10
+    AND e.category = 'nimbus_events'
+    AND e.name = 'enrollment_status'
+    AND (SELECT value FROM UNNEST(e.extra) WHERE key = 'slug') = experiment_slug
+  GROUP BY 1
+)
+
+SELECT
+  SUM(IF(status = 'Enrolled',    clients, 0)) * 10    AS enrolled_sdk,
+  SUM(IF(status = 'NotEnrolled', clients, 0)) * 10    AS not_enrolled_sdk,
+  SUM(IF(status IN ('Enrolled', 'NotEnrolled'), clients, 0)) * 10  AS eligible_sdk,
+  ROUND(SAFE_DIVIDE(
+    SUM(IF(status = 'Enrolled', clients, 0)),
+    SUM(IF(status IN ('Enrolled', 'NotEnrolled'), clients, 0))
+  ), 4)                                               AS hit_rate_sdk,
+  -- Compare to eligible_clients_full from the main query:
+  -- SAFE_DIVIDE(<eligible_clients_full>, eligible_sdk) AS agreement_pct,
+  validation_date,
+  experiment_slug
+FROM sdk_counts;

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5637,7 +5637,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_monitoring_health_warnings_feature_conflict(self):
         experiment = NimbusExperimentFactory.create(
-            start_date=datetime.date.today()
+            _start_date=datetime.date.today()
             - datetime.timedelta(days=NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD),
             monitoring_data={
                 "total_enrollments": 2000,
@@ -5667,7 +5667,7 @@ class TestNimbusExperiment(TestCase):
 
     def test_monitoring_health_warnings_low_enrollment(self):
         experiment = NimbusExperimentFactory.create(
-            start_date=datetime.date.today()
+            _start_date=datetime.date.today()
             - datetime.timedelta(days=NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD),
             monitoring_data={
                 "total_enrollments": 0,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5663,7 +5663,7 @@ class TestNimbusExperiment(TestCase):
         )
         warnings = experiment.monitoring_health_warnings
         self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["type"], "feature_conflict")
+        self.assertEqual(warnings[0]["type"], NimbusConstants.AlertType.FEATURE_CONFLICT)
 
     def test_monitoring_health_warnings_low_enrollment(self):
         experiment = NimbusExperimentFactory.create(
@@ -5676,7 +5676,7 @@ class TestNimbusExperiment(TestCase):
         )
         warnings = experiment.monitoring_health_warnings
         self.assertEqual(len(warnings), 1)
-        self.assertEqual(warnings[0]["type"], "low_enrollment")
+        self.assertEqual(warnings[0]["type"], NimbusConstants.AlertType.ZERO_ENROLLMENT)
 
     def test_enrollment_funnel_stages_returns_none_when_no_monitoring_data(self):
         experiment = NimbusExperimentFactory.create(monitoring_data=None)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5643,17 +5643,17 @@ class TestNimbusExperiment(TestCase):
                 "total_enrollments": 2000,
                 "enrollment_funnel": [
                     {
-                        "status": "NotEnrolled",
-                        "reason": "FeatureConflict",
-                        "app_name": "firefox_desktop",
+                        "status": NimbusExperiment.FunnelStatus.NOT_ENROLLED,
+                        "reason": NimbusExperiment.FunnelReason.FEATURE_CONFLICT,
+                        "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
                         "branch": "control",
                         "conflict_slug": "other-slug",
                         "client_count": 8000,
                     },
                     {
-                        "status": "Enrolled",
-                        "reason": "Qualified",
-                        "app_name": "firefox_desktop",
+                        "status": NimbusExperiment.FunnelStatus.ENROLLED,
+                        "reason": NimbusExperiment.FunnelReason.QUALIFIED,
+                        "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
                         "branch": "control",
                         "conflict_slug": None,
                         "client_count": 2000,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5635,6 +5635,49 @@ class TestNimbusExperiment(TestCase):
         branch = summary["branches"][0]
         self.assertEqual(branch["top_reason"], "targeting_mismatch")
 
+    def test_monitoring_health_warnings_feature_conflict(self):
+        experiment = NimbusExperimentFactory.create(
+            start_date=datetime.date.today()
+            - datetime.timedelta(days=NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD),
+            monitoring_data={
+                "total_enrollments": 2000,
+                "enrollment_funnel": [
+                    {
+                        "status": "NotEnrolled",
+                        "reason": "FeatureConflict",
+                        "app_name": "firefox_desktop",
+                        "branch": "control",
+                        "conflict_slug": "other-slug",
+                        "client_count": 8000,
+                    },
+                    {
+                        "status": "Enrolled",
+                        "reason": "Qualified",
+                        "app_name": "firefox_desktop",
+                        "branch": "control",
+                        "conflict_slug": None,
+                        "client_count": 2000,
+                    },
+                ],
+            },
+        )
+        warnings = experiment.monitoring_health_warnings
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["type"], "feature_conflict")
+
+    def test_monitoring_health_warnings_low_enrollment(self):
+        experiment = NimbusExperimentFactory.create(
+            start_date=datetime.date.today()
+            - datetime.timedelta(days=NimbusConstants.ZERO_ENROLLMENT_DAYS_THRESHOLD),
+            monitoring_data={
+                "total_enrollments": 0,
+                "enrollment_funnel": [],
+            },
+        )
+        warnings = experiment.monitoring_health_warnings
+        self.assertEqual(len(warnings), 1)
+        self.assertEqual(warnings[0]["type"], "low_enrollment")
+
     def test_enrollment_funnel_stages_returns_none_when_no_monitoring_data(self):
         experiment = NimbusExperimentFactory.create(monitoring_data=None)
         self.assertIsNone(experiment.enrollment_funnel_stages)

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -30,80 +30,20 @@
 
     {% with funnel=experiment.enrollment_funnel_stages summary=experiment.monitoring_summary %}
 
-      {# ── Summary Header: key numbers + all alerts in one place ── #}
-      <section>
-        <div class="row g-3 mb-3">
-          {% if funnel %}
-            <div class="col-auto">
-              <div class="border rounded px-3 py-2 text-center">
-                <div class="fs-5 fw-semibold">{{ funnel.total }}</div>
-                <div class="text-muted small">Evaluated</div>
-              </div>
-            </div>
-          {% endif %}
-          {% if summary %}
-            <div class="col-auto">
-              <div class="border rounded px-3 py-2 text-center">
-                <div class="fs-5 fw-semibold">{{ summary.total_enrollments }}</div>
-                <div class="text-muted small">Enrolled</div>
-              </div>
-            </div>
-            <div class="col-auto">
-              <div class="border rounded px-3 py-2 text-center {% if summary.is_unenrollment_spike %}border-warning bg-warning-subtle{% endif %}">
-                <div class="fs-5 fw-semibold">{{ summary.unenrollment_rate|floatformat:1 }}%</div>
-                <div class="text-muted small">Unenrollment Rate</div>
-              </div>
-            </div>
-          {% endif %}
-        </div>
-
-        {# Active alerts — all in one row #}
-        {% if summary %}
-          <div class="d-flex flex-wrap gap-2">
-            {% if summary.is_unenrollment_spike %}
-              <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
-                <i class="fa-solid fa-triangle-exclamation"></i>
-                Unenrollment Spike {{ summary.unenrollment_rate|floatformat:1 }}%
-              </span>
-            {% else %}
-              <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
-                <i class="fa-solid fa-circle-check"></i>
-                Unenrollment Healthy
-              </span>
-            {% endif %}
-            {% if not experiment.is_rollout %}
-              {% if summary.is_srm %}
-                <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1"
-                      data-bs-toggle="tooltip"
-                      title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: < {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})">
-                  <i class="fa-solid fa-triangle-exclamation"></i>
-                  SRM Mismatch
-                </span>
-              {% else %}
-                <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
-                  <i class="fa-solid fa-circle-check"></i>
-                  Branch Ratio Healthy
-                </span>
-              {% endif %}
-            {% endif %}
-            {% if funnel %}
-              {% for stage in funnel.stages %}
-                {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}
-                  <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
-                    <i class="fa-solid fa-triangle-exclamation"></i>
-                    Feature Conflict {{ stage.pct|floatformat:0 }}%
-                  </span>
-                {% endif %}
-              {% endfor %}
-            {% endif %}
-          </div>
-        {% endif %}
-      </section>
-
-      {# ── Enrollment Funnel: who got in and why ── #}
+      {# ── Enrollment Funnel ── #}
       {% if funnel %}
         <section>
-          <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Enrollment Funnel</h6>
+          <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">
+            <h6 class="text-uppercase text-muted small fw-semibold mb-0">Enrollment Funnel</h6>
+            {% for stage in funnel.stages %}
+              {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}
+                <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  Feature Conflict {{ stage.pct|floatformat:0 }}%
+                </span>
+              {% endif %}
+            {% endfor %}
+          </div>
           <table class="table table-sm table-bordered mb-0">
             <thead class="table-light">
               <tr>
@@ -142,10 +82,38 @@
         </section>
       {% endif %}
 
-      {# ── Branch Health: enrollments + unenrollments + ratios in one table ── #}
+      {# ── Branch Health ── #}
       {% if summary %}
         <section>
-          <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Branch Health</h6>
+          <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">
+            <h6 class="text-uppercase text-muted small fw-semibold mb-0">Branch Health</h6>
+            {% if summary.is_unenrollment_spike %}
+              <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                Unenrollment Spike {{ summary.unenrollment_rate|floatformat:1 }}%
+              </span>
+            {% else %}
+              <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-circle-check"></i>
+                Unenrollment {{ summary.unenrollment_rate|floatformat:1 }}%
+              </span>
+            {% endif %}
+            {% if not experiment.is_rollout %}
+              {% if summary.is_srm %}
+                <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1"
+                      data-bs-toggle="tooltip"
+                      title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: < {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  SRM Mismatch
+                </span>
+              {% else %}
+                <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
+                  <i class="fa-solid fa-circle-check"></i>
+                  Branch Ratio Healthy
+                </span>
+              {% endif %}
+            {% endif %}
+          </div>
           <table class="table table-sm table-bordered mb-0">
             <thead class="table-light">
               <tr>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -73,7 +73,8 @@
                     {% endif %}
                   </td>
                   <td class="text-end">{{ stage.client_count }}</td>
-                  <td class="text-end" style="{{ stage|funnel_row_bg }}">{{ stage.pct|floatformat:1 }}%</td>
+                  <td class="text-end"
+                      style="background: linear-gradient(to left, rgba(var(--bs-{{ stage.color }}-rgb), 0.25) {{ stage.pct|floatformat:1 }}%, transparent 0%)">{{ stage.pct|floatformat:1 }}%</td>
                 </tr>
               {% endfor %}
             </tbody>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -27,9 +27,7 @@
         This experiment has ended. Monitoring data reflects the last update before the experiment concluded.
       </div>
     {% endif %}
-
     {% with funnel=experiment.enrollment_funnel_stages summary=experiment.monitoring_summary %}
-
       {% if funnel %}
         <section>
           <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">
@@ -55,7 +53,10 @@
               <tr class="table-secondary fw-semibold">
                 <td>Evaluated (total)</td>
                 <td class="text-end">{{ funnel.total }}</td>
-                <td class="text-end" style="background: linear-gradient(to left, rgba(var(--bs-secondary-rgb), 0.25) 100%, transparent 0%)">100%</td>
+                <td class="text-end"
+                    style="background: linear-gradient(to left, rgba(var(--bs-secondary-rgb), 0.25) 100%, transparent 0%)">
+                  100%
+                </td>
               </tr>
               {% for stage in funnel.stages %}
                 <tr>
@@ -65,7 +66,8 @@
                     {% if stage.conflict_slugs %}
                       —
                       {% for slug in stage.conflict_slugs %}
-                        <a href="{% url 'nimbus-ui-detail' slug=slug %}">{{ slug }}</a>{% if not forloop.last %},{% endif %}
+                        <a href="{% url 'nimbus-ui-detail' slug=slug %}">{{ slug }}</a>
+                        {% if not forloop.last %},{% endif %}
                       {% endfor %}
                     {% endif %}
                     {% if stage.has_null_conflict %}
@@ -74,14 +76,15 @@
                   </td>
                   <td class="text-end">{{ stage.client_count }}</td>
                   <td class="text-end"
-                      style="background: linear-gradient(to left, rgba(var(--bs-{{ stage.color }}-rgb), 0.25) {{ stage.pct|floatformat:1 }}%, transparent 0%)">{{ stage.pct|floatformat:1 }}%</td>
+                      style="background: linear-gradient(to left, rgba(var(--bs-{{ stage.color }}-rgb), 0.25) {{ stage.pct|floatformat:1 }}%, transparent 0%)">
+                    {{ stage.pct|floatformat:1 }}%
+                  </td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
         </section>
       {% endif %}
-
       {% if summary %}
         <section>
           <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">
@@ -132,7 +135,10 @@
                 <td class="text-end">{{ summary.total_enrollments }}</td>
                 <td class="text-end">{{ summary.total_unenrollments }}</td>
                 <td></td>
-                {% if not experiment.is_rollout %}<td></td><td></td>{% endif %}
+                {% if not experiment.is_rollout %}
+                  <td></td>
+                  <td></td>
+                {% endif %}
               </tr>
               {% for branch in summary.branches %}
                 <tr {% if not experiment.is_rollout and summary.is_srm %}class="table-warning"{% endif %}>
@@ -160,7 +166,6 @@
           </div>
         </section>
       {% endif %}
-
     {% endwith %}
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -30,7 +30,6 @@
 
     {% with funnel=experiment.enrollment_funnel_stages summary=experiment.monitoring_summary %}
 
-      {# ── Enrollment Funnel ── #}
       {% if funnel %}
         <section>
           <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">
@@ -56,7 +55,7 @@
               <tr class="table-secondary fw-semibold">
                 <td>Evaluated (total)</td>
                 <td class="text-end">{{ funnel.total }}</td>
-                <td class="text-end" style="background: linear-gradient(to left, #6c757d40 100%, transparent 0%)">100%</td>
+                <td class="text-end" style="background: linear-gradient(to left, rgba(var(--bs-secondary-rgb), 0.25) 100%, transparent 0%)">100%</td>
               </tr>
               {% for stage in funnel.stages %}
                 <tr>
@@ -82,7 +81,6 @@
         </section>
       {% endif %}
 
-      {# ── Branch Health ── #}
       {% if summary %}
         <section>
           <div class="d-flex align-items-center gap-2 border-bottom pb-1 mb-2">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_monitoring.html
@@ -27,27 +27,88 @@
         This experiment has ended. Monitoring data reflects the last update before the experiment concluded.
       </div>
     {% endif %}
-    {# ── Enrollment Funnel ── #}
-    {% with funnel=experiment.enrollment_funnel_stages %}
+
+    {% with funnel=experiment.enrollment_funnel_stages summary=experiment.monitoring_summary %}
+
+      {# ── Summary Header: key numbers + all alerts in one place ── #}
+      <section>
+        <div class="row g-3 mb-3">
+          {% if funnel %}
+            <div class="col-auto">
+              <div class="border rounded px-3 py-2 text-center">
+                <div class="fs-5 fw-semibold">{{ funnel.total }}</div>
+                <div class="text-muted small">Evaluated</div>
+              </div>
+            </div>
+          {% endif %}
+          {% if summary %}
+            <div class="col-auto">
+              <div class="border rounded px-3 py-2 text-center">
+                <div class="fs-5 fw-semibold">{{ summary.total_enrollments }}</div>
+                <div class="text-muted small">Enrolled</div>
+              </div>
+            </div>
+            <div class="col-auto">
+              <div class="border rounded px-3 py-2 text-center {% if summary.is_unenrollment_spike %}border-warning bg-warning-subtle{% endif %}">
+                <div class="fs-5 fw-semibold">{{ summary.unenrollment_rate|floatformat:1 }}%</div>
+                <div class="text-muted small">Unenrollment Rate</div>
+              </div>
+            </div>
+          {% endif %}
+        </div>
+
+        {# Active alerts — all in one row #}
+        {% if summary %}
+          <div class="d-flex flex-wrap gap-2">
+            {% if summary.is_unenrollment_spike %}
+              <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                Unenrollment Spike {{ summary.unenrollment_rate|floatformat:1 }}%
+              </span>
+            {% else %}
+              <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-circle-check"></i>
+                Unenrollment Healthy
+              </span>
+            {% endif %}
+            {% if not experiment.is_rollout %}
+              {% if summary.is_srm %}
+                <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1"
+                      data-bs-toggle="tooltip"
+                      title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: < {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  SRM Mismatch
+                </span>
+              {% else %}
+                <span class="badge bg-success-subtle text-success border border-success-subtle d-inline-flex align-items-center gap-1">
+                  <i class="fa-solid fa-circle-check"></i>
+                  Branch Ratio Healthy
+                </span>
+              {% endif %}
+            {% endif %}
+            {% if funnel %}
+              {% for stage in funnel.stages %}
+                {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}
+                  <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
+                    <i class="fa-solid fa-triangle-exclamation"></i>
+                    Feature Conflict {{ stage.pct|floatformat:0 }}%
+                  </span>
+                {% endif %}
+              {% endfor %}
+            {% endif %}
+          </div>
+        {% endif %}
+      </section>
+
+      {# ── Enrollment Funnel: who got in and why ── #}
       {% if funnel %}
         <section>
           <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Enrollment Funnel</h6>
-          <div class="progress mb-3" style="height:22px" role="progressbar">
-            {% for stage in funnel.stages %}
-              <div class="progress-bar bg-{{ stage.color }} text-{{ stage.text_color }}"
-                   style="width:{{ stage.pct }}%"
-                   title="{{ stage.label }}: {{ stage.client_count }} ({{ stage.pct|floatformat:1 }}%)">
-                {% if stage.pct >= 5 %}
-                  {{ stage.pct|floatformat:0 }}%
-                {% endif %}
-              </div>
-            {% endfor %}
-          </div>
           <table class="table table-sm table-bordered mb-0">
             <thead class="table-light">
               <tr>
                 <th>Stage</th>
-                <th class="text-end">Clients (est.)</th>
+                <th class="text-end">Clients</th>
                 <th class="text-end">% of Evaluated</th>
               </tr>
             </thead>
@@ -55,18 +116,17 @@
               <tr class="table-secondary fw-semibold">
                 <td>Evaluated (total)</td>
                 <td class="text-end">{{ funnel.total }}</td>
-                <td class="text-end">100%</td>
+                <td class="text-end" style="background: linear-gradient(to left, #6c757d40 100%, transparent 0%)">100%</td>
               </tr>
               {% for stage in funnel.stages %}
                 <tr>
-                  <td>
+                  <td {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}class="fw-semibold"{% endif %}>
                     <span class="badge bg-{{ stage.color }} text-{{ stage.text_color }} me-1">{{ stage.status }}</span>
                     {{ stage.label }}
                     {% if stage.conflict_slugs %}
                       —
                       {% for slug in stage.conflict_slugs %}
-                        <a href="{% url 'nimbus-ui-detail' slug=slug %}">{{ slug }}</a>
-                        {% if not forloop.last %},{% endif %}
+                        <a href="{% url 'nimbus-ui-detail' slug=slug %}">{{ slug }}</a>{% if not forloop.last %},{% endif %}
                       {% endfor %}
                     {% endif %}
                     {% if stage.has_null_conflict %}
@@ -74,122 +134,66 @@
                     {% endif %}
                   </td>
                   <td class="text-end">{{ stage.client_count }}</td>
-                  <td class="text-end">{{ stage.pct|floatformat:1 }}%</td>
+                  <td class="text-end" style="{{ stage|funnel_row_bg }}">{{ stage.pct|floatformat:1 }}%</td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
         </section>
       {% endif %}
-    {% endwith %}
-    {# ── Unenrollment Health ── #}
-    {% with summary=experiment.monitoring_summary %}
-      <section>
-        <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Unenrollment Health</h6>
-        {% if summary.is_unenrollment_spike %}
-          <div class="alert alert-warning mb-2" role="alert">
-            ⚠️ <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong>
-            &ge; {{ NimbusUIConstants.UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY }} alert threshold.
-            <a href="{{ experiment.monitoring_dashboard_url }}"
-               target="_blank"
-               rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-          </div>
-        {% else %}
-          <div class="alert alert-success mb-2" role="alert">
-            ✅ <strong>Unenrollment rate {{ summary.unenrollment_rate|floatformat:1 }}%</strong>
-            — {{ NimbusUIConstants.MONITORING_UNENROLLMENT_HEALTHY_DETAIL }}
-            <a href="{{ experiment.monitoring_dashboard_url }}"
-               target="_blank"
-               rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-          </div>
-        {% endif %}
-        <table class="table table-sm table-bordered mb-0">
-          <thead class="table-light">
-            <tr>
-              <th>Branch</th>
-              <th class="text-end">Enrollments</th>
-              <th class="text-end">Unenrollments</th>
-              <th>Top Unenrollment Reason</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="table-secondary fw-semibold">
-              <td>Total</td>
-              <td class="text-end">{{ summary.total_enrollments }}</td>
-              <td class="text-end">{{ summary.total_unenrollments }}</td>
-              <td></td>
-            </tr>
-            {% for branch in summary.branches %}
-              <tr>
-                <td>{{ branch.name }}</td>
-                <td class="text-end">{{ branch.enrollments }}</td>
-                <td class="text-end">{{ branch.unenrollments }}</td>
-                <td>{{ branch.top_reason|default:"—" }}</td>
-              </tr>
-            {% empty %}
-              <tr>
-                <td colspan="4" class="text-muted">No branch data available</td>
-              </tr>
-            {% endfor %}
-          </tbody>
-        </table>
-      </section>
-      {# ── Sample Ratio Mismatch ── #}
-      {% if not experiment.is_rollout %}
+
+      {# ── Branch Health: enrollments + unenrollments + ratios in one table ── #}
+      {% if summary %}
         <section>
-          <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Sample Ratio Mismatch</h6>
-          {% if summary.is_srm %}
-            <div class="alert alert-warning mb-2" role="alert">
-              ⚠️ <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-              <i class="fa-regular fa-circle-question"
-                 tabindex="0"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                 style="cursor: help"></i>
-              — {{ NimbusUIConstants.MONITORING_SRM_SPIKE_DETAIL }}
-              <a href="{{ experiment.monitoring_dashboard_url }}"
-                 target="_blank"
-                 rel="noopener noreferrer">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
-            </div>
-          {% else %}
-            <div class="alert alert-success mb-2" role="alert">
-              ✅ <strong>{{ NimbusUIConstants.MONITORING_SECTION_SRM }}</strong>
-              <i class="fa-regular fa-circle-question"
-                 tabindex="0"
-                 data-bs-toggle="tooltip"
-                 data-bs-placement="top"
-                 title="p-value {{ summary.srm_p_value|format_p_value }} (threshold: &lt; {{ NimbusUIConstants.SRM_P_VALUE_THRESHOLD_DISPLAY }})"
-                 style="cursor: help"></i>
-              — {{ NimbusUIConstants.MONITORING_SRM_HEALTHY_DETAIL }}
-            </div>
-          {% endif %}
+          <h6 class="text-uppercase text-muted small fw-semibold mb-2 border-bottom pb-1">Branch Health</h6>
           <table class="table table-sm table-bordered mb-0">
             <thead class="table-light">
               <tr>
                 <th>Branch</th>
-                <th class="text-end">Enrollments</th>
-                <th class="text-end text-nowrap">Expected Ratio</th>
-                <th class="text-end text-nowrap">Actual Ratio</th>
+                <th class="text-end">Enrolled</th>
+                <th class="text-end">Unenrolled</th>
+                <th class="text-end">Top Unenroll Reason</th>
+                {% if not experiment.is_rollout %}
+                  <th class="text-end text-nowrap">Expected Ratio</th>
+                  <th class="text-end text-nowrap">Actual Ratio</th>
+                {% endif %}
               </tr>
             </thead>
             <tbody>
+              <tr class="table-secondary fw-semibold">
+                <td>Total</td>
+                <td class="text-end">{{ summary.total_enrollments }}</td>
+                <td class="text-end">{{ summary.total_unenrollments }}</td>
+                <td></td>
+                {% if not experiment.is_rollout %}<td></td><td></td>{% endif %}
+              </tr>
               {% for branch in summary.branches %}
-                <tr>
+                <tr {% if not experiment.is_rollout and summary.is_srm %}class="table-warning"{% endif %}>
                   <td>{{ branch.name }}</td>
                   <td class="text-end">{{ branch.enrollments }}</td>
-                  <td class="text-end">{{ branch.expected_ratio|floatformat:1 }}%</td>
-                  <td class="text-end">{{ branch.actual_ratio|floatformat:1 }}%</td>
+                  <td class="text-end">{{ branch.unenrollments }}</td>
+                  <td class="text-end">{{ branch.top_reason|default:"—" }}</td>
+                  {% if not experiment.is_rollout %}
+                    <td class="text-end">{{ branch.expected_ratio|floatformat:1 }}%</td>
+                    <td class="text-end">{{ branch.actual_ratio|floatformat:1 }}%</td>
+                  {% endif %}
                 </tr>
               {% empty %}
                 <tr>
-                  <td colspan="4" class="text-muted">No branch data available</td>
+                  <td colspan="6" class="text-muted">No branch data available</td>
                 </tr>
               {% endfor %}
             </tbody>
           </table>
+          <div class="d-flex gap-3 mt-2">
+            <a href="{{ experiment.monitoring_dashboard_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="small">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
+          </div>
         </section>
       {% endif %}
+
     {% endwith %}
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/features.html
@@ -99,6 +99,7 @@
                       </th>
                     {% endif %}
                   {% endfor %}
+                  <th scope="col" class="fw-semibold text-decoration-none">Health</th>
                 </tr>
               </thead>
               <tbody>
@@ -130,6 +131,26 @@
                     <td id="delivery-min-version">{{ experiment.firefox_min_version|parse_version }}</td>
                     <td id="delivery-population-percent">{{ experiment.total_enrolled_clients|floatformat:"-1" }}</td>
                     <td id="delivery-brief">{{ experiment.delivery_brief|format_not_set }}</td>
+                    <td id="delivery-health">
+                      {% with warnings=experiment.monitoring_health_warnings %}
+                        {% if warnings %}
+                          <div class="d-flex flex-column gap-1">
+                            {% for warning in warnings %}
+                              <span class="badge bg-warning text-dark d-inline-flex align-items-center gap-1">
+                                <i class="fa-solid fa-triangle-exclamation"></i>
+                                {{ warning.label }}
+                              </span>
+                            {% endfor %}
+                          </div>
+                        {% elif experiment.monitoring_data %}
+                          <span class="badge bg-success-subtle text-success border border-success-subtle">
+                            <i class="fa-solid fa-circle-check me-1"></i>Healthy
+                          </span>
+                        {% else %}
+                          <span class="text-muted small">No data</span>
+                        {% endif %}
+                      {% endwith %}
+                    </td>
                   </tr>
                 {% empty %}
                   <tr>

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -377,6 +377,23 @@ def sanitize_html(value):
     return mark_safe(nh3.clean(str(value)))
 
 
+_FUNNEL_COLOR_HEX = {
+    "success":   "#19875440",
+    "secondary": "#6c757d40",
+    "warning":   "#ffc10740",
+    "danger":    "#dc354540",
+    "dark":      "#21252940",
+}
+
+
+@register.filter
+def funnel_row_bg(stage):
+    """Return an inline CSS background gradient for a funnel table row."""
+    color = _FUNNEL_COLOR_HEX.get(stage.get("color", "secondary"), "#6c757d40")
+    pct = stage.get("pct", 0)
+    return f"background: linear-gradient(to left, {color} {pct:.1f}%, transparent 0%)"
+
+
 @register.filter
 def format_p_value(value):
     try:

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -377,7 +377,6 @@ def sanitize_html(value):
     return mark_safe(nh3.clean(str(value)))
 
 
-
 @register.filter
 def format_p_value(value):
     try:

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -377,21 +377,11 @@ def sanitize_html(value):
     return mark_safe(nh3.clean(str(value)))
 
 
-_FUNNEL_COLOR_HEX = {
-    "success":   "#19875440",
-    "secondary": "#6c757d40",
-    "warning":   "#ffc10740",
-    "danger":    "#dc354540",
-    "dark":      "#21252940",
-}
-
-
 @register.filter
 def funnel_row_bg(stage):
-    """Return an inline CSS background gradient for a funnel table row."""
-    color = _FUNNEL_COLOR_HEX.get(stage.get("color", "secondary"), "#6c757d40")
+    color = stage.get("color", "secondary")
     pct = stage.get("pct", 0)
-    return f"background: linear-gradient(to left, {color} {pct:.1f}%, transparent 0%)"
+    return f"background: linear-gradient(to left, rgba(var(--bs-{color}-rgb), 0.25) {pct:.1f}%, transparent 0%)"
 
 
 @register.filter

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -377,12 +377,6 @@ def sanitize_html(value):
     return mark_safe(nh3.clean(str(value)))
 
 
-@register.filter
-def funnel_row_bg(stage):
-    color = stage.get("color", "secondary")
-    pct = stage.get("pct", 0)
-    return f"background: linear-gradient(to left, rgba(var(--bs-{color}-rgb), 0.25) {pct:.1f}%, transparent 0%)"
-
 
 @register.filter
 def format_p_value(value):


### PR DESCRIPTION
Because

- we send notifications to the users when there is issue with enrollments such as no enrollments, feature conflict etc etc, now we can better visualise this data with the monitoring data on the summary page

This commit

- Improves the funnel data and shows warnings

Fixes #15903 