### PR TITLE
feat(nimbus): Add warnings to rollout page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/audience_overlap_warnings.html
@@ -1,0 +1,72 @@
+<div id="audience-overlap-warnings"
+     style="display: contents"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  {% if experiment.audience_overlap_warnings %}
+    {% for warning in experiment.audience_overlap_warnings %}
+      <div class="rounded-2 p-3 small"
+           style="background-color: var(--bs-warning-bg-subtle);
+                  border: 1px solid var(--bs-warning-border-subtle)"
+           role="alert">
+        <p class="mb-1 d-flex align-items-center gap-2 fw-semibold">
+          <i class="fa-solid fa-triangle-exclamation"
+             style="color: var(--bs-orange)"></i>
+          {{ warning.text }}
+        </p>
+        <ul class="mb-1">
+          {% for entry in warning.entries %}
+            <li>
+              <a target="_blank" href="{% url "nimbus-ui-detail" slug=entry.slug %}">{{ entry.slug }}</a>
+              <span class="text-muted">
+                (
+                {% for reason in entry.reasons %}
+                  {% if reason.shared_features %}
+                    {{ reason.label_prefix }}
+                    {% for feature in reason.shared_features %}
+                      <a target="_blank" href="{{ feature.url }}">{{ feature.slug }}</a>
+                      {% if not forloop.last %},{% endif %}
+                    {% endfor %}
+                  {% else %}
+                    {{ reason.label }}
+                  {% endif %}
+                  <i class="fa-regular fa-circle-question fa-sm"
+                     data-bs-toggle="tooltip"
+                     data-bs-placement="top"
+                     title="{{ reason.detail }}"></i>
+                  {% if reason.learn_more_url %}
+                    <a href="{{ reason.learn_more_url }}"
+                       target="_blank"
+                       rel="noopener noreferrer"
+                       class="ms-1">Learn more</a>
+                  {% endif %}
+                  {% if not forloop.last %},{% endif %}
+                {% endfor %}
+                )
+              </span>
+            </li>
+          {% endfor %}
+          {% for issue in warning.self_issues %}
+            <li>
+              <span>{{ issue.label }}</span>
+              <i class="fa-regular fa-circle-question fa-sm"
+                 data-bs-toggle="tooltip"
+                 data-bs-placement="top"
+                 title="{{ issue.detail }}"></i>
+              {% if issue.learn_more_url %}
+                <a href="{{ issue.learn_more_url }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="ms-1">Learn more</a>
+              {% endif %}
+            </li>
+          {% endfor %}
+        </ul>
+        {% if warning.learn_more_link %}
+          <a href="{{ warning.learn_more_link }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="btn btn-link btn-sm p-0">Learn more</a>
+        {% endif %}
+      </div>
+    {% endfor %}
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -150,3 +150,7 @@
     {% endif %}
   </div>
 </div>
+{% if hx_swap_oob %}
+  {% include "new/common/audience_overlap_warnings.html" with oob=True %}
+
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -6,6 +6,8 @@
 {% block title %}{{ experiment.name }}{% endblock %}
 {% block main_content %}
   <div id="RolloutSummary" class="d-flex flex-column gap-4">
+    {% include "new/common/audience_overlap_warnings.html" %}
+
     {# ── Define ── #}
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Define</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -18,3 +18,7 @@
     {% endfor %}
   </div>
 </div>
+{% if hx_swap_oob %}
+  {% include "new/common/audience_overlap_warnings.html" with oob=True %}
+
+{% endif %}


### PR DESCRIPTION
Because

* the new rollouts page is missing the conflict warnings that appear near the top of the current UI

This commit

* copies the warnings file into the new/ templates and restyles it to match the new rollout page UI
* includes the warnings near the top of the rollout page using the existing experiment.audience_overlap_warnings data

Fixes #16267

<img width="1720" height="881" alt="Screenshot 2026-07-13 at 1 10 35 PM" src="https://github.com/user-attachments/assets/2b864e1d-c7a5-4cc7-b1d7-980fd7a157fe" />
