### PR TITLE
feat(nimbus): Add preview card to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/context_processors.py
+++ b/experimenter/experimenter/nimbus_ui/context_processors.py
@@ -1,13 +1,16 @@
+from experimenter.experiments.constants import EXTERNAL_URLS
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 
 
 def nimbus_ui_constants(request):
     """
-    Context processor that makes NimbusUIConstants available to all templates.
+    Context processor that makes NimbusUIConstants and EXTERNAL_URLS
+    available to all templates.
 
     This allows templates to access UI constants directly via:
     {{ NimbusUIConstants.PROPERTY_NAME }}
     """
     return {
         "NimbusUIConstants": NimbusUIConstants,
+        "EXTERNAL_URLS": EXTERNAL_URLS,
     }

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.views.generic import DetailView
 from django.views.generic.edit import UpdateView
 
+from experimenter.experiments.constants import EXTERNAL_URLS
 from experimenter.experiments.models import NimbusExperiment, Tag
 from experimenter.nimbus_ui.filtersets import (
     TagSearchFilterSet,
@@ -100,6 +101,11 @@ class NimbusRolloutDetailView(
     DetailView,
 ):
     template_name = "new/rollouts/rollout_detail.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["EXTERNAL_URLS"] = EXTERNAL_URLS
+        return context
 
 
 class CardMixin:

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -4,7 +4,6 @@ from django.urls import reverse
 from django.views.generic import DetailView
 from django.views.generic.edit import UpdateView
 
-from experimenter.experiments.constants import EXTERNAL_URLS
 from experimenter.experiments.models import NimbusExperiment, Tag
 from experimenter.nimbus_ui.filtersets import (
     TagSearchFilterSet,
@@ -101,11 +100,6 @@ class NimbusRolloutDetailView(
     DetailView,
 ):
     template_name = "new/rollouts/rollout_detail.html"
-
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context["EXTERNAL_URLS"] = EXTERNAL_URLS
-        return context
 
 
 class CardMixin:

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
@@ -1,0 +1,85 @@
+{% load static %}
+
+<div class="d-flex flex-column gap-3" id="rollout-preview-body">
+  <p class="small text-body mb-0">
+    <strong>Note:</strong> Before generating links, go to <code>about:config</code>
+    and enable the <code>nimbus.debug</code> configuration first.
+  </p>
+  {# Rollout experience card #}
+  <div class="row g-3">
+    <div class="col-12 col-md-6">
+      <div class="d-flex flex-column gap-3 h-100 rounded-3 bg-body-tertiary p-3">
+        <div>
+          <div class="fw-semibold mb-1">Rollout experience</div>
+          <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
+             class="small text-decoration-none"
+             target="_blank"
+             rel="noopener noreferrer"><i class="fa-regular fa-eye me-2" aria-hidden="true"></i>Testing details</a>
+        </div>
+        {# Screenshot from the rollout branch #}
+        {% with shot=experiment.reference_branch.screenshots.first %}
+          <div class="position-relative border border-secondary-subtle rounded-3 overflow-hidden">
+            {% if shot and shot.image %}
+              <img src="{{ shot.image.url }}"
+                   alt="{{ shot.description|default:'Rollout experience screenshot' }}"
+                   class="w-100"
+                   style="height: 160px;
+                          object-fit: cover" />
+              <button type="button"
+                      class="position-absolute top-0 end-0 m-1 p-2 border-0 rounded lh-1 opacity-75 bg-body-secondary"
+                      data-bs-toggle="modal"
+                      data-bs-target="#rollout-preview-screenshot-modal"
+                      aria-label="Enlarge screenshot">
+                <i class="fa-solid fa-up-right-and-down-left-from-center text-muted"
+                   aria-hidden="true"></i>
+              </button>
+            {% else %}
+              <img src="{% static 'assets/img-placeholder.svg' %}"
+                   alt="No screenshot uploaded yet"
+                   class="w-100"
+                   style="height: 160px;
+                          object-fit: cover" />
+            {% endif %}
+          </div>
+          {% if shot and shot.image %}
+            <div class="modal fade"
+                 id="rollout-preview-screenshot-modal"
+                 tabindex="-1"
+                 aria-labelledby="rollout-preview-screenshot-modal-label"
+                 aria-hidden="true">
+              <div class="modal-dialog modal-md modal-dialog-centered">
+                <div class="modal-content">
+                  <div class="modal-header">
+                    <h1 class="modal-title fs-5" id="rollout-preview-screenshot-modal-label">Rollout experience</h1>
+                    <button type="button"
+                            class="btn-close"
+                            data-bs-dismiss="modal"
+                            aria-label="Close"></button>
+                  </div>
+                  <div class="modal-body d-flex flex-column gap-3">
+                    {% for screenshot in experiment.reference_branch.screenshots.all %}
+                      {% if screenshot.image %}
+                        <div>
+                          <img src="{{ screenshot.image.url }}"
+                               alt="{{ screenshot.description|default:'Rollout experience screenshot' }}"
+                               class="img-fluid w-100" />
+                          {% if screenshot.description %}<div class="mt-2 small text-body">{{ screenshot.description }}</div>{% endif %}
+                        </div>
+                      {% endif %}
+                    {% endfor %}
+                  </div>
+                </div>
+              </div>
+            </div>
+          {% endif %}
+        {% endwith %}
+        {# about:studies opt-in URL for the rollout branch #}
+        <button type="button"
+                class="btn btn-primary d-inline-flex align-items-center justify-content-center"
+                onclick="navigator.clipboard.writeText('about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview');this.innerText='Copied';">
+          <i class="fa-regular fa-eye me-2" aria-hidden="true"></i>Preview link
+        </button>
+      </div>
+    </div>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -8,6 +8,12 @@
   <div id="RolloutSummary" class="d-flex flex-column gap-4">
     {% include "new/common/audience_overlap_warnings.html" %}
 
+    {% if experiment.is_preview %}
+      <div class="d-flex flex-column gap-2" id="rollout-preview-section">
+        {% include "new/rollouts/detail_card.html" with card_id="preview" title="Preview links & testing details" subtitle="Rollout experience" show_edit_btn=False body_template="new/rollouts/preview/card.html" %}
+
+      </div>
+    {% endif %}
     {# ── Define ── #}
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Define</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -12,11 +12,13 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
+from experimenter.experiments.constants import EXTERNAL_URLS
 from experimenter.experiments.models import (
     NimbusExperiment,
     NimbusRolloutPlanTemplate,
 )
 from experimenter.experiments.tests.factories import (
+    NimbusBranchScreenshotFactory,
     NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
     NimbusRolloutPhaseFactory,
@@ -134,6 +136,53 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertIsInstance(response.context["create_form"], NimbusExperimentCreateForm)
         self.assertIn(tag, response.context["all_tags"])
         self.assertTrue(response.context["sidebar_links"])
+
+    def test_preview_card_hidden_when_not_in_preview(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(experiment.is_preview)
+        self.assertNotContains(response, "Preview links & testing details")
+
+    def test_preview_card_shown_when_in_preview(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(experiment.is_preview)
+        self.assertContains(response, "Preview links & testing details")
+        self.assertContains(response, "Rollout experience")
+        self.assertContains(response, EXTERNAL_URLS["PREVIEW_LAUNCH_DOC"])
+
+    def test_preview_card_lists_all_screenshots(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW
+        )
+        screenshot_1 = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+        screenshot_2 = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, screenshot_1.image.url)
+        self.assertContains(response, screenshot_2.image.url)
 
 
 class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):


### PR DESCRIPTION
Because

* we need to add the preview card from the Figma design

This commit

* adds a preview card to the rollout page shown only when the rollout is in the Preview state
* provides the rollout branch screenshots and a button that copies the about:studies opt-in URL

Fixes #15083



https://github.com/user-attachments/assets/3af25baa-e802-4125-80ec-af92b73b6b2c


