### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 154.4.20260708.42619

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4770,6 +4770,20 @@ FX_154_3_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_154_4_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx154 Jul-08 Trainhop",
+    slug="newtab-154-0708-trainhop",
+    description=(
+        "Desktop users having the New Tab 154.4.20260708.42619 train hop, "
+        "which includes users of Fx152"
+    ),
+    targeting="newtabAddonVersion|versionCompare('154.4.20260708.42619') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIDGETS_LISTS_OR_TIMER_INTERACTED_NOT_DISABLED = NimbusTargetingConfig(
     name="New Tab Lists/Timer Interaction, Neither Widget Disabled",
     slug="widgets-lists-timer-interacted-not-disabled",


### PR DESCRIPTION
Adds `FX_154_4_TRAINHOP`, advanced targeting for the New Tab `154.4.20260708.42619` train hop, which includes users of Fx152 on the release channel.

Fixes mozilla#16288