### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 154.2.20260624.61428

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4742,6 +4742,20 @@ FX_154_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_154_2_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx154 Jun-24 Trainhop",
+    slug="newtab-154-0624-trainhop",
+    description=(
+        "Desktop users having the New Tab 154.2.20260624.61428 train hop, "
+        "which includes users of Fx152"
+    ),
+    targeting="newtabAddonVersion|versionCompare('154.2.20260624.61428') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIDGETS_LISTS_OR_TIMER_INTERACTED_NOT_DISABLED = NimbusTargetingConfig(
     name="New Tab Lists/Timer Interaction, Neither Widget Disabled",
     slug="widgets-lists-timer-interacted-not-disabled",


### PR DESCRIPTION
This commit adds new targeting for the 154.2.20260624.61428 trainhop

Fixes #16248