### PR TITLE
feat(nimbus): add full targeting expression to rollouts audience summary page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -90,6 +90,12 @@
     <div class="text-secondary mb-1" style="font-size: 12px;">Advanced targeting</div>
     <div class="small text-body">{{ experiment.targeting_config_slug|default:"—" }}</div>
   </div>
+  {# Full targeting expression #}
+  <div>
+    <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
+    {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
+
+  </div>
   {# Required experiments #}
   <div>
     <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing experiments</div>


### PR DESCRIPTION
Because

- The full JEXL targeting expression was missing from the rollouts audience summary section

This commit

- Adds the full read-only targeting expression

Fixes #15922 