### PR TITLE
fix(nimbus): correct featmon path and use $__all for Grafana metrics variable

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -1,7 +1,6 @@
 import functools
 import json
 import logging
-import tomllib
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from itertools import chain
@@ -454,6 +453,12 @@ def get_experiment_data(experiment: NimbusExperiment):
     }
 
 
+def get_population_sizing_data():
+    sizing_data = get_sizing_data(suffix="latest")
+    sizing = SampleSizes.model_validate(sizing_data) if sizing_data is not None else {}
+    return {"v1": sizing}
+
+
 @functools.lru_cache(maxsize=1)
 def get_featmon_slugs():
     path = settings.METRIC_HUB_FEATMON_DESKTOP_PATH
@@ -465,11 +470,3 @@ def get_featmon_slugs():
         )
     except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
         return frozenset()
-
-
-def get_population_sizing_data():
-    sizing_data = get_sizing_data(suffix="latest")
-    sizing = SampleSizes.model_validate(sizing_data) if sizing_data is not None else {}
-    return {"v1": sizing}
-
-

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -1,6 +1,7 @@
 import functools
 import json
 import logging
+import tomllib
 from collections import defaultdict
 from datetime import date, datetime, timedelta
 from itertools import chain
@@ -453,12 +454,6 @@ def get_experiment_data(experiment: NimbusExperiment):
     }
 
 
-def get_population_sizing_data():
-    sizing_data = get_sizing_data(suffix="latest")
-    sizing = SampleSizes.model_validate(sizing_data) if sizing_data is not None else {}
-    return {"v1": sizing}
-
-
 @functools.lru_cache(maxsize=1)
 def get_featmon_slugs():
     path = settings.METRIC_HUB_FEATMON_DESKTOP_PATH
@@ -470,3 +465,11 @@ def get_featmon_slugs():
         )
     except (FileNotFoundError, OSError, tomllib.TOMLDecodeError):
         return frozenset()
+
+
+def get_population_sizing_data():
+    sizing_data = get_sizing_data(suffix="latest")
+    sizing = SampleSizes.model_validate(sizing_data) if sizing_data is not None else {}
+    return {"v1": sizing}
+
+

--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -441,7 +441,7 @@ ROLLOUT_MONITORING_URL = (
 ROLLOUT_MONITORING_EXPIRATION_DAYS = 90
 FEATURE_MONITORING_URL = (
     "https://yardstick.mozilla.org/d/dtfz7xv/nimbus-feature-monitoring"
-    "?orgId=1&var-feature_slug={slug}&var-application={application}&var-metrics=All"
+    "?orgId=1&var-feature_slug={slug}&var-application={application}&var-metrics=$__all"
 )
 GRAFANA_INTERNAL_URL = config(
     "GRAFANA_INTERNAL_URL",
@@ -563,7 +563,7 @@ METRIC_HUB_OUTCOMES_PATH = (
 )
 
 METRIC_HUB_FEATMON_DESKTOP_PATH = (
-    BASE_DIR / "featmon" / "metric-hub-main" / "featmon" / "firefox_desktop.toml"
+    BASE_DIR / "outcomes" / "metric-hub-main" / "featmon" / "firefox_desktop.toml"
 )
 
 METRIC_HUB_SEGMENTS_PATH_DEFAULT = BASE_DIR / "segments" / "metric-hub-main"

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -98,6 +98,7 @@ exclude = [
     "**/migrations",
     "experimenter/legacy",
     "**/tests",
+    "**/metric-hub-main",
 ]
 
 reportAttributeAccessIssue = false

--- a/experimenter/pyproject.toml
+++ b/experimenter/pyproject.toml
@@ -144,6 +144,7 @@ exclude = [
     "legacy",
     ".pyenv",
     "experimenter/glean/generated",
+    "**/metric-hub-main",
 ]
 
 # Same as Black.

--- a/experimenter/pytest.ini
+++ b/experimenter/pytest.ini
@@ -4,4 +4,4 @@ DJANGO_SETTINGS_MODULE = experimenter.settings
 # -- recommended but optional:
 addopts = -vvvv --ignore=tests/integration --show-capture=no --disable-warnings -n 4
 python_files = tests.py test_*.py *_tests.py
-norecursedirs = .cache .pytest_cache .vscode bin fixtures node_modules requirements static served
+norecursedirs = .cache .pytest_cache .vscode bin fixtures node_modules requirements static served metric-hub-main


### PR DESCRIPTION
Because

- The Grafana dashboard link on the Feature Health Dashboard was using var-metrics=All which Grafana does not recognise as "select all" — the correct value is $__all
- Features with monitoring configured in metric-hub were incorrectly showing "Grafana dashboard not available" because the featmon TOML path was pointing to a directory that does not exist in the Docker environment

This commit

- Updates FEATURE_MONITORING_URL to use var-metrics=$__all so the Grafana dashboard opens with all metrics selected
- Fixes METRIC_HUB_FEATMON_DESKTOP_PATH to point to outcomes/metric-hub-main/featmon/firefox_desktop.toml, 

Fixes #16013 