### PR TITLE
docs(nimbus): Add rollout mermaid diagrams

### DIFF
--- a/docs/experimenter/rollouts.md
+++ b/docs/experimenter/rollouts.md
@@ -13,7 +13,7 @@ A new rollout which has yet to be sent for review or put into preview is marked 
     
     rect rgb(255,204,255) 
         Rollout Owner->>Experimenter UI: Create rollout
-        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
     end
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -36,7 +36,7 @@ A draft rollout that has been validly completed is marked for Preview, is publis
     
     rect rgb(255,204,255) 
         Rollout Owner->>Experimenter UI: Send to Preview
-        Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None
+        Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None
     end 
  
     Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds all Preview  <br/> rollouts. Any Preview  <br/> items not in Remote Settings are <br/> created. Any non-Preview items <br/> in RS are deleted.
@@ -107,7 +107,7 @@ A draft rollout that has been validly completed is reviewed and approved in Expe
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase 1 <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase 1 <br/> Phase Next: None <br/> + changelog
     end
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -141,7 +141,7 @@ A draft rollout that has been validly completed is rejected by a reviewer in Exp
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer rejects in Experimenter
         Reviewer->>Experimenter UI: Reject
-        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
     end 
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -202,7 +202,7 @@ A draft rollout that has been validly completed is reviewed and approved in Expe
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
-        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
     end 
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -263,7 +263,7 @@ A draft rollout that has been validly completed is reviewed and approved in Expe
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
     end 
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -315,7 +315,7 @@ A draft rollout that has been validly completed is reviewed and approved in Expe
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
-        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
     end
 %%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
 ```
@@ -347,7 +347,7 @@ When a draft rollout has requested review in Experimenter, the review can also b
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
         end
 ```
 
@@ -368,7 +368,7 @@ This can also be canceled when a rollout is in the Preview state and requests to
     
         rect rgb(255,204,255) 
             Rollout Owner->>Experimenter UI: Send to Preview
-            Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None
+            Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None
         end 
         
         Note over Rollout Owner: An owner is ready to launch <br/> their rollout <br/> from preview and clicks the <br/> Launch button
@@ -384,7 +384,7 @@ This can also be canceled when a rollout is in the Preview state and requests to
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: None <br/> Phase: None <br/> Phase Next: None <br/> + changelog
         end
 ```
 
@@ -445,7 +445,7 @@ A live rollout can have its next phase pushed to its state while remaining Live.
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X + 1 <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X + 1 <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -479,7 +479,7 @@ A live rollout phase change is reviewed and rejected in Experimenter. A rejectio
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer rejects in Experimenter
         Reviewer->>Experimenter UI: Reject
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -539,7 +539,7 @@ A live rollout phase change is reviewed and approved in Experimenter, and is the
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -599,7 +599,7 @@ A live rollout phase change is reviewed and approved in Experimenter, and is the
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -650,7 +650,7 @@ A live rollout phase change is reviewed and approved in Experimenter, is publish
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
@@ -682,7 +682,7 @@ A live rollout phase change can be requested while the rollout remains Live. The
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
 ```
 
@@ -743,7 +743,7 @@ A live rollout that is published in Remote Settings is requested to be disabled 
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
-        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -776,7 +776,7 @@ A live rollout that is published in Remote Settings is requested to be disabled 
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer rejects in Experimenter
         Reviewer->>Experimenter UI: Reject
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -836,7 +836,7 @@ A live rollout that is published in Remote Settings is requested to be disabled 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -896,7 +896,7 @@ A live rollout that is published in Remote Settings is requested to be disabled 
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
@@ -947,7 +947,7 @@ A live rollout that is published in Remote Settings is requested to be disabled 
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
@@ -979,13 +979,13 @@ A live rollout that is published in Remote Settings is requested to be disabled 
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
 ```
 
 ## Enable (Approve/Approve)
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, reviewed and approved in Remote Settings, is published to the collection, and is then accessible to clients.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner. Enabling always moves the rollout to its next phase. The request is reviewed and approved in Experimenter, reviewed and approved in Remote Settings, the rollout is published to the collection, moves to Phase X + 1, and is then accessible to clients.
 
 ```mermaid
   sequenceDiagram
@@ -1003,7 +1003,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,204,255)
         Note right of Rollout Owner: Owner enables in Experimenter
         Rollout Owner->>Experimenter UI: Enable
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1012,7 +1012,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
@@ -1021,7 +1021,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
         Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1040,13 +1040,13 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(204,255,255)
         Note over Experimenter Worker: Worker updates rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
-        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X + 1 <br/> Phase Next: None <br/> + changelog
     end
 ```
 
 ## Enable (Reject/------)
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, and is then reviewed and rejected in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter. No change is made to Remote Settings and the rollout remains unpublished.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, which would move it to its next phase, and is then reviewed and rejected in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter. No change is made to Remote Settings and the rollout remains unpublished in its current phase.
 
 ```mermaid
   sequenceDiagram
@@ -1064,7 +1064,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,204,255)
         Note right of Rollout Owner: Owner enables in Experimenter
         Rollout Owner->>Experimenter UI: Enable
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1073,13 +1073,13 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer rejects in Experimenter
         Reviewer->>Experimenter UI: Reject
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
 ## Enable (Approve/Reject)
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. No change is made to Remote Settings and the rollout remains unpublished. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, which would move it to its next phase, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. No change is made to Remote Settings and the rollout remains unpublished in its current phase. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter.
 
 ```mermaid
   sequenceDiagram
@@ -1097,7 +1097,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,204,255)
         Note right of Rollout Owner: Owner enables in Experimenter
         Rollout Owner->>Experimenter UI: Enable
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1106,7 +1106,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
@@ -1115,7 +1115,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
         Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1133,13 +1133,13 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
-        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
 ## Enable (Approve/Reject) + manual rollback
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason. No change is made to Remote Settings and the rollout remains unpublished.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, which would move it to its next phase, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason. No change is made to Remote Settings and the rollout remains unpublished in its current phase.
 
 ```mermaid
   sequenceDiagram
@@ -1157,7 +1157,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,204,255)
         Note right of Rollout Owner: Owner enables in Experimenter
         Rollout Owner->>Experimenter UI: Enable
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1166,7 +1166,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
@@ -1175,7 +1175,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
         Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1193,13 +1193,13 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(204,255,255)
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
 ## Enable (Approve/Timeout)
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and the publish change is pushed to Remote Settings. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout remains unpublished in Remote Settings, returns to Idle, and the owner must request review again.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, which would move it to its next phase, reviewed and approved in Experimenter, and the publish change is pushed to Remote Settings. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout remains unpublished in Remote Settings and in its current phase, returns to Idle, and the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -1217,7 +1217,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,204,255)
         Note right of Rollout Owner: Owner enables in Experimenter
         Rollout Owner->>Experimenter UI: Enable
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1226,7 +1226,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
@@ -1235,7 +1235,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
         Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
