### PR TITLE
feat(nimbus): Show holdback flag

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -9,7 +9,7 @@
       <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
     {% endif %}
     {% if experiment.is_rollout %}<span class="badge rounded-pill bg-primary" id="rollout-badge">Rollout</span>{% endif %}
-    {% if experiment.is_holdback %}<span class="badge rounded-pill bg-secondary" id="holdback-badge">Holdback</span>{% endif %}
+    {% if experiment.is_holdback %}<span class="badge rounded-pill bg-danger" id="holdback-badge">Holdback</span>{% endif %}
     {% if experiment.project_impact %}
       <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact</span>
     {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -9,7 +9,9 @@
       <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
     {% endif %}
     {% if experiment.is_rollout %}<span class="badge rounded-pill bg-primary" id="rollout-badge">Rollout</span>{% endif %}
-    {% if experiment.is_holdback %}<span class="badge rounded-pill bg-danger" id="holdback-badge">Holdback</span>{% endif %}
+    {% if experiment.is_holdback %}
+      <span class="badge rounded-pill bg-danger" id="holdback-badge">Holdback</span>
+    {% endif %}
     {% if experiment.project_impact %}
       <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact</span>
     {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -9,6 +9,7 @@
       <span class="badge rounded-pill bg-danger" id="archive-badge">Archived</span>
     {% endif %}
     {% if experiment.is_rollout %}<span class="badge rounded-pill bg-primary" id="rollout-badge">Rollout</span>{% endif %}
+    {% if experiment.is_holdback %}<span class="badge rounded-pill bg-secondary" id="holdback-badge">Holdback</span>{% endif %}
     {% if experiment.project_impact %}
       <span class="badge rounded-pill text-bg-warning border border-secondary-subtle"><i class="fa-solid fa-trophy me-2"></i>{{ experiment.project_impact|lower|capfirst }} impact</span>
     {% endif %}


### PR DESCRIPTION
Because

- Now users can check the holdback flag on the branches page, but we should show the value on the summary page

This commit

- Adds a tile holdback if its checked

Fixes #16270 