### PR TITLE
fix(nimbus): support multiple conflict_slugs reported in telemetry

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1468,8 +1468,29 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             key = (row["status"], row.get("reason") or "")
             by_key[key]["client_count"] += row["client_count"]
             by_key[key]["apps"].add(row["app_name"])
-            if row.get("conflict_slug"):
-                by_key[key]["conflict_slugs"].add(row["conflict_slug"])
+            if conflict_slugs := row.get("conflict_slug"):
+                by_key[key]["conflict_slugs"].update(
+                    slug for slug in conflict_slugs.split(",") if slug
+                )
+
+        # Do a single query to get the set of all slugs mentioned that actually
+        # exist.
+        #
+        # It is possible that a slug could get cut off in telemetry (or
+        # corrupted or submitted by a malicious client), which would result in
+        # referencing data that does not exist. Then, when we go to render the
+        # list of slugs, we would attempt to generate links to these
+        # non-existant recipes and cause a 500.
+        existing_slugs = set(
+            NimbusExperiment.objects.filter(
+                slug__in={
+                    slug for value in by_key.values() for slug in value["conflict_slugs"]
+                }
+            ).values_list("slug", flat=True)
+        )
+
+        for value in by_key.values():
+            value["conflict_slugs"] &= existing_slugs
 
         def _build_stage(key, data):
             status, reason = key

--- a/experimenter/experimenter/experiments/monitoring_utils.py
+++ b/experimenter/experimenter/experiments/monitoring_utils.py
@@ -127,9 +127,8 @@ def check_feature_conflict(monitoring_data, threshold):
     for row in funnel:
         if row.get("reason") == NimbusConstants.FunnelReason.FEATURE_CONFLICT:
             conflict_count += row.get("client_count", 0)
-            slug = row.get("conflict_slug")
-            if slug:
-                conflict_slugs.add(slug)
+            if slugs := row.get("conflict_slug"):
+                conflict_slugs.update(slug for slug in slugs.split(",") if slug)
 
     rate = conflict_count / total
     return FeatureConflictResult(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5747,7 +5747,13 @@ class TestNimbusExperiment(TestCase):
         self.assertAlmostEqual(enrolled["pct"], 75.0)
 
     def test_enrollment_funnel_stages_links_conflict_slugs(self):
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="other-experiment",
+        )
         experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
             monitoring_data={
                 "enrollment_funnel": [
                     {
@@ -5759,7 +5765,7 @@ class TestNimbusExperiment(TestCase):
                         "client_count": 100000,
                     },
                 ]
-            }
+            },
         )
         result = experiment.enrollment_funnel_stages
         conflict_stage = next(
@@ -5769,6 +5775,41 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertIn("other-experiment", conflict_stage["conflict_slugs"])
         self.assertFalse(conflict_stage["has_null_conflict"])
+
+    def test_enrollment_funnel_stages_multiple_conflict_slugs(self):
+        for i in (0, 1, 2):
+            NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                application=NimbusExperiment.Application.DESKTOP,
+                slug=f"conflict-{i}",
+            )
+
+        experiment = NimbusExperimentFactory.create(
+            monitoring_data={
+                "enrollment_funnel": [
+                    {
+                        "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
+                        "branch": None,
+                        "status": NimbusConstants.FunnelStatus.NOT_ENROLLED,
+                        "reason": NimbusConstants.FunnelReason.FEATURE_CONFLICT,
+                        "conflict_slug": "conflict-0,conflict-1,conflict-2,conflict-3",
+                        "client_count": 100,
+                    }
+                ]
+            }
+        )
+
+        result = experiment.enrollment_funnel_stages
+        conflict_stage = next(
+            s
+            for s in result["stages"]
+            if s["reason"] == NimbusExperiment.FunnelReason.FEATURE_CONFLICT
+        )
+
+        self.assertEqual(
+            set(conflict_stage["conflict_slugs"]),
+            {"conflict-0", "conflict-1", "conflict-2"},
+        )
 
     def test_enrollment_funnel_stages_flags_null_conflict_on_mobile(self):
         experiment = NimbusExperimentFactory.create(

--- a/experimenter/experimenter/slack/tests/test_tasks.py
+++ b/experimenter/experimenter/slack/tests/test_tasks.py
@@ -83,7 +83,7 @@ _FEATURE_CONFLICT_MONITORING_DATA = {
             "reason": NimbusConstants.FunnelReason.FEATURE_CONFLICT,
             "app_name": APPLICATION_CONFIG_DESKTOP.app_name,
             "branch": "control",
-            "conflict_slug": "blocking-recipe-slug",
+            "conflict_slug": "blocking-recipe-slug,other-slug",
             "client_count": 800,
         },
         {
@@ -1154,7 +1154,7 @@ class TestCheckFeatureConflict(TestCase):
         result = self._check(_FEATURE_CONFLICT_MONITORING_DATA)
         self.assertTrue(result.is_conflict)
         self.assertAlmostEqual(result.rate, 0.80)
-        self.assertEqual(result.slugs, ["blocking-recipe-slug"])
+        self.assertEqual(result.slugs, ["blocking-recipe-slug", "other-slug"])
 
     def test_returns_false_when_conflict_rate_below_threshold(self):
         monitoring_data = {


### PR DESCRIPTION
Because:

- the code handling `conflict_slug` assumed it was always a single slug;
- the enrollment funnel tries to generate links to conflicting experiments;
- the conflict_slug field became multi-valued in https://bugzilla.mozilla.org/show_bug.cgi?id=2041806, which shipped in Firefox 152; and
- if the slug doesn't exist the page fails to load

this commit:

- updates both the enrollment funnel and monitoring utilities to support multiple conflict_slugs; and
- updates the enrollment funnel to only report slugs that exist

Fixes #16217