### PR TITLE
refactor(nimbus): refactor experimenter redesign forms

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1295,32 +1295,6 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         return f"{self.request.user} updated audience"
 
 
-class RolloutAudienceForm(AudienceForm):
-    YES_NO_CHOICES = (
-        (True, "Yes"),
-        (False, "No"),
-    )
-    localizations = forms.CharField(required=False, widget=forms.HiddenInput())
-
-    class Meta:
-        model = NimbusExperiment
-
-        fields = (
-            *AudienceForm.Meta.fields,
-            "localizations",
-        )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        self.fields["is_sticky"] = forms.TypedChoiceField(
-            required=False,
-            choices=self.YES_NO_CHOICES,
-            widget=InlineRadioSelect,
-            coerce=lambda x: x == "True",
-        )
-
-
 class SubscribeForm(NimbusChangeLogFormMixin, forms.ModelForm):
     class Meta:
         model = NimbusExperiment

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1,0 +1,474 @@
+from collections import defaultdict
+
+import markus
+from django import forms
+from django.db import transaction
+from django.forms import inlineformset_factory
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils import timezone
+
+from experimenter.base.models import Country, Language, Locale
+from experimenter.experiments.changelog_utils import generate_nimbus_changelog
+from experimenter.experiments.models import (
+    NimbusBranch,
+    NimbusDocumentationLink,
+    NimbusExperiment,
+    NimbusExperimentBranchThroughExcluded,
+    NimbusExperimentBranchThroughRequired,
+)
+from experimenter.targeting.constants import NimbusTargetingConfig
+
+metrics = markus.get_metrics("experimenter.nimbus_ui_forms")
+
+
+class SelectedFirstMixin:
+    def optgroups(self, name, value, attrs=None):
+        groups = super().optgroups(name, value, attrs)
+        selected = [g for g in groups if any(o.get("selected") for o in g[1])]
+        unselected = [g for g in groups if not any(o.get("selected") for o in g[1])]
+        return [*selected, *unselected]
+
+
+class InlineRadioSelect(forms.RadioSelect):
+    template_name = "common/widgets/inline_radio.html"
+    option_template_name = "common/widgets/inline_radio_option.html"
+
+
+class MultiSelectWidget(SelectedFirstMixin, forms.SelectMultiple):
+    class_attrs = "selectpicker form-control"
+
+    def __init__(self, *args, attrs=None, **kwargs):
+        attrs = attrs or {}
+        attrs.update(
+            {
+                "class": self.class_attrs,
+                "data-live-search": "true",
+                "data-live-search-placeholder": "Search",
+            }
+        )
+
+        super().__init__(*args, attrs=attrs, **kwargs)
+
+
+class NimbusChangeLogFormMixin:
+    def __init__(self, *args, request: HttpRequest = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.request = request
+
+    def get_changelog_message(self) -> str:
+        raise NotImplementedError
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        experiment = super().save(*args, **kwargs)
+
+        generate_nimbus_changelog(
+            experiment, self.request.user, self.get_changelog_message()
+        )
+        metrics.incr("changelog_form.save", tags=[f"form:{type(self).__name__}"])
+        return experiment
+
+
+class NimbusDocumentationLinkForm(forms.ModelForm):
+    title = forms.ChoiceField(
+        choices=NimbusExperiment.DocumentationLink.choices,
+        required=False,
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    link = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+
+    class Meta:
+        model = NimbusDocumentationLink
+        fields = ("title", "link")
+
+
+class SingleSelectWidget(SelectedFirstMixin, forms.Select):
+    class_attrs = "selectpicker form-control"
+
+    def __init__(self, *args, attrs=None, **kwargs):
+        attrs = attrs or {}
+        attrs.update(
+            {
+                "class": self.class_attrs,
+                "data-live-search": "true",
+                "data-live-search-placeholder": "Search",
+                "data-max-options": 1,
+            }
+        )
+
+        super().__init__(*args, attrs=attrs, **kwargs)
+
+
+class RolloutOverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    name = forms.CharField(
+        required=True, widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+    hypothesis = forms.CharField(
+        required=False, widget=forms.Textarea(attrs={"class": "form-control"})
+    )
+    public_description = forms.CharField(
+        required=False, widget=forms.Textarea(attrs={"class": "form-control", "rows": 3})
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "name",
+            "hypothesis",
+            "public_description",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.NimbusDocumentationLinkFormSet = inlineformset_factory(
+            NimbusExperiment,
+            NimbusDocumentationLink,
+            form=NimbusDocumentationLinkForm,
+            extra=0,  # Number of empty forms to display initially
+        )
+        self.documentation_links = self.NimbusDocumentationLinkFormSet(
+            data=self.data or None,
+            instance=self.instance,
+        )
+
+    def is_valid(self):
+        return super().is_valid() and self.documentation_links.is_valid()
+
+    @transaction.atomic
+    def save(self):
+        experiment = super().save()
+        self.documentation_links.save()
+        return experiment
+
+    def get_changelog_message(self):
+        return f"{self.request.user} updated rollouts overview"
+
+
+class RolloutRisksForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    YES_NO_CHOICES = (
+        (True, "Yes"),
+        (False, "No"),
+    )
+
+    risk_brand = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+    risk_message = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+    risk_revenue = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+    risk_partner_related = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+    risk_ai = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "risk_partner_related",
+            "risk_revenue",
+            "risk_brand",
+            "risk_message",
+            "risk_ai",
+        ]
+
+    def get_changelog_message(self):
+        return f"{self.request.user} updated rollout risks"
+
+
+class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    def get_version_choices():
+        return [
+            (
+                NimbusExperiment.Version.NO_VERSION.value,
+                NimbusExperiment.Version.NO_VERSION.label,
+            ),
+            *NimbusExperiment.Version.choices[1:][::-1],
+        ]
+
+    def get_targeting_config_choices(self):
+        application_name = NimbusExperiment.Application(self.instance.application).name
+        return sorted(
+            [
+                (targeting.slug, f"{targeting.name} - {targeting.description}")
+                for targeting in NimbusTargetingConfig.targeting_configs
+                if application_name in targeting.application_choice_names
+            ],
+            key=lambda choice: choice[1].lower(),
+        )
+
+    YES_NO_CHOICES = (
+        (True, "Yes"),
+        (False, "No"),
+    )
+    localizations = forms.CharField(required=False, widget=forms.HiddenInput())
+    channel = forms.ChoiceField(
+        required=False,
+        label="",
+        choices=NimbusExperiment.Channel.choices,
+        widget=forms.widgets.Select(
+            attrs={
+                "class": "form-select",
+            },
+        ),
+    )
+    channels = forms.MultipleChoiceField(
+        required=False,
+        label="",
+        choices=NimbusExperiment.Channel.choices,
+        widget=MultiSelectWidget(),
+    )
+    firefox_min_version = forms.ChoiceField(
+        required=False,
+        label="",
+        choices=get_version_choices,
+        widget=forms.widgets.Select(
+            attrs={
+                "class": "form-select",
+            },
+        ),
+    )
+    firefox_max_version = forms.ChoiceField(
+        required=False,
+        label="",
+        choices=get_version_choices,
+        widget=forms.widgets.Select(
+            attrs={
+                "class": "form-select",
+            },
+        ),
+    )
+    locales = forms.ModelMultipleChoiceField(
+        required=False,
+        queryset=Locale.objects.all().order_by("code"),
+        widget=MultiSelectWidget(),
+    )
+    exclude_locales = forms.BooleanField(required=False)
+    languages = forms.ModelMultipleChoiceField(
+        required=False,
+        queryset=Language.objects.all().order_by("code"),
+        widget=MultiSelectWidget(),
+    )
+    exclude_languages = forms.BooleanField(required=False)
+    countries = forms.ModelMultipleChoiceField(
+        required=False,
+        queryset=Country.objects.all().order_by("code"),
+        widget=MultiSelectWidget(),
+    )
+    exclude_countries = forms.BooleanField(required=False)
+    targeting_config_slug = forms.ChoiceField(
+        required=False,
+        label="",
+        widget=SingleSelectWidget(),
+    )
+
+    excluded_experiments_branches = forms.MultipleChoiceField(
+        required=False,
+        widget=MultiSelectWidget(),
+    )
+    required_experiments_branches = forms.MultipleChoiceField(
+        required=False,
+        widget=MultiSelectWidget(),
+    )
+    is_sticky = forms.TypedChoiceField(
+        required=False,
+        choices=YES_NO_CHOICES,
+        widget=InlineRadioSelect,
+        coerce=lambda x: x == "True",
+    )
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "channel",
+            "channels",
+            "countries",
+            "exclude_countries",
+            "exclude_languages",
+            "exclude_locales",
+            "excluded_experiments_branches",
+            "firefox_max_version",
+            "firefox_min_version",
+            "is_first_run",
+            "is_sticky",
+            "languages",
+            "locales",
+            "required_experiments_branches",
+            "targeting_config_slug",
+            "localizations",
+        ]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["targeting_config_slug"].choices = self.get_targeting_config_choices()
+        self.setup_experiment_branch_choices()
+        self.setup_initial_experiments_branches("required_experiments_branches")
+        self.setup_initial_experiments_branches("excluded_experiments_branches")
+        self.setup_channel_choices()
+
+        self.fields["is_first_run"].widget.attrs.update(
+            {
+                "hx-post": reverse(
+                    "nimbus-ui-update-audience", kwargs={"slug": self.instance.slug}
+                ),
+                "hx-trigger": "change",
+                "hx-select": "#first-run-fields",
+                "hx-target": "#first-run-fields",
+            }
+        )
+
+    def format_branch_choice(self, experiment_slug, experiment_name, branch_slug):
+        if branch_slug is None:
+            return f"{experiment_slug}:None", f"{experiment_name} (All branches)"
+        return (
+            f"{experiment_slug}:{branch_slug}",
+            f"{experiment_name} ({branch_slug.capitalize()})",
+        )
+
+    def setup_experiment_branch_choices(self):
+        branch_slugs = (
+            NimbusBranch.objects.filter(
+                experiment__application=self.instance.application,
+            )
+            .exclude(experiment__id=self.instance.id)
+            .values_list("experiment__slug", "experiment__name", "slug")
+        )
+
+        branches_by_experiment_slug = defaultdict(list)
+        for experiment_slug, experiment_name, branch_slug in branch_slugs:
+            branches_by_experiment_slug[(experiment_slug, experiment_name)].append(
+                branch_slug
+            )
+
+        all_choices = []
+        for (experiment_slug, experiment_name), branch_slugs in sorted(
+            branches_by_experiment_slug.items()
+        ):
+            all_choices.append(
+                self.format_branch_choice(experiment_slug, experiment_name, None)
+            )
+            for branch_slug in sorted(branch_slugs):
+                all_choices.append(
+                    self.format_branch_choice(
+                        experiment_slug, experiment_name, branch_slug
+                    )
+                )
+
+        self.fields["excluded_experiments_branches"].choices = all_choices
+        self.fields["required_experiments_branches"].choices = all_choices
+
+    def setup_initial_experiments_branches(self, field_name):
+        self.initial[field_name] = [
+            self.format_branch_choice(
+                branch.child_experiment.slug,
+                branch.child_experiment.name,
+                branch.branch_slug,
+            )[0]
+            for branch in getattr(self.instance, field_name)
+        ]
+
+    def save_experiments_branches(self, field_name, model):
+        experiments_branches = self.cleaned_data.pop(field_name)
+
+        if experiments_branches is not None:
+            model.objects.filter(parent_experiment=self.instance).all().delete()
+            for experiment_branch in experiments_branches:
+                experiment_slug, branch_slug = experiment_branch.split(":")
+                if branch_slug.strip() == "None":
+                    branch_slug = None
+                model.objects.create(
+                    parent_experiment=self.instance,
+                    child_experiment=NimbusExperiment.objects.get(slug=experiment_slug),
+                    branch_slug=branch_slug,
+                )
+
+    def setup_channel_choices(self):
+        self.fields["channel"].choices = [
+            (channel.value, channel.label)
+            for channel in NimbusExperiment.Channel
+            if channel in self.instance.application_config.channel_app_id
+        ]
+
+        self.fields["channels"].choices = [
+            (channel.value, channel.label)
+            for channel in NimbusExperiment.Channel
+            if (
+                channel in self.instance.application_config.channel_app_id
+                and channel != NimbusExperiment.Channel.NO_CHANNEL
+            )
+        ]
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        instance = super().save(*args, **kwargs)
+        self.save_experiments_branches(
+            "required_experiments_branches", NimbusExperimentBranchThroughRequired
+        )
+        self.save_experiments_branches(
+            "excluded_experiments_branches", NimbusExperimentBranchThroughExcluded
+        )
+        return instance
+
+    def get_changelog_message(self):
+        return f"{self.request.user} updated audience"
+
+
+class RolloutQAStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "qa_status",
+            "qa_comment",
+            "qa_run_test_plan_url",
+            "qa_run_testrail_url",
+        ]
+        widgets = {
+            "qa_status": forms.Select(choices=NimbusExperiment.QAStatus),
+            "qa_comment": forms.Textarea(
+                attrs={
+                    "class": "form-control",
+                    "rows": 4,
+                    "placeholder": "Add QA comment or attach relevant links",
+                }
+            ),
+            "qa_run_test_plan_url": forms.URLInput(attrs={"class": "form-control"}),
+            "qa_run_testrail_url": forms.URLInput(attrs={"class": "form-control"}),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._initial_qa_status = self.instance.qa_status if self.instance.pk else None
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        new_qa_status = self.cleaned_data.get("qa_status")
+        if self._initial_qa_status != new_qa_status:
+            if new_qa_status != NimbusExperiment.QAStatus.NOT_SET:
+                self.instance.qa_run_date = timezone.now().date()
+
+        return super().save(*args, **kwargs)
+
+    def get_changelog_message(self):
+        return f"{self.request.user} updated QA"

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -1,0 +1,381 @@
+import datetime
+
+from django.test import RequestFactory, TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from experimenter.base.tests.factories import (
+    CountryFactory,
+    LanguageFactory,
+    LocaleFactory,
+)
+from experimenter.experiments.models import (
+    NimbusExperiment,
+    NimbusExperimentBranchThroughExcluded,
+    NimbusExperimentBranchThroughRequired,
+)
+from experimenter.experiments.tests.factories import (
+    NimbusDocumentationLinkFactory,
+    NimbusExperimentFactory,
+)
+from experimenter.nimbus_ui.new.forms import (
+    RolloutAudienceForm,
+    RolloutOverviewForm,
+    RolloutQAStatusForm,
+    RolloutRisksForm,
+)
+from experimenter.openidc.tests.factories import UserFactory
+from experimenter.targeting.constants import NimbusTargetingConfig
+
+
+class RequestFormTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory.create(email="dev@example.com")
+        request_factory = RequestFactory()
+        self.request = request_factory.get(reverse("nimbus-ui-create"))
+        self.request.user = self.user
+
+
+class TestRolloutOverviewForm(RequestFormTestCase):
+    def test_valid_form_saves(self):
+        documentation_link = NimbusDocumentationLinkFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            documentation_links=[documentation_link],
+        )
+
+        form = RolloutOverviewForm(
+            instance=experiment,
+            data={
+                "name": "new rollout name",
+                "hypothesis": "new hypothesis",
+                "public_description": "new description",
+                "documentation_links-TOTAL_FORMS": "1",
+                "documentation_links-INITIAL_FORMS": "1",
+                "documentation_links-0-id": documentation_link.id,
+                "documentation_links-0-title": (
+                    NimbusExperiment.DocumentationLink.DESIGN_DOC.value
+                ),
+                "documentation_links-0-link": "https://www.example.com",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.name, "new rollout name")
+        self.assertEqual(experiment.hypothesis, "new hypothesis")
+        self.assertEqual(experiment.public_description, "new description")
+
+        documentation_link = experiment.documentation_links.all().get()
+        self.assertEqual(
+            documentation_link.title, NimbusExperiment.DocumentationLink.DESIGN_DOC
+        )
+        self.assertEqual(documentation_link.link, "https://www.example.com")
+        self.assertEqual(
+            form.get_changelog_message(),
+            f"{self.request.user} updated rollouts overview",
+        )
+
+    def test_name_field_is_required(self):
+        form_data = {
+            "name": "",
+            "hypothesis": "new hypothesis",
+            "public_description": "new description",
+            "documentation_links-TOTAL_FORMS": "0",
+            "documentation_links-INITIAL_FORMS": "0",
+        }
+
+        form = RolloutOverviewForm(data=form_data)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("name", form.errors)
+
+
+class TestRolloutRisksForm(RequestFormTestCase):
+    def test_valid_form_saves(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            risk_brand=False,
+            risk_message=False,
+            risk_revenue=False,
+            risk_partner_related=False,
+            risk_ai=False,
+        )
+        form = RolloutRisksForm(
+            instance=experiment,
+            data={
+                "risk_brand": True,
+                "risk_message": True,
+                "risk_revenue": True,
+                "risk_partner_related": True,
+                "risk_ai": True,
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.risk_brand)
+        self.assertTrue(experiment.risk_message)
+        self.assertTrue(experiment.risk_revenue)
+        self.assertTrue(experiment.risk_partner_related)
+        self.assertTrue(experiment.risk_ai)
+        self.assertEqual(
+            form.get_changelog_message(), f"{self.request.user} updated rollout risks"
+        )
+
+
+class TestRolloutAudienceForm(RequestFormTestCase):
+    def _audience_data(self, **overrides):
+        data = {
+            "channel": NimbusExperiment.Channel.BETA,
+            "channels": [NimbusExperiment.Channel.BETA],
+            "countries": [],
+            "exclude_countries": False,
+            "exclude_languages": False,
+            "exclude_locales": False,
+            "excluded_experiments_branches": [],
+            "firefox_max_version": NimbusExperiment.Version.FIREFOX_84,
+            "firefox_min_version": NimbusExperiment.Version.FIREFOX_83,
+            "is_first_run": False,
+            "is_sticky": False,
+            "languages": [],
+            "locales": [],
+            "localizations": "",
+            "required_experiments_branches": [],
+            "targeting_config_slug": NimbusExperiment.TargetingConfig.NO_TARGETING,
+        }
+        data.update(overrides)
+        return data
+
+    def test_valid_form_saves_desktop(self):
+        country = CountryFactory.create()
+        locale = LocaleFactory.create()
+        language = LanguageFactory.create()
+        excluded = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        required = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
+            countries=[],
+            locales=[],
+            languages=[],
+        )
+
+        form = RolloutAudienceForm(
+            instance=experiment,
+            data=self._audience_data(
+                channels=[
+                    NimbusExperiment.Channel.NIGHTLY,
+                    NimbusExperiment.Channel.BETA,
+                ],
+                countries=[country.id],
+                exclude_countries=True,
+                exclude_languages=True,
+                exclude_locales=True,
+                excluded_experiments_branches=[f"{excluded.slug}:control"],
+                is_first_run=True,
+                is_sticky=True,
+                languages=[language.id],
+                locales=[locale.id],
+                required_experiments_branches=[f"{required.slug}:None"],
+                targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            ),
+            request=self.request,
+        )
+
+        self.assertIn(
+            form.format_branch_choice(excluded.slug, excluded.name, None),
+            form.fields["excluded_experiments_branches"].choices,
+        )
+        self.assertIn(
+            form.format_branch_choice(excluded.slug, excluded.name, "control"),
+            form.fields["excluded_experiments_branches"].choices,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(
+            set(experiment.channels),
+            {NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.BETA},
+        )
+        self.assertEqual(list(experiment.countries.all()), [country])
+        self.assertEqual(list(experiment.locales.all()), [locale])
+        self.assertEqual(list(experiment.languages.all()), [language])
+        self.assertTrue(experiment.exclude_countries)
+        self.assertTrue(experiment.exclude_locales)
+        self.assertTrue(experiment.exclude_languages)
+        self.assertTrue(experiment.is_first_run)
+        self.assertTrue(experiment.is_sticky)
+        self.assertTrue(
+            NimbusExperimentBranchThroughExcluded.objects.filter(
+                parent_experiment=experiment,
+                child_experiment=excluded,
+                branch_slug="control",
+            ).exists()
+        )
+        self.assertTrue(
+            NimbusExperimentBranchThroughRequired.objects.filter(
+                parent_experiment=experiment,
+                child_experiment=required,
+                branch_slug=None,
+            ).exists()
+        )
+        self.assertEqual(
+            form.get_changelog_message(), f"{self.request.user} updated audience"
+        )
+
+    def test_check_rollout_dirty_does_not_set_flag_for_non_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=False,
+            population_percent=5,
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.BETA],
+        )
+
+        form = RolloutAudienceForm(
+            instance=experiment,
+            data=self._audience_data(population_percent=10),
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        updated_experiment = form.save()
+        updated_experiment.refresh_from_db()
+
+        self.assertFalse(updated_experiment.is_rollout_dirty)
+
+    def test_targeting_config_choices_filtered_by_application_and_sorted(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        form = RolloutAudienceForm(instance=experiment, request=self.request)
+
+        actual_choices = form.fields["targeting_config_slug"].choices
+        application = NimbusExperiment.Application(experiment.application)
+        expected_choices = sorted(
+            [
+                (targeting.slug, f"{targeting.name} - {targeting.description}")
+                for targeting in NimbusTargetingConfig.targeting_configs
+                if application.name in targeting.application_choice_names
+            ],
+            key=lambda choice: choice[1].lower(),
+        )
+
+        self.assertEqual(actual_choices, expected_choices)
+
+    def test_initial_experiment_branch_choices_include_existing_relations(self):
+        required = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        excluded = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            required_experiments_branches=[required],
+            excluded_experiments_branches=[excluded],
+        )
+
+        form = RolloutAudienceForm(instance=experiment, request=self.request)
+
+        self.assertEqual(
+            form.initial["required_experiments_branches"],
+            [f"{required.slug}:{required.reference_branch.slug}"],
+        )
+        self.assertEqual(
+            form.initial["excluded_experiments_branches"],
+            [f"{excluded.slug}:{excluded.reference_branch.slug}"],
+        )
+
+
+class TestRolloutQAStatusForm(RequestFormTestCase):
+    def test_form_updates_qa_fields_and_qa_run_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            qa_status=NimbusExperiment.QAStatus.NOT_SET,
+            qa_run_date=None,
+        )
+        data = {
+            "qa_status": NimbusExperiment.QAStatus.SELF_GREEN,
+            "qa_comment": "QA completed",
+            "qa_run_test_plan_url": "https://www.example.com/test-plan",
+            "qa_run_testrail_url": "https://www.example.com/testrail",
+        }
+        form = RolloutQAStatusForm(data, request=self.request, instance=experiment)
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.qa_status, NimbusExperiment.QAStatus.SELF_GREEN)
+        self.assertEqual(experiment.qa_run_date, timezone.now().date())
+        self.assertEqual(experiment.qa_comment, "QA completed")
+        self.assertEqual(
+            experiment.qa_run_test_plan_url, "https://www.example.com/test-plan"
+        )
+        self.assertEqual(
+            experiment.qa_run_testrail_url, "https://www.example.com/testrail"
+        )
+        self.assertEqual(form.get_changelog_message(), f"{self.request.user} updated QA")
+
+    def test_form_does_not_update_qa_run_date_when_changing_to_not_set(self):
+        old_date = datetime.date(2024, 1, 1)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            qa_status=NimbusExperiment.QAStatus.SELF_GREEN,
+            qa_run_date=old_date,
+        )
+        data = {
+            "qa_status": NimbusExperiment.QAStatus.NOT_SET,
+            "qa_comment": "",
+            "qa_run_test_plan_url": "",
+            "qa_run_testrail_url": "",
+        }
+        form = RolloutQAStatusForm(data, request=self.request, instance=experiment)
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.qa_status, NimbusExperiment.QAStatus.NOT_SET)
+        self.assertEqual(experiment.qa_run_date, old_date)
+
+
+class TestSelectedFirstMixin(TestCase):
+    def test_selected_options_appear_first(self):
+        LocaleFactory.create(code="en-US", name="English (US)")
+        LocaleFactory.create(code="de-DE", name="German (Germany)")
+        locale1 = LocaleFactory.create(code="fr-FR", name="French (France)")
+        locale2 = LocaleFactory.create(code="es-ES", name="Spanish (Spain)")
+
+        experiment = NimbusExperimentFactory.create()
+        experiment.locales.set([locale1, locale2])
+
+        form = RolloutAudienceForm(instance=experiment)
+        bound_field = form["locales"]
+
+        first_two_ids = {
+            int(str(bound_field[0].data["value"])),
+            int(str(bound_field[1].data["value"])),
+        }
+
+        self.assertEqual(first_two_ids, {locale1.id, locale2.id})

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -73,7 +73,6 @@ from experimenter.nimbus_ui.forms import (
     QAStatusForm,
     ReviewToApproveForm,
     ReviewToDraftForm,
-    RolloutAudienceForm,
     SignoffForm,
     SubscribeForm,
     TagAssignForm,
@@ -82,6 +81,12 @@ from experimenter.nimbus_ui.forms import (
     ToggleArchiveForm,
     ToggleReviewSlackNotificationsForm,
     UnsubscribeForm,
+)
+from experimenter.nimbus_ui.new.forms import (
+    RolloutAudienceForm,
+    RolloutOverviewForm,
+    RolloutQAStatusForm,
+    RolloutRisksForm,
 )
 
 
@@ -1313,8 +1318,8 @@ class OverviewCardMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if not isinstance(kwargs.get("form"), OverviewForm):
-            context["form"] = OverviewForm(instance=self.object)
+        if not isinstance(kwargs.get("form"), RolloutOverviewForm):
+            context["form"] = RolloutOverviewForm(instance=self.object)
         context["cancel_url"] = reverse(
             self.cancel_url_name, kwargs={"slug": self.object.slug}
         )
@@ -1327,8 +1332,8 @@ class RisksCardMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if not isinstance(kwargs.get("form"), OverviewForm):
-            context["form"] = OverviewForm(instance=self.object)
+        if not isinstance(kwargs.get("form"), RolloutRisksForm):
+            context["form"] = RolloutRisksForm(instance=self.object)
         context["cancel_url"] = reverse(
             self.cancel_url_name, kwargs={"slug": self.object.slug}
         )
@@ -1341,8 +1346,8 @@ class QACardMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        if not isinstance(kwargs.get("form"), QAStatusForm):
-            context["form"] = QAStatusForm(instance=self.object)
+        if not isinstance(kwargs.get("form"), RolloutQAStatusForm):
+            context["form"] = RolloutQAStatusForm(instance=self.object)
         context["cancel_url"] = reverse(
             self.cancel_url_name, kwargs={"slug": self.object.slug}
         )
@@ -1380,10 +1385,12 @@ class NewCardUpdateView(OverviewUpdateView):
 
 
 class NewOverviewUpdateView(OverviewCardMixin, NewCardUpdateView):
+    form_class = RolloutOverviewForm
     display_template = "nimbus_experiments/overview/card.html"
 
 
 class NewRisksUpdateView(RisksCardMixin, NewCardUpdateView):
+    form_class = RolloutRisksForm
     display_template = "nimbus_experiments/risks/card.html"
 
 


### PR DESCRIPTION
Because

- As we continue to work on the new experimenter pages it is becoming increasingly cluttered and confusing to work between files

This commit

- Moves forms related to the new designs into nimbus_ui/new/forms.py with accompanying tests in `nimbus_ui/tests/test_new_forms.py`

Fixes #15958 