@@ -1244,13 +1244,13 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
-        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
 ## Enable (Cancel ------/------)
 
-A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner. The enable request can be canceled before it is approved in Experimenter. No change is made to Remote Settings and the rollout remains unpublished.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, which would move it to its next phase. The enable request can be canceled before it is approved in Experimenter. No change is made to Remote Settings and the rollout remains unpublished in its current phase.
 
 ```mermaid
     sequenceDiagram
@@ -1268,7 +1268,7 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner enables in Experimenter
             Rollout Owner->>Experimenter UI: Enable
-            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
         end
 
         Experimenter Backend-->>Reviewer: To review
@@ -1276,6 +1276,97 @@ A disabled rollout that is not published in Remote Settings is requested to be e
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
+```
+
+## Enable with no next phase (Create New Phase)
+
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, but no next phase is defined. Experimenter displays a warning that a new phase will be created with the same current size X%. If the owner confirms, a new Phase X + 1 is created with the same population size and the enable request proceeds to review.
+
+```mermaid
+    sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Enable with no next phase (Create New Phase)
+
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI-->>Rollout Owner: Warning: No next phase defined, <br/> a new phase will be created <br/> with the same current size X%.
+        Rollout Owner->>Experimenter UI: Yes, create new phase
+        Experimenter UI->>Experimenter Backend: Create Phase X + 1 <br/> Population size: X%
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
+
+    rect rgb(204,255,255)
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and approves <br/> the change in the collection.
+
+    rect rgb(255,255,204)
+        Note right of Reviewer: Reviewer approves in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Approve
+        Remote Settings UI->>Remote Settings Backend: Approve
+        Remote Settings Backend->>Remote Settings UI: RS status: to-sign
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the rollout <br/> approved in the RS collection
+
+    rect rgb(204,255,255)
+        Note over Experimenter Worker: Worker updates rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X + 1 <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Enable with no next phase (Cancel)
+
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, but no next phase is defined. Experimenter displays a warning that a new phase will be created with the same current size X%. If the owner cancels, no new phase is created, no review is requested, and the rollout remains Disabled and unpublished in its current phase.
+
+```mermaid
+    sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Enable with no next phase (Cancel)
+
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI-->>Rollout Owner: Warning: No next phase defined, <br/> a new phase will be created <br/> with the same current size X%.
+        Rollout Owner->>Experimenter UI: Cancel
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: None <br/> Phase: Phase X <br/> Phase Next: None
+    end
 ```

--- a/docs/experimenter/rollouts.md
+++ b/docs/experimenter/rollouts.md
@@ -1,0 +1,1281 @@
+## Create
+
+A new rollout is created in Experimenter. Since it has not been sent to Preview or sent for review yet, it remains in Draft with no active phase.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    title Draft (Create)
+    Note over Rollout Owner: An owner is ready to create <br/>  a new rollout <br/> and clicks the create button
+    
+    rect rgb(255,204,255) 
+        Rollout Owner->>Experimenter UI: Create rollout
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+    end
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Preview
+
+A draft rollout is sent to Preview. The rollout is published to the Preview collection in Remote Settings, but it is not Live yet and does not have an active phase.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Preview
+    Note over Rollout Owner: An owner is ready to publish <br/> their draft rollout <br/> to Preview
+    
+    rect rgb(255,204,255) 
+        Rollout Owner->>Experimenter UI: Send to Preview
+        Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds all Preview  <br/> rollouts. Any Preview  <br/> items not in Remote Settings are <br/> created. Any non-Preview items <br/> in RS are deleted.
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Send to Preview
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Create Record <br/> RS status: to-review
+        Experimenter Worker->>Remote Settings Backend: Delete Record <br/> RS status: to-review
+    end 
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (approve/approve)
+
+A draft rollout is sent for review, approved in Experimenter, published to Remote Settings, and then approved in Remote Settings. After both approvals are complete, the rollout becomes Live and starts in Phase 1.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Publish (Approve/Approve)
+    Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Review button
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner launches in Experimenter
+        Rollout Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> approve button
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> to publish, and creates the new published <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Draft <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Create Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Draft <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and approves <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer approves in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Approve
+        Remote Settings UI->>Remote Settings Backend: Approve
+        Remote Settings Backend->>Remote Settings UI: RS status: to-sign
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> rollout approved <br/> in the RS collection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase 1 <br/> Phase Next: None <br/> + changelog
+    end
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (reject/----)
+
+A draft rollout is sent for review but rejected in Experimenter. The rollout stays in Draft and returns to Idle so the owner can make changes and request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Publish (Reject/------)
+    Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Launch button
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner launches in Experimenter
+        Rollout Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> reject button.
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer rejects in Experimenter
+        Reviewer->>Experimenter UI: Reject
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+    end 
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (approve/reject)
+
+A draft rollout is approved in Experimenter and sent to Remote Settings, but the Remote Settings reviewer rejects it. The rollout is rolled back and returns to Draft and Idle so the owner can request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Publish (Approve/Reject)
+    Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Launch button
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner launches in Experimenter
+        Rollout Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> approve button.
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> to publish, and creates the new published <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Draft <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Create Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Draft <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> rollout in <br/> work-in-progress, collects the <br/> rejection message, and rolls back
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+    end 
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (approve/reject) + manual rollback
+
+A draft rollout is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout returns to Draft and Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Publish (Approve/Reject + Manual Rollback)
+    Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Launch button
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner launches in Experimenter
+        Rollout Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> approve button.
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> to publish, and creates the new published <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Draft <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Create Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Draft <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+        Remote Settings UI->>Remote Settings Backend: RS status: to-rollback
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> collection in to-sign with no <br/> record of the rejection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+    end 
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (approve/timed out)
+
+A draft rollout is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout returns to Draft and Idle, so the owner must request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Publish (Approve/Timeout)
+    Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Launch button
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner launches in Experimenter
+        Rollout Owner->>Experimenter UI: Send to Review
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> approve button.
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> to publish, and creates the new published <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Draft <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Create Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Draft <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+    end 
+
+    Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
+   
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
+        Experimenter Worker->>Experimenter Backend:  Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+    end
+%%{init:{'themeCSS':'g:nth-of-type(1) .note { stroke: purple ;fill: white; };'}}%%
+```
+
+## Launch (cancel)
+
+A rollout launch review is canceled in Experimenter before it is approved in Experimenter. The rollout returns to Idle and the owner can request review again later.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Rollout Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Cancel from Draft (Cancel ------/------)
+        Note over Rollout Owner: An owner is ready to launch <br/> their draft rollout <br/> from draft and clicks the <br/> Review button
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner launches in Experimenter
+            Rollout Owner->>Experimenter UI: Send to Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
+            Rollout Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        end
+```
+
+A rollout can also be launched from Preview. If that review is canceled before approval, the rollout returns to Draft and Idle.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Rollout Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Cancel from Preview (Cancel ------/------)
+        
+        Note over Rollout Owner: An owner is ready to publish <br/> their draft rollout <br/> to Preview
+    
+        rect rgb(255,204,255) 
+            Rollout Owner->>Experimenter UI: Send to Preview
+            Experimenter UI->>Experimenter Backend: Update to Preview <br/> Status: Preview <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None
+        end 
+        
+        Note over Rollout Owner: An owner is ready to launch <br/> their rollout <br/> from preview and clicks the <br/> Launch button
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner launches in Experimenter
+            Rollout Owner->>Experimenter UI: Send to Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Review <br/> Status next: Live <br/> Phase: None <br/> Phase Next: Phase 1 <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
+            Rollout Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Draft <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: None <br/> Phase Next: None <br/> + changelog
+        end
+```
+
+## Change Phase (Approve/Approve)
+
+A live rollout moves to the next phase while remaining Live. The phase change is approved in Experimenter, approved in Remote Settings, and then the active phase is updated.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Approve/Approve)
+    
+    Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner requests the next phase in Experimenter
+        Rollout Owner->>Experimenter UI: Start Next Phase
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> phase change to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and approves <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer approves in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Approve
+        Remote Settings UI->>Remote Settings Backend: Approve
+        Remote Settings Backend->>Remote Settings UI: RS status: to-sign
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the rollout <br/> approved in the RS collection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X + 1 <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Change Phase (Reject/------)
+
+A live rollout phase change is sent for review but rejected in Experimenter. The rollout remains Live in the current phase and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Reject/------)
+    
+    Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner requests the next phase in Experimenter
+        Rollout Owner->>Experimenter UI: Start Next Phase
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> reject button.
+    
+
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer rejects in Experimenter
+        Reviewer->>Experimenter UI: Reject
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Change Phase (Approve/Reject)
+
+A live rollout phase change is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Live in the current phase.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Approve/Reject)
+    
+    Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner requests the next phase in Experimenter
+        Rollout Owner->>Experimenter UI: Start Next Phase
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> phase change to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> rollout in <br/> work-in-progress, collects the <br/> rejection message, and rolls back
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Change Phase (Approve/Reject) + manual rollback
+
+A live rollout phase change is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Live in the current phase and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Approve/Reject + Manual Rollback)
+    
+    Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner requests the next phase in Experimenter
+        Rollout Owner->>Experimenter UI: Start Next Phase
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> phase change to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+        Remote Settings UI->>Remote Settings Backend: RS status: to-rollback
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> collection in to-sign with no <br/> record of the rejection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Change Phase (Approve/Timeout)
+
+A live rollout phase change is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Live in the current phase and returns to Idle, so the owner must request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Update (Approve/Timeout)
+    
+    Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner requests the next phase in Experimenter
+        Rollout Owner->>Experimenter UI: Start Next Phase
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> phase change to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+    end 
+
+    Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
+   
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Change Phase (Cancel ------/------)
+
+A live rollout phase change review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live in the current phase and returns to Idle.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Rollout Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Update (Cancel ------/------)
+        
+        Note over Rollout Owner: An owner is ready to start <br/> the next phase of their live rollout
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner requests the next phase in Experimenter
+            Rollout Owner->>Experimenter UI: Start Next Phase
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: Phase X + 1 <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
+            Rollout Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        end
+```
+
+## Pause (Approve/Approve)
+
+A live rollout is paused after being approved in Experimenter and approved in Remote Settings. The rollout moves from Live to Paused while staying in the same phase.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Pause (Approve/Approve)
+    
+    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner pauses in Experimenter
+        Rollout Owner->>Experimenter UI: Pause
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and approves <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer approves in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Approve
+        Remote Settings UI->>Remote Settings Backend: Approve
+        Remote Settings Backend->>Remote Settings UI: RS status: to-sign
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the rollout <br/> approved in the RS collection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Pause (Reject/------)
+
+A live rollout pause request is rejected in Experimenter. The rollout remains Live and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Pause (Reject/------)
+    
+    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner pauses in Experimenter
+        Rollout Owner->>Experimenter UI: Pause
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> reject button.
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer rejects in Experimenter
+        Reviewer->>Experimenter UI: Reject
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Pause (Approve/Reject)
+
+A live rollout pause request is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Live.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Pause (Approve/Reject)
+    
+    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner pauses in Experimenter
+        Rollout Owner->>Experimenter UI: Pause
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> rollout in <br/> work-in-progress, collects the <br/> rejection message, and rolls back
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Pause (Approve/Reject) + manual rollback
+
+A live rollout pause request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Live and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Pause (Approve/Reject + Manual Rollback)
+    
+    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner pauses in Experimenter
+        Rollout Owner->>Experimenter UI: Pause
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+    
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204) 
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+        Remote Settings UI->>Remote Settings Backend: RS status: to-rollback
+    end 
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> collection in to-sign with no <br/> record of the rejection
+
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+```
+
+## Pause (Approve/Timeout)
+
+A live rollout pause request is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Live and returns to Idle, so the owner must request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Pause (Approve/Timeout)
+    
+    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    
+    rect rgb(255,204,255) 
+        Note right of Rollout Owner: Owner pauses in Experimenter
+        Rollout Owner->>Experimenter UI: Pause
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+    
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+    
+    rect rgb(255,255,204) 
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+ 
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    
+    rect rgb(204,255,255) 
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end 
+
+    Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
+   
+    rect rgb(204,255,255) 
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Pause (Cancel ------/------)
+
+A live rollout pause review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live and returns to Idle.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Rollout Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Pause (Cancel ------/------)
+        
+        Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner pauses in Experimenter
+            Rollout Owner->>Experimenter UI: Pause
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+        
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
+            Rollout Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        end
+```
+
+## Resume (Approve/Approve)
+
+A paused rollout is resumed after being approved in Experimenter and approved in Remote Settings. The rollout moves from Paused back to Live while staying in the same phase.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Resume (Approve/Approve)
+
+    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner resumes in Experimenter
+        Rollout Owner->>Experimenter UI: Resume
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+
+    rect rgb(204,255,255)
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and approves <br/> the change in the collection.
+
+    rect rgb(255,255,204)
+        Note right of Reviewer: Reviewer approves in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Approve
+        Remote Settings UI->>Remote Settings Backend: Approve
+        Remote Settings Backend->>Remote Settings UI: RS status: to-sign
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the rollout <br/> approved in the RS collection
+
+    rect rgb(204,255,255)
+        Note over Experimenter Worker: Worker updates rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Experimenter Backend:  Status: Live <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Resume (Reject/------)
+
+A paused rollout resume request is rejected in Experimenter. The rollout remains Paused and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Resume (Reject/------)
+
+    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner resumes in Experimenter
+        Rollout Owner->>Experimenter UI: Resume
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the <br/> rollout's details on the <br/> summary page and clicks the <br/> reject button.
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer rejects in Experimenter
+        Reviewer->>Experimenter UI: Reject
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Resume (Approve/Reject)
+
+A paused rollout resume request is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Paused.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Resume (Approve/Reject)
+
+    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner resumes in Experimenter
+        Rollout Owner->>Experimenter UI: Resume
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+
+    rect rgb(204,255,255)
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204)
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> rollout in <br/> work-in-progress, collects the <br/> rejection message, and rolls back
+
+    rect rgb(204,255,255)
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
+        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Resume (Approve/Reject) + manual rollback
+
+A paused rollout resume request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Paused and returns to Idle.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Resume (Approve/Reject + Manual Rollback)
+
+    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner resumes in Experimenter
+        Rollout Owner->>Experimenter UI: Resume
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+
+    rect rgb(204,255,255)
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review in Remote Settings
+
+    Note over Reviewer: The reviewer opens Remote <br/> Settings and rejects <br/> the change in the collection.
+
+    rect rgb(255,255,204)
+        Note right of Reviewer: Reviewer rejects in <br/>Remote Settings
+        Reviewer->>Remote Settings UI: Reject
+        Remote Settings UI->>Remote Settings Backend: RS status: to-rollback
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked and finds the <br/> collection in to-sign with no <br/> record of the rejection
+
+    rect rgb(204,255,255)
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
+        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Resume (Approve/Timeout)
+
+A paused rollout resume request is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Paused and returns to Idle, so the owner must request review again.
+
+```mermaid
+  sequenceDiagram
+    participant Reviewer
+    participant Rollout Owner
+    participant Experimenter UI
+    participant Experimenter Backend
+    participant Experimenter Worker
+    participant Remote Settings UI
+    participant Remote Settings Backend
+    title Resume (Approve/Timeout)
+
+    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+    rect rgb(255,204,255)
+        Note right of Rollout Owner: Owner resumes in Experimenter
+        Rollout Owner->>Experimenter UI: Resume
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Experimenter Backend-->>Reviewer: To review
+    Note over Reviewer: The reviewer reviews the rollout's <br/> details on the summary page <br/> and clicks the approve button
+
+    rect rgb(255,255,204)
+        Note over Rollout Owner: Reviewer approves in Experimenter
+        Reviewer->>Experimenter UI: Approve
+        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+
+    rect rgb(204,255,255)
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+
+    Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
+
+    rect rgb(204,255,255)
+        Note over Experimenter Worker: Worker updates <br/> rollout
+        Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
+        Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
+        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+    end
+```
+
+## Resume (Cancel ------/------)
+
+A paused rollout resume review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Paused and returns to Idle.
+
+```mermaid
+    sequenceDiagram
+        participant Reviewer
+        participant Rollout Owner
+        participant Experimenter UI
+        participant Experimenter Backend
+        participant Experimenter Worker
+        participant Remote Settings UI
+        participant Remote Settings Backend
+        title Resume (Cancel ------/------)
+
+        Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner resumes in Experimenter
+            Rollout Owner->>Experimenter UI: Resume
+            Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        end
+
+        Experimenter Backend-->>Reviewer: To review
+
+        rect rgb(255,204,255)
+            Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
+            Rollout Owner->>Experimenter UI: Cancel the Review
+            Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        end
+```

--- a/docs/experimenter/rollouts.md
+++ b/docs/experimenter/rollouts.md
@@ -686,9 +686,9 @@ A live rollout phase change review is canceled in Experimenter before it is appr
         end
 ```
 
