### PR TITLE
fix(nimbus): fix rollout features form incorrectly submitting

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -289,14 +289,13 @@ class NimbusBranchFeatureValueForm(forms.ModelForm):
                     self.instance.feature_config.slug
                 )
 
+        feature_config = (
+            self.instance.feature_config if self.instance.feature_config_id else None
+        )
+
         if (
-            self.instance.id is not None
-            and self.instance.feature_config
-            and (
-                schema := self.instance.feature_config.schemas.filter(
-                    version=None
-                ).first()
-            )
+            feature_config
+            and (schema := feature_config.schemas.filter(version=None).first())
             and schema is not None
             and schema.schema is not None
         ):
@@ -314,10 +313,34 @@ class NimbusBranchFeatureValueForm(forms.ModelForm):
         return value
 
 
+class RolloutBranchFeatureValueForm(NimbusBranchFeatureValueForm):
+    class Meta:
+        model = NimbusBranchFeatureValue
+        fields = ("feature_config", "value")
+        widgets = {"feature_config": forms.HiddenInput()}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        if (
+            self.is_bound
+            and not self.instance.feature_config_id
+            and (feature_config_id := self.data.get(f"{self.prefix}-feature_config"))
+        ):
+            self.instance.feature_config = NimbusFeatureConfig.objects.filter(
+                id=feature_config_id
+            ).first()
+
+    def clean_feature_config(self):
+        return self.cleaned_data.get("feature_config") or (
+            self.instance.feature_config if self.instance.feature_config_id else None
+        )
+
+
 RolloutBranchFeatureValueFormSet = inlineformset_factory(
     NimbusBranch,
     NimbusBranchFeatureValue,
-    form=NimbusBranchFeatureValueForm,
+    form=RolloutBranchFeatureValueForm,
     extra=0,
 )
 
@@ -796,7 +819,7 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             )
 
         self.branch_feature_values = RolloutBranchFeatureValueFormSet(
-            data=self.data or None,
+            data=self.get_branch_feature_values_data(),
             instance=self.reference_branch,
             prefix="branch-feature-value",
         )
@@ -836,6 +859,47 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 "hx-target": "#rollout-rollout-features-body",
             }
         )
+
+    def get_branch_feature_values_data(self):
+        # Add temporary formset rows so newly selected, unsaved features get JSON
+        # editors during the HTMX preview before Save persists them.
+        if not self.is_bound:
+            return None
+
+        data = self.data.copy()
+        prefix = "branch-feature-value"
+        total_forms_key = f"{prefix}-TOTAL_FORMS"
+        total_forms = int(data[total_forms_key])
+
+        for feature_config_id in self._get_new_feature_config_ids(
+            data, prefix, total_forms
+        ):
+            data[f"{prefix}-{total_forms}-feature_config"] = feature_config_id
+            data[f"{prefix}-{total_forms}-value"] = "{}"
+            total_forms += 1
+
+        data[total_forms_key] = str(total_forms)
+        return data
+
+    def _get_new_feature_config_ids(self, data, prefix, total_forms):
+        selected_values = self.fields["feature_configs"].widget.value_from_datadict(
+            data, self.files, "feature_configs"
+        )
+        selected = [
+            int(feature_config_id)
+            for feature_config_id in selected_values or []
+            if feature_config_id
+        ]
+        submitted = {
+            int(data[f"{prefix}-{index}-feature_config"])
+            for index in range(total_forms)
+            if data.get(f"{prefix}-{index}-feature_config")
+        }
+        return [
+            feature_config_id
+            for feature_config_id in selected
+            if feature_config_id not in submitted
+        ]
 
     @property
     def errors(self):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -339,30 +339,32 @@ class NewRolloutFeaturesUpdateView(CardMixin, NewCardUpdateView):
     form_class = RolloutFeaturesForm
     display_template = "new/rollouts/rollout_features/card.html"
     template_name = "new/rollouts/rollout_features/edit_form.html"
+    save_without_explicit_submit = False
 
-    def render_valid_response(self):
-        self.object.refresh_from_db()
-
+    def form_valid(self, form):
         # If the request came from the explicit Save button, return the read-only card
         # view so the UI swaps back to the card. When the form is posted for intermediate
         # updates (e.g. feature_configs changed via hx-post on change), return the
         # editable form so the user can continue editing.
-        if "save" in self.request.POST:
-            return super().render_valid_response()
 
-        return self.render_to_response(self.get_context_data())
+        if "save" in self.request.POST or self.save_without_explicit_submit:
+            return super().form_valid(form)
+
+        return self.render_to_response(self.get_context_data(form=form))
 
 
 class NewRolloutScreenshotCreateView(
     RenderParentDBResponseMixin, NewRolloutFeaturesUpdateView
 ):
     form_class = RolloutScreenshotCreateForm
+    save_without_explicit_submit = True
 
 
 class NewRolloutScreenshotDeleteView(
     RenderParentDBResponseMixin, NewRolloutFeaturesUpdateView
 ):
     form_class = RolloutScreenshotDeleteForm
+    save_without_explicit_submit = True
 
 
 class NewQAUpdateView(CardMixin, NewCardUpdateView):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -36,6 +36,7 @@
         {{ branch_feature_values.management_form }}
         {% for branch_feature_values_form in branch_feature_values %}
           {{ branch_feature_values_form.id }}
+          {{ branch_feature_values_form.feature_config }}
           <div class="row mt-2">
             <div class="col">
               <label class="small mb-2 text-secondary">

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -729,6 +729,109 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
             )
         )
 
+    def test_selected_feature_without_value_gets_temporary_form(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-preview",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+        )
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [feature_config.id],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+            },
+            request=self.request,
+        )
+
+        self.assertEqual(len(form.branch_feature_values.forms), 1)
+        feature_value_form = form.branch_feature_values.forms[0]
+        self.assertEqual(feature_value_form.instance.feature_config, feature_config)
+        self.assertEqual(feature_value_form["value"].value(), "{}")
+        self.assertEqual(experiment.feature_configs.count(), 0)
+
+    def test_temporary_feature_value_form_saves_typed_value(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-preview-save",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+        )
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [feature_config.id],
+                "branch-feature-value-TOTAL_FORMS": "1",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "branch-feature-value-0-feature_config": feature_config.id,
+                "branch-feature-value-0-value": '{"enabled": true}',
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+        self.assertEqual(feature_value.value, '{"enabled": true}')
+
+    def test_selected_feature_without_submitted_value_saves_default_value(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-default-value",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+        )
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [feature_config.id],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.branch_feature_values.save = lambda: None
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+        self.assertEqual(feature_value.value, "{}")
+
     def test_form_reports_branch_feature_value_errors(self):
         feature_config = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP,
@@ -750,6 +853,7 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
                 "branch-feature-value-INITIAL_FORMS": "1",
                 "branch-feature-value-MIN_NUM_FORMS": "0",
                 "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "branch-feature-value-0-feature_config": feature_config.id,
                 "branch-feature-value-0-value": "{}",
                 "rollout-screenshots-TOTAL_FORMS": "0",
                 "rollout-screenshots-INITIAL_FORMS": "0",
@@ -846,6 +950,7 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
                 "branch-feature-value-MIN_NUM_FORMS": "0",
                 "branch-feature-value-MAX_NUM_FORMS": "1000",
                 "branch-feature-value-0-id": reference_feature_value.id,
+                "branch-feature-value-0-feature_config": feature_config.id,
                 "branch-feature-value-0-value": reference_feature_value.value,
                 "rollout-screenshots-TOTAL_FORMS": "0",
                 "rollout-screenshots-INITIAL_FORMS": "0",

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -27,6 +27,7 @@ from experimenter.experiments.tests.factories import (
     NimbusBranchScreenshotFactory,
     NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
+    NimbusFeatureConfigFactory,
     NimbusRolloutPhaseFactory,
     TagFactory,
 )
@@ -800,16 +801,22 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
         self.assertTrue(response.context["hx_swap_oob"])
 
     def test_post_change_returns_edit_form(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature",
+        )
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
             feature_configs=[],
+            takeaways_summary="Original rollout experience",
         )
 
         response = self.client.post(
             reverse(self.url_name, kwargs={"slug": experiment.slug}),
             {
                 "rollout_experience": "Updated rollout experience",
-                "feature_configs": [],
+                "feature_configs": [feature_config.id],
                 "branch-feature-value-TOTAL_FORMS": "0",
                 "branch-feature-value-INITIAL_FORMS": "0",
                 "rollout-screenshots-TOTAL_FORMS": "0",
@@ -819,8 +826,11 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
+        self.assertContains(response, "rollout-feature")
+        self.assertContains(response, "value-editor")
         experiment.refresh_from_db()
-        self.assertEqual(experiment.takeaways_summary, "Updated rollout experience")
+        self.assertEqual(experiment.takeaways_summary, "Original rollout experience")
+        self.assertEqual(experiment.feature_configs.count(), 0)
 
 
 class TestNewRolloutScreenshotCreateView(AuthTestCase):


### PR DESCRIPTION
Because

- Rollout feature changes should be editable before Save without being persisted by intermediate HTMX updates

This commit

- Prevents intermediate rollout feature form updates from saving
- Renders temporary feature value editors for newly selected rollout features

Fixes #16119