### PR TITLE
chore(project): add @RJAK11 to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @freshstrangemusic @jaredlockhart @mikewilli @yashikakhurana
+* @freshstrangemusic @jaredlockhart @mikewilli @RJAK11 @yashikakhurana


### PR DESCRIPTION
Because

* Rana is back on the team full time and should be a code owner

This commit

* Adds @RJAK11 to the global owners line in .github/CODEOWNERS

Fixes #16178