-## Pause (Approve/Approve)
+## Disable (Approve/Approve)
 
-A live rollout is paused after being approved in Experimenter and approved in Remote Settings. The rollout moves from Live to Paused while staying in the same phase.
+A live rollout is disabled after being approved in Experimenter and approved in Remote Settings. Disabling means the rollout is unpublished from Remote Settings. The rollout moves from Live to Disabled while staying in the same phase.
 
 ```mermaid
   sequenceDiagram
@@ -699,14 +699,14 @@ A live rollout is paused after being approved in Experimenter and approved in Re
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Pause (Approve/Approve)
+    title Disable (Approve/Approve)
     
-    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
     
     rect rgb(255,204,255) 
-        Note right of Rollout Owner: Owner pauses in Experimenter
-        Rollout Owner->>Experimenter UI: Pause
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner disables in Experimenter
+        Rollout Owner->>Experimenter UI: Disable
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
     
     Experimenter Backend-->>Reviewer: To review
@@ -715,16 +715,16 @@ A live rollout is paused after being approved in Experimenter and approved in Re
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
  
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> disable request and unpublishes the <br/> record with the serialized DTO
     
     rect rgb(204,255,255) 
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
-        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Disabled
+        Note over Experimenter Worker: Worker unpublishes from <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Unpublish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -743,13 +743,13 @@ A live rollout is paused after being approved in Experimenter and approved in Re
     rect rgb(204,255,255) 
         Note over Experimenter Worker: Worker updates rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
-        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 ```
 
