### PR TITLE
fix(nimbus): retry nimbus-cli fetch on transient GitHub 5xx

### DIFF
--- a/experimenter/manifesttool/nimbus_cli.py
+++ b/experimenter/manifesttool/nimbus_cli.py
@@ -1,5 +1,4 @@
 import json
-import re
 import subprocess
 import sys
 import time
@@ -14,12 +13,6 @@ NIMBUS_CLI_PATH = "/application-services/bin/nimbus-cli"
 
 NIMBUS_CLI_MAX_ATTEMPTS = 3
 NIMBUS_CLI_RETRY_BACKOFF_SECONDS = 5
-
-TRANSIENT_ERROR_RE = re.compile(rb"returned (?:429|5\d\d)")
-
-
-def _is_transient_error(stderr: Optional[bytes]) -> bool:
-    return stderr is not None and TRANSIENT_ERROR_RE.search(stderr) is not None
 
 
 def _check_output(args: list[str]) -> bytes:
@@ -36,9 +29,10 @@ def nimbus_cli(args: list[str]) -> bytes:
     """Run nimbus-cli with the given arguments.
 
     nimbus-cli fetches each included FML file from the GitHub API, which
-    intermittently returns a 5xx/429 for individual files under the burst of
-    requests. Retry those transient responses so one flaky response does not
-    drop an app-version from the fetch.
+    intermittently fails for individual files under the burst of requests. The
+    exit code cannot distinguish a transient fetch failure from a genuine
+    error, so retry on any failure: a flaky response recovers, and a real error
+    still surfaces once the retries are exhausted.
     """
     print("nimbus-cli", " ".join(args))
 
@@ -46,13 +40,11 @@ def nimbus_cli(args: list[str]) -> bytes:
         try:
             return _check_output(args)
         except subprocess.CalledProcessError as e:
-            if not _is_transient_error(e.stderr):
-                raise
-
             delay = NIMBUS_CLI_RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+            stderr = e.stderr.decode(errors="replace") if e.stderr else ""
             print(
-                f"nimbus-cli transient error on attempt {attempt} of "
-                f"{NIMBUS_CLI_MAX_ATTEMPTS}, retrying in {delay}s",
+                f"nimbus-cli failed on attempt {attempt} of "
+                f"{NIMBUS_CLI_MAX_ATTEMPTS}, retrying in {delay}s: {stderr}",
                 file=sys.stderr,
             )
             time.sleep(delay)

--- a/experimenter/manifesttool/nimbus_cli.py
+++ b/experimenter/manifesttool/nimbus_cli.py
@@ -1,6 +1,8 @@
 import json
+import re
 import subprocess
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
@@ -10,11 +12,17 @@ from manifesttool.version import Version
 
 NIMBUS_CLI_PATH = "/application-services/bin/nimbus-cli"
 
+NIMBUS_CLI_MAX_ATTEMPTS = 3
+NIMBUS_CLI_RETRY_BACKOFF_SECONDS = 5
 
-def nimbus_cli(args: list[str]) -> bytes:
-    """Run nimbus-cli with the given arguments."""
-    print("nimbus-cli", " ".join(args))
+TRANSIENT_ERROR_RE = re.compile(rb"returned (?:429|5\d\d)")
 
+
+def _is_transient_error(stderr: Optional[bytes]) -> bool:
+    return stderr is not None and TRANSIENT_ERROR_RE.search(stderr) is not None
+
+
+def _check_output(args: list[str]) -> bytes:
     return subprocess.check_output(
         [
             NIMBUS_CLI_PATH,
@@ -22,6 +30,34 @@ def nimbus_cli(args: list[str]) -> bytes:
         ],
         stderr=subprocess.PIPE,
     )
