### PR TITLE
chore(project): cache docker image layers across CI jobs with buildx gha cache

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -1,5 +1,5 @@
 name: "Setup Docker Build"
-description: "Free disk space, set up Buildx, and build megazords/schemas/cirrus images with retry"
+description: "Free disk space, start a local registry, set up a buildx builder with a GitHub Actions layer cache, and build megazords/schemas/cirrus images"
 
 runs:
   using: composite
@@ -13,15 +13,33 @@ runs:
         docker system prune -af
         df -h /
 
+    - name: Start local registry
+      shell: bash
+      run: docker run -d -p 5000:5000 --name registry registry:2
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
       with:
-        driver: docker
+        driver-opts: network=host
+
+    - name: Export build flags
+      shell: bash
+      run: |
+        MEGA="docker-image://localhost:5000/experimenter/megazords"
+        {
+          echo "MEGAZORD_IMAGE=localhost:5000/experimenter/megazords"
+          echo "MEGAZORD_BUILD_FLAGS=--push --cache-from type=gha,scope=megazords --cache-to type=gha,mode=max,scope=megazords"
+          echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=$MEGA --cache-from type=gha,scope=experimenter --cache-to type=gha,mode=max,scope=experimenter --load"
+          echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=$MEGA --cache-from type=gha,scope=experimenter-dev --cache-to type=gha,mode=max,scope=experimenter-dev --load"
+          echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=$MEGA --cache-from type=gha,scope=cirrus --cache-to type=gha,mode=max,scope=cirrus --load"
+          echo "SCHEMAS_BUILD_FLAGS=--cache-from type=gha,scope=schemas --cache-to type=gha,mode=max,scope=schemas --load"
+          echo "DOCKER_RUN_INTERACTIVE="
+        } >> "$GITHUB_ENV"
 
     - uses: ./.github/actions/retry
       with:
         label: Build megazords
-        run: MEGAZORD_BUILD_FLAGS=--load make build_megazords
+        run: make build_megazords
 
     - uses: ./.github/actions/retry
       with:
@@ -31,6 +49,8 @@ runs:
             --file schemas/Dockerfile \
             --target dev \
             --tag schemas:dev \
+            --cache-from type=gha,scope=schemas \
+            --cache-to type=gha,mode=max,scope=schemas \
             --load \
             schemas/
 
@@ -42,17 +62,9 @@ runs:
             --file cirrus/server/Dockerfile \
             --target deploy \
             --tag cirrus:deploy \
+            --cache-from type=gha,scope=cirrus \
+            --cache-to type=gha,mode=max,scope=cirrus \
             --load \
-            --build-context experimenter:megazords=docker-image://experimenter:megazords \
+            --build-context experimenter:megazords=docker-image://localhost:5000/experimenter/megazords \
             --build-context fml=experimenter/experimenter/features/manifests/ \
             cirrus/server/
-
-    - name: Export build flags
-      shell: bash
-      run: |
-        echo "MEGAZORD_BUILD_FLAGS=--load" >> "$GITHUB_ENV"
-        echo "EXPERIMENTER_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
-        echo "DEV_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
-        echo "CIRRUS_BUILD_FLAGS=--build-context experimenter:megazords=docker-image://experimenter:megazords --load" >> "$GITHUB_ENV"
-        echo 'SCHEMAS_BUILD_FLAGS=--load' >> "$GITHUB_ENV"
-        echo 'DOCKER_RUN_INTERACTIVE=' >> "$GITHUB_ENV"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@ COMPOSE_INTEGRATION_RUN = ${COMPOSE_INTEGRATION} run --rm
 DOCKER_BUILD = docker buildx build
 PYTEST_BASE_URL ?= https://nginx/nimbus/
 
+# Image tag for the application-services megazords build. CI overrides this with a
+# local registry ref so the container-driver builder can consume it as a build context.
+MEGAZORD_IMAGE ?= experimenter:megazords
+
 # Extra flags for docker buildx build, per target. Override to add caching, --load, etc.
 MEGAZORD_BUILD_FLAGS ?=
 EXPERIMENTER_BUILD_FLAGS ?=
@@ -106,7 +110,7 @@ compose_build:  ## Build containers
 	$(COMPOSE) build
 
 build_megazords:
-	$(DOCKER_BUILD) $(MEGAZORD_BUILD_FLAGS) -f application-services/Dockerfile -t experimenter:megazords application-services/
+	$(DOCKER_BUILD) $(MEGAZORD_BUILD_FLAGS) -f application-services/Dockerfile -t $(MEGAZORD_IMAGE) application-services/
 
 update_application_services: build_megazords
 	docker run \


### PR DESCRIPTION
Because

* setup-cached-build ran buildx with `driver: docker` and no `cache-from`/`cache-to`, so every CI job rebuilt megazords, schemas, cirrus and the experimenter images from scratch, duplicating the poetry/npm install and application-services fetch layers across the whole PR run.

This commit

* switches the builder to the `docker-container` driver and adds `type=gha` cache to every build the action drives, scoped per image.
* stands up a throwaway `localhost:5000` registry and pushes megazords there so the container-driver builds can resolve the `experimenter:megazords` build context (previously satisfied from a locally loaded image under the daemon driver).
* parametrizes the megazords tag as `MEGAZORD_IMAGE` so local builds keep loading into the daemon while CI targets the registry.

This PR touches root/`.github` paths, so `check-changed-paths` runs the full CI suite here: the cache warms on this run and the payoff shows on subsequent runs of the same branch/base.

Fixes #16332