-## Pause (Reject/------)
+## Disable (Reject/------)
 
-A live rollout pause request is rejected in Experimenter. The rollout remains Live and returns to Idle.
+A live rollout disable request is rejected in Experimenter. The rollout remains Live and published in Remote Settings, and returns to Idle.
 
 ```mermaid
   sequenceDiagram
@@ -760,14 +760,14 @@ A live rollout pause request is rejected in Experimenter. The rollout remains Li
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Pause (Reject/------)
+    title Disable (Reject/------)
     
-    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
     
     rect rgb(255,204,255) 
-        Note right of Rollout Owner: Owner pauses in Experimenter
-        Rollout Owner->>Experimenter UI: Pause
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner disables in Experimenter
+        Rollout Owner->>Experimenter UI: Disable
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
     
     Experimenter Backend-->>Reviewer: To review
@@ -780,9 +780,9 @@ A live rollout pause request is rejected in Experimenter. The rollout remains Li
     end 
 ```
 
-## Pause (Approve/Reject)
+## Disable (Approve/Reject)
 
-A live rollout pause request is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Live.
+A live rollout disable request is approved in Experimenter but rejected in Remote Settings. The unpublish change is rolled back and the rollout remains Live and published in Remote Settings.
 
 ```mermaid
   sequenceDiagram
@@ -793,14 +793,14 @@ A live rollout pause request is approved in Experimenter but rejected in Remote 
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Pause (Approve/Reject)
+    title Disable (Approve/Reject)
     
-    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
     
     rect rgb(255,204,255) 
-        Note right of Rollout Owner: Owner pauses in Experimenter
-        Rollout Owner->>Experimenter UI: Pause
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner disables in Experimenter
+        Rollout Owner->>Experimenter UI: Disable
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
     
     Experimenter Backend-->>Reviewer: To review
@@ -809,16 +809,16 @@ A live rollout pause request is approved in Experimenter but rejected in Remote 
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
  
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> disable request and unpublishes the <br/> record with the serialized DTO
     
     rect rgb(204,255,255) 
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
-        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Disabled
+        Note over Experimenter Worker: Worker unpublishes from <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Unpublish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -840,9 +840,9 @@ A live rollout pause request is approved in Experimenter but rejected in Remote 
     end 
 ```
 
