### PR TITLE
fix(nimbus): Adjust Rollouts History and Help Links Styling

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -111,15 +111,15 @@
 {# History & Help #}
 <div class="d-flex flex-column gap-1">
   <a href="{% url 'nimbus-ui-history' experiment.slug %}"
-     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-2 px-2 text-body">
-    <i class="fa-regular fa-clock text-secondary"></i>
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 pt-3 px-2 small text-body">
+    <i class="fa-regular fa-clock text-body"></i>
     History
   </a>
   <a href="https://mozilla.slack.com/?redir=%2Farchives%2FCF94YGE03"
      target="_blank"
      rel="noopener noreferrer"
-     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-2 px-2 text-body">
-    <i class="fa-regular fa-circle-question text-secondary"></i>
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-3 px-2 small text-body">
+    <i class="fa-regular fa-circle-question text-body"></i>
     Help
   </a>
 </div>


### PR DESCRIPTION
Because

* The History and Help links in the sidebar did not match the Figma design

This commit

* Adjusts the History and Help link font size to match the Set up section links
* Fixes the spacing around the History and Help links

Fixes #15924

<img width="1719" height="950" alt="Screenshot 2026-06-26 at 5 28 44 PM" src="https://github.com/user-attachments/assets/895f545e-1b41-496c-8c9c-a93bb58d2e07" />
