### PR TITLE
fix(nimbus): fix results page showing stale errors

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -411,26 +411,31 @@ def get_experiment_data(experiment: NimbusExperiment):
 
     errors_by_metric = {}
     errors_experiment_overall = []
+
+    def include_error_after_analysis_start(err):
+        try:
+            analysis_start_time = datetime.fromisoformat(
+                experiment_metadata.get("analysis_start_time")
+                if experiment_metadata is not None
+                else ""
+            )
+            timestamp = datetime.fromisoformat(err.get("timestamp"))
+
+            return timestamp >= analysis_start_time
+        except (ValueError, TypeError, KeyError):
+            # ill-formatted/missing timestamp: default to including the error
+            return True
+
     if experiment_errors is not None:
         for err in experiment_errors:
             metric_slug = err.get("metric")
             if "metric" in err and metric_slug is not None:
-                if metric_slug not in errors_by_metric:
-                    errors_by_metric[metric_slug] = []
-                errors_by_metric[metric_slug].append(err)
+                if include_error_after_analysis_start(err):
+                    if metric_slug not in errors_by_metric:
+                        errors_by_metric[metric_slug] = []
+                    errors_by_metric[metric_slug].append(err)
             else:
-                try:
-                    analysis_start_time = datetime.fromisoformat(
-                        experiment_metadata.get("analysis_start_time")
-                        if experiment_metadata is not None
-                        else ""
-                    )
-                    timestamp = datetime.fromisoformat(err.get("timestamp"))
-
-                    if timestamp >= analysis_start_time:
-                        errors_experiment_overall.append(err)
-                except (ValueError, TypeError, KeyError):
-                    # ill-formatted/missing timestamp: default to including the error
+                if include_error_after_analysis_start(err):
                     errors_experiment_overall.append(err)
 
     for e in runtime_errors:

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -1185,6 +1185,78 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
                 experiment = NimbusExperiment.objects.get(id=experiment.id)
                 self.assertEqual(experiment.results_data, FULL_DATA)
 
+    def test_metric_errors_before_analysis_start_time_are_excluded(self):
+        experiment = NimbusExperimentFactory.create(
+            primary_outcomes=[],
+            secondary_outcomes=[],
+        )
+        fresh_error = {
+            "exception": "(<class 'MetricException'>)",
+            "exception_type": "MetricException",
+            "experiment": "test-experiment-slug",
+            "filename": "metrics.py",
+            "func_name": "execute",
+            "log_level": "ERROR",
+            "message": "test-experiment-slug -> metric error",
+            "metric": "custom_metric",
+            "statistic": None,
+            "timestamp": "2026-05-19T04:30:03+00:00",
+            "analysis_basis": "enrollments",
+            "segment": "all",
+        }
+        stale_error = {
+            "exception": "(<class 'MetricException'>)",
+            "exception_type": "MetricException",
+            "experiment": "test-experiment-slug",
+            "filename": "metrics.py",
+            "func_name": "execute",
+            "log_level": "ERROR",
+            "message": "test-experiment-slug -> stale metric error",
+            "metric": "custom_metric",
+            "statistic": None,
+            "timestamp": "2026-05-17T04:30:03+00:00",
+            "analysis_basis": "enrollments",
+            "segment": "all",
+        }
+        malformed_error = {
+            "exception": "(<class 'MetricException'>)",
+            "exception_type": "MetricException",
+            "experiment": "test-experiment-slug",
+            "filename": "metrics.py",
+            "func_name": "execute",
+            "log_level": "ERROR",
+            "message": "test-experiment-slug -> malformed metric error",
+            "metric": "malformed_metric",
+            "statistic": None,
+            "timestamp": "not-a-date",
+            "analysis_basis": "enrollments",
+            "segment": "all",
+        }
+
+        with (
+            patch("experimenter.jetstream.client.get_data") as mock_get_data,
+            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
+            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
+        ):
+            mock_get_data.return_value = []
+            mock_get_metadata.return_value = {
+                "analysis_start_time": "2026-05-18T04:30:03+00:00",
+                "outcomes": {},
+                "metrics": {},
+            }
+            mock_get_errors.return_value = [fresh_error, stale_error, malformed_error]
+            tasks.fetch_experiment_data(experiment.id)
+            experiment = NimbusExperiment.objects.get(id=experiment.id)
+
+            self.assertEqual(
+                experiment.results_data["v3"]["errors"],
+                {
+                    "custom_metric": [fresh_error],
+                    "malformed_metric": [malformed_error],
+                    "experiment": [],
+                },
+            )
+
     @parameterized.expand(
         [
             (NimbusExperimentFactory.Lifecycles.CREATED,),


### PR DESCRIPTION
Because

- Metric level analysis errors could include stale errors from before the current analysis run

This commit

- Applies the existing `analysis_start_time` filtering to metric level errors as well as experiment level errors
- Adds test coverage for including fresh metric errors, excluding stale ones, and preserving malformed timestamp fallback behavior

Fixes #15946 