### PR TITLE
chore(project): add SSDLC Actions security scanning workflow

### DIFF
--- a/.github/workflows/ssdlc-actions.yml
+++ b/.github/workflows/ssdlc-actions.yml
@@ -1,0 +1,15 @@
+name: SSDLC Actions
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  code-security-analysis:
+    permissions:
+      security-events: write # required for uploading code scanning alerts
+    uses: mozilla/ssdlc-actions/.github/workflows/code-security-analysis-public-repo.yml@ca8be48f3c06204fb16a3bd5ffa6d916782bbc76 # v1


### PR DESCRIPTION
Because

* The Vulnerability Identification and GitHub Actions Build Resilience standards require the Security-maintained SSDLC Actions workflow (semgrep source scan + zizmor workflow scan).

This commit

* Adds .github/workflows/ssdlc-actions.yml running the public-repo code-security-analysis reusable workflow on push and pull_request to main.

Fixes #16315