### PR TITLE
feat(nimbus): Add screenshot uploads to Rollout features

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -16,6 +16,7 @@ from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchFeatureValue,
+    NimbusBranchScreenshot,
     NimbusDocumentationLink,
     NimbusExperiment,
     NimbusExperimentBranchThroughExcluded,
@@ -26,6 +27,7 @@ from experimenter.experiments.models import (
     Tag,
 )
 from experimenter.nimbus_ui.constants import NimbusUIConstants
+from experimenter.nimbus_ui.forms import NimbusBranchScreenshotForm
 from experimenter.targeting.constants import NimbusTargetingConfig
 
 metrics = markus.get_metrics("experimenter.nimbus_ui_forms")
@@ -311,6 +313,14 @@ RolloutBranchFeatureValueFormSet = inlineformset_factory(
     NimbusBranchFeatureValue,
     form=NimbusBranchFeatureValueForm,
     extra=0,
+)
+
+RolloutScreenshotFormSet = inlineformset_factory(
+    NimbusBranch,
+    NimbusBranchScreenshot,
+    form=NimbusBranchScreenshotForm,
+    extra=0,
+    can_delete=False,
 )
 
 
@@ -705,6 +715,28 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        screenshot_formset_args = {
+            "data": self.data or None,
+            "instance": self.reference_branch,
+            "prefix": "rollout-screenshots",
+        }
+        if self.files:
+            screenshot_formset_args["files"] = self.files
+        self.rollout_screenshots = RolloutScreenshotFormSet(**screenshot_formset_args)
+
+        for screenshot_form in self.rollout_screenshots.forms:
+            screenshot_form.fields["image"].widget.attrs.update(
+                {
+                    "hx-post": reverse(
+                        "nimbus-ui-new-update-rollout-features",
+                        kwargs={"slug": self.instance.slug},
+                    ),
+                    "hx-trigger": "change",
+                    "hx-select": "#rollout-rollout-features-body",
+                    "hx-target": "#rollout-rollout-features-body",
+                }
+            )
+
         self.branch_feature_values = RolloutBranchFeatureValueFormSet(
             data=self.data or None,
             instance=self.reference_branch,
@@ -735,14 +767,21 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         errors = super().errors
         if any(self.branch_feature_values.errors):
             errors["branch_feature_values"] = self.branch_feature_values.errors
+        if any(self.rollout_screenshots.errors):
+            errors["rollout_screenshots"] = self.rollout_screenshots.errors
         return errors
 
     def is_valid(self):
-        return super().is_valid() and self.branch_feature_values.is_valid()
+        return (
+            super().is_valid()
+            and self.branch_feature_values.is_valid()
+            and self.rollout_screenshots.is_valid()
+        )
 
     @transaction.atomic
     def save(self, *args, **kwargs):
         self.branch_feature_values.save()
+        self.rollout_screenshots.save()
         self.instance.takeaways_summary = self.cleaned_data.get("rollout_experience", "")
 
         experiment = super().save(*args, **kwargs)
@@ -778,6 +817,38 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     @property
     def reference_branch(self):
         return self.instance.reference_branch or self.instance.branches.first()
+
+
+class RolloutScreenshotCreateForm(RolloutFeaturesForm):
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        experiment = super().save(*args, **kwargs)
+        self.reference_branch.screenshots.create()
+        return experiment
+
+    def get_changelog_message(self):
+        return f"{self.request.user} added a rollout screenshot"
+
+
+class RolloutScreenshotDeleteForm(RolloutFeaturesForm):
+    screenshot_id = forms.ModelChoiceField(queryset=NimbusBranchScreenshot.objects.all())
+
+    class Meta:
+        model = NimbusExperiment
+        fields = [
+            "screenshot_id",
+            *RolloutFeaturesForm.Meta.fields,
+        ]
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        experiment = super().save(*args, **kwargs)
+        screenshot = self.cleaned_data["screenshot_id"]
+        screenshot.delete()
+        return experiment
+
+    def get_changelog_message(self):
+        return f"{self.request.user} removed a rollout screenshot"
 
 
 class RolloutQAStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -25,6 +25,8 @@ from experimenter.nimbus_ui.new.forms import (
     RolloutQAStatusForm,
     RolloutRisksForm,
     RolloutScheduleForm,
+    RolloutScreenshotCreateForm,
+    RolloutScreenshotDeleteForm,
     RolloutSignoffForm,
     SubscribeForm,
     TagAssignForm,
@@ -176,6 +178,18 @@ class NewRolloutFeaturesUpdateView(CardMixin, NewCardUpdateView):
             return super().render_valid_response()
 
         return self.render_to_response(self.get_context_data())
+
+
+class NewRolloutScreenshotCreateView(
+    RenderParentDBResponseMixin, NewRolloutFeaturesUpdateView
+):
+    form_class = RolloutScreenshotCreateForm
+
+
+class NewRolloutScreenshotDeleteView(
+    RenderParentDBResponseMixin, NewRolloutFeaturesUpdateView
+):
+    form_class = RolloutScreenshotDeleteForm
 
 
 class NewQAUpdateView(CardMixin, NewCardUpdateView):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -30,7 +30,7 @@
                      alt="{{ screenshot.description }}"
                      title="{{ screenshot.description }}"
                      class="rounded"
-                     style="height: 72px;
+                     style="height: 125px;
                             width: auto;
                             object-fit: cover">
               </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -17,6 +17,31 @@
       {% endfor %}
     {% endfor %}
   </div>
+  {# Rollout screenshots #}
+  <div>
+    <div class="text-secondary mb-1" style="font-size: 12px;">Rollout screenshots</div>
+    {% with screenshots=experiment.reference_branch.screenshots.all %}
+      {% if screenshots %}
+        <div class="d-flex flex-wrap gap-2">
+          {% for screenshot in screenshots %}
+            {% if screenshot.image %}
+              <div class="border border-secondary-subtle rounded overflow-hidden">
+                <img src="{{ screenshot.image.url }}"
+                     alt="{{ screenshot.description }}"
+                     title="{{ screenshot.description }}"
+                     class="rounded"
+                     style="height: 72px;
+                            width: auto;
+                            object-fit: cover">
+              </div>
+            {% endif %}
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="small text-body">—</div>
+      {% endif %}
+    {% endwith %}
+  </div>
 </div>
 {% if hx_swap_oob %}
   {% include "new/common/audience_overlap_warnings.html" with oob=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -8,6 +8,7 @@
         hx-post="{% url 'nimbus-ui-new-update-rollout-features' experiment.slug %}"
         hx-target="#rollout-rollout-features-body"
         hx-swap="outerHTML"
+        hx-encoding="multipart/form-data"
         class="d-flex flex-column gap-4">
     {% csrf_token %}
     <div class="d-flex flex-column gap-4">
@@ -69,6 +70,67 @@
         {% endfor %}
       </div>
     {% endwith %}
+    {#  Rollout screenshots  #}
+    <div>
+      {% with rollout_screenshots=form.rollout_screenshots %}
+        {{ rollout_screenshots.management_form }}
+        <div class="d-flex flex-column gap-2 mt-4">
+          {% for screenshot_form in rollout_screenshots %}
+            <div>
+              {{ screenshot_form.id }}
+              <div class="d-flex gap-3">
+                <label class="small text-secondary mb-1 flex-shrink-0" style="width: 360px;">Screenshot</label>
+                <label class="small text-secondary mb-1 flex-grow-1">Description</label>
+              </div>
+              <div class="d-flex align-items-center gap-3 mb-2">
+                <div class="flex-shrink-0" style="width: 360px;">
+                  {{ screenshot_form.image }}
+                  {% for error in screenshot_form.image.errors %}<div class="text-danger small mt-1">{{ error }}</div>{% endfor %}
+                </div>
+                <div class="flex-grow-1">
+                  {{ screenshot_form.description }}
+                  {% for error in screenshot_form.description.errors %}<div class="text-danger small mt-1">{{ error }}</div>{% endfor %}
+                </div>
+                {% if screenshot_form.instance.pk %}
+                  <button type="button"
+                          class="btn p-0 border-0 text-secondary flex-shrink-0"
+                          title="Delete screenshot"
+                          hx-post="{% url 'nimbus-ui-new-delete-rollout-screenshot' experiment.slug %}"
+                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                          hx-vals='{"screenshot_id": "{{ screenshot_form.instance.pk }}"}'
+                          hx-target="#rollout-rollout-features-body"
+                          hx-swap="outerHTML">
+                    <i class="fa-solid fa-trash-can"></i>
+                  </button>
+                {% endif %}
+              </div>
+              {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
+                <div class="border border-secondary-subtle rounded overflow-hidden mt-2 d-inline-block">
+                  <img src="{{ screenshot_form.instance.image.url }}"
+                       alt="{{ screenshot_form.instance.description }}"
+                       title="{{ screenshot_form.instance.description }}"
+                       class="rounded"
+                       style="height: 96px;
+                              width: auto;
+                              object-fit: cover">
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+        <div>
+          <button type="button"
+                  class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small"
+                  hx-post="{% url 'nimbus-ui-new-create-rollout-screenshot' experiment.slug %}"
+                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                  hx-target="#rollout-rollout-features-body"
+                  hx-swap="outerHTML">
+            <i class="fa-solid fa-plus"></i>
+            Add screenshot
+          </button>
+        </div>
+      {% endwith %}
+    </div>
   </div>
 </div>
 {# Action buttons #}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -1,6 +1,7 @@
 import datetime
 import json
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -17,6 +18,7 @@ from experimenter.experiments.models import (
     NimbusExperimentBranchThroughRequired,
 )
 from experimenter.experiments.tests.factories import (
+    NimbusBranchScreenshotFactory,
     NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
@@ -37,6 +39,8 @@ from experimenter.nimbus_ui.new.forms import (
     RolloutPhaseForm,
     RolloutQAStatusForm,
     RolloutRisksForm,
+    RolloutScreenshotCreateForm,
+    RolloutScreenshotDeleteForm,
     TagAssignForm,
 )
 from experimenter.openidc.tests.factories import UserFactory
@@ -704,6 +708,10 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
                 "branch-feature-value-MIN_NUM_FORMS": "0",
                 "branch-feature-value-MAX_NUM_FORMS": "1000",
                 "branch-feature-value-0-value": "{}",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
             },
             request=self.request,
         )
@@ -740,6 +748,10 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
                 "branch-feature-value-INITIAL_FORMS": "0",
                 "branch-feature-value-MIN_NUM_FORMS": "0",
                 "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
             },
             request=self.request,
         )
@@ -792,6 +804,10 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
                 "branch-feature-value-MAX_NUM_FORMS": "1000",
                 "branch-feature-value-0-id": reference_feature_value.id,
                 "branch-feature-value-0-value": reference_feature_value.value,
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
             },
             request=self.request,
         )
@@ -810,6 +826,194 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
         self.assertEqual(
             experiment.changes.latest("changed_on").message,
             f"{self.user} updated rollout features",
+        )
+
+    def test_form_uploads_rollout_screenshots_to_reference_branch(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+            takeaways_summary="",
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        image = NimbusBranchScreenshotFactory.build().image
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "1",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-0-description": "Test description",
+            },
+            files={"rollout-screenshots-0-image": image},
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        screenshots = experiment.reference_branch.screenshots.all()
+        self.assertEqual(screenshots.count(), 1)
+        self.assertTrue(screenshots.first().image)
+        self.assertEqual(screenshots.first().description, "Test description")
+
+    def test_form_supports_multiple_rollout_screenshots(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+            takeaways_summary="",
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        first_image = NimbusBranchScreenshotFactory.build().image
+        second_image = NimbusBranchScreenshotFactory.build().image
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "2",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-0-description": "First",
+                "rollout-screenshots-1-description": "Second",
+            },
+            files={
+                "rollout-screenshots-0-image": first_image,
+                "rollout-screenshots-1-image": second_image,
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        self.assertEqual(experiment.reference_branch.screenshots.count(), 2)
+
+    def test_form_reports_rollout_screenshot_errors(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "1",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-0-description": "Not a real image",
+            },
+            files={
+                "rollout-screenshots-0-image": SimpleUploadedFile(
+                    "bad.png", b"this is not an image", content_type="image/png"
+                )
+            },
+            request=self.request,
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("rollout_screenshots", form.errors)
+
+
+class TestRolloutScreenshotCreateForm(RequestFormTestCase):
+    def test_form_creates_empty_screenshot_and_logs_change(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        form = RolloutScreenshotCreateForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.assertEqual(experiment.reference_branch.screenshots.count(), 1)
+        self.assertEqual(
+            experiment.changes.latest("changed_on").message,
+            f"{self.user} added a rollout screenshot",
+        )
+
+
+class TestRolloutScreenshotDeleteForm(RequestFormTestCase):
+    def test_form_deletes_screenshot_and_logs_change(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment.reference_branch.screenshots.all().delete()
+        screenshot = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+
+        form = RolloutScreenshotDeleteForm(
+            instance=experiment,
+            data={
+                "screenshot_id": screenshot.id,
+                "rollout_experience": "",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "1",
+                "rollout-screenshots-INITIAL_FORMS": "1",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-0-id": screenshot.id,
+                "rollout-screenshots-0-description": screenshot.description,
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+
+        self.assertEqual(experiment.reference_branch.screenshots.count(), 0)
+        self.assertEqual(
+            experiment.changes.latest("changed_on").message,
+            f"{self.user} removed a rollout screenshot",
         )
 
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -405,6 +405,8 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
                 "feature_configs": [],
                 "branch-feature-value-TOTAL_FORMS": "0",
                 "branch-feature-value-INITIAL_FORMS": "0",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
                 "save": "True",
             },
         )
@@ -428,6 +430,8 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
                 "feature_configs": [],
                 "branch-feature-value-TOTAL_FORMS": "0",
                 "branch-feature-value-INITIAL_FORMS": "0",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
             },
         )
 
@@ -435,6 +439,66 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
         self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
         experiment.refresh_from_db()
         self.assertEqual(experiment.takeaways_summary, "Updated rollout experience")
+
+
+class TestNewRolloutScreenshotCreateView(AuthTestCase):
+    url_name = "nimbus-ui-new-create-rollout-screenshot"
+
+    def test_post_creates_screenshot_and_returns_edit_form(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[],
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_experience": "",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
+        self.assertEqual(experiment.reference_branch.screenshots.count(), 1)
+
+
+class TestNewRolloutScreenshotDeleteView(AuthTestCase):
+    url_name = "nimbus-ui-new-delete-rollout-screenshot"
+
+    def test_post_deletes_image_and_returns_edit_form(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            feature_configs=[],
+        )
+        experiment.reference_branch.screenshots.all().delete()
+        screenshot = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "screenshot_id": screenshot.id,
+                "rollout_experience": "",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "rollout-screenshots-TOTAL_FORMS": "1",
+                "rollout-screenshots-INITIAL_FORMS": "1",
+                "rollout-screenshots-0-id": screenshot.id,
+                "rollout-screenshots-0-description": screenshot.description,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
+        self.assertEqual(experiment.reference_branch.screenshots.count(), 0)
 
 
 class TestNewQAUpdateView(NewViewTestMixin, AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -18,6 +18,8 @@ from experimenter.nimbus_ui.new.views import (
     NewRolloutPlanApplyView,
     NewRolloutPlanCreateView,
     NewRolloutScheduleUpdateView,
+    NewRolloutScreenshotCreateView,
+    NewRolloutScreenshotDeleteView,
     NewSignoffUpdateView,
     NewSubscriberSearchView,
     NewSubscribeView,
@@ -354,6 +356,16 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/update_rollout_features/$",
         NewRolloutFeaturesUpdateView.as_view(),
         name="nimbus-ui-new-update-rollout-features",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/create_rollout_screenshot/$",
+        NewRolloutScreenshotCreateView.as_view(),
+        name="nimbus-ui-new-create-rollout-screenshot",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/delete_rollout_screenshot/$",
+        NewRolloutScreenshotDeleteView.as_view(),
+        name="nimbus-ui-new-delete-rollout-screenshot",
     ),
     re_path(
         r"^new/(?P<slug>[\w-]+)/update_audience/$",


### PR DESCRIPTION
Because

* In the old UI users could upload screenshots on the branches page and rollouts need the same

This commit

* Adds an "Add screenshot" button on the features card that creates a screenshot row with a file upload and a description field
* Shows the uploaded screenshots as thumbnails on the features card

Fixes #16316


https://github.com/user-attachments/assets/70d9a57f-48c1-40ab-8c99-d8f7702dac9c

