### PR TITLE
feat(nimbus): add application field to rollouts overview form

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -321,6 +321,15 @@ class RolloutOverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
     public_description = forms.CharField(
         required=False, widget=forms.Textarea(attrs={"class": "form-control", "rows": 3})
     )
+    application = forms.ChoiceField(
+        disabled=True,
+        choices=NimbusExperiment.Application.choices,
+        widget=forms.widgets.Select(
+            attrs={
+                "class": "form-select",
+            },
+        ),
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -328,6 +337,7 @@ class RolloutOverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "name",
             "hypothesis",
             "public_description",
+            "application",
         ]
 
     def __init__(self, *args, **kwargs):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -9,6 +9,11 @@
     <div class="text-secondary mb-1" style="font-size: 12px;">Observations &amp; Problem space</div>
     <div class="small text-body" style="white-space: pre-wrap;">{{ experiment.hypothesis|default:"—" }}</div>
   </div>
+  {# Application #}
+  <div>
+    <div class="text-secondary mb-1" style="font-size: 12px;">Application</div>
+    <div class="small text-body">{{ experiment.get_application_display }}</div>
+  </div>
   {# Important Links #}
   <div>
     <div class="text-secondary mb-1" style="font-size: 12px;">Important Links</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -22,6 +22,19 @@
           <div class="text-danger small mt-1">{{ form.hypothesis.errors|join:", " }}</div>
         {% endif %}
       </div>
+      {# Application #}
+      <div>
+        <label for="id_application" class="small text-body mb-1">Application</label>
+        {{ form.application }}
+        {% if form.application.errors %}
+          <div class="text-danger small mt-1">{{ form.application.errors|join:", " }}</div>
+        {% endif %}
+        <p class="form-text mb-0">
+          Rollouts can only target one Application at a time.
+          <br>
+          Application can not be changed after a rollout is created.
+        </p>
+      </div>
       {# Important Links #}
       <div>
         <label class="small text-body mb-1">Important Links</label>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -260,6 +260,7 @@ class TestRolloutOverviewForm(RequestFormTestCase):
             "name": "",
             "hypothesis": "new hypothesis",
             "public_description": "new description",
+            "application": NimbusExperiment.Application.DESKTOP,
             "documentation_links-TOTAL_FORMS": "0",
             "documentation_links-INITIAL_FORMS": "0",
         }
@@ -283,6 +284,7 @@ class TestDocumentationLinkCreateForm(RequestFormTestCase):
                 "name": "new name",
                 "hypothesis": "new hypothesis",
                 "public_description": "new description",
+                "application": experiment.application,
                 "documentation_links-TOTAL_FORMS": "0",
                 "documentation_links-INITIAL_FORMS": "0",
             },
@@ -314,6 +316,7 @@ class TestDocumentationLinkDeleteForm(RequestFormTestCase):
                 "name": "new name",
                 "hypothesis": "new hypothesis",
                 "public_description": "new description",
+                "application": experiment.application,
                 "documentation_links-TOTAL_FORMS": "1",
                 "documentation_links-INITIAL_FORMS": "1",
                 "documentation_links-0-id": documentation_link.id,

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -51,6 +51,7 @@ class NewViewTestMixin:
             "name": experiment.name,
             "hypothesis": experiment.hypothesis,
             "public_description": experiment.public_description,
+            "application": experiment.application,
             "documentation_links-TOTAL_FORMS": "0",
             "documentation_links-INITIAL_FORMS": "0",
         }
@@ -438,6 +439,7 @@ class TestNewDocumentationLinkCreateView(AuthTestCase):
             {
                 "name": experiment.name,
                 "hypothesis": experiment.hypothesis,
+                "application": experiment.application,
                 "risk_brand": True,
                 "risk_message": True,
                 "public_description": experiment.public_description,
@@ -466,6 +468,7 @@ class TestNewDocumentationLinkDeleteView(AuthTestCase):
             {
                 "name": experiment.name,
                 "hypothesis": experiment.hypothesis,
+                "application": experiment.application,
                 "risk_brand": True,
                 "risk_message": True,
                 "public_description": experiment.public_description,


### PR DESCRIPTION
Because

- Overview section in new rollouts form was missing the applications field

This commit

- Adds a field to specify application

Fixes #15920 