### PR TITLE
feat(nimbus): Add widgets-any-four-engaged targeting for newtab 153.5 trainhop

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4829,6 +4829,23 @@ FX_153_3_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_153_5_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
+    name=(
+        "New Tab Fx153 Jun-15 Trainhop, engaged with any of 4 widgets, "
+        "that widget not disabled"
+    ),
+    slug="widgets-any-four-engaged-153-0615-trainhop",
+    description=(
+        "Users having the New Tab 153.5.20260615.213953 train hop who engaged with the "
+        "Sports, Clocks, Lists, or Timer widget and still have that widget enabled"
+    ),
+    targeting=f"{FX_153_5_TRAINHOP.targeting} && ({WIDGETS_ANY_FOUR_ENGAGED.targeting})",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FX_153_3_TRAINHOP_ANY_WIDGET_ENABLED = NimbusTargetingConfig(
     name="New Tab Fx153 Jun-05 Trainhop, any of 4 widgets enabled",
     slug="any-widget-enabled-153-0605-trainhop",


### PR DESCRIPTION
Adds `FX_153_5_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED`, targeting New Tab users on the `153.5.20260615.213953` train hop who engaged with the Sports, Clocks, Lists, or Timer widget and still have that widget enabled.

Mirrors the existing `widgets-any-four-engaged-153-0605-trainhop` (153.3) target, reusing `FX_153_5_TRAINHOP` and `WIDGETS_ANY_FOUR_ENGAGED` via f-string composition.

Fixes mozilla#16134