-## Pause (Approve/Reject) + manual rollback
+## Disable (Approve/Reject) + manual rollback
 
-A live rollout pause request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Live and returns to Idle.
+A live rollout disable request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The unpublish change is rolled back, so the rollout remains Live and published in Remote Settings.
 
 ```mermaid
   sequenceDiagram
@@ -853,14 +853,14 @@ A live rollout pause request is approved in Experimenter and rejected in Remote 
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Pause (Approve/Reject + Manual Rollback)
+    title Disable (Approve/Reject + Manual Rollback)
     
-    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
     
     rect rgb(255,204,255) 
-        Note right of Rollout Owner: Owner pauses in Experimenter
-        Rollout Owner->>Experimenter UI: Pause
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner disables in Experimenter
+        Rollout Owner->>Experimenter UI: Disable
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
     
     Experimenter Backend-->>Reviewer: To review
@@ -869,16 +869,16 @@ A live rollout pause request is approved in Experimenter and rejected in Remote 
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
  
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> disable request and unpublishes the <br/> record with the serialized DTO
     
     rect rgb(204,255,255) 
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
-        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Disabled
+        Note over Experimenter Worker: Worker unpublishes from <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Unpublish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -900,9 +900,9 @@ A live rollout pause request is approved in Experimenter and rejected in Remote 
     end 
 ```
 
-## Pause (Approve/Timeout)
+## Disable (Approve/Timeout)
 
-A live rollout pause request is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Live and returns to Idle, so the owner must request review again.
+A live rollout disable request is approved in Experimenter and sent to Remote Settings as an unpublish change, but the Remote Settings review times out. The rollout stays Live and published in Remote Settings, and returns to Idle so the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -913,14 +913,14 @@ A live rollout pause request is approved in Experimenter and sent to Remote Sett
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Pause (Approve/Timeout)
+    title Disable (Approve/Timeout)
     
-    Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+    Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
     
     rect rgb(255,204,255) 
-        Note right of Rollout Owner: Owner pauses in Experimenter
-        Rollout Owner->>Experimenter UI: Pause
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner disables in Experimenter
+        Rollout Owner->>Experimenter UI: Disable
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
     
     Experimenter Backend-->>Reviewer: To review
@@ -929,16 +929,16 @@ A live rollout pause request is approved in Experimenter and sent to Remote Sett
     rect rgb(255,255,204) 
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Approved <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
  
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> pause to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> disable request and unpublishes the <br/> record with the serialized DTO
     
     rect rgb(204,255,255) 
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Paused
-        Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Live <br/> Publish status: Approved <br/> Status next: Disabled
+        Note over Experimenter Worker: Worker unpublishes from <br/>Remote Settings
+        Experimenter Worker->>Remote Settings Backend: Unpublish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Live <br/> Publish status: Waiting <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end 
 
     Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
@@ -951,9 +951,9 @@ A live rollout pause request is approved in Experimenter and sent to Remote Sett
     end
 ```
 
-## Pause (Cancel ------/------)
+## Disable (Cancel ------/------)
 
-A live rollout pause review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live and returns to Idle.
+A live rollout disable review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live and published in Remote Settings, and returns to Idle.
 
 ```mermaid
     sequenceDiagram
@@ -964,14 +964,14 @@ A live rollout pause review is canceled in Experimenter before it is approved in
         participant Experimenter Worker
         participant Remote Settings UI
         participant Remote Settings Backend
-        title Pause (Cancel ------/------)
+        title Disable (Cancel ------/------)
         
-        Note over Rollout Owner: An owner is ready to pause <br/> their live rollout
+        Note over Rollout Owner: An owner is ready to disable <br/> their live rollout
 
         rect rgb(255,204,255)
-            Note right of Rollout Owner: Owner pauses in Experimenter
-            Rollout Owner->>Experimenter UI: Pause
-            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Paused <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Note right of Rollout Owner: Owner disables in Experimenter
+            Rollout Owner->>Experimenter UI: Disable
+            Experimenter UI->>Experimenter Backend: Status: Live <br/> Publish status: Review <br/> Status next: Disabled <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
 
         Experimenter Backend-->>Reviewer: To review
@@ -983,9 +983,9 @@ A live rollout pause review is canceled in Experimenter before it is approved in
         end
 ```
 
-## Resume (Approve/Approve)
+## Enable (Approve/Approve)
 
-A paused rollout is resumed after being approved in Experimenter and approved in Remote Settings. The rollout moves from Paused back to Live while staying in the same phase.
+A disabled rollout is enabled after being approved in Experimenter and approved in Remote Settings. Enabling means the rollout is published in Remote Settings. The rollout moves from Disabled back to Live while staying in the same phase.
 
 ```mermaid
   sequenceDiagram
@@ -996,14 +996,14 @@ A paused rollout is resumed after being approved in Experimenter and approved in
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Resume (Approve/Approve)
+    title Enable (Approve/Approve)
 
-    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
     rect rgb(255,204,255)
-        Note right of Rollout Owner: Owner resumes in Experimenter
-        Rollout Owner->>Experimenter UI: Resume
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1012,16 +1012,16 @@ A paused rollout is resumed after being approved in Experimenter and approved in
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
 
     rect rgb(204,255,255)
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1044,9 +1044,9 @@ A paused rollout is resumed after being approved in Experimenter and approved in
     end
 ```
 
-## Resume (Reject/------)
+## Enable (Reject/------)
 
-A paused rollout resume request is rejected in Experimenter. The rollout remains Paused and returns to Idle.
+A disabled rollout enable request is rejected in Experimenter. The rollout remains Disabled and unpublished in Remote Settings, and returns to Idle.
 
 ```mermaid
   sequenceDiagram
@@ -1057,14 +1057,14 @@ A paused rollout resume request is rejected in Experimenter. The rollout remains
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Resume (Reject/------)
+    title Enable (Reject/------)
 
-    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
     rect rgb(255,204,255)
