### PR TITLE
fix(nimbus): fix incorrect error modals

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-fragment.html
@@ -39,12 +39,12 @@
                         </small>
                         <button class="btn btn-link p-0"
                                 data-bs-toggle="modal"
-                                data-bs-target="#{{ experiment.slug }}-error-{{ forloop.counter }}">
+                                data-bs-target="#{{ experiment.slug }}-error-{{ error_group|slugify }}-{{ forloop.counter }}">
                           <small>View details</small>
                         </button>
                       </li>
                       <div class="modal fade"
-                           id="{{ experiment.slug }}-error-{{ forloop.counter }}"
+                           id="{{ experiment.slug }}-error-{{ error_group|slugify }}-{{ forloop.counter }}"
                            tabindex="-1"
                            aria-labelledby="exampleModalLabel"
                            aria-hidden="true">


### PR DESCRIPTION
Because

- Error detail modals could reuse the same id across different error groups, causing the wrong modal content to open

This commit

- Includes the error group in each results error modal ID and matching `data-bs-target` so every “View details” button points to the correct modal

Fixes #15963