### PR TITLE
chore(project): pin third-party github actions to commit shas

### DIFF
--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload to PyPI
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
         with:
           packages-dir: schemas/dist/
           skip-existing: true

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Run Fenix enrollment test on emulator
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 34
           arch: x86_64

--- a/.github/workflows/glean-probe-scraper.yml
+++ b/.github/workflows/glean-probe-scraper.yml
@@ -4,4 +4,4 @@ on: [push, pull_request]
 jobs:
   glean-probe-scraper:
     if: github.repository == 'mozilla/experimenter'
-    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@main
+    uses: mozilla/probe-scraper/.github/workflows/glean.yaml@7c102589ab2dfb6da2614a90dbf1d70fa183f613 # main


### PR DESCRIPTION
Because

* The GitHub Actions Build Resilience Standard requires third-party actions to be pinned to a full commit SHA.

This commit

* Pins reactivecircus/android-emulator-runner and pypa/gh-action-pypi-publish to commit SHAs.
* Replaces the floating mozilla/probe-scraper glean.yaml @main reference with a pinned SHA.

Fixes #16312