### PR TITLE
feat(nimbus): Add holdback checkbox to Experimenter

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -249,6 +249,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "project_impact": """Set an impact rating so others can understand the scale of
         this experiment's effect.""",
     }
+    HOLDBACK_LABEL = "Is this a holdback experiment?"
+    HOLDBACK_HELP_TEXT = (
+        "Holdback experiments continuously enroll users and run for an extended period. "
+        "Analysis will automatically run each week based on a 21-day observation period, "
+        "and an enrollment period encompassing the rest of the time between launch and "
+        "21 days from the run date."
+    )
+
     COENROLLMENT_NOTE = (
         "Note: This feature supports co-enrollment with other experiments/rollouts "
         "for the selected versions."

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -719,6 +719,9 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     requires_restart = forms.BooleanField(
         required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
     )
+    is_holdback = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
 
     update_on_change_fields = (
         "equal_branch_ratio",
@@ -744,6 +747,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "firefox_labs_description_links",
             "firefox_labs_group",
             "requires_restart",
+            "is_holdback",
         )
         widgets = {
             "is_rollout": forms.CheckboxInput(attrs={"class": "form-check-input"}),

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -55,6 +55,17 @@
           <div class="row mb-3">
             <div class="col">
               <div class="form-check">
+                {{ form.is_holdback }}
+                <label class="form-check-label" for="id_is_holdback">{{ NimbusUIConstants.HOLDBACK_LABEL }}</label>
+              </div>
+              <p class="form-text">{{ NimbusUIConstants.HOLDBACK_HELP_TEXT }}</p>
+              {% for error in form.is_holdback.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
+              {% for error in validation_errors.is_holdback %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col">
+              <div class="form-check">
                 {{ form.warn_feature_schema }}
                 <label class="form-check-label" for="id_warn_feature_schema">Warn only on feature schema validation failure</label>
               </div>


### PR DESCRIPTION
Because

- Users need a way to mark an experiment as a holdback so the weekly task can identify and process it

This commit

- Adds an is_holdback checkbox to the Audience page in the Experimenter UI

Fixes #16085 