### PR TITLE
fix(nimbus): re-enroll in fenix poll loop instead of bare log-state

### DIFF
--- a/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
+++ b/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
@@ -8,9 +8,8 @@ import pytest
 from nimbus.models.base_dataclass import BaseExperimentApplications
 
 FENIX_APP = BaseExperimentApplications.FIREFOX_FENIX.value
-APP_APPLY_WAIT = 15
-LOG_STATE_TIMEOUT = 120
-LOG_STATE_POLL_INTERVAL = 5
+ENROLL_TIMEOUT = 120
+ENROLL_POLL_INTERVAL = 5
 
 
 @pytest.mark.fenix_enrollment
@@ -27,7 +26,6 @@ def test_fenix_enrollment(
     recipe_path.write_text(json.dumps(recipe))
 
     subprocess.check_call(["adb", "install", fenix_apk_path])
-    subprocess.check_call(["adb", "logcat", "-c"])
 
     # Prevent the real Nimbus RS fetch from overwriting our local enrollment
     # (without this, Nimbus evolves against the fresh fetch — which does not
@@ -36,26 +34,26 @@ def test_fenix_enrollment(
         ["adb", "shell", "cmd", "connectivity", "airplane-mode", "enable"]
     )
 
-    subprocess.check_call(
-        [
-            "nimbus-cli",
-            "--app",
-            FENIX_APP,
-            "--channel",
-            fenix_channel,
-            "enroll",
-            experiment_slug,
-            "--branch",
-            "control",
-            "--file",
-            str(recipe_path),
-            "--preserve-targeting",
-            "--preserve-bucketing",
-            "--reset-app",
-            "--no-validate",
-        ]
-    )
-    time.sleep(APP_APPLY_WAIT)
+    def enroll():
+        subprocess.check_call(
+            [
+                "nimbus-cli",
+                "--app",
+                FENIX_APP,
+                "--channel",
+                fenix_channel,
+                "enroll",
+                experiment_slug,
+                "--branch",
+                "control",
+                "--file",
+                str(recipe_path),
+                "--preserve-targeting",
+                "--preserve-bucketing",
+                "--reset-app",
+                "--no-validate",
+            ]
+        )
 
     pattern = re.compile(
         rf"nimbus_client:\s*{re.escape(experiment_slug)}\s+\|\s*\S+\s+\|\s*(\S+)"
@@ -63,13 +61,11 @@ def test_fenix_enrollment(
 
     logcat = ""
     match = None
-    deadline = time.monotonic() + LOG_STATE_TIMEOUT
+    deadline = time.monotonic() + ENROLL_TIMEOUT
     while time.monotonic() < deadline:
         subprocess.check_call(["adb", "logcat", "-c"])
-        subprocess.check_call(
-            ["nimbus-cli", "--app", FENIX_APP, "--channel", fenix_channel, "log-state"]
-        )
-        time.sleep(LOG_STATE_POLL_INTERVAL)
+        enroll()
+        time.sleep(ENROLL_POLL_INTERVAL)
         logcat = subprocess.check_output(["adb", "logcat", "-d"], text=True)
         match = pattern.search(logcat)
         if match is not None:
@@ -77,7 +73,7 @@ def test_fenix_enrollment(
 
     nimbus_lines = [line for line in logcat.splitlines() if "nimbus_client" in line]
     assert match is not None, (
-        f"No log-state row found for {experiment_slug} after {LOG_STATE_TIMEOUT}s.\n"
+        f"No enrollment row found for {experiment_slug} after {ENROLL_TIMEOUT}s.\n"
         f"--- last 30 nimbus_client lines ---\n" + "\n".join(nimbus_lines[-30:])
     )
     enrolled_branch = match.group(1)


### PR DESCRIPTION
Because

* The nimbus-cli `enroll` launch is self-contained — it resets the db, injects the experiment payload, applies it, and prints log-state in one launch. The recipe is 100%/targeting=true, so enrollment is deterministic, yet beta intermittently shows an empty table for the full 120s window.
* The poll loop (post-#15846) re-issued bare `log-state`, which injects no payload and does not reset. When a loaded emulator backgrounds the enroll launch before `applyPendingExperiments` commits, the db is left wiped with nothing to surface — and bare `log-state` can never recover it, so the loop fails every iteration.

This commit

* Re-issues the full `enroll` (reset + inject + apply + log-state) each poll iteration so an incomplete apply self-heals on the next poll.
* Factors the enroll call into a local helper; renames the LOG_STATE_* constants to ENROLL_* to match the new behavior.

Fixes #15845