### PR TITLE
feat(nimbus): Add targetingSql field to v8 API

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1660,6 +1660,10 @@
           "requiresRestart": {
             "type": "string",
             "readOnly": true
+          },
+          "targetingSql": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1672,6 +1672,10 @@
           "requiresRestart": {
             "type": "string",
             "readOnly": true
+          },
+          "targetingSql": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [

--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -5,6 +5,7 @@ import json
 from django.conf import settings
 from rest_framework import serializers
 
+from experimenter.experiments.jexl_to_sql import jexl_to_sql
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBucketRange,
@@ -120,6 +121,7 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     firefoxLabsDescriptionLinks = serializers.SerializerMethodField()
     firefoxLabsGroup = serializers.ReadOnlyField(source="firefox_labs_group")
     requiresRestart = serializers.ReadOnlyField(source="requires_restart")
+    targetingSql = serializers.SerializerMethodField()
 
     class Meta:
         model = NimbusExperiment
@@ -160,7 +162,19 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
             "firefoxLabsDescriptionLinks",
             "firefoxLabsGroup",
             "requiresRestart",
+            "targetingSql",
         )
+
+    def get_targetingSql(self, obj):
+        if obj.status != NimbusExperiment.Status.DRAFT:
+            return None
+        result = jexl_to_sql(obj.targeting)
+        if result.sql is None and not result.warnings:
+            return None
+        return {
+            "sql": result.sql,
+            "warnings": result.warnings,
+        }
 
     def _holdback_enrollment_end(self, obj):
         if obj.is_holdback and not obj.end_date and not obj.actual_enrollment_end_date:

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -293,6 +293,11 @@ def _array_to_sql(node: ArrayLiteral, warnings: list[str]) -> Optional[str]:
 def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
     subject_path = _identifier_path(node.subject)
 
+    # If the subject itself is untranslatable, warn about it rather than the transform
+    if subject_path and _is_untranslatable(subject_path):
+        _add_warning(warnings, subject_path)
+        return None
+
     if node.name == "date":
         # profileAgeCreated is stored as epoch ms — return column directly for arithmetic
         if subject_path == "profileAgeCreated":

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -503,7 +503,6 @@ class TestNimbusExperimentSerializer(TestCase):
 
     def test_targeting_sql_populated_for_draft(self):
         _os = "metrics.object.nimbus_targeting_context_os"
-        # Create a minimal Draft with only the windows_only targeting config
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=WINDOWS_ONLY.slug,

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -512,7 +512,7 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIn("sql", targeting_sql)
         self.assertIn("warnings", targeting_sql)
         self.assertIsNotNone(targeting_sql["sql"])
-        # The composed targeting includes os.isWindows → derived as NOT isMac AND NOT isLinux
+        # os.isWindows is derived as NOT isMac AND NOT isLinux
         self.assertIn("nimbus_targeting_context_os", targeting_sql["sql"])
         self.assertIn("isMac", targeting_sql["sql"])
         self.assertIn("isLinux", targeting_sql["sql"])

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -8,6 +8,7 @@ from parameterized import parameterized
 
 from experimenter.base.tests.factories import LocaleFactory
 from experimenter.experiments.api.v8.serializers import NimbusExperimentSerializer
+from experimenter.experiments.jexl_to_sql import jexl_to_sql
 from experimenter.experiments.models import NimbusBranchFeatureValue, NimbusExperiment
 from experimenter.experiments.tests.factories import (
     TEST_LOCALIZATIONS,
@@ -501,34 +502,60 @@ class TestNimbusExperimentSerializer(TestCase):
         }
 
     def test_targeting_sql_populated_for_draft(self):
+        _os = "metrics.object.nimbus_targeting_context_os"
+        # Create a minimal Draft with only the windows_only targeting config
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug=WINDOWS_ONLY.slug,
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
         )
-        serializer = NimbusExperimentSerializer(experiment)
-        targeting_sql = serializer.data["targetingSql"]
+        experiment.locales.clear()
+        experiment.countries.clear()
+        experiment.languages.clear()
 
-        self.assertIsNotNone(targeting_sql)
-        self.assertIn("sql", targeting_sql)
-        self.assertIn("warnings", targeting_sql)
-        self.assertIsNotNone(targeting_sql["sql"])
-        # os.isWindows is derived as NOT isMac AND NOT isLinux
-        self.assertIn("nimbus_targeting_context_os", targeting_sql["sql"])
-        self.assertIn("isMac", targeting_sql["sql"])
-        self.assertIn("isLinux", targeting_sql["sql"])
-        self.assertEqual(targeting_sql["warnings"], [])
+        expected_sql = (
+            f"(NOT CAST(JSON_VALUE({_os}, '$.isMac') AS BOOL)"
+            f" AND NOT CAST(JSON_VALUE({_os}, '$.isLinux') AS BOOL))"
+        )
+
+        jexl_result = jexl_to_sql(experiment.targeting)
+        self.assertEqual(jexl_result.sql, expected_sql)
+        self.assertEqual(jexl_result.warnings, [])
+
+        # Validate the serializer returns the same SQL in the correct shape
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(
+            serializer.data["targetingSql"],
+            {"sql": expected_sql, "warnings": []},
+        )
 
     def test_targeting_sql_with_warnings_for_draft(self):