-        Note right of Rollout Owner: Owner resumes in Experimenter
-        Rollout Owner->>Experimenter UI: Resume
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1073,13 +1073,13 @@ A paused rollout resume request is rejected in Experimenter. The rollout remains
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer rejects in Experimenter
         Reviewer->>Experimenter UI: Reject
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
-## Resume (Approve/Reject)
+## Enable (Approve/Reject)
 
-A paused rollout resume request is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Paused.
+A disabled rollout enable request is approved in Experimenter but rejected in Remote Settings. The publish change is rolled back and the rollout remains Disabled and unpublished in Remote Settings.
 
 ```mermaid
   sequenceDiagram
@@ -1090,14 +1090,14 @@ A paused rollout resume request is approved in Experimenter but rejected in Remo
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Resume (Approve/Reject)
+    title Enable (Approve/Reject)
 
-    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
     rect rgb(255,204,255)
-        Note right of Rollout Owner: Owner resumes in Experimenter
-        Rollout Owner->>Experimenter UI: Resume
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1106,16 +1106,16 @@ A paused rollout resume request is approved in Experimenter but rejected in Remo
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
 
     rect rgb(204,255,255)
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1133,13 +1133,13 @@ A paused rollout resume request is approved in Experimenter but rejected in Remo
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: Rollback <br/> RS status: work-in-progress
-        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
-## Resume (Approve/Reject) + manual rollback
+## Enable (Approve/Reject) + manual rollback
 
-A paused rollout resume request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Paused and returns to Idle.
+A disabled rollout enable request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The publish change is rolled back, so the rollout remains Disabled and unpublished in Remote Settings.
 
 ```mermaid
   sequenceDiagram
@@ -1150,14 +1150,14 @@ A paused rollout resume request is approved in Experimenter and rejected in Remo
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Resume (Approve/Reject + Manual Rollback)
+    title Enable (Approve/Reject + Manual Rollback)
 
-    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
     rect rgb(255,204,255)
-        Note right of Rollout Owner: Owner resumes in Experimenter
-        Rollout Owner->>Experimenter UI: Resume
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1166,16 +1166,16 @@ A paused rollout resume request is approved in Experimenter and rejected in Remo
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
 
     rect rgb(204,255,255)
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review in Remote Settings
@@ -1193,13 +1193,13 @@ A paused rollout resume request is approved in Experimenter and rejected in Remo
     rect rgb(204,255,255)
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout) <br/> RS status: to-sign
-        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
-## Resume (Approve/Timeout)
+## Enable (Approve/Timeout)
 
-A paused rollout resume request is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Paused and returns to Idle, so the owner must request review again.
+A disabled rollout enable request is approved in Experimenter and sent to Remote Settings as a publish change, but the Remote Settings review times out. The rollout stays Disabled and unpublished in Remote Settings, and returns to Idle so the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -1210,14 +1210,14 @@ A paused rollout resume request is approved in Experimenter and sent to Remote S
     participant Experimenter Worker
     participant Remote Settings UI
     participant Remote Settings Backend
-    title Resume (Approve/Timeout)
+    title Enable (Approve/Timeout)
 
-    Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+    Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
     rect rgb(255,204,255)
-        Note right of Rollout Owner: Owner resumes in Experimenter
-        Rollout Owner->>Experimenter UI: Resume
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Note right of Rollout Owner: Owner enables in Experimenter
+        Rollout Owner->>Experimenter UI: Enable
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Experimenter Backend-->>Reviewer: To review
@@ -1226,16 +1226,16 @@ A paused rollout resume request is approved in Experimenter and sent to Remote S
     rect rgb(255,255,204)
         Note over Rollout Owner: Reviewer approves in Experimenter
         Reviewer->>Experimenter UI: Approve
-        Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Approved <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
-    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> resume to publish, and updates the <br/> record with the serialized DTO
+    Note over Experimenter Backend: The scheduled background task <br/> is invoked, finds an approved rollout <br/> enable request and publishes the <br/> record with the serialized DTO
 
     rect rgb(204,255,255)
-        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Paused <br/> Publish status: Approved <br/> Status next: Live
+        Experimenter Backend->>Experimenter Worker: Find rollouts: <br/> Status: Disabled <br/> Publish status: Approved <br/> Status next: Live
         Note over Experimenter Worker: Worker publishes to <br/>Remote Settings
-        Experimenter Worker->>Remote Settings Backend: Update Record <br/> RS status: to-review
-        Experimenter Worker->>Experimenter Backend: Status: Paused <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Remote Settings Backend: Publish Record <br/> RS status: to-review
+        Experimenter Worker->>Experimenter Backend: Status: Disabled <br/> Publish status: Waiting <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 
     Note over Experimenter Backend: The scheduled background task is <br/> invoked, finds a pending unattended review, <br/> rolls back, and reverts the rollout <br/> back to idle so the owner must request review again
@@ -1244,13 +1244,13 @@ A paused rollout resume request is approved in Experimenter and sent to Remote S
         Note over Experimenter Worker: Worker updates <br/> rollout
         Experimenter Worker->>Remote Settings Backend: Check collection (timeout)
         Experimenter Worker->>Remote Settings Backend: RS status: to-rollback
-        Experimenter Worker->>Experimenter Backend:  Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+        Experimenter Worker->>Experimenter Backend:  Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
     end
 ```
 
-## Resume (Cancel ------/------)
+## Enable (Cancel ------/------)
 
-A paused rollout resume review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Paused and returns to Idle.
+A disabled rollout enable review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Disabled and unpublished in Remote Settings, and returns to Idle.
 
 ```mermaid
     sequenceDiagram
@@ -1261,14 +1261,14 @@ A paused rollout resume review is canceled in Experimenter before it is approved
         participant Experimenter Worker
         participant Remote Settings UI
         participant Remote Settings Backend
-        title Resume (Cancel ------/------)
+        title Enable (Cancel ------/------)
 
-        Note over Rollout Owner: An owner is ready to resume <br/> their paused rollout
+        Note over Rollout Owner: An owner is ready to enable <br/> their disabled rollout
 
         rect rgb(255,204,255)
-            Note right of Rollout Owner: Owner resumes in Experimenter
-            Rollout Owner->>Experimenter UI: Resume
-            Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Note right of Rollout Owner: Owner enables in Experimenter
+            Rollout Owner->>Experimenter UI: Enable
+            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Review <br/> Status next: Live <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
 
         Experimenter Backend-->>Reviewer: To review
@@ -1276,6 +1276,6 @@ A paused rollout resume review is canceled in Experimenter before it is approved
         rect rgb(255,204,255)
             Note right of Rollout Owner: Owner cancels the review request <br/> in Experimenter
             Rollout Owner->>Experimenter UI: Cancel the Review
