### PR TITLE
feat(nimbus): Add widget-engagement targeting (any of 4 widgets) + 153.3 trainhop variant

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4747,6 +4747,59 @@ WIDGETS_LISTS_OR_TIMER_INTERACTED_NOT_DISABLED_FX_153_1_TRAINHOP_MAX = (
     )
 )
 
+WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
+    name="Engaged with Sports/Clocks/Lists/Timer widget, that widget not disabled",
+    slug="widgets-any-four-engaged",
+    description=(
+        "Users who engaged with Sports, Lists, or Timer (interacted) or Clocks "
+        "(changed hour format, or added/removed/edited clocks), AND still have that "
+        "widget enabled. Clocks has no interaction pref, so customization is its "
+        "engagement signal."
+    ),
+    targeting=(
+        "(("
+        "'browser.newtabpage.activity-stream.widgets.lists.interaction'"
+        "|preferenceValue) && ("
+        "'browser.newtabpage.activity-stream.widgets.lists.enabled'"
+        "|preferenceValue)) || (("
+        "'browser.newtabpage.activity-stream.widgets.focusTimer.interaction'"
+        "|preferenceValue) && ("
+        "'browser.newtabpage.activity-stream.widgets.focusTimer.enabled'"
+        "|preferenceValue)) || (("
+        "'browser.newtabpage.activity-stream.widgets.sportsWidget.interaction'"
+        "|preferenceValue) && ("
+        "'browser.newtabpage.activity-stream.widgets.sportsWidget.enabled'"
+        "|preferenceValue)) || ((("
+        "'browser.newtabpage.activity-stream.widgets.clocks.zones'"
+        "|preferenceValue) || ("
+        "'browser.newtabpage.activity-stream.widgets.clocks.hourFormat'"
+        "|preferenceValue)) && ("
+        "'browser.newtabpage.activity-stream.widgets.clocks.enabled'"
+        "|preferenceValue))"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+FX_153_3_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
+    name=(
+        "New Tab Fx153 Jun-05 Trainhop, engaged with any of 4 widgets, "
+        "that widget not disabled"
+    ),
+    slug="widgets-any-four-engaged-153-0605-trainhop",
+    description=(
+        "Users having the New Tab 153.3.20260605.21338 train hop who engaged with the "
+        "Sports, Clocks, Lists, or Timer widget and still have that widget enabled"
+    ),
+    targeting=f"{FX_153_3_TRAINHOP.targeting} && ({WIDGETS_ANY_FOUR_ENGAGED.targeting})",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 BUILDID_20251006095753 = NimbusTargetingConfig(
     name="Build ID 20251006095753 or higher",
     slug="buildid-20251006095753",


### PR DESCRIPTION
Adds WIDGETS_ANY_FOUR_ENGAGED targeting for users who engaged with the
Sports, Clocks, Lists, or Timer widget and still have that widget enabled,
plus a variant gated to the 153.3.20260605.21338 trainhop.

Fixes mozilla#16004
