### PR TITLE
fix(nimbus): track featmon config so feature monitoring works on deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,7 @@ google-credentials.json
 
 # Jetstream config
 experimenter/experimenter/outcomes/metric-hub-main/*
+!experimenter/experimenter/outcomes/metric-hub-main/featmon/
 !experimenter/experimenter/outcomes/metric-hub-main/jetstream/
 experimenter/experimenter/outcomes/metric-hub-main/jetstream/*
 !experimenter/experimenter/outcomes/metric-hub-main/jetstream/outcomes/

--- a/experimenter/experimenter/outcomes/metric-hub-main/featmon/README.md
+++ b/experimenter/experimenter/outcomes/metric-hub-main/featmon/README.md
@@ -1,0 +1,64 @@
+# featmon — Nimbus Feature Monitoring Configs
+
+This directory contains per-application TOML configuration files for Nimbus
+feature monitoring (like `opmon/` is for operational monitoring).
+
+Each file is named `<application>.toml` (e.g. `firefox_desktop.toml`) and
+defines the BigQuery data sources and Nimbus features to monitor.  The BigQuery
+**dataset** is inferred from the filename stem, so it does not need to be
+repeated inside the file.
+
+See [example_config.toml.example](example_config.toml.example) for a fully
+annotated example.
+
+## Structure
+
+### `[data_sources.<name>]`
+
+Each data source maps to a BigQuery table in the application's dataset.
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `table_name` | yes | BigQuery table name within the application dataset |
+| `type` | yes | One of `"metrics"`, `"event_stream"`, or `"clients_daily"` |
+| `analysis_unit_id` | no | Field used to identify analysis units (default: `"client_info.client_id"`) |
+
+#### `[data_sources.<name>.dimensions]`
+
+Optional grouping dimensions.  Each key is a dimension name.  Use an inline
+table `{ field = "..." }` to specify the BigQuery field if it differs from the
+dimension name.  For constrained dimensions add `value_in` and `default_value`.
+
+```toml
+[data_sources.metrics.dimensions]
+normalized_channel = {}
+locale = { field = "client_info.locale" }
+normalized_country_code = { value_in = ["CA", "DE", "FR", "GB", "US"], default_value = "OTHER" }
+```
+
+### `[features.<key>]`
+
+Each feature key must be valid TOML (snake_case).  When the actual Nimbus
+feature slug contains hyphens, add a `slug` field:
+
+```toml
+[features.address_autofill_feature]
+slug = "address-autofill-feature"
+```
+
+#### `[features.<key>.metrics_by_source.<source>.<type>]`
+
+Metrics to collect, grouped by data source and metric type.
+
+Supported types: `boolean`, `quantity`, `labeled_counter`, `labeled_boolean`,
+`string`, `event`.
+
+For `event` metrics an extra level of nesting groups by category:
+
+```toml
+[features.my_feature.metrics_by_source.events_stream.event.my_category]
+my_event = {}
+```
+
+Metric values are inline tables.  An empty table `{}` picks sensible defaults.
+Common optional keys: `field`, `aggregators`, `label_in`.

--- a/experimenter/experimenter/outcomes/metric-hub-main/featmon/example_config.toml.example
+++ b/experimenter/experimenter/outcomes/metric-hub-main/featmon/example_config.toml.example
@@ -1,0 +1,67 @@
+# Example featmon config.  Copy this file, rename it to <application>.toml
+# (e.g. firefox_desktop.toml), and fill in the sections below.
+#
+# The BigQuery dataset is inferred from the filename stem — do NOT add a
+# `dataset` field inside the file.
+
+# ---------------------------------------------------------------------------
+# Data sources
+# ---------------------------------------------------------------------------
+# Each data_source maps to a BigQuery table.  The key is an arbitrary name
+# used to reference this source from feature definitions below.
+
+[data_sources.metrics]
+# Required: the BigQuery table name within the application dataset.
+table_name = "metrics"
+# Required: one of "metrics", "event_stream", or "clients_daily".
+type = "metrics"
+# Optional: field used to identify analysis units.
+# Default: "client_info.client_id"
+analysis_unit_id = "metrics.uuid.legacy_telemetry_profile_group_id"
+
+# Optional: dimensions to group metrics by.  Each key is a dimension name.
+# Use an empty table {} to derive the field name from the dimension name.
+# Use { field = "..." } when the BigQuery field path differs.
+# Use value_in + default_value to restrict to a known set of values.
+[data_sources.metrics.dimensions]
+normalized_channel = {}
+normalized_os = {}
+locale = { field = "client_info.locale" }
+normalized_country_code = { value_in = ["CA", "DE", "FR", "GB", "US"], default_value = "OTHER" }
+
+[data_sources.events_stream]
+table_name = "events_stream"
+type = "event_stream"
+analysis_unit_id = "profile_group_id"
+
+# ---------------------------------------------------------------------------
+# Features
+# ---------------------------------------------------------------------------
+# Each feature key must be a valid TOML bare key (snake_case recommended).
+# If the actual Nimbus feature slug contains hyphens, add a `slug` field.
+
+[features.my_feature]
+# Optional: set when the Nimbus slug differs from the TOML key (e.g. hyphens).
+slug = "my-feature"
+
+# Metrics from the "metrics" data source above.
+# Supported metric types: boolean, quantity, labeled_counter, labeled_boolean,
+#                         string, event.
+
+[features.my_feature.metrics_by_source.metrics.boolean]
+# An empty table {} uses sensible defaults (aggregator = count_true).
+my_boolean_metric = {}
+
+[features.my_feature.metrics_by_source.metrics.quantity]
+my_quantity_metric = {}
+
+[features.my_feature.metrics_by_source.metrics.labeled_counter.my_labeled_metric]
+# Optional: restrict to a subset of labels.
+aggregators = ["sum", "avg"]
+label_in = ["label_a", "label_b"]
+
+# Event metrics from the "events_stream" data source.
+# Events have an extra nesting level for the Glean category.
+[features.my_feature.metrics_by_source.events_stream.event.my_category]
+my_event = {}
+another_event = {}

--- a/experimenter/experimenter/outcomes/metric-hub-main/featmon/firefox_desktop.toml
+++ b/experimenter/experimenter/outcomes/metric-hub-main/featmon/firefox_desktop.toml
@@ -1,0 +1,304 @@
+# Data sources define the BigQuery tables used for feature monitoring.
+# Each data source specifies:
+#   - analysis_unit_id: field used to identify analysis units (client/profile IDs)
+#   - table_name: the BigQuery table name within the application dataset
+#   - type: one of "metrics", "events_stream", or "clients_daily"
+#   - dimensions: optional fields to group metrics by
+
+[data_sources.metrics]
+analysis_unit_id = "metrics.uuid.legacy_telemetry_profile_group_id"
+table_name = "metrics"
+type = "metrics"
+
+[data_sources.metrics.dimensions]
+app_display_version = { field = "client_info.app_display_version" }
+app_version_major = {}
+app_version_minor = {}
+app_version_patch = {}
+locale = { field = "client_info.locale" }
+normalized_channel = {}
+normalized_os = {}
+normalized_os_version = {}
+normalized_country_code = { value_in = ["CA", "DE", "FR", "GB", "US"], default_value = "OTHER" }
+
+[data_sources.events_stream]
+analysis_unit_id = "profile_group_id"
+table_name = "events_stream"
+type = "events_stream"
+
+[data_sources.newtab]
+analysis_unit_id = "metrics.uuid.legacy_telemetry_profile_group_id"
+table_name = "newtab"
+type = "metrics"
+
+# Features define which metrics to collect from which data sources.
+# Each feature key is snake_case. Use `slug` to specify the actual Nimbus
+# feature name when it differs from the key (e.g. when hyphens or camelCase
+# are present in the real Nimbus feature ID).
+# For boolean, quantity, and labeled_* types: keys are metric names.
+# For event type: keys are categories, then event names.
+
+[features.address_autofill_feature]
+slug = "address-autofill-feature"
+
+[features.address_autofill_feature.metrics_by_source.metrics.boolean]
+formautofill_availability = {}
+
+[features.address_autofill_feature.metrics_by_source.metrics.labeled_counter.login_autofill]
+field = "metrics.labeled_counter.pwmgr_form_autofill_result"
+aggregators = ["sum", "avg"]
+label_in = ["filled", "filled_username_only_form"]
+
+[features.address_autofill_feature.metrics_by_source.metrics.quantity]
+formautofill_addresses_autofill_profiles_count = {}
+
+[features.address_autofill_feature.metrics_by_source.events_stream.event.address]
+detected_address_form = {}
+popup_shown_address_form = {}
+filled_address_form = {}
+filled_on_fields_update_address_form = {}
+filled_modified_address_form = {}
+submitted_address_form = {}
+cleared_address_form = {}
+detected_address_form_ext = {}
+filled_address_form_ext = {}
+submitted_address_form_ext = {}
+
+[features.address_autofill_feature.metrics_by_source.events_stream.event.formautofill]
+iframe_layout_detection = {}
+
+[features.newtab_trainhop_addon]
+slug = "newtabTrainhopAddon"
+
+[features.newtab_trainhop_addon.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.newtab_sponsored_content]
+slug = "newtabSponsoredContent"
+
+[features.newtab_sponsored_content.metrics_by_source.newtab.boolean]
+pocket_is_signed_in = {}
+pocket_enabled = {}
+pocket_sponsored_stories_enabled = {}
+topsites_enabled = {}
+topsites_sponsored_enabled = {}
+
+[features.newtab_sponsored_content.metrics_by_source.newtab.quantity]
+topsites_rows = {}
+topsites_sponsored_tiles_configured = {}
+
+[features.newtab_sponsored_content.metrics_by_source.newtab.event.pocket]
+click = {}
+impression = {}
+dismiss = {}
+save = {}
+
+[features.newtab_sponsored_content.metrics_by_source.newtab.event.topsites]
+impression = {}
+click = {}
+pin = {}
+unpin = {}
+add = {}
+edit = {}
+show_privacy_click = {}
+dismiss = {}
+pref_changed = {}
+
+[features.new_tab_sections_experiment]
+slug = "newTabSectionsExperiment"
+
+[features.new_tab_sections_experiment.metrics_by_source.newtab.event.newtab]
+sections_impression = {}
+sections_follow_section = {}
+sections_unfollow_section = {}
+sections_block_section = {}
+sections_unblock_section = {}
+
+[features.newtab_trainhop]
+slug = "newtabTrainhop"
+
+[features.newtab_trainhop.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.newtab_trainhop.metrics_by_source.newtab.event.pocket]
+impression = {}
+click = {}
+save = {}
+dismiss = {}
+
+[features.newtab_trainhop.metrics_by_source.newtab.event.topsites]
+impression = {}
+click = {}
+
+[features.pocket_newtab]
+slug = "pocketNewtab"
+
+[features.pocket_newtab.metrics_by_source.newtab.boolean]
+pocket_is_signed_in = {}
+pocket_enabled = {}
+pocket_sponsored_stories_enabled = {}
+
+[features.pocket_newtab.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.pocket_newtab.metrics_by_source.newtab.event.pocket]
+impression = {}
+click = {}
+save = {}
+dismiss = {}
+
+[features.newtab_private_ping]
+slug = "newtabPrivatePing"
+
+[features.newtab_private_ping.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.newtab_merino_ohttp]
+slug = "newtabMerinoOhttp"
+
+[features.newtab_merino_ohttp.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.newtab_merino_ohttp.metrics_by_source.newtab.event.pocket]
+impression = {}
+click = {}
+
+[features.newtab_ad_sizing_experiment]
+slug = "newtabAdSizingExperiment"
+
+[features.newtab_ad_sizing_experiment.metrics_by_source.newtab.boolean]
+topsites_sponsored_enabled = {}
+
+[features.newtab_ad_sizing_experiment.metrics_by_source.newtab.event.topsites]
+impression = {}
+click = {}
+dismiss = {}
+
+[features.newtab_promo_card]
+slug = "newtabPromoCard"
+
+[features.newtab_promo_card.metrics_by_source.newtab.event.newtab]
+opened = {}
+
+[features.newtab_promo_card.metrics_by_source.newtab.event.topsites]
+impression = {}
+click = {}
+dismiss = {}
+
+[features.newtab_inferred_personalization]
+slug = "newtabInferredPersonalization"
+
+[features.newtab_inferred_personalization.metrics_by_source.newtab.event.pocket]
+impression = {}
+click = {}
+save = {}
+dismiss = {}
+
+[features.newtab_inferred_personalization.metrics_by_source.newtab.event.topsites]
+impression = {}
+click = {}
+
+[data_sources.events]
+analysis_unit_id = "client_info.client_id"
+table_name = "events"
+type = "metrics"
+
+[features.urlbar]
+slug = "urlbar"
+
+[features.urlbar.metrics_by_source.events.boolean]
+urlbar_pref_suggest_sponsored = {}
+urlbar_pref_suggest_nonsponsored = {}
+urlbar_pref_suggest_all = {}
+urlbar_pref_suggest_data_collection = {}
+urlbar_pref_suggest_online_available = {}
+urlbar_pref_suggest_online_enabled = {}
+
+[data_sources.messaging_system]
+analysis_unit_id = "client_info.client_id"
+table_name = "messaging_system"
+type = "metrics"
+
+[features.infobar]
+slug = "infobar"
+
+[features.infobar.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.aboutwelcome]
+slug = "aboutwelcome"
+
+[features.aboutwelcome.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.feature_callout]
+slug = "featureCallout"
+
+[features.feature_callout.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_bmb_button]
+slug = "fxms-bmb-button"
+
+[features.fxms_bmb_button.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_22]
+slug = "fxms-message-22"
+
+[features.fxms_message_22.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_1]
+slug = "fxms-message-1"
+
+[features.fxms_message_1.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_20]
+slug = "fxms-message-20"
+
+[features.fxms_message_20.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_7]
+slug = "fxms-message-7"
+
+[features.fxms_message_7.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_16]
+slug = "fxms-message-16"
+
+[features.fxms_message_16.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.fxms_message_21]
+slug = "fxms-message-21"
+
+[features.fxms_message_21.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.background_task_message]
+slug = "backgroundTaskMessage"
+
+[features.background_task_message.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}
+
+[features.preonboarding]
+slug = "preonboarding"
+
+[features.preonboarding.metrics_by_source.messaging_system.string]
+messaging_system_event = {}
+messaging_system_ping_type = {}


### PR DESCRIPTION
Because

- The Feature Monitoring card reads outcomes/metric-hub-main/featmon/firefox_desktop.toml to decide whether to show the Grafana dashboard link, but .gitignore excluded that file. It was never committed or baked into the deploy image, so it only existed in local dev trees — on stage/prod every feature showed "Grafana dashboard not available".

This commit

- Un-ignores the featmon/ directory in .gitignore (mirroring the existing jetstream/outcomes/ whitelist) and commits the current featmon config so it ships in the deploy image.

Fixes #16013 