### PR TITLE
fix(nimbus): show 3-Day Retention for mobile experiment results

### DIFF
--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -125,6 +125,7 @@ def get_results_metrics_map(
     results_metrics_map: dict[str, set[Statistic]] = {
         Metric.RETENTION: {Statistic.BINOMIAL},
         Metric.RETENTION_3_DAYS: {Statistic.BINOMIAL},
+        Metric.RETENTION_3_DAYS_LEGACY: {Statistic.BINOMIAL},
         Metric.SEARCH: {Statistic.LINEAR_MODEL_MEAN, Statistic.MEAN},
         Metric.DAYS_OF_USE: {Statistic.LINEAR_MODEL_MEAN, Statistic.MEAN},
         Metric.USER_COUNT: {Statistic.COUNT, Statistic.PERCENT},

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -28,7 +28,8 @@ class BranchComparison(StrEnum):
 
 class Metric(StrEnum):
     RETENTION = "retained"
-    RETENTION_3_DAYS = "active_in_last_3_days_legacy"
+    RETENTION_3_DAYS = "active_in_last_3_days"
+    RETENTION_3_DAYS_LEGACY = "active_in_last_3_days_legacy"
     SEARCH = "search_count"
     DAYS_OF_USE = "days_of_use"
     USER_COUNT = "identity"
@@ -79,6 +80,7 @@ GROUPED_METRICS = {
 }
 RETENTION_2_WEEKS_WINDOW_INDEX = 2
 RETENTION_3_DAYS_WINDOW_INDEX = 4
+RETENTION_3_DAYS_METRICS = (Metric.RETENTION_3_DAYS, Metric.RETENTION_3_DAYS_LEGACY)
 
 
 # A map of metric -> group for quick lookups.
@@ -176,25 +178,33 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
         ]
         self.extend(retention_data)
 
+    def get_retention_3_days_by_window(self, window_index, daily_data):
+        retention_data = []
+        for metric in RETENTION_3_DAYS_METRICS:
+            retention_data.extend(
+                self.get_retention_by_window(window_index, daily_data, metric)
+            )
+        return retention_data
+
     def append_retention_3_days(self, daily_data):
         # Extract the 3-day retention data (window index 4)
         # without falling back to earlier windows
-        retention_data = self.get_retention_by_window(
-            RETENTION_3_DAYS_WINDOW_INDEX, daily_data, Metric.RETENTION_3_DAYS
+        retention_data = self.get_retention_3_days_by_window(
+            RETENTION_3_DAYS_WINDOW_INDEX, daily_data
         )
 
         self.extend(retention_data)
 
     def replace_retention_3_days(self, daily_data):
         # Extract and replace with the 3-day retention data (window index 4)
-        retention_data = self.get_retention_by_window(
-            RETENTION_3_DAYS_WINDOW_INDEX, daily_data, Metric.RETENTION_3_DAYS
+        retention_data = self.get_retention_3_days_by_window(
+            RETENTION_3_DAYS_WINDOW_INDEX, daily_data
         )
 
         self.root = [
             jetstream_data_point
             for jetstream_data_point in self.root
-            if jetstream_data_point.metric != Metric.RETENTION_3_DAYS
+            if jetstream_data_point.metric not in RETENTION_3_DAYS_METRICS
         ]
         self.extend(retention_data)
 

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -61,6 +61,21 @@ class TestJetstreamData(TestCase):
 
         self.assertIn(retention, data)
 
+    def test_append_retention_3_days_extracts_legacy_data(self):
+        retention = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS_LEGACY,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="4",
+        )
+
+        data = JetstreamData([])
+        data.append_retention_3_days([retention])
+
+        self.assertIn(retention, data)
+
     def test_append_retention_data_ignores_week_1_only_data(self):
         week_1_retention = JetstreamDataPoint(
             metric=Metric.RETENTION,
@@ -177,4 +192,28 @@ class TestJetstreamData(TestCase):
         self.assertNotIn(existing_retention_1, data)
         self.assertNotIn(existing_retention_2, data)
         self.assertNotIn(existing_retention_3, data)
+        self.assertIn(kept_retention, data)
+
+    def test_replace_retention_3_days_handles_legacy_metric_name(self):
+        existing_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS_LEGACY,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.25,
+            segment=Segment.ALL,
+            window_index="1",
+        )
+        kept_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS_LEGACY,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="4",
+        )
+
+        data = JetstreamData([existing_retention, kept_retention])
+        data.replace_retention_3_days(data)
+
+        self.assertNotIn(existing_retention, data)
         self.assertIn(kept_retention, data)


### PR DESCRIPTION
Because

* The results ingest synthesizes the "3-Day Retention" KPI from the daily active-in-last-3-days metric but only matched the desktop legacy-telemetry name (`active_in_last_3_days_legacy`), so mobile (Glean) experiments, which emit `active_in_last_3_days`, never got 3-Day Retention in the weekly and overall results.

This commit

* Matches both the Glean (`active_in_last_3_days`) and desktop legacy (`active_in_last_3_days_legacy`) metric names when extracting 3-day retention into the weekly and overall windows.
* Registers both names in the results metrics map so desktop points continue to be kept.
* Adds regression tests covering both metric names.

Fixes #16346