### PR TITLE
fix(nimbus): Fix Rollouts Subscribe Bell Button

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -668,3 +668,33 @@ class CollaboratorsForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def get_changelog_message(self):
         return f"{self.request.user} updated collaborators"
+
+
+class SubscribeForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = []
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.subscribers.add(self.request.user)
+        return experiment
+
+    def get_changelog_message(self):
+        return f"{self.request.user} added subscriber"
+
+
+class UnsubscribeForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = []
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.subscribers.remove(self.request.user)
+        return experiment
+
+    def get_changelog_message(self):
+        return f"{self.request.user} removed subscriber"

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -19,7 +19,9 @@ from experimenter.nimbus_ui.new.forms import (
     RolloutOverviewForm,
     RolloutQAStatusForm,
     RolloutRisksForm,
+    SubscribeForm,
     TagAssignForm,
+    UnsubscribeForm,
 )
 
 
@@ -267,3 +269,17 @@ class NewAddSubscriberView(NewSubscriberView):
 
 class NewRemoveSubscriberView(NewSubscriberView):
     add = False
+
+
+class NewSubscribeView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
+    model = NimbusExperiment
+    form_class = SubscribeForm
+    template_name = "new/common/subscribe_bell.html"
+
+    def form_valid(self, form):
+        self.object = form.save()
+        return self.render_to_response(self.get_context_data())
+
+
+class NewUnsubscribeView(NewSubscribeView):
+    form_class = UnsubscribeForm

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -52,9 +52,8 @@
           <div>
             <div class="d-flex align-items-center gap-2">
               <h1 id="experiment-header-name" class="mb-0 fw-semibold fs-4 text-body">{{ experiment.name }}</h1>
-              <button class="btn p-0 border-0 text-secondary" aria-label="Notifications">
-                <i class="fa-solid fa-bell"></i>
-              </button>
+              {% include "new/common/subscribe_bell.html" %}
+
               <div class="dropdown">
                 <button class="btn p-0 border-0 text-secondary"
                         data-bs-toggle="dropdown"

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
@@ -1,0 +1,25 @@
+{% if request.user in experiment.subscribers.all %}
+  <form id="subscribe-bell"
+        hx-post="{% url 'nimbus-ui-new-unsubscribe' experiment.slug %}"
+        hx-swap="outerHTML"
+        class="d-inline">
+    {% csrf_token %}
+    <button type="submit"
+            class="btn p-0 border-0 text-secondary"
+            aria-label="Unsubscribe from this experiment">
+      <i class="fa-solid fa-bell"></i>
+    </button>
+  </form>
+{% else %}
+  <form id="subscribe-bell"
+        hx-post="{% url 'nimbus-ui-new-subscribe' experiment.slug %}"
+        hx-swap="outerHTML"
+        class="d-inline">
+    {% csrf_token %}
+    <button type="submit"
+            class="btn p-0 border-0 text-secondary"
+            aria-label="Subscribe to this experiment">
+      <i class="fa-regular fa-bell"></i>
+    </button>
+  </form>
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -571,3 +571,40 @@ class TestNewRemoveSubscriberView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
         self.assertNotIn(user, experiment.subscribers.all())
+
+
+class TestNewSubscribeView(AuthTestCase):
+    def test_post_subscribes_current_user(self):
+        experiment = NimbusExperimentFactory.create()
+
+        response = self.client.post(
+            reverse("nimbus-ui-new-subscribe", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/common/subscribe_bell.html")
+        experiment.refresh_from_db()
+        self.assertIn(self.user, experiment.subscribers.all())
+        self.assertContains(
+            response,
+            reverse("nimbus-ui-new-unsubscribe", kwargs={"slug": experiment.slug}),
+        )
+
+
+class TestNewUnsubscribeView(AuthTestCase):
+    def test_post_unsubscribes_current_user(self):
+        experiment = NimbusExperimentFactory.create()
+        experiment.subscribers.add(self.user)
+
+        response = self.client.post(
+            reverse("nimbus-ui-new-unsubscribe", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/common/subscribe_bell.html")
+        experiment.refresh_from_db()
+        self.assertNotIn(self.user, experiment.subscribers.all())
+        self.assertContains(
+            response,
+            reverse("nimbus-ui-new-subscribe", kwargs={"slug": experiment.slug}),
+        )

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -13,7 +13,9 @@ from experimenter.nimbus_ui.new.views import (
     NewRemoveTagView,
     NewRisksUpdateView,
     NewSubscriberSearchView,
+    NewSubscribeView,
     NewTagSearchView,
+    NewUnsubscribeView,
     NimbusRolloutDetailView,
 )
 from experimenter.nimbus_ui.views import (
@@ -390,5 +392,15 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/remove_subscriber/$",
         NewRemoveSubscriberView.as_view(),
         name="nimbus-ui-new-remove-subscriber",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/subscribe/$",
+        NewSubscribeView.as_view(),
+        name="nimbus-ui-new-subscribe",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/unsubscribe/$",
+        NewUnsubscribeView.as_view(),
+        name="nimbus-ui-new-unsubscribe",
     ),
 ]


### PR DESCRIPTION
Because

* The bell button in the new rollouts page currently does not do anything

This commit

* Adds functionality to toggle the current user on the experiment's subscribers

Fixes #15921