### PR TITLE
fix(schemas): clear DOCKER_RUN_INTERACTIVE in the deploy job

### DIFF
--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -10,6 +10,8 @@ jobs:
   deploy:
     name: Deploy Schemas
     runs-on: ubuntu-24.04
+    env:
+      DOCKER_RUN_INTERACTIVE: ""
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Because

* the Deploy Schemas build step runs `make schemas_build`, whose `docker run` uses `DOCKER_RUN_INTERACTIVE` (default `-ti`). CI runners have no TTY, so `docker run -t` fails with `the input device is not a TTY` and the PyPI/npm publish steps are skipped (run [27574386275](https://github.com/mozilla/experimenter/actions/runs/27574386275)).
* `check-schemas.yml` avoids this via the `setup-cached-build` action, which clears the flag; `deploy-schemas.yml` runs `make` directly and never did.

This commit

* sets `DOCKER_RUN_INTERACTIVE: ""` as a job-level env so `docker run` is invoked without `-t` in CI

After this merges, a fresh schemas version bump will trigger a clean publish to both registries.

Fixes #15966