-            Experimenter UI->>Experimenter Backend: Status: Paused <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
+            Experimenter UI->>Experimenter Backend: Status: Disabled <br/> Publish status: Idle <br/> Status next: <none> <br/> Phase: Phase X <br/> Phase Next: None <br/> + changelog
         end
 ```

--- a/docs/experimenter/rollouts.md
+++ b/docs/experimenter/rollouts.md
@@ -1,6 +1,6 @@
 ## Create
 
-A new rollout is created in Experimenter. Since it has not been sent to Preview or sent for review yet, it remains in Draft with no active phase.
+A new rollout which has yet to be sent for review or put into preview is marked for Draft.
 
 ```mermaid
   sequenceDiagram
@@ -20,7 +20,7 @@ A new rollout is created in Experimenter. Since it has not been sent to Preview 
 
 ## Preview
 
-A draft rollout is sent to Preview. The rollout is published to the Preview collection in Remote Settings, but it is not Live yet and does not have an active phase.
+A draft rollout that has been validly completed is marked for Preview, is published to the preview collection in Remote Settings, and is then accessible to specially configured clients.
 
 ```mermaid
   sequenceDiagram
@@ -52,7 +52,7 @@ A draft rollout is sent to Preview. The rollout is published to the Preview coll
 
 ## Launch (approve/approve)
 
-A draft rollout is sent for review, approved in Experimenter, published to Remote Settings, and then approved in Remote Settings. After both approvals are complete, the rollout becomes Live and starts in Phase 1.
+A draft rollout that has been validly completed is reviewed and approved in Experimenter, is reviewed and approved in Remote Settings, and is then accessible to clients.
 
 ```mermaid
   sequenceDiagram
@@ -114,7 +114,7 @@ A draft rollout is sent for review, approved in Experimenter, published to Remot
 
 ## Launch (reject/----)
 
-A draft rollout is sent for review but rejected in Experimenter. The rollout stays in Draft and returns to Idle so the owner can make changes and request review again.
+A draft rollout that has been validly completed is rejected by a reviewer in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter.
 
 ```mermaid
   sequenceDiagram
@@ -148,7 +148,7 @@ A draft rollout is sent for review but rejected in Experimenter. The rollout sta
 
 ## Launch (approve/reject)
 
-A draft rollout is approved in Experimenter and sent to Remote Settings, but the Remote Settings reviewer rejects it. The rollout is rolled back and returns to Draft and Idle so the owner can request review again.
+A draft rollout that has been validly completed is reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter.
 
 ```mermaid
   sequenceDiagram
@@ -209,7 +209,7 @@ A draft rollout is approved in Experimenter and sent to Remote Settings, but the
 
 ## Launch (approve/reject) + manual rollback
 
-A draft rollout is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout returns to Draft and Idle.
+A draft rollout that has been validly completed is reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason.
 
 ```mermaid
   sequenceDiagram
@@ -270,7 +270,7 @@ A draft rollout is approved in Experimenter and rejected in Remote Settings, but
 
 ## Launch (approve/timed out)
 
-A draft rollout is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout returns to Draft and Idle, so the owner must request review again.
+A draft rollout that has been validly completed is reviewed and approved in Experimenter, is published to Remote Settings, and the collection is marked for review. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout returns to Idle so the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -322,7 +322,7 @@ A draft rollout is approved in Experimenter and sent to Remote Settings, but the
 
 ## Launch (cancel)
 
-A rollout launch review is canceled in Experimenter before it is approved in Experimenter. The rollout returns to Idle and the owner can request review again later.
+When a draft rollout has requested review in Experimenter, the review can also be canceled in Experimenter. The review can only be canceled before it has been reviewed in Experimenter.
 
 ```mermaid
     sequenceDiagram
@@ -351,7 +351,7 @@ A rollout launch review is canceled in Experimenter before it is approved in Exp
         end
 ```
 
-A rollout can also be launched from Preview. If that review is canceled before approval, the rollout returns to Draft and Idle.
+This can also be canceled when a rollout is in the Preview state and requests to be launched. When the review is canceled, the Preview rollout is sent back to Draft.
 
 ```mermaid
     sequenceDiagram
@@ -390,7 +390,7 @@ A rollout can also be launched from Preview. If that review is canceled before a
 
 ## Change Phase (Approve/Approve)
 
-A live rollout moves to the next phase while remaining Live. The phase change is approved in Experimenter, approved in Remote Settings, and then the active phase is updated.
+A live rollout can have its next phase pushed to its state while remaining Live. This phase change must be reviewed in order to be published to the user, following the same flow to be approved in both Experimenter and Remote Settings.
 
 ```mermaid
   sequenceDiagram
@@ -451,7 +451,7 @@ A live rollout moves to the next phase while remaining Live. The phase change is
 
 ## Change Phase (Reject/------)
 
-A live rollout phase change is sent for review but rejected in Experimenter. The rollout remains Live in the current phase and returns to Idle.
+A live rollout phase change is reviewed and rejected in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter. The rollout remains in its current phase after the rejection.
 
 ```mermaid
   sequenceDiagram
@@ -485,7 +485,7 @@ A live rollout phase change is sent for review but rejected in Experimenter. The
 
 ## Change Phase (Approve/Reject)
 
-A live rollout phase change is approved in Experimenter but rejected in Remote Settings. The rollout is rolled back and remains Live in the current phase.
+A live rollout phase change is reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter. The rollout remains in its current phase after the rejection.
 
 ```mermaid
   sequenceDiagram
@@ -545,7 +545,7 @@ A live rollout phase change is approved in Experimenter but rejected in Remote S
 
 ## Change Phase (Approve/Reject) + manual rollback
 
-A live rollout phase change is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The rollout remains Live in the current phase and returns to Idle.
+A live rollout phase change is reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason. The rollout remains in its current phase after the rejection.
 
 ```mermaid
   sequenceDiagram
@@ -605,7 +605,7 @@ A live rollout phase change is approved in Experimenter and rejected in Remote S
 
 ## Change Phase (Approve/Timeout)
 
-A live rollout phase change is approved in Experimenter and sent to Remote Settings, but the Remote Settings review times out. The rollout stays Live in the current phase and returns to Idle, so the owner must request review again.
+A live rollout phase change is reviewed and approved in Experimenter, is published to Remote Settings, and the collection is marked for review. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout returns to Idle, remains in its current phase, and the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -656,7 +656,7 @@ A live rollout phase change is approved in Experimenter and sent to Remote Setti
 
 ## Change Phase (Cancel ------/------)
 