-        # relay_user config uses attachedFxAOAuthClients which is untranslatable
+        # relay_user uses attachedFxAOAuthClients which is KNOWN_UNTRANSLATABLE
+        # → sql is None, warning is attachedFxAOAuthClients
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             targeting_config_slug="relay_user",
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
         )
-        serializer = NimbusExperimentSerializer(experiment)
-        targeting_sql = serializer.data["targetingSql"]
+        experiment.locales.clear()
+        experiment.countries.clear()
+        experiment.languages.clear()
 
-        self.assertIsNotNone(targeting_sql)
-        self.assertTrue(len(targeting_sql["warnings"]) > 0)
+        # relay_user uses attachedFxAOAuthClients (KNOWN_UNTRANSLATABLE) → sql=None
+        jexl_result = jexl_to_sql(experiment.targeting)
+        self.assertIsNone(jexl_result.sql)
+        self.assertEqual(jexl_result.warnings, ["attachedFxAOAuthClients"])
+
+        # Serializer should produce the same result as jexl_to_sql
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertEqual(
+            serializer.data["targetingSql"],
+            {"sql": jexl_result.sql, "warnings": jexl_result.warnings},
+        )
 
     def test_targeting_sql_none_for_live_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -496,4 +496,26 @@ class TestNimbusExperimentSerializer(TestCase):
             "firefoxLabsDescriptionLinks": None,
             "firefoxLabsGroup": None,
             "requiresRestart": False,
+            "targetingSql": None,  # None for non-Draft experiments
         }
+
+    def test_targeting_sql_populated_for_draft(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            targeting_config_slug="windows_only",
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        targeting_sql = serializer.data["targetingSql"]
+
+        self.assertIsNotNone(targeting_sql)
+        self.assertIn("sql", targeting_sql)
+        self.assertIn("warnings", targeting_sql)
+        self.assertIsNotNone(targeting_sql["sql"])
+        self.assertIn("nimbus_targeting_context_os", targeting_sql["sql"])
+
+    def test_targeting_sql_none_for_live_experiment(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        self.assertIsNone(serializer.data["targetingSql"])

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -15,6 +15,7 @@ from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
 )
+from experimenter.targeting.constants import WINDOWS_ONLY
 
 
 class TestNimbusExperimentSerializer(TestCase):
@@ -502,7 +503,7 @@ class TestNimbusExperimentSerializer(TestCase):
     def test_targeting_sql_populated_for_draft(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            targeting_config_slug="windows_only",
+            targeting_config_slug=WINDOWS_ONLY.slug,
         )
         serializer = NimbusExperimentSerializer(experiment)
         targeting_sql = serializer.data["targetingSql"]
@@ -511,7 +512,23 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIn("sql", targeting_sql)
         self.assertIn("warnings", targeting_sql)
         self.assertIsNotNone(targeting_sql["sql"])
+        # The composed targeting includes os.isWindows → derived as NOT isMac AND NOT isLinux
         self.assertIn("nimbus_targeting_context_os", targeting_sql["sql"])
+        self.assertIn("isMac", targeting_sql["sql"])
+        self.assertIn("isLinux", targeting_sql["sql"])
+        self.assertEqual(targeting_sql["warnings"], [])
+
+    def test_targeting_sql_with_warnings_for_draft(self):
+        # relay_user config uses attachedFxAOAuthClients which is untranslatable
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            targeting_config_slug="relay_user",
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        targeting_sql = serializer.data["targetingSql"]
+
+        self.assertIsNotNone(targeting_sql)
+        self.assertTrue(len(targeting_sql["warnings"]) > 0)
 
     def test_targeting_sql_none_for_live_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -181,7 +181,7 @@ class TestJEXLToSQL(TestCase):
             (
                 "length_untranslatable_subject",
                 "attachedFxAOAuthClients|length >= 1",
-                "|length",
+                "attachedFxAOAuthClients",
             ),
             ("preference_value_variable", "someVar|preferenceValue", "|preferenceValue"),
             (


### PR DESCRIPTION
Because

- `bigquery-etl` needs the translated SQL to run sizing queries against `nimbus_targeting_context` for the draft experiment to estimate the population

This commit

- Adds `targetingSql` field to `/api/v8/experiments/` API response
- For Draft experiments: returns the translated BigQuery SQL WHERE clause and any warnings for untranslatable attributes
- For Live/Complete experiments: returns null — they don't need sizing
- bigquery-etl reads this field directly, no JEXL parser needed on its side

Fixes #16352 