### PR TITLE
chore(project): add SBOM generation workflow

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,18 @@
+name: ssdlc-sbom
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  sbom:
+    permissions:
+      actions: read
+      contents: write
+    uses: mozilla/ssdlc-actions/.github/workflows/ssdlc-sbom.yml@5cc2b20e42d53d1643853f12244fbec9ed2f2e0c
+    with:
+      sbom_name: ${{ github.sha }}


### PR DESCRIPTION
Because

* The SBOM Standard requires a CycloneDX SBOM for each production release, generated via the Security-maintained reusable workflow.

This commit

* Adds .github/workflows/sbom.yml using the ssdlc-sbom reusable workflow, triggered on push to main and workflow_dispatch.

Fixes #16314