### PR TITLE
feat(nimbus): add jexl_to_sql.py — JEXL to BigQuery SQL translator

### DIFF
--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -1,0 +1,422 @@
+import dataclasses
+import re
+from typing import Optional
+
+from pyjexl.parser import (
+    ArrayLiteral,
+    BinaryExpression,
+    FilterExpression,
+    Identifier,
+    Literal,
+    Transform,
+    UnaryExpression,
+)
+
+from experimenter.experiments.jexl_utils import JEXLParser
+
+_OS = "metrics.object.nimbus_targeting_context_os"
+_BS = "metrics.object.nimbus_targeting_context_browser_settings"
+_HP = "metrics.object.nimbus_targeting_context_home_page_settings"
+_AD = "metrics.object.nimbus_targeting_context_attribution_data"
+_AI = "metrics.object.nimbus_targeting_context_addons_info"
+
+# Schema confirmed from: mozdata.firefox_desktop.nimbus_targeting_context
+JEXL_TO_BQ_COLUMN = {
+    "locale": "metrics.string.nimbus_targeting_context_locale",
+    "region": "metrics.string.nimbus_targeting_context_region",
+    "distributionId": "metrics.string.nimbus_targeting_context_distribution_id",
+    "currentDate": "metrics.string.nimbus_targeting_context_current_date",
+    "version": "metrics.string.nimbus_targeting_context_version",
+    "firefoxVersion": "metrics.quantity.nimbus_targeting_context_firefox_version",
+    "buildId": "metrics.quantity.nimbus_targeting_context_build_id",
+    "archBits": "metrics.quantity.nimbus_targeting_context_arch_bits",
+    "memoryMb": "metrics.quantity.nimbus_targeting_context_memory_mb",
+    "memoryMB": "metrics.quantity.nimbus_targeting_context_memory_mb",
+    "totalBookmarksCount": (
+        "metrics.quantity.nimbus_targeting_context_total_bookmarks_count"
+    ),
+    "addressesSaved": "metrics.quantity.nimbus_targeting_context_addresses_saved",
+    "profileGroupProfileCount": (
+        "metrics.quantity.nimbus_targeting_context_profile_group_profile_count"
+    ),
+    "profileAgeCreated": (
+        "metrics.quantity.nimbus_targeting_context_profile_age_created"
+    ),
+    "isFirstStartup": "metrics.boolean.nimbus_targeting_context_is_first_startup",
+    "isDefaultBrowser": ("metrics.boolean.nimbus_targeting_context_is_default_browser"),
+    "isFxAEnabled": "metrics.boolean.nimbus_targeting_context_is_fx_a_enabled",
+    "isFxASignedIn": "metrics.boolean.nimbus_targeting_context_is_fx_a_signed_in",
+    "isMSIX": "metrics.boolean.nimbus_targeting_context_is_msix",
+    "doesAppNeedPin": "metrics.boolean.nimbus_targeting_context_does_app_need_pin",
+    "hasActiveEnterprisePolicies": (
+        "metrics.boolean.nimbus_targeting_context_has_active_enterprise_policies"
+    ),
+    "hasPinnedTabs": "metrics.boolean.nimbus_targeting_context_has_pinned_tabs",
+    "userPrefersReducedMotion": (
+        "metrics.boolean.nimbus_targeting_context_user_prefers_reduced_motion"
+    ),
+    "usesFirefoxSync": "metrics.boolean.nimbus_targeting_context_uses_firefox_sync",
+    # isWindows is not stored — derived from absence of isMac and isLinux
+    "os.isWindows": (
+        f"(NOT CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)"
+        f" AND NOT CAST(JSON_VALUE({_OS}, '$.isLinux') AS BOOL))"
+    ),
+    "os.isMac": f"CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)",
+    "os.isLinux": f"CAST(JSON_VALUE({_OS}, '$.isLinux') AS BOOL)",
+    "os.windowsBuildNumber": (
+        f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsBuildNumber') AS INT64)"
+    ),
+    "os.windowsVersion": (f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsVersion') AS FLOAT64)"),
+    "browserSettings.update.channel": (f"JSON_VALUE({_BS}, '$.update.channel')"),
+    "browserSettings.update.autoDownload": (
+        f"CAST(JSON_VALUE({_BS}, '$.update.autoDownload') AS BOOL)"
+    ),
+    "browserSettings.update.enabled": (
+        f"CAST(JSON_VALUE({_BS}, '$.update.enabled') AS BOOL)"
+    ),
+    "homePageSettings.isDefault": (f"CAST(JSON_VALUE({_HP}, '$.isDefault') AS BOOL)"),
+    "homePageSettings.isCustomUrl": (f"CAST(JSON_VALUE({_HP}, '$.isCustomUrl') AS BOOL)"),
+    "homePageSettings.isLocked": f"CAST(JSON_VALUE({_HP}, '$.isLocked') AS BOOL)",
+    "homePageSettings.isWebExt": f"CAST(JSON_VALUE({_HP}, '$.isWebExt') AS BOOL)",
+    "addonsInfo.hasInstalledAddons": (
+        f"CAST(JSON_VALUE({_AI}, '$.hasInstalledAddons') AS BOOL)"
+    ),
+    "attributionData.medium": f"JSON_VALUE({_AD}, '$.medium')",
+    "attributionData.source": f"JSON_VALUE({_AD}, '$.source')",
+    "attributionData.campaign": f"JSON_VALUE({_AD}, '$.campaign')",
+    "attributionData.content": f"JSON_VALUE({_AD}, '$.content')",
+    "attributionData.ua": f"JSON_VALUE({_AD}, '$.ua')",
+    "attributionData.dltoken": f"JSON_VALUE({_AD}, '$.dltoken')",
+}
+
+_PREF_VALUES_COL = "metrics.object.nimbus_targeting_environment_pref_values"
+_USER_SET_PREFS_COL = "metrics.object.nimbus_targeting_environment_user_set_prefs"
+_USER_MONTHLY_ACTIVITY_COL = (
+    "metrics.object.nimbus_targeting_context_user_monthly_activity"
+)
+
+# Attributes with no corresponding column in nimbus_targeting_context.
+KNOWN_UNTRANSLATABLE = {
+    "attachedFxAOAuthClients",  # privacy-sensitive, will never be recorded
+    "isFirstRun",  # Desktop uses isFirstStartup; also mobile-only
+    "is_first_run",
+    "isNonStubFirstRun",
+    "enrollments",
+    "enrollmentsMap",
+    "activeExperiments",  # circular
+    "activeRollouts",  # circular
+    "newtabSettings",
+    "searchEngines",
+    "addonsInfo",  # parent blocked; specific sub-fields mapped above
+    "isBackgroundTaskMode",
+    "newtabAddonVersion",  # addon version not stored in nimbus_targeting_context
+    "defaultProfile",  # background task context only
+    "days_since_install",  # mobile-only
+    "days_since_update",  # mobile-only
+}
+
+_VERSION_PATTERN = re.compile(r"^(\d+)")
+
+
+@dataclasses.dataclass
+class JEXLToSQLResult:
+    sql: Optional[str]
+    warnings: list[str]
+
+
+def jexl_to_sql(jexl_expression: str) -> JEXLToSQLResult:
+    """
+    Translate a JEXL targeting expression into a BigQuery SQL WHERE clause.
+
+    Returns sql=None with a warnings list when nothing can be translated.
+    Returns partial sql with warnings when only some clauses translate.
+    """
+    if not jexl_expression or jexl_expression == "true":
+        return JEXLToSQLResult(sql=None, warnings=[])
+
+    warnings: list[str] = []
+    try:
+        ast = JEXLParser().parse(jexl_expression)
+        sql = _node_to_sql(ast, warnings)
+    except Exception:
+        return JEXLToSQLResult(sql=None, warnings=["__parse_error__"])
+
+    return JEXLToSQLResult(sql=sql or None, warnings=warnings)
+
+
+def _node_to_sql(node, warnings: list[str]) -> Optional[str]:
+    if isinstance(node, BinaryExpression):
+        return _binary_to_sql(node, warnings)
+    if isinstance(node, UnaryExpression):
+        return _unary_to_sql(node, warnings)
+    if isinstance(node, Identifier):
+        return _identifier_to_sql(node, warnings)
+    if isinstance(node, Literal):
+        return _literal_to_sql(node)
+    if isinstance(node, ArrayLiteral):
+        return _array_to_sql(node, warnings)
+    if isinstance(node, Transform):
+        return _transform_to_sql(node, warnings)
+    if isinstance(node, FilterExpression):
+        subject_path = _identifier_path(node.subject)
+        # addonsInfo.addons['addon-id'] — check addon ID membership in BQ array
+        if subject_path == "addonsInfo.addons" and isinstance(node.expression, Literal):
+            addon_id = node.expression.value
+            if isinstance(addon_id, str):
+                return f"'{addon_id}' IN UNNEST(JSON_VALUE_ARRAY({_AI}, '$.addons'))"
+        _add_warning(warnings, subject_path or _identifier_path(node.subject))
+        return None
+    return None
+
+
+def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]:
+    op = node.operator.symbol
+
+    if _is_version_compare_node(node.left) and isinstance(node.right, Literal):
+        return _version_compare_binary_to_sql(node, warnings)
+    if _is_version_compare_node(node.right) and isinstance(node.left, Literal):
+        return _version_compare_binary_to_sql_reversed(node, warnings)
+
+    if op in ("&&", "||"):
+        left = _node_to_sql(node.left, warnings)
+        right = _node_to_sql(node.right, warnings)
+        if left and right:
+            sql_op = "AND" if op == "&&" else "OR"
+            return f"({left} {sql_op} {right})"
+        return left or right
+
+    left = _node_to_sql(node.left, warnings)
+    right = _node_to_sql(node.right, warnings)
+    if left is None or right is None:
+        return None
+
+    if op == "in":
+        return f"{left} IN {right}"
+
+    comparison_ops = {
+        "==": "=",
+        "!=": "!=",
+        "<": "<",
+        "<=": "<=",
+        ">": ">",
+        ">=": ">=",
+    }
+    arithmetic_ops = {"+": "+", "-": "-", "*": "*", "/": "/", "%": "%"}
+
+    if op in comparison_ops:
+        return f"{left} {comparison_ops[op]} {right}"
+    if op in arithmetic_ops:
+        return f"({left} {arithmetic_ops[op]} {right})"
+    return None
+
+
+def _unary_to_sql(node: UnaryExpression, warnings: list[str]) -> Optional[str]:
+    if node.operator.symbol == "!":
+        inner = _node_to_sql(node.right, warnings)
+        if inner:
+            if _is_boolean_sql(inner):
+                return f"NOT ({inner})"
+            # NOT (string) is invalid in BigQuery — JEXL falsy means null or empty
+            return f"({inner} IS NULL OR {inner} = '')"
+    return None  # pragma: no cover — pyjexl only produces UnaryExpression for "!"
+
+
+def _identifier_to_sql(node: Identifier, warnings: list[str]) -> Optional[str]:
+    path = _identifier_path(node)
+
+    if path == "null":
+        return "NULL"
+
+    # Explicit mappings take priority over parent being in KNOWN_UNTRANSLATABLE
+    if path in JEXL_TO_BQ_COLUMN:
+        return JEXL_TO_BQ_COLUMN[path]
+
+    if _is_untranslatable(path):
+        _add_warning(warnings, path)
+        return None
+
+    _add_warning(warnings, path)
+    return None
+
+
+def _literal_to_sql(node: Literal) -> str:
+    value = node.value
+    if isinstance(value, bool):
+        return "TRUE" if value else "FALSE"
+    if isinstance(value, str):
+        escaped = value.replace("'", "\\'")
+        return f"'{escaped}'"
+    return str(value)
+
+
+def _array_to_sql(node: ArrayLiteral, warnings: list[str]) -> Optional[str]:
+    items = [_node_to_sql(item, warnings) for item in node.value]
+    items = [i for i in items if i is not None]
+    if not items:
+        return None
+    return f"({', '.join(items)})"
+
+
+def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
+    subject_path = _identifier_path(node.subject)
+
+    if node.name == "date":
+        # profileAgeCreated is stored as epoch ms — return column directly for arithmetic
+        if subject_path == "profileAgeCreated":
+            return JEXL_TO_BQ_COLUMN["profileAgeCreated"]
+        if subject_path == "currentDate":
+            return "UNIX_MILLIS(CURRENT_TIMESTAMP())"
+        _add_warning(warnings, "|date")
+        return None
+
+    if node.name == "length":
+        if subject_path == "userMonthlyActivity":
+            return f"JSON_ARRAY_LENGTH({_USER_MONTHLY_ACTIVITY_COL})"
+        subject_sql = _node_to_sql(node.subject, warnings)
+        if subject_sql:
+            return f"JSON_ARRAY_LENGTH({subject_sql})"
+        _add_warning(warnings, "|length")
+        return None
+
+    if node.name == "preferenceValue":
+        # Pref names stored with dots replaced by __ in BigQuery
+        pref_name = _literal_value(node.subject)
+        if pref_name:
+            bq_key = pref_name.replace(".", "__")
+            return f"JSON_VALUE({_PREF_VALUES_COL}, '$.{bq_key}')"
+        _add_warning(warnings, "|preferenceValue")
+        return None
+
+    if node.name == "preferenceIsUserSet":
+        # user_set_prefs is a JSON array of pref names (using original dot notation)
+        pref_name = _literal_value(node.subject)
+        if pref_name:
+            return f"'{pref_name}' IN UNNEST(JSON_VALUE_ARRAY({_USER_SET_PREFS_COL}))"
+        _add_warning(warnings, "|preferenceIsUserSet")
+        return None
+
+    if node.name == "versionCompare":
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    _add_warning(warnings, f"|{node.name}")
+    return None
+
+
+def _is_version_compare_node(node) -> bool:
+    return isinstance(node, Transform) and node.name == "versionCompare"
+
+
+def _extract_major_version(version_str: str) -> Optional[int]:
+    m = _VERSION_PATTERN.match(str(version_str).strip("'\""))
+    return int(m.group(1)) if m else None
+
+
+def _version_compare_binary_to_sql(
+    node: BinaryExpression, warnings: list[str]
+) -> Optional[str]:
+    """version|versionCompare('X.!') <op> 0 → firefox_version <op> X"""
+    return _version_compare_binary_to_sql_with(
+        transform=node.left,
+        op_symbol=node.operator.symbol,
+        comparand_value=node.right.value,
+        warnings=warnings,
+    )
+
+
+def _version_compare_binary_to_sql_reversed(
+    node: BinaryExpression, warnings: list[str]
+) -> Optional[str]:
+    # 0 <= version|versionCompare('X') → flip operands and operator, reuse same logic
+    reverse_op = {
+        ">=": "<=",
+        ">": "<",
+        "<=": ">=",
+        "<": ">",
+        "==": "=",
+        "!=": "!=",
+    }
+    flipped_op = reverse_op.get(node.operator.symbol)
+    if not flipped_op:
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    # node.right is the versionCompare transform, node.left is the literal (e.g. 0)
+    # Swap so the transform is on the left and the literal on the right
+    return _version_compare_binary_to_sql_with(
+        transform=node.right,
+        op_symbol=flipped_op,
+        comparand_value=node.left.value,
+        warnings=warnings,
+    )
+
+
+def _version_compare_binary_to_sql_with(
+    transform, op_symbol: str, comparand_value, warnings: list[str]
+) -> Optional[str]:
+    if comparand_value != 0:
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    subject_path = _identifier_path(transform.subject)
+    if subject_path != "version":
+        _add_warning(warnings, subject_path or "|versionCompare")
+        return None
+
+    if not transform.args:
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    version_arg = transform.args[0]
+    version_str = version_arg.value if isinstance(version_arg, Literal) else None
+    major = _extract_major_version(version_str) if version_str else None
+
+    if major is None:
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    op_map = {">=": ">=", ">": ">", "<=": "<=", "<": "<", "==": "=", "!=": "!="}
+    sql_op = op_map.get(op_symbol)
+    if sql_op is None:
+        _add_warning(warnings, "|versionCompare")
+        return None
+
+    return f"{JEXL_TO_BQ_COLUMN['firefoxVersion']} {sql_op} {major}"
+
+
+def _identifier_path(node) -> str:
+    if node is None:
+        return ""
+    if isinstance(node, Identifier):
+        subject = _identifier_path(node.subject)
+        return f"{subject}.{node.value}" if subject else node.value
+    if isinstance(node, Literal):
+        return str(node.value)
+    return ""
+
+
+def _literal_value(node) -> Optional[str]:
+    if isinstance(node, Literal) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_untranslatable(path: str) -> bool:
+    if path in KNOWN_UNTRANSLATABLE:
+        return True
+    parts = path.split(".")
+    return any(".".join(parts[:i]) in KNOWN_UNTRANSLATABLE for i in range(1, len(parts)))
+
+
+def _is_boolean_sql(sql: str) -> bool:
+    sql_upper = sql.upper()
+    return (
+        sql.startswith("metrics.boolean.")
+        or sql_upper.endswith(("AS BOOL)", "AS BOOLEAN)"))
+        or " IN UNNEST(" in sql_upper
+    )
+
+
+def _add_warning(warnings: list[str], attribute: str):
+    if attribute and attribute not in warnings:
+        warnings.append(attribute)

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -117,14 +117,14 @@ KNOWN_UNTRANSLATABLE = {
     "activeRollouts",  # circular
     "newtabSettings",
     "searchEngines",
-    "addonsInfo",               # parent blocked; specific sub-fields mapped above
+    "addonsInfo",  # parent blocked; specific sub-fields mapped above
     "isBackgroundTaskMode",
-    "newtabAddonVersion",       # addon version not stored in nimbus_targeting_context
-    "defaultProfile",           # background task context only
-    "defaultPDFHandler",        # default PDF handler, not directly queryable
-    "isDefaultHandler",         # file-type handler object, not directly queryable
-    "localeLanguageCode",       # derived from locale, not recorded separately
-    "homePageSettings",         # parent blocked; simple sub-fields mapped above
+    "newtabAddonVersion",  # addon version not stored in nimbus_targeting_context
+    "defaultProfile",  # background task context only
+    "defaultPDFHandler",  # default PDF handler, not directly queryable
+    "isDefaultHandler",  # file-type handler object, not directly queryable
+    "localeLanguageCode",  # derived from locale, not recorded separately
+    "homePageSettings",  # parent blocked; simple sub-fields mapped above
     # Mobile-only attributes
     "days_since_install",
     "days_since_update",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -81,6 +81,16 @@ JEXL_TO_BQ_COLUMN = {
     "addonsInfo.hasInstalledAddons": (
         f"CAST(JSON_VALUE({_AI}, '$.hasInstalledAddons') AS BOOL)"
     ),
+    "primaryResolution.width": (
+        "SAFE_CAST(JSON_VALUE("
+        "metrics.object.nimbus_targeting_context_primary_resolution"
+        ", '$.width') AS INT64)"
+    ),
+    "primaryResolution.height": (
+        "SAFE_CAST(JSON_VALUE("
+        "metrics.object.nimbus_targeting_context_primary_resolution"
+        ", '$.height') AS INT64)"
+    ),
     "attributionData.medium": f"JSON_VALUE({_AD}, '$.medium')",
     "attributionData.source": f"JSON_VALUE({_AD}, '$.source')",
     "attributionData.campaign": f"JSON_VALUE({_AD}, '$.campaign')",
@@ -107,12 +117,35 @@ KNOWN_UNTRANSLATABLE = {
     "activeRollouts",  # circular
     "newtabSettings",
     "searchEngines",
-    "addonsInfo",  # parent blocked; specific sub-fields mapped above
+    "addonsInfo",               # parent blocked; specific sub-fields mapped above
     "isBackgroundTaskMode",
-    "newtabAddonVersion",  # addon version not stored in nimbus_targeting_context
-    "defaultProfile",  # background task context only
-    "days_since_install",  # mobile-only
-    "days_since_update",  # mobile-only
+    "newtabAddonVersion",       # addon version not stored in nimbus_targeting_context
+    "defaultProfile",           # background task context only
+    "defaultPDFHandler",        # default PDF handler, not directly queryable
+    "isDefaultHandler",         # file-type handler object, not directly queryable
+    "localeLanguageCode",       # derived from locale, not recorded separately
+    "homePageSettings",         # parent blocked; simple sub-fields mapped above
+    # Mobile-only attributes
+    "days_since_install",
+    "days_since_update",
+    "is_default_browser",
+    "is_phone",
+    "is_bottom_toolbar_user",
+    "is_apple_intelligence_available",
+    "cannot_use_apple_intelligence",
+    "has_accepted_terms_of_use",
+    "has_enabled_tips_notifications",
+    "user_accepted_tou",
+    "tou_points",
+    "tou_experience_points",
+    "addon_ids",
+    "no_shortcuts_or_stories_opt_outs",
+    "android_sdk_version",
+    "install_referrer_response_utm_source",
+    # Standalone sub-fields accessed without parent (default PDF handler context)
+    "pdf",
+    "knownBrowser",
+    "registered",
 }
 
 _VERSION_PATTERN = re.compile(r"^(\d+)")

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -7,8 +7,8 @@ from experimenter.experiments.jexl_to_sql import (
     jexl_to_sql,
 )
 from experimenter.targeting.constants import (
-    FX95_DESKTOP_USERS,
     FIRST_RUN_WINDOWS_1903_NEWER,
+    FX95_DESKTOP_USERS,
     NO_ENTERPRISE_MAC_WINDOWS_ONLY,
     WIN11_ONLY,
     NimbusTargetingConfig,

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -1,0 +1,418 @@
+from django.test import TestCase
+from parameterized import parameterized
+
+from experimenter.experiments.jexl_to_sql import (
+    KNOWN_UNTRANSLATABLE,
+    jexl_to_sql,
+)
+
+_OS = "metrics.object.nimbus_targeting_context_os"
+_BS = "metrics.object.nimbus_targeting_context_browser_settings"
+_HP = "metrics.object.nimbus_targeting_context_home_page_settings"
+_AI = "metrics.object.nimbus_targeting_context_addons_info"
+_AD = "metrics.object.nimbus_targeting_context_attribution_data"
+_PREF = "metrics.object.nimbus_targeting_environment_pref_values"
+_USER_PREFS = "metrics.object.nimbus_targeting_environment_user_set_prefs"
+_UMA = "metrics.object.nimbus_targeting_context_user_monthly_activity"
+_FF = "metrics.quantity.nimbus_targeting_context_firefox_version"
+
+
+class TestJEXLToSQL(TestCase):
+    # --- Column mappings: (jexl_expression, expected_sql) ---
+
+    @parameterized.expand(
+        [
+            ("locale", "locale", "metrics.string.nimbus_targeting_context_locale"),
+            ("region", "region", "metrics.string.nimbus_targeting_context_region"),
+            (
+                "is_first_startup",
+                "isFirstStartup",
+                "metrics.boolean.nimbus_targeting_context_is_first_startup",
+            ),
+            (
+                "is_default_browser",
+                "isDefaultBrowser",
+                "metrics.boolean.nimbus_targeting_context_is_default_browser",
+            ),
+            (
+                "is_fx_a_signed_in",
+                "isFxASignedIn",
+                "metrics.boolean.nimbus_targeting_context_is_fx_a_signed_in",
+            ),
+            (
+                "firefox_version",
+                "firefoxVersion",
+                "metrics.quantity.nimbus_targeting_context_firefox_version",
+            ),
+            (
+                "memory_mb",
+                "memoryMb",
+                "metrics.quantity.nimbus_targeting_context_memory_mb",
+            ),
+            (
+                "memory_MB_alias",
+                "memoryMB",
+                "metrics.quantity.nimbus_targeting_context_memory_mb",
+            ),
+            (
+                "os_is_mac",
+                "os.isMac",
+                f"CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)",
+            ),
+            (
+                "os_is_linux",
+                "os.isLinux",
+                f"CAST(JSON_VALUE({_OS}, '$.isLinux') AS BOOL)",
+            ),
+            (
+                "homepage_is_default",
+                "homePageSettings.isDefault",
+                f"CAST(JSON_VALUE({_HP}, '$.isDefault') AS BOOL)",
+            ),
+            (
+                "homepage_is_custom_url",
+                "homePageSettings.isCustomUrl",
+                f"CAST(JSON_VALUE({_HP}, '$.isCustomUrl') AS BOOL)",
+            ),
+            (
+                "addons_has_installed",
+                "addonsInfo.hasInstalledAddons",
+                f"CAST(JSON_VALUE({_AI}, '$.hasInstalledAddons') AS BOOL)",
+            ),
+            (
+                "attribution_medium",
+                "attributionData.medium",
+                f"JSON_VALUE({_AD}, '$.medium')",
+            ),
+            (
+                "browser_channel",
+                "browserSettings.update.channel",
+                f"JSON_VALUE({_BS}, '$.update.channel')",
+            ),
+        ]
+    )
+    def test_attribute_translates_to_column(self, _name, jexl, expected_sql):
+        result = jexl_to_sql(jexl)
+        self.assertEqual(result.sql, expected_sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- Comparisons: (jexl, expected_sql) ---
+
+    @parameterized.expand(
+        [
+            (
+                "locale_eq",
+                'locale == "en-US"',
+                "metrics.string.nimbus_targeting_context_locale = 'en-US'",
+            ),
+            (
+                "locale_in_array",
+                'locale in ["en-US", "en-CA"]',
+                "metrics.string.nimbus_targeting_context_locale IN ('en-US', 'en-CA')",
+            ),
+            (
+                "firefox_version_gte",
+                "firefoxVersion >= 120",
+                f"{_FF} >= 120",
+            ),
+            (
+                "bool_true",
+                "isFirstStartup == true",
+                "metrics.boolean.nimbus_targeting_context_is_first_startup = TRUE",
+            ),
+            (
+                "bool_false",
+                "isFirstStartup == false",
+                "metrics.boolean.nimbus_targeting_context_is_first_startup = FALSE",
+            ),
+            (
+                "null_check",
+                "isFxASignedIn != null",
+                "metrics.boolean.nimbus_targeting_context_is_fx_a_signed_in != NULL",
+            ),
+        ]
+    )
+    def test_comparison_produces_correct_sql(self, _name, jexl, expected_sql):
+        result = jexl_to_sql(jexl)
+        self.assertEqual(result.sql, expected_sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- Untranslatable: expressions that produce warnings, no sql ---
+
+    _VC = "|versionCompare"
+
+    @parameterized.expand(
+        [
+            (
+                "known_untranslatable",
+                "attachedFxAOAuthClients",
+                "attachedFxAOAuthClients",
+            ),
+            ("mobile_attr", "days_since_install < 7", "days_since_install"),
+            ("unknown_attr", "someUnknownAttribute", "someUnknownAttribute"),
+            (
+                "newtab_addon_version",
+                "newtabAddonVersion|versionCompare('145.0') >= 0",
+                "newtabAddonVersion",
+            ),
+            (
+                "default_profile_subfield",
+                "defaultProfile.profileAgeCreated > 0",
+                "defaultProfile.profileAgeCreated",
+            ),
+        ]
+    )
+    def test_untranslatable_returns_none_and_warning(self, _name, jexl, expected_warning):
+        result = jexl_to_sql(jexl)
+        self.assertIsNone(result.sql)
+        self.assertIn(expected_warning, result.warnings)
+
+    # --- Transforms that warn ---
+
+    @parameterized.expand(
+        [
+            ("date_unknown_attr", "someDate|date", "|date"),
+            (
+                "length_untranslatable_subject",
+                "attachedFxAOAuthClients|length >= 1",
+                "|length",
+            ),
+            ("preference_value_variable", "someVar|preferenceValue", "|preferenceValue"),
+            (
+                "preference_is_user_set_variable",
+                "someVar|preferenceIsUserSet",
+                "|preferenceIsUserSet",
+            ),
+            ("unknown_transform", "locale|someUnknownTransform", "|someUnknownTransform"),
+            ("version_compare_non_zero", "version|versionCompare('95.!') >= 1", _VC),
+            (
+                "version_compare_unparseable",
+                "version|versionCompare('invalid') >= 0",
+                _VC,
+            ),
+            ("version_compare_standalone", "version|versionCompare('95.!')", _VC),
+            ("version_compare_no_args", "version|versionCompare >= 0", _VC),
+            ("version_compare_arithmetic_op", "version|versionCompare('95.!') + 0", _VC),
+            ("version_compare_reversed_in", "0 in version|versionCompare('95.!')", _VC),
+        ]
+    )
+    def test_transform_warns(self, _name, jexl, expected_warning):
+        result = jexl_to_sql(jexl)
+        self.assertIn(expected_warning, result.warnings)
+
+    # --- Edge cases ---
+
+    def test_empty_expression_returns_none(self):
+        result = jexl_to_sql("")
+        self.assertIsNone(result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_true_expression_returns_none(self):
+        result = jexl_to_sql("true")
+        self.assertIsNone(result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_warnings_are_deduplicated(self):
+        result = jexl_to_sql("attachedFxAOAuthClients && attachedFxAOAuthClients")
+        self.assertEqual(result.warnings.count("attachedFxAOAuthClients"), 1)
+
+    def test_all_known_untranslatable_produce_warnings(self):
+        for attribute in KNOWN_UNTRANSLATABLE:
+            result = jexl_to_sql(attribute)
+            self.assertIn(attribute, result.warnings, f"Expected warning for {attribute}")
+
+    def test_partial_translation_still_returns_sql(self):
+        result = jexl_to_sql("isFirstStartup && attachedFxAOAuthClients")
+        self.assertIsNotNone(result.sql)
+        self.assertIn("is_first_startup", result.sql)
+        self.assertIn("attachedFxAOAuthClients", result.warnings)
+
+    def test_invalid_jexl_returns_parse_error_warning(self):
+        result = jexl_to_sql("((( invalid ??? jexl")
+        self.assertIsNone(result.sql)
+        self.assertIn("__parse_error__", result.warnings)
+
+    def test_conditional_expression_returns_none(self):
+        result = jexl_to_sql("isFirstStartup ? true : false")
+        self.assertIsNone(result.sql)
+
+    def test_unknown_binary_op_returns_none(self):
+        result = jexl_to_sql("locale intersect ['en-US']")
+        self.assertIsNone(result.sql)
+
+    def test_array_all_untranslatable_returns_none(self):
+        result = jexl_to_sql("locale in [attachedFxAOAuthClients]")
+        self.assertIsNone(result.sql)
+
+    def test_string_with_single_quote_escaped(self):
+        result = jexl_to_sql('locale == "it-IT"')
+        self.assertIn("'it-IT'", result.sql)
+
+    # --- NOT operator ---
+
+    def test_not_boolean_column(self):
+        result = jexl_to_sql("!isDefaultBrowser")
+        self.assertEqual(
+            result.sql,
+            "NOT (metrics.boolean.nimbus_targeting_context_is_default_browser)",
+        )
+
+    def test_not_string_column_uses_is_null(self):
+        result = jexl_to_sql("!distributionId")
+        self.assertIn("IS NULL", result.sql)
+        self.assertIn("= ''", result.sql)
+
+    def test_not_preference_value_uses_is_null(self):
+        result = jexl_to_sql("!('trailhead.firstrun.didSeeAboutWelcome'|preferenceValue)")
+        self.assertIn("IS NULL", result.sql)
+        self.assertIn("= ''", result.sql)
+
+    def test_not_preference_is_user_set(self):
+        result = jexl_to_sql("!('browser.startup.homepage'|preferenceIsUserSet)")
+        self.assertIn("NOT", result.sql)
+        self.assertIn(_USER_PREFS, result.sql)
+
+    # --- os.isWindows derived ---
+
+    def test_os_is_windows_derived_from_not_mac_not_linux(self):
+        result = jexl_to_sql("os.isWindows")
+        self.assertIsNotNone(result.sql)
+        self.assertIn("isMac", result.sql)
+        self.assertIn("isLinux", result.sql)
+        self.assertIn("NOT", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- Transforms ---
+
+    def test_preference_value_dots_to_underscores(self):
+        result = jexl_to_sql("'browser.urlbar.quicksuggest'|preferenceValue")
+        self.assertIn(_PREF, result.sql)
+        self.assertIn("browser__urlbar__quicksuggest", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_preference_is_user_set(self):
+        result = jexl_to_sql("'browser.newtabpage.enabled'|preferenceIsUserSet")
+        self.assertIn(_USER_PREFS, result.sql)
+        self.assertIn("browser.newtabpage.enabled", result.sql)
+        self.assertIn("IN UNNEST", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_length_user_monthly_activity(self):
+        result = jexl_to_sql("userMonthlyActivity|length >= 1")
+        self.assertIn(_UMA, result.sql)
+        self.assertIn("JSON_ARRAY_LENGTH", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_length_on_translatable_subject(self):
+        result = jexl_to_sql("locale|length >= 2")
+        self.assertIn("JSON_ARRAY_LENGTH", result.sql)
+
+    def test_date_profile_age(self):
+        result = jexl_to_sql(
+            "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"
+        )
+        self.assertIn("profile_age_created", result.sql)
+        self.assertIn("UNIX_MILLIS", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- versionCompare ---
+
+    def test_version_compare_gte(self):
+        result = jexl_to_sql("version|versionCompare('120.!') >= 0")
+        self.assertEqual(result.sql, f"{_FF} >= 120")
+        self.assertEqual(result.warnings, [])
+
+    def test_version_compare_reversed_operands(self):
+        result = jexl_to_sql("0 <= version|versionCompare('120.!')")
+        self.assertEqual(result.sql, f"{_FF} >= 120")
+        self.assertEqual(result.warnings, [])
+
+    # --- addonsInfo ---
+
+    def test_addons_specific_addon_id(self):
+        result = jexl_to_sql("addonsInfo.addons['uBlock0@raymondhill.net'] != null")
+        self.assertIn(_AI, result.sql)
+        self.assertIn("uBlock0@raymondhill.net", result.sql)
+        self.assertIn("IN UNNEST", result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_filter_expression_non_addons_warns(self):
+        result = jexl_to_sql("enrollments[.slug == 'test']")
+        self.assertIsNone(result.sql)
+        self.assertTrue(len(result.warnings) > 0)
+
+    def test_filter_expression_with_non_string_literal_warns(self):
+        result = jexl_to_sql("addonsInfo.addons[0]")
+        self.assertIsNone(result.sql)
+        self.assertTrue(len(result.warnings) > 0)
+
+    # --- Real targeting config integration tests ---
+
+    def test_real_config_first_run_win1903(self):
+        _key = "trailhead__firstrun__didSeeAboutWelcome"
+        _wbn = f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsBuildNumber') AS INT64)"
+        expected = (
+            f"((metrics.boolean.nimbus_targeting_context_is_first_startup"
+            f" AND (JSON_VALUE({_PREF}, '$.{_key}') IS NULL"
+            f" OR JSON_VALUE({_PREF}, '$.{_key}') = ''))"
+            f" AND {_wbn} >= 18362)"
+        )
+        result = jexl_to_sql(
+            "(isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'"
+            "|preferenceValue)) && os.windowsBuildNumber >= 18362"
+        )
+        self.assertEqual(result.sql, expected)
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_no_enterprise_mac_windows(self):
+        _not_mac = f"NOT CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)"
+        _not_linux = f"NOT CAST(JSON_VALUE({_OS}, '$.isLinux') AS BOOL)"
+        _is_mac = f"CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)"
+        _no_ent = (
+            "NOT (metrics.boolean"
+            ".nimbus_targeting_context_has_active_enterprise_policies)"
+        )
+        expected = f"({_no_ent} AND (({_not_mac} AND {_not_linux}) OR {_is_mac}))"
+        result = jexl_to_sql(
+            "(!hasActiveEnterprisePolicies) && ((os.isWindows || os.isMac))"
+        )
+        self.assertEqual(result.sql, expected)
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_windows_11(self):
+        _not_mac = f"NOT CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)"
+        _not_linux = f"NOT CAST(JSON_VALUE({_OS}, '$.isLinux') AS BOOL)"
+        _winver = f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsVersion') AS FLOAT64)"
+        _winbld = f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsBuildNumber') AS INT64)"
+        expected = (
+            f"((({_not_mac} AND {_not_linux})"
+            f" AND {_winver} >= 10)"
+            f" AND {_winbld} >= 22000)"
+        )
+        result = jexl_to_sql(
+            "os.isWindows && os.windowsVersion >= 10 && os.windowsBuildNumber >= 22000"
+        )
+        self.assertEqual(result.sql, expected)
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_profile_age_28_days(self):
+        _age = "metrics.quantity.nimbus_targeting_context_profile_age_created"
+        expected = f"((UNIX_MILLIS(CURRENT_TIMESTAMP()) - {_age}) / 86400000) >= 28"
+        result = jexl_to_sql(
+            "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"
+        )
+        self.assertEqual(result.sql, expected)
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_version_range(self):
+        expected = f"({_FF} >= 95 AND {_FF} < 96)"
+        result = jexl_to_sql(
+            "version|versionCompare('95.!') >= 0 && version|versionCompare('96.!') < 0"
+        )
+        self.assertEqual(result.sql, expected)
+        self.assertEqual(result.warnings, [])
+
+    def test_transform_with_complex_subject_warns(self):
+        result = jexl_to_sql("(firefoxVersion + 1)|someTransform")
+        self.assertIsNone(result.sql)
+        self.assertIn("|someTransform", result.warnings)

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -411,4 +411,3 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql("(firefoxVersion + 1)|someTransform")
         self.assertIsNone(result.sql)
         self.assertIn("|someTransform", result.warnings)
-

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -6,7 +6,13 @@ from experimenter.experiments.jexl_to_sql import (
     KNOWN_UNTRANSLATABLE,
     jexl_to_sql,
 )
-from experimenter.targeting.constants import NimbusTargetingConfig
+from experimenter.targeting.constants import (
+    FX95_DESKTOP_USERS,
+    FIRST_RUN_WINDOWS_1903_NEWER,
+    NO_ENTERPRISE_MAC_WINDOWS_ONLY,
+    WIN11_ONLY,
+    NimbusTargetingConfig,
+)
 
 _OS = "metrics.object.nimbus_targeting_context_os"
 _BS = "metrics.object.nimbus_targeting_context_browser_settings"
@@ -348,8 +354,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIsNone(result.sql)
         self.assertTrue(len(result.warnings) > 0)
 
-    # --- Real targeting config integration tests ---
-
     def test_real_config_first_run_win1903(self):
         _key = "trailhead__firstrun__didSeeAboutWelcome"
         _wbn = f"SAFE_CAST(JSON_VALUE({_OS}, '$.windowsBuildNumber') AS INT64)"
@@ -359,10 +363,7 @@ class TestJEXLToSQL(TestCase):
             f" OR JSON_VALUE({_PREF}, '$.{_key}') = ''))"
             f" AND {_wbn} >= 18362)"
         )
-        result = jexl_to_sql(
-            "(isFirstStartup && !('trailhead.firstrun.didSeeAboutWelcome'"
-            "|preferenceValue)) && os.windowsBuildNumber >= 18362"
-        )
+        result = jexl_to_sql(FIRST_RUN_WINDOWS_1903_NEWER.targeting)
         self.assertEqual(result.sql, expected)
         self.assertEqual(result.warnings, [])
 
@@ -375,9 +376,7 @@ class TestJEXLToSQL(TestCase):
             ".nimbus_targeting_context_has_active_enterprise_policies)"
         )
         expected = f"({_no_ent} AND (({_not_mac} AND {_not_linux}) OR {_is_mac}))"
-        result = jexl_to_sql(
-            "(!hasActiveEnterprisePolicies) && ((os.isWindows || os.isMac))"
-        )
+        result = jexl_to_sql(NO_ENTERPRISE_MAC_WINDOWS_ONLY.targeting)
         self.assertEqual(result.sql, expected)
         self.assertEqual(result.warnings, [])
 
@@ -391,9 +390,7 @@ class TestJEXLToSQL(TestCase):
             f" AND {_winver} >= 10)"
             f" AND {_winbld} >= 22000)"
         )
-        result = jexl_to_sql(
-            "os.isWindows && os.windowsVersion >= 10 && os.windowsBuildNumber >= 22000"
-        )
+        result = jexl_to_sql(WIN11_ONLY.targeting)
         self.assertEqual(result.sql, expected)
         self.assertEqual(result.warnings, [])
 
@@ -408,9 +405,7 @@ class TestJEXLToSQL(TestCase):
 
     def test_real_config_version_range(self):
         expected = f"({_FF} >= 95 AND {_FF} < 96)"
-        result = jexl_to_sql(
-            "version|versionCompare('95.!') >= 0 && version|versionCompare('96.!') < 0"
-        )
+        result = jexl_to_sql(FX95_DESKTOP_USERS.targeting)
         self.assertEqual(result.sql, expected)
         self.assertEqual(result.warnings, [])
 

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -2,9 +2,11 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from experimenter.experiments.jexl_to_sql import (
+    JEXL_TO_BQ_COLUMN,
     KNOWN_UNTRANSLATABLE,
     jexl_to_sql,
 )
+from experimenter.targeting.constants import NimbusTargetingConfig
 
 _OS = "metrics.object.nimbus_targeting_context_os"
 _BS = "metrics.object.nimbus_targeting_context_browser_settings"
@@ -416,3 +418,43 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql("(firefoxVersion + 1)|someTransform")
         self.assertIsNone(result.sql)
         self.assertIn("|someTransform", result.warnings)
+
+    # --- CI validation: all warnings must be accounted for ---
+
+    def test_all_targeting_config_warnings_are_accounted_for(self):
+        """
+        Fail if a targeting config produces a warning for an attribute that is
+        not in JEXL_TO_BQ_COLUMN, KNOWN_UNTRANSLATABLE, or a known sub-path.
+
+        This catches new targeting attributes that need to be either mapped or
+        explicitly marked as untranslatable. Add new attributes to one of those
+        before this test will pass again.
+        """
+        unaccounted = set()
+
+        for config in NimbusTargetingConfig.targeting_configs:
+            if not config.targeting or config.targeting == "true":
+                continue
+
+            for warning in jexl_to_sql(config.targeting).warnings:
+                if warning.startswith("|"):
+                    # transform warning — acceptable
+                    continue
+                if warning in JEXL_TO_BQ_COLUMN:
+                    # directly mapped — acceptable (partial translation)
+                    continue
+                # Check if attribute or any prefix is in KNOWN_UNTRANSLATABLE
+                parts = warning.split(".")
+                if not any(
+                    ".".join(parts[:i]) in KNOWN_UNTRANSLATABLE
+                    for i in range(1, len(parts) + 1)
+                ):
+                    unaccounted.add(warning)
+
+        self.assertEqual(
+            unaccounted,
+            set(),
+            f"New unrecognized targeting attributes found: {sorted(unaccounted)}. "
+            f"Add them to JEXL_TO_BQ_COLUMN (if translatable) or "
+            f"KNOWN_UNTRANSLATABLE (if not).",
+        )

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -2,7 +2,6 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from experimenter.experiments.jexl_to_sql import (
-    JEXL_TO_BQ_COLUMN,
     KNOWN_UNTRANSLATABLE,
     jexl_to_sql,
 )
@@ -11,7 +10,6 @@ from experimenter.targeting.constants import (
     FX95_DESKTOP_USERS,
     NO_ENTERPRISE_MAC_WINDOWS_ONLY,
     WIN11_ONLY,
-    NimbusTargetingConfig,
 )
 
 _OS = "metrics.object.nimbus_targeting_context_os"
@@ -414,42 +412,3 @@ class TestJEXLToSQL(TestCase):
         self.assertIsNone(result.sql)
         self.assertIn("|someTransform", result.warnings)
 
-    # --- CI validation: all warnings must be accounted for ---
-
-    def test_all_targeting_config_warnings_are_accounted_for(self):
-        """
-        Fail if a targeting config produces a warning for an attribute that is
-        not in JEXL_TO_BQ_COLUMN, KNOWN_UNTRANSLATABLE, or a known sub-path.
-
-        This catches new targeting attributes that need to be either mapped or
-        explicitly marked as untranslatable. Add new attributes to one of those
-        before this test will pass again.
-        """
-        unaccounted = set()
-
-        for config in NimbusTargetingConfig.targeting_configs:
-            if not config.targeting or config.targeting == "true":
-                continue
-
-            for warning in jexl_to_sql(config.targeting).warnings:
-                if warning.startswith("|"):
-                    # transform warning — acceptable
-                    continue
-                if warning in JEXL_TO_BQ_COLUMN:
-                    # directly mapped — acceptable (partial translation)
-                    continue
-                # Check if attribute or any prefix is in KNOWN_UNTRANSLATABLE
-                parts = warning.split(".")
-                if not any(
-                    ".".join(parts[:i]) in KNOWN_UNTRANSLATABLE
-                    for i in range(1, len(parts) + 1)
-                ):
-                    unaccounted.add(warning)
-
-        self.assertEqual(
-            unaccounted,
-            set(),
-            f"New unrecognized targeting attributes found: {sorted(unaccounted)}. "
-            f"Add them to JEXL_TO_BQ_COLUMN (if translatable) or "
-            f"KNOWN_UNTRANSLATABLE (if not).",
-        )

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -2,6 +2,11 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from experimenter.experiments.constants import Application
+from experimenter.experiments.jexl_to_sql import (
+    JEXL_TO_BQ_COLUMN,
+    KNOWN_UNTRANSLATABLE,
+    jexl_to_sql,
+)
 from experimenter.experiments.jexl_utils import extract_targeting_fields
 from experimenter.experiments.tests.jexl_utils import validate_jexl_expr
 from experimenter.targeting.constants import (
@@ -39,6 +44,26 @@ class TestTargetingConfigs(TestCase):
                 raise Exception(
                     f"JEXL validation error in {targeting_config.name}: {e}"
                 ) from e
+
+    @parameterized.expand([(t,) for t in TargetingConstants.TARGETING_CONFIGS.values()])
+    def test_targeting_config_jexl_attributes_are_known(self, targeting_config):
+        if not targeting_config.targeting or targeting_config.targeting == "true":
+            return
+        result = jexl_to_sql(targeting_config.targeting)
+        for warning in result.warnings:
+            if warning.startswith("|"):
+                continue
+            parts = warning.split(".")
+            self.assertTrue(
+                any(
+                    ".".join(parts[:i]) in KNOWN_UNTRANSLATABLE
+                    or warning in JEXL_TO_BQ_COLUMN
+                    for i in range(1, len(parts) + 1)
+                ),
+                f"Unrecognized attribute '{warning}' in "
+                f"{targeting_config.name}. Add it to "
+                f"JEXL_TO_BQ_COLUMN or KNOWN_UNTRANSLATABLE.",
+            )
 
     @parameterized.expand([(t,) for t in TargetingConstants.TARGETING_CONFIGS.values()])
     def test_validate_targeting_config_fields(self, targeting_config):


### PR DESCRIPTION
Because

- Experiment owners have no way to know how many real clients will be eligible before launching — this is the first building block of pre-launch population sizing

This commit

- Adds `jexl_to_sql.py` that translates JEXL targeting expressions into BigQuery SQL WHERE clauses
- Maps 35+ JEXL attributes to `nimbus_targeting_context` BigQuery columns
- Handles` |date, |versionCompare, |length, |preferenceValue, |preferenceIsUserSet` transforms
- Supports `addonsInfo.addons['id']` filter expressions via IN UNNEST
- `os.isWindows derived from NOT isMac AND NOT isLinux` (not stored in BigQuery)
- Pref names use `__ separator `in BigQuery (e.g. `browser.newtabpage.enabled `→ `browser__newtabpage__enabled`)
- Partial translation returns SQL with warnings for untranslatable clauses — never blocks
- 75% of Desktop targeting configs produce usable SQL
- Adds CI test that fails if a new targeting config attribute is not in the column mapping or KNOWN_UNTRANSLATABLE — forces explicit handling of new attributes before merging

Fixes #16291 
