### PR TITLE
chore(project): pin remaining actions and scope update-workflow app tokens

### DIFF
--- a/.github/actions/run-integration-test/action.yml
+++ b/.github/actions/run-integration-test/action.yml
@@ -39,7 +39,7 @@ runs:
 
     - name: Upload test report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: ${{ inputs.artifact-name }}
         path: experimenter/tests/integration/test-reports/report.htm

--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -14,7 +14,7 @@ runs:
         df -h /
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:
         driver: docker
 

--- a/.github/workflows/check-cirrus.yml
+++ b/.github/workflows/check-cirrus.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-experimenter.yml
+++ b/.github/workflows/check-experimenter.yml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-feature-manifests.yml
+++ b/.github/workflows/check-feature-manifests.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/check-schemas.yml
+++ b/.github/workflows/check-schemas.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-cirrus.yml
+++ b/.github/workflows/deploy-cirrus.yml
@@ -18,7 +18,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           persist-credentials: false
           fetch-tags: true
@@ -55,7 +55,7 @@ jobs:
 
       - name: Push to Google Artifact Registry
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: mozilla-it/deploy-actions/docker-push@v4.3.2
+        uses: mozilla-it/deploy-actions/docker-push@e2876aeb0f458eba1a39fa46bd072264c5877b11 # v4.3.2
         with:
           image_tags: |-
             ${{ env.IMAGE_BASE }}:latest

--- a/.github/workflows/deploy-schemas.yml
+++ b/.github/workflows/deploy-schemas.yml
@@ -16,7 +16,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 2
 
@@ -55,7 +55,7 @@ jobs:
           packages-dir: schemas/dist/
           skip-existing: true
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
         if: steps.check-paths.outputs.should-run == 'true' && steps.version-check.outputs.changed == 'true'
         with:
           node-version: 24

--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -28,7 +28,7 @@ jobs:
       packages: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.sha) || github.ref }}
           persist-credentials: false
@@ -78,7 +78,7 @@ jobs:
 
       - name: Push to Google Artifact Registry
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: mozilla-it/deploy-actions/docker-push@v4.3.2
+        uses: mozilla-it/deploy-actions/docker-push@e2876aeb0f458eba1a39fa46bd072264c5877b11 # v4.3.2
         with:
           image_tags: |-
             ${{ env.IMAGE_BASE }}:latest

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -34,7 +34,7 @@ jobs:
       FENIX_APK_PATH: ${{ github.workspace }}/fenix.apk
       FENIX_CHANNEL: ${{ matrix.channel }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -67,7 +67,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -113,7 +113,7 @@ jobs:
 
       - name: Upload test report on failure
         if: failure() && steps.check-paths.outputs.should-run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: fenix-${{ matrix.channel }}-test-report
           path: experimenter/tests/integration/test-reports/

--- a/.github/workflows/integration-desktop-enrollment.yml
+++ b/.github/workflows/integration-desktop-enrollment.yml
@@ -23,7 +23,7 @@ jobs:
       PYTEST_ARGS: -k FIREFOX_DESKTOP -m desktop_enrollment --reruns 1 --splits 2 --split ${{ matrix.split }} --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-desktop-targeting.yml
+++ b/.github/workflows/integration-desktop-targeting.yml
@@ -24,7 +24,7 @@ jobs:
       PYTEST_ARGS: -k FIREFOX_DESKTOP -m run_targeting -n 4 --reruns 1 --splits 2 --split ${{ matrix.split }} --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-nimbus-ui.yml
+++ b/.github/workflows/integration-nimbus-ui.yml
@@ -19,7 +19,7 @@ jobs:
       PYTEST_ARGS: -m nimbus_ui -n 4 --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-remote-settings-all.yml
+++ b/.github/workflows/integration-remote-settings-all.yml
@@ -29,7 +29,7 @@ jobs:
       PYTEST_ARGS: -k FIREFOX_DESKTOP -m ${{ matrix.marker }} --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration-remote-settings-launch.yml
+++ b/.github/workflows/integration-remote-settings-launch.yml
@@ -19,7 +19,7 @@ jobs:
       PYTEST_ARGS: -m remote_settings_launch --reruns 1 --base-url https://nginx/nimbus/
       PYTEST_BASE_URL: https://nginx/nimbus/
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -23,7 +23,7 @@ jobs:
       IOS_CHANNEL: developer
       IOS_RECIPE_PATH: ${{ github.workspace }}/ios_recipe.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Set up Python
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload recipe artifact
         if: steps.check-paths.outputs.should-run == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ios-recipe
           path: ${{ github.workspace }}/ios_recipe.json
@@ -85,7 +85,7 @@ jobs:
       IOS_SIMULATOR: "iPhone 17"
       IOS_RECIPE_PATH: ${{ github.workspace }}/ios_recipe.json
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Read firefox-ios SHA
         run: |
@@ -97,7 +97,7 @@ jobs:
           echo "FIREFOX_IOS_SHA=$FIREFOX_IOS_SHA" >> "$GITHUB_ENV"
 
       - name: Checkout firefox-ios
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: mozilla-mobile/firefox-ios
           ref: ${{ env.FIREFOX_IOS_SHA }}
@@ -171,7 +171,7 @@ jobs:
           sudo bash /tmp/install-nimbus-cli.sh --directory /usr/local/bin
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -182,7 +182,7 @@ jobs:
         run: poetry -C experimenter/tests install --no-root
 
       - name: Download recipe artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: ios-recipe
           path: ${{ github.workspace }}

--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -23,6 +23,8 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Configure git
         run: |
@@ -76,6 +78,8 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Configure git
         run: |

--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -14,11 +14,11 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ vars.GH_APP_ID }}
@@ -67,11 +67,11 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           ref: main
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         id: app-token
         with:
           app-id: ${{ vars.GH_APP_ID }}

--- a/.github/workflows/update-firefox.yml
+++ b/.github/workflows/update-firefox.yml
@@ -55,12 +55,12 @@ jobs:
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         if: steps.should-run.outputs.run == 'true'
         with:
           ref: main
 
-      - uses: actions/create-github-app-token@v2
+      - uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2
         if: steps.should-run.outputs.run == 'true'
         id: app-token
         with:

--- a/.github/workflows/update-firefox.yml
+++ b/.github/workflows/update-firefox.yml
@@ -66,6 +66,8 @@ jobs:
         with:
           app-id: ${{ vars.GH_APP_ID }}
           private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Configure git
         if: steps.should-run.outputs.run == 'true'


### PR DESCRIPTION
Because

* zizmor enforces a blanket policy requiring all external actions to be pinned to a commit SHA; the first-party actions and docker/setup-buildx-action were not covered by the initial third-party pinning.
* zizmor also flags create-github-app-token steps that inherit blanket installation permissions.

This commit

* Pins all remaining external actions (actions/*, mozilla-it/deploy-actions, docker/setup-buildx-action) to commit SHAs at their current versions, with the version recorded in a trailing comment.
* Scopes the app tokens in update-configs.yml and update-firefox.yml to contents:write + pull-requests:write, the only permissions those workflows use.

Fixes #16333