+
+
+def nimbus_cli(args: list[str]) -> bytes:
+    """Run nimbus-cli with the given arguments.
+
+    nimbus-cli fetches each included FML file from the GitHub API, which
+    intermittently returns a 5xx/429 for individual files under the burst of
+    requests. Retry those transient responses so one flaky response does not
+    drop an app-version from the fetch.
+    """
+    print("nimbus-cli", " ".join(args))
+
+    for attempt in range(1, NIMBUS_CLI_MAX_ATTEMPTS):
+        try:
+            return _check_output(args)
+        except subprocess.CalledProcessError as e:
+            if not _is_transient_error(e.stderr):
+                raise
+
+            delay = NIMBUS_CLI_RETRY_BACKOFF_SECONDS * 2 ** (attempt - 1)
+            print(
+                f"nimbus-cli transient error on attempt {attempt} of "
+                f"{NIMBUS_CLI_MAX_ATTEMPTS}, retrying in {delay}s",
+                file=sys.stderr,
+            )
+            time.sleep(delay)
+
+    return _check_output(args)
 
 
 def _assert_ref_xor_github_repo(repo_type: RepositoryType, ref: Optional[Ref]):

--- a/experimenter/manifesttool/tests/test_nimbus_cli.py
+++ b/experimenter/manifesttool/tests/test_nimbus_cli.py
@@ -181,15 +181,7 @@ class NimbusCliTests(TestCase):
             )
 
 
-TRANSIENT_STDERR = (
-    b"Error: Problem with https://raw.githubusercontent.com/owner/repo/ref/feature.yaml: "
-    b"Can't find file: Invalid Response Status: Error: GET "
-    b"https://api.github.com/repos/owner/repo/contents/feature.yaml?ref=ref returned 502"
-)
-NON_TRANSIENT_STDERR = b"Error: Problem parsing manifest: unexpected token"
-
-
-def make_called_process_error(stderr):
+def make_called_process_error(stderr=None):
     return subprocess.CalledProcessError(
         returncode=1,
         cmd=[nimbus_cli.NIMBUS_CLI_PATH, "fml"],
@@ -198,15 +190,12 @@ def make_called_process_error(stderr):
 
 
 class NimbusCliRetryTests(TestCase):
-    """Tests for nimbus_cli transient-error retry."""
+    """Tests for nimbus_cli retry."""
 
     @patch.object(nimbus_cli.time, "sleep")
     @patch.object(nimbus_cli.subprocess, "check_output")
-    def test_retries_transient_error_then_succeeds(self, check_output, sleep):
-        check_output.side_effect = [
-            make_called_process_error(TRANSIENT_STDERR),
-            b"output",
-        ]
+    def test_retries_error_then_succeeds(self, check_output, sleep):
+        check_output.side_effect = [make_called_process_error(b"boom"), b"output"]
 
         self.assertEqual(nimbus_cli.nimbus_cli(["fml"]), b"output")
         self.assertEqual(check_output.call_count, 2)
@@ -215,35 +204,10 @@ class NimbusCliRetryTests(TestCase):
     @patch.object(nimbus_cli.time, "sleep")
     @patch.object(nimbus_cli.subprocess, "check_output")
     def test_raises_after_exhausting_retries(self, check_output, sleep):
-        check_output.side_effect = make_called_process_error(TRANSIENT_STDERR)
+        check_output.side_effect = make_called_process_error()
 
         with self.assertRaises(subprocess.CalledProcessError):
             nimbus_cli.nimbus_cli(["fml"])
 
         self.assertEqual(check_output.call_count, nimbus_cli.NIMBUS_CLI_MAX_ATTEMPTS)
         self.assertEqual(sleep.call_count, nimbus_cli.NIMBUS_CLI_MAX_ATTEMPTS - 1)
-
-    @patch.object(nimbus_cli.time, "sleep")
-    @patch.object(nimbus_cli.subprocess, "check_output")
-    def test_does_not_retry_non_transient_error(self, check_output, sleep):
-        check_output.side_effect = make_called_process_error(NON_TRANSIENT_STDERR)
-
-        with self.assertRaises(subprocess.CalledProcessError):
-            nimbus_cli.nimbus_cli(["fml"])
-
-        check_output.assert_called_once()
-        sleep.assert_not_called()
-
-    @parameterized.expand(
-        [
-            (b"GET https://api.github.com/... returned 502", True),
-            (b"GET https://api.github.com/... returned 500", True),
-            (b"GET https://api.github.com/... returned 503", True),
-            (b"GET https://api.github.com/... returned 429", True),
-            (b"GET https://api.github.com/... returned 404", False),
-            (b"Error: Problem parsing manifest", False),
-            (None, False),
-        ]
-    )
-    def test_is_transient_error(self, stderr, expected):
-        self.assertEqual(nimbus_cli._is_transient_error(stderr), expected)

--- a/experimenter/manifesttool/tests/test_nimbus_cli.py
+++ b/experimenter/manifesttool/tests/test_nimbus_cli.py
@@ -179,3 +179,71 @@ class NimbusCliTests(TestCase):
                 ],
                 stderr=subprocess.PIPE,
             )
