### PR TITLE
feat(nimbus): require newtabTrainhopAddon feature for trainhop targeting

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -1413,6 +1413,34 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return data
 
+    def _validate_newtab_trainhop_targeting(self, data):
+        if not self.instance.is_desktop:
+            return data
+
+        targeting_config_slug = data.get("targeting_config_slug")
+        targeting_config = NimbusExperiment.TARGETING_CONFIGS[targeting_config_slug]
+
+        if (
+            NimbusConstants.DESKTOP_NEWTAB_ADDON_VERSION_ATTR
+            not in targeting_config.targeting
+        ):
+            return data
+
+        feature_configs = data.get("feature_configs", [])
+        if not any(
+            feature_config.slug == NimbusConstants.DESKTOP_NEWTAB_TRAINHOP_SLUG
+            for feature_config in feature_configs
+        ):
+            raise serializers.ValidationError(
+                {
+                    "feature_configs": [
+                        NimbusConstants.ERROR_NEWTAB_TRAINHOP_TARGETING_REQUIRES_FEATURE
+                    ]
+                }
+            )
+
+        return data
+
     def _validate_sticky_enrollment(self, data):
         targeting_config_slug = data.get("targeting_config_slug")
         targeting_config = NimbusExperiment.TARGETING_CONFIGS[targeting_config_slug]
@@ -1952,6 +1980,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_feature_configs(data)
         data = self._validate_enrollment_targeting(data)
         data = self._validate_targeting_parses(data)
+        data = self._validate_newtab_trainhop_targeting(data)
         data = self._validate_sticky_enrollment(data)
         data = self._validate_bucket_duplicates(data)
         data = self._validate_proposed_release_date(data)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -258,6 +258,8 @@ class ApplicationConfig:
 
 DESKTOP_PREFFLIPS_SLUG = "prefFlips"
 DESKTOP_NEWTAB_ADDON_SLUG = "newtabTrainhopAddon"
+DESKTOP_NEWTAB_TRAINHOP_SLUG = "newtabTrainhop"
+DESKTOP_NEWTAB_ADDON_VERSION_ATTR = "newtabAddonVersion"
 
 APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
     name="Firefox Desktop",
@@ -532,6 +534,8 @@ class NimbusConstants:
 
     DESKTOP_PREFFLIPS_SLUG = DESKTOP_PREFFLIPS_SLUG
     DESKTOP_NEWTAB_ADDON_SLUG = DESKTOP_NEWTAB_ADDON_SLUG
+    DESKTOP_NEWTAB_TRAINHOP_SLUG = DESKTOP_NEWTAB_TRAINHOP_SLUG
+    DESKTOP_NEWTAB_ADDON_VERSION_ATTR = DESKTOP_NEWTAB_ADDON_VERSION_ATTR
 
     MOBILE_MESSAGING_SLUG = "messaging"
     MOBILE_MESSAGING_MESSAGES_FIELD = "messages"
@@ -860,6 +864,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_FEATURE_TARGET_COLLECTION = (
         "Feature '{feature_id}' publishes to collection '{collection}'"
+    )
+    ERROR_NEWTAB_TRAINHOP_TARGETING_REQUIRES_FEATURE = (
+        "Targeting the newtab addon version requires the "
+        f"{DESKTOP_NEWTAB_TRAINHOP_SLUG} feature. You must select it from the "
+        "feature configuration drop down on the Branches page."
     )
     ERROR_CANNOT_PUBLISH_TO_PREVIEW = "This experiment cannot be published to preview."
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -34,6 +34,7 @@ from experimenter.experiments.tests.factories import (
     NimbusVersionedSchemaFactory,
 )
 from experimenter.openidc.tests.factories import UserFactory
+from experimenter.targeting.constants import FX_153_3_TRAINHOP
 from experimenter.targeting.targeting_context_parser import TargetingContextFields
 
 BASIC_JSON_SCHEMA = """\
@@ -3610,6 +3611,81 @@ class TestNimbusReviewSerializerSingleFeature(
                 "non_field_errors": [NimbusConstants.ERROR_CANNOT_PARSE_TARGETING],
             },
         )
+
+    def test_newtab_trainhop_targeting_without_trainhop_feature_is_invalid(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[
+                NimbusFeatureConfigFactory(
+                    application=NimbusExperiment.Application.DESKTOP
+                )
+            ],
+            targeting_config_slug=FX_153_3_TRAINHOP.slug,
+            is_sticky=True,
+            firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors,
+            {
+                "feature_configs": [
+                    NimbusConstants.ERROR_NEWTAB_TRAINHOP_TARGETING_REQUIRES_FEATURE
+                ]
+            },
+        )
+
+    def test_newtab_trainhop_targeting_with_trainhop_feature_is_valid(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[
+                NimbusFeatureConfigFactory(
+                    application=NimbusExperiment.Application.DESKTOP,
+                    slug=NimbusConstants.DESKTOP_NEWTAB_TRAINHOP_SLUG,
+                )
+            ],
+            targeting_config_slug=FX_153_3_TRAINHOP.slug,
+            is_sticky=True,
+            firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_non_trainhop_targeting_without_trainhop_feature_is_valid(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[
+                NimbusFeatureConfigFactory(
+                    application=NimbusExperiment.Application.DESKTOP
+                )
+            ],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            is_sticky=True,
+            firefox_min_version=NimbusExperiment.MIN_REQUIRED_VERSION,
+        )
+
+        serializer = NimbusReviewSerializer(
+            experiment,
+            data=NimbusReviewSerializer(experiment, context={"user": self.user}).data,
+            context={"user": self.user},
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
Because

* After a trainhopped newtab XPI initializes, Firefox only recomputes Nimbus recipes touching the `newtabTrainhop` feature, so a recipe that targets a trainhop version but touches only a message feature is skipped and its clients aren't unenrolled until the next runtime recompute.

This commit

* Adds a review validation requiring the `newtabTrainhopAddon` feature on any desktop recipe whose targeting asserts on `newtabAddonVersion`.

Fixes #16253