### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 153.5.20260615.213953

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4680,6 +4680,20 @@ FX_153_4_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_153_5_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx153 Jun-15 Trainhop",
+    slug="newtab-153-0615-trainhop",
+    description=(
+        "Desktop users having the New Tab 153.5.20260615.213953 train hop, "
+        "which includes users of Fx151"
+    ),
+    targeting="newtabAddonVersion|versionCompare('153.5.20260615.213953') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIDGETS_LISTS_OR_TIMER_INTERACTED_NOT_DISABLED = NimbusTargetingConfig(
     name="New Tab Lists/Timer Interaction, Neither Widget Disabled",
     slug="widgets-lists-timer-interacted-not-disabled",


### PR DESCRIPTION
This commit adds new targeting for the 153.5.20260615.213953 trainhop, which includes users of Fx151 on the release channel.

Fixes mozilla#15993