+
+
+TRANSIENT_STDERR = (
+    b"Error: Problem with https://raw.githubusercontent.com/owner/repo/ref/feature.yaml: "
+    b"Can't find file: Invalid Response Status: Error: GET "
+    b"https://api.github.com/repos/owner/repo/contents/feature.yaml?ref=ref returned 502"
+)
+NON_TRANSIENT_STDERR = b"Error: Problem parsing manifest: unexpected token"
+
+
+def make_called_process_error(stderr):
+    return subprocess.CalledProcessError(
+        returncode=1,
+        cmd=[nimbus_cli.NIMBUS_CLI_PATH, "fml"],
+        stderr=stderr,
+    )
+
+
+class NimbusCliRetryTests(TestCase):
+    """Tests for nimbus_cli transient-error retry."""
+
+    @patch.object(nimbus_cli.time, "sleep")
+    @patch.object(nimbus_cli.subprocess, "check_output")
+    def test_retries_transient_error_then_succeeds(self, check_output, sleep):
+        check_output.side_effect = [
+            make_called_process_error(TRANSIENT_STDERR),
+            b"output",
+        ]
+
+        self.assertEqual(nimbus_cli.nimbus_cli(["fml"]), b"output")
+        self.assertEqual(check_output.call_count, 2)
+        sleep.assert_called_once()
+
+    @patch.object(nimbus_cli.time, "sleep")
+    @patch.object(nimbus_cli.subprocess, "check_output")
+    def test_raises_after_exhausting_retries(self, check_output, sleep):
+        check_output.side_effect = make_called_process_error(TRANSIENT_STDERR)
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            nimbus_cli.nimbus_cli(["fml"])
+
+        self.assertEqual(check_output.call_count, nimbus_cli.NIMBUS_CLI_MAX_ATTEMPTS)
+        self.assertEqual(sleep.call_count, nimbus_cli.NIMBUS_CLI_MAX_ATTEMPTS - 1)
+
+    @patch.object(nimbus_cli.time, "sleep")
+    @patch.object(nimbus_cli.subprocess, "check_output")
+    def test_does_not_retry_non_transient_error(self, check_output, sleep):
+        check_output.side_effect = make_called_process_error(NON_TRANSIENT_STDERR)
+
+        with self.assertRaises(subprocess.CalledProcessError):
+            nimbus_cli.nimbus_cli(["fml"])
+
+        check_output.assert_called_once()
+        sleep.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (b"GET https://api.github.com/... returned 502", True),
+            (b"GET https://api.github.com/... returned 500", True),
+            (b"GET https://api.github.com/... returned 503", True),
+            (b"GET https://api.github.com/... returned 429", True),
+            (b"GET https://api.github.com/... returned 404", False),
+            (b"Error: Problem parsing manifest", False),
+            (None, False),
+        ]
+    )
+    def test_is_transient_error(self, stderr, expected):
+        self.assertEqual(nimbus_cli._is_transient_error(stderr), expected)


### PR DESCRIPTION
Because

* The Update Configs cron shells out to `nimbus-cli`, which fetches each included FML file from the GitHub contents API in a burst, and GitHub intermittently fails individual files.
* With no retry, one transient failure drops an app-version into the PR FAILURES section, making that section effectively permanent noise (a different file fails almost every run).

This commit

* Retries the `nimbus-cli` subprocess with exponential backoff. The exit code cannot distinguish a transient failure from a genuine error, so retry on any failure; a real error still surfaces once the retries are exhausted.

Fixes #13374