### PR TITLE
feat(nimbus): Add advanced targeting for newtab trainhop 154.8.20260716.43450

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4935,6 +4935,23 @@ FX_153_5_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_154_8_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingConfig(
+    name=(
+        "New Tab Fx154 Jul-16 Trainhop, engaged with any of 4 widgets, "
+        "that widget not disabled"
+    ),
+    slug="widgets-any-four-engaged-154-0716-trainhop",
+    description=(
+        "Users having the New Tab 154.8.20260716.43450 train hop who engaged with the "
+        "Sports, Clocks, Lists, or Timer widget and still have that widget enabled"
+    ),
+    targeting=f"{FX_154_8_TRAINHOP.targeting} && ({WIDGETS_ANY_FOUR_ENGAGED.targeting})",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FX_153_3_TRAINHOP_ANY_WIDGET_ENABLED = NimbusTargetingConfig(
     name="New Tab Fx153 Jun-05 Trainhop, any of 4 widgets enabled",
     slug="any-widget-enabled-153-0605-trainhop",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -4784,6 +4784,20 @@ FX_154_4_TRAINHOP = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_154_8_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx154 Jul-16 Trainhop",
+    slug="newtab-154-0716-trainhop",
+    description=(
+        "Desktop users having the New Tab 154.8.20260716.43450 train hop, "
+        "which includes users of Fx151"
+    ),
+    targeting="newtabAddonVersion|versionCompare('154.8.20260716.43450') >= 0",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WIDGETS_LISTS_OR_TIMER_INTERACTED_NOT_DISABLED = NimbusTargetingConfig(
     name="New Tab Lists/Timer Interaction, Neither Widget Disabled",
     slug="widgets-lists-timer-interacted-not-disabled",


### PR DESCRIPTION
This commit adds new targeting for the 154.8.20260716.43450 trainhop, which includes users of Fx151 on the release channel.

Fixes mozilla#16364