### PR TITLE
fix(nimbus): use Services.prefs instead of about:config UI in desktop integration tests

### DIFF
--- a/experimenter/tests/integration/nimbus/pages/browser/__init__.py
+++ b/experimenter/tests/integration/nimbus/pages/browser/__init__.py
@@ -3,8 +3,6 @@
 import time
 
 from pypom import Page
-from selenium.webdriver.common.by import By
-from selenium.webdriver.support import expected_conditions as EC
 
 
 class Browser:
@@ -19,16 +17,8 @@ class Browser:
 class AboutConfig(Page):
     URL_TEMPLATE = "about:config"
 
-    _search_bar_locator = (By.ID, "about-config-search")
-    _row_locator = (By.CSS_SELECTOR, "tr > td > span > span")
-    _pref_locator = (By.CSS_SELECTOR, "tr > th > span")
-
     def __init__(self, selenium, **kwargs):
         super().__init__(selenium, timeout=80, **kwargs)
-
-    def wait_for_page_to_load(self):
-        self.wait.until(EC.presence_of_element_located(self._search_bar_locator))
-        return self
 
     def wait_for_pref_flip(self, pref, pref_value, action=None, pref_type=str):
         timeout = time.time() + 60 * 5
@@ -61,44 +51,35 @@ class AboutConfig(Page):
                     return
         raise (error)
 
-    def flip_pref(self, pref):
-        timeout = time.time() + 15
-        error = None
-        while time.time() < timeout:
-            try:
-                search_bar = self.find_element(*self._search_bar_locator)
-                search_bar.send_keys(pref)
-                self.wait.until(EC.presence_of_element_located(self._row_locator))
-                actual_row = (By.CSS_SELECTOR, "table > tr")
-                new_pref_locator = (By.CSS_SELECTOR, "th > span")
-                elements = self.find_elements(*actual_row)
-                el = next(
-                    element
-                    for element in elements
-                    if pref in element.find_element(*new_pref_locator).text
-                )
-                el.find_element(By.CSS_SELECTOR, ".cell-edit").click()
-            except Exception as e:
-                error = e
-                time.sleep(2)
-                self.selenium.get("about:config")
-                self.wait_for_page_to_load()
-            else:
-                return True
-        raise (error)
+    def get_pref_value(self, pref, pref_type=str):
+        match pref_type:
+            case _ if pref_type is bool:
+                method = "getBoolPref"
+            case _ if pref_type is int:
+                method = "getIntPref"
+            case _ if pref_type is str:
+                method = "getStringPref"
+            case _:
+                raise TypeError(f"Unsupported pref type {pref_type}")
+        with self.selenium.context(self.selenium.CONTEXT_CHROME):
+            return self.selenium.execute_script(
+                f"return Services.prefs.{method}(arguments[0]);", pref
+            )
 
-    def get_pref_value(self, pref):
-        self.selenium.get("about:config")
-        self = self.wait_for_page_to_load()
-        search_bar = self.find_element(*self._search_bar_locator)
-        search_bar.send_keys(pref)
-        self.wait.until(EC.presence_of_element_located(self._row_locator))
-        actual_row = (By.CSS_SELECTOR, "table > tr")
-        new_pref_locator = (By.CSS_SELECTOR, "th > span")
-        elements = self.find_elements(*actual_row)
-        el = next(
-            element
-            for element in elements
-            if pref in element.find_element(*new_pref_locator).text
-        )
-        return el.find_element(By.CSS_SELECTOR, ".cell-value").text
+    def set_pref(self, pref, value):
+        match value:
+            case bool():
+                method = "setBoolPref"
+            case int():
+                method = "setIntPref"
+            case str():
+                method = "setStringPref"
+            case _:
+                raise TypeError(f"Unsupported pref type {type(value)}")
+        with self.selenium.context(self.selenium.CONTEXT_CHROME):
+            self.selenium.execute_script(
+                f"Services.prefs.{method}(arguments[0], arguments[1]);", pref, value
+            )
+
+    def flip_pref(self, pref):
+        self.set_pref(pref, not self.get_pref_value(pref, pref_type=bool))

--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -133,7 +133,6 @@ def test_check_telemetry_pref_flip(
             "is_rollout": True,
         },
     )
-    about_config = about_config.open().wait_for_page_to_load()
     about_config.wait_for_pref_flip(
         "nimbus.qa.pref-1", "default", action=trigger_experiment_loader
     )
@@ -151,7 +150,6 @@ def test_check_telemetry_pref_flip(
         if time.time() > timeout:
             raise AssertionError("Experiment enrollment was never seen in ping Data")
 
-    about_config = about_config.open().wait_for_page_to_load()
     about_config.wait_for_pref_flip(
         "nimbus.qa.pref-1", "test_string_automation", action=trigger_experiment_loader
     )
@@ -168,7 +166,6 @@ def test_check_telemetry_pref_flip(
         control = telemetry_event_check(experiment_slug, "unenrollment")
         if time.time() > timeout:
             raise AssertionError("Experiment unenrollment was never seen in ping Data")
-    about_config = about_config.open().wait_for_page_to_load()
     about_config.wait_for_pref_flip(
         "nimbus.qa.pref-1", "default", action=trigger_experiment_loader
     )
@@ -209,12 +206,11 @@ def test_check_telemetry_sticky_targeting(
             raise AssertionError("Experiment enrollment was never seen in ping Data")
 
     # flip pref
-    about_config = about_config.open().wait_for_page_to_load()
     about_config.wait_for_pref_flip(
         pref_name, True, action=trigger_experiment_loader, pref_type=bool
     )
     about_config.flip_pref(pref_name)
-    assert about_config.get_pref_value(pref_name) == "false"
+    assert about_config.get_pref_value(pref_name, pref_type=bool) is False
     # check experiment doesn't unenroll after pref flip
     control = False
     timeout = time.time() + 60
@@ -238,4 +234,4 @@ def test_check_telemetry_sticky_targeting(
         if time.time() > timeout:
             raise AssertionError("Experiment unenrollment was never seen in ping Data")
     # check pref still matches user change
-    assert about_config.get_pref_value(pref_name) == "false"
+    assert about_config.get_pref_value(pref_name, pref_type=bool) is False


### PR DESCRIPTION
Because

* The desktop integration tests toggled and read prefs by scraping the about:config UI, which broke on Firefox 152 — a single click on the edit cell no longer toggles a boolean pref, so the sticky-targeting test failed on every release-version bump to 152+ (it surfaced misleadingly as a rerun `Unable to find live status` timeout).
* Driving the about:config DOM was always fragile; the chrome-context `Services.prefs` API (already used by `wait_for_pref_flip`) is version-stable.

This commit

* Rewrites `get_pref_value` and `flip_pref`, and adds `set_pref`, to use `Services.prefs.{get,set}{Bool,Int,String}Pref` via the chrome context.
* Drops the now-unneeded about:config navigation, DOM locators, and `wait_for_page_to_load`.

Fixes #16043