### PR TITLE
feat(nimbus): make end buttons distinct and confirm before ending

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -73,6 +73,17 @@ const setupSlugCopyToast = () => {
   }
 };
 
+const cleanupOrphanedModalBackdrops = () => {
+  if (!document.querySelector(".modal.show")) {
+    document
+      .querySelectorAll(".modal-backdrop")
+      .forEach((backdrop) => backdrop.remove());
+    document.body.classList.remove("modal-open");
+    document.body.style.removeProperty("overflow");
+    document.body.style.removeProperty("padding-right");
+  }
+};
+
 const setupHTMXLoadingOverlay = () => {
   document.addEventListener("htmx:beforeRequest", function () {
     const loadingOverlay = document.querySelector("#htmx-loading-overlay");
@@ -111,6 +122,7 @@ $(() => {
     setupToasts();
     setupSlugCopyToast();
     setupReadonlyJsonEditors();
+    cleanupOrphanedModalBackdrops();
   });
 
   // To support HTMX onchange updates on selectpicker, we need to

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/end_experiment_modal.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/end_experiment_modal.html
@@ -1,0 +1,60 @@
+{% load nimbus_extras %}
+
+<div class="modal fade"
+     id="end-experiment-modal-{{ experiment.slug }}"
+     tabindex="-1"
+     aria-labelledby="end-experiment-modal-label-{{ experiment.slug }}"
+     aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5"
+            id="end-experiment-modal-label-{{ experiment.slug }}">
+          End this
+          {% if experiment.is_rollout %}
+            rollout?
+          {% else %}
+            experiment?
+          {% endif %}
+        </h1>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <p class="mb-0">
+          This requests to permanently end
+          {% if experiment.is_rollout %}
+            rollout
+          {% else %}
+            experiment
+          {% endif %}
+          <strong>{{ experiment.name }}</strong> and stop collecting data. This can't be undone.
+          {% if not experiment.is_rollout %}
+            If you only want to stop new participants from enrolling, use <strong>End Enrollment</strong> instead.
+          {% endif %}
+        </p>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+        <button type="button"
+                id="end-experiment"
+                class="btn btn-danger"
+                data-bs-dismiss="modal"
+                hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}{{ post_query }}"
+                hx-select="{{ target|default:'#content' }}"
+                hx-target="{{ target|default:'#content' }}"
+                hx-swap="outerHTML">
+          <i class="fa-solid fa-circle-stop me-1"></i>
+          End
+          {% if experiment.is_rollout %}
+            Rollout
+          {% else %}
+            Experiment
+          {% endif %}
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -268,16 +268,18 @@
                     hx-target="#content"
                     hx-swap="outerHTML"
                     class="btn btn-primary m-1 end-enrollment_btn"
-                    {% if experiment.is_rollout_dirty %}disabled{% endif %}>End Enrollment</button>
+                    {% if experiment.is_rollout_dirty %}disabled{% endif %}>
+              <i class="fa-solid fa-user-slash me-1"></i>
+              End Enrollment
+            </button>
           {% endif %}
           {% if experiment.should_show_end_experiment %}
             <button type="button"
-                    hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}"
-                    hx-select="#content"
-                    hx-target="#content"
-                    hx-swap="outerHTML"
-                    id="end-experiment"
-                    class="btn btn-primary m-1 end_experiment_btn">
+                    id="end-experiment-trigger"
+                    class="btn btn-danger m-1 end_experiment_btn"
+                    data-bs-toggle="modal"
+                    data-bs-target="#end-experiment-modal-{{ experiment.slug }}">
+              <i class="fa-solid fa-circle-stop me-1"></i>
               End
               {% if experiment.is_rollout %}
                 Rollout
@@ -297,6 +299,10 @@
                     {% if not experiment.is_rollout_dirty %}disabled{% endif %}>Request Update</button>
           {% endif %}
         </div>
+        {% if experiment.should_show_end_experiment %}
+          {% include "nimbus_experiments/end_experiment_modal.html" with experiment=experiment %}
+
+        {% endif %}
       {% endif %}
     {% endif %}
   </form>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls_v2.html
@@ -74,16 +74,18 @@
                             hx-target="#{{ experiment.slug }}-progress-card"
                             hx-swap="outerHTML"
                             class="btn btn-primary end-enrollment_btn"
-                            {% if experiment.is_rollout_dirty %}disabled{% endif %}>Close Enrollment</button>
+                            {% if experiment.is_rollout_dirty %}disabled{% endif %}>
+                      <i class="fa-solid fa-user-slash me-1"></i>
+                      Close Enrollment
+                    </button>
                   {% endif %}
                   {% if experiment.should_show_end_experiment %}
                     <button type="button"
-                            hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
-                            hx-select="#{{ experiment.slug }}-progress-card"
-                            hx-target="#{{ experiment.slug }}-progress-card"
-                            hx-swap="outerHTML"
-                            id="end-experiment"
-                            class="btn btn-primary m-1 end_experiment_btn">
+                            id="end-experiment-trigger"
+                            class="btn btn-danger m-1 end_experiment_btn"
+                            data-bs-toggle="modal"
+                            data-bs-target="#end-experiment-modal-{{ experiment.slug }}">
+                      <i class="fa-solid fa-circle-stop me-1"></i>
                       End
                       {% if experiment.is_rollout %}
                         Rollout
@@ -92,6 +94,10 @@
                       {% endif %}
                     </button>
                   {% endif %}
+                {% endif %}
+                {% if experiment.should_show_end_experiment %}
+                  {% include "nimbus_experiments/end_experiment_modal.html" with experiment=experiment post_query="?fragment=progress_card" target="#"|add:experiment.slug|add:"-progress-card" %}
+
                 {% endif %}
               </form>
             </div>
@@ -145,12 +151,11 @@
               {% elif experiment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
                 {% if experiment.should_show_end_experiment %}
                   <button type="button"
-                          hx-post="{% url 'nimbus-ui-live-to-complete' slug=experiment.slug %}?fragment=progress_card"
-                          hx-select="#{{ experiment.slug }}-progress-card"
-                          hx-target="#{{ experiment.slug }}-progress-card"
-                          hx-swap="outerHTML"
-                          id="end-experiment"
-                          class="btn btn-primary m-1 end_experiment_btn">
+                          id="end-experiment-trigger"
+                          class="btn btn-danger m-1 end_experiment_btn"
+                          data-bs-toggle="modal"
+                          data-bs-target="#end-experiment-modal-{{ experiment.slug }}">
+                    <i class="fa-solid fa-circle-stop me-1"></i>
                     End
                     {% if experiment.is_rollout %}
                       rollout
@@ -160,6 +165,10 @@
                     early
                   </button>
                 {% endif %}
+              {% endif %}
+              {% if experiment.should_show_end_experiment %}
+                {% include "nimbus_experiments/end_experiment_modal.html" with experiment=experiment post_query="?fragment=progress_card" target="#"|add:experiment.slug|add:"-progress-card" %}
+
               {% endif %}
             </form>
           </div>

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -36,6 +36,7 @@ class SummaryPage(ExperimenterBase):
         By.CSS_SELECTOR,
         ".header-experiment-status .border-primary",
     )
+    _end_experiment_trigger_locator = (By.CSS_SELECTOR, "#end-experiment-trigger")
     _end_experiment_button_locator = (By.CSS_SELECTOR, "#end-experiment")
     _archive_button_locator = (By.CSS_SELECTOR, 'button[data-testid="nav-edit-archive"]')
     _archive_label_locator = (By.CSS_SELECTOR, "#archive-badge")
@@ -205,6 +206,7 @@ class SummaryPage(ExperimenterBase):
         self.approve()
 
     def end_and_approve(self):
+        self.click_element(self._end_experiment_trigger_locator)
         self.click_element(self._end_experiment_button_locator)
         self.approve()
 


### PR DESCRIPTION
Because

* "End Enrollment" and "End Experiment" rendered near-identically and sat adjacent, so users have accidentally ended experiments when they meant to end enrollment
* the same risk applies to rollouts, where "End Rollout" sits next to "Request Update"

This commit

* restyles the destructive End Experiment / End Rollout button as `btn-danger` with a stop icon, and keeps End Enrollment as `btn-primary` with a distinct icon
* gates the End Experiment / End Rollout action behind a confirmation modal on both the Summary page and the Results progress card, for experiments and rollouts
* clears orphaned modal backdrops after HTMX swaps so a dismissed modal can't block the page
* updates the integration page object to drive the new trigger + confirm flow

Fixes #16066