### PR TITLE
chore(project): add github-actions dependabot ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,3 +60,8 @@ updates:
       - dependency-name: "vega"
         update-types:
           ["version-update:semver-major", "version-update:semver-minor", "version-update:semver-patch"]
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+    target-branch: main


### PR DESCRIPTION
Because

* The SBOM and GitHub Actions Build Resilience standards require Dependabot for GitHub Actions to keep pinned reusable-workflow SHAs and pinned actions current.

This commit

* Adds a github-actions package-ecosystem entry to .github/dependabot.yml (weekly).

Fixes #16313