-A live rollout phase change review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live in the current phase and returns to Idle.
+A live rollout phase change can be requested while the rollout remains Live. These phase changes must be reviewed in order to be published to the user, following the same flow to be approved in both Experimenter and Remote Settings. Like the publish flow, these reviews can be canceled from Experimenter.
 
 ```mermaid
     sequenceDiagram
@@ -688,7 +688,7 @@ A live rollout phase change review is canceled in Experimenter before it is appr
 
 ## Disable (Approve/Approve)
 
-A live rollout is disabled after being approved in Experimenter and approved in Remote Settings. Disabling means the rollout is unpublished from Remote Settings. The rollout moves from Live to Disabled while staying in the same phase.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner, reviewed and approved in Experimenter, reviewed and approved in Remote Settings, is unpublished from the collection, and is then no longer accessible by clients.
 
 ```mermaid
   sequenceDiagram
@@ -749,7 +749,7 @@ A live rollout is disabled after being approved in Experimenter and approved in 
 
 ## Disable (Reject/------)
 
-A live rollout disable request is rejected in Experimenter. The rollout remains Live and published in Remote Settings, and returns to Idle.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner, and is then reviewed and rejected in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter. No change is made to Remote Settings and the rollout remains published.
 
 ```mermaid
   sequenceDiagram
@@ -782,7 +782,7 @@ A live rollout disable request is rejected in Experimenter. The rollout remains 
 
 ## Disable (Approve/Reject)
 
-A live rollout disable request is approved in Experimenter but rejected in Remote Settings. The unpublish change is rolled back and the rollout remains Live and published in Remote Settings.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. No change is made to Remote Settings and clients will continue to access the published rollout. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter.
 
 ```mermaid
   sequenceDiagram
@@ -842,7 +842,7 @@ A live rollout disable request is approved in Experimenter but rejected in Remot
 
 ## Disable (Approve/Reject) + manual rollback
 
-A live rollout disable request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The unpublish change is rolled back, so the rollout remains Live and published in Remote Settings.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason. No change is made to Remote Settings and the rollout remains published.
 
 ```mermaid
   sequenceDiagram
@@ -902,7 +902,7 @@ A live rollout disable request is approved in Experimenter and rejected in Remot
 
 ## Disable (Approve/Timeout)
 
-A live rollout disable request is approved in Experimenter and sent to Remote Settings as an unpublish change, but the Remote Settings review times out. The rollout stays Live and published in Remote Settings, and returns to Idle so the owner must request review again.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner, reviewed and approved in Experimenter, and the unpublish change is pushed to Remote Settings. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout remains published in Remote Settings, returns to Idle, and the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -953,7 +953,7 @@ A live rollout disable request is approved in Experimenter and sent to Remote Se
 
 ## Disable (Cancel ------/------)
 
-A live rollout disable review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Live and published in Remote Settings, and returns to Idle.
+A live rollout that is published in Remote Settings is requested to be disabled by the owner. The disable request can be canceled before it is approved in Experimenter. No change is made to Remote Settings and the rollout remains published.
 
 ```mermaid
     sequenceDiagram
@@ -985,7 +985,7 @@ A live rollout disable review is canceled in Experimenter before it is approved 
 
 ## Enable (Approve/Approve)
 
-A disabled rollout is enabled after being approved in Experimenter and approved in Remote Settings. Enabling means the rollout is published in Remote Settings. The rollout moves from Disabled back to Live while staying in the same phase.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, reviewed and approved in Remote Settings, is published to the collection, and is then accessible to clients.
 
 ```mermaid
   sequenceDiagram
@@ -1046,7 +1046,7 @@ A disabled rollout is enabled after being approved in Experimenter and approved 
 
 ## Enable (Reject/------)
 
-A disabled rollout enable request is rejected in Experimenter. The rollout remains Disabled and unpublished in Remote Settings, and returns to Idle.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, and is then reviewed and rejected in Experimenter. A rejection reason is captured in Experimenter and is displayed to the owner in Experimenter. No change is made to Remote Settings and the rollout remains unpublished.
 
 ```mermaid
   sequenceDiagram
@@ -1079,7 +1079,7 @@ A disabled rollout enable request is rejected in Experimenter. The rollout remai
 
 ## Enable (Approve/Reject)
 
-A disabled rollout enable request is approved in Experimenter but rejected in Remote Settings. The publish change is rolled back and the rollout remains Disabled and unpublished in Remote Settings.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. No change is made to Remote Settings and the rollout remains unpublished. A rejection reason is captured in Remote Settings and is displayed to the owner in Experimenter.
 
 ```mermaid
   sequenceDiagram
@@ -1139,7 +1139,7 @@ A disabled rollout enable request is approved in Experimenter but rejected in Re
 
 ## Enable (Approve/Reject) + manual rollback
 
-A disabled rollout enable request is approved in Experimenter and rejected in Remote Settings, but the Remote Settings rollback is handled manually before Experimenter can recover the rejection reason. The publish change is rolled back, so the rollout remains Disabled and unpublished in Remote Settings.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and is then reviewed and rejected in Remote Settings. The reviewer **manually rolls back** the Remote Settings collection. A rejection reason is captured in Remote Settings but is **unable to be recovered by Experimenter** because the collection was manually rolled back **before Experimenter could query its status**, and so Experimenter shows a generic rejection reason. No change is made to Remote Settings and the rollout remains unpublished.
 
 ```mermaid
   sequenceDiagram
@@ -1199,7 +1199,7 @@ A disabled rollout enable request is approved in Experimenter and rejected in Re
 
 ## Enable (Approve/Timeout)
 
-A disabled rollout enable request is approved in Experimenter and sent to Remote Settings as a publish change, but the Remote Settings review times out. The rollout stays Disabled and unpublished in Remote Settings, and returns to Idle so the owner must request review again.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner, reviewed and approved in Experimenter, and the publish change is pushed to Remote Settings. Before the reviewer is able to review it in Remote Settings, the scheduled celery task is invoked and finds that the collection is blocked from further changes by having an unattended review pending. It rolls back the pending review to allow other queued changes to be made. This prevents unattended reviews in a collection from blocking other queued changes. The rollout remains unpublished in Remote Settings, returns to Idle, and the owner must request review again.
 
 ```mermaid
   sequenceDiagram
@@ -1250,7 +1250,7 @@ A disabled rollout enable request is approved in Experimenter and sent to Remote
 
 ## Enable (Cancel ------/------)
 
-A disabled rollout enable review is canceled in Experimenter before it is approved in Experimenter. The rollout remains Disabled and unpublished in Remote Settings, and returns to Idle.
+A disabled rollout that is not published in Remote Settings is requested to be enabled by the owner. The enable request can be canceled before it is approved in Experimenter. No change is made to Remote Settings and the rollout remains unpublished.
 
 ```mermaid
     sequenceDiagram


### PR DESCRIPTION
Because

* we need to add Mermaid diagrams reflecting the new rollout-specific state machine

This commit

* adds the Mermaid diagrams for rollouts
* updates timeout flows to return to idle after timeout

Fixes #16153 