### PR TITLE
feat(nimbus): Add public description and AI risk to new Rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -35,6 +35,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY = "10%"
     SRM_P_VALUE_THRESHOLD_DISPLAY = "0.001"
 
+    PUBLIC_DESCRIPTION_TEXT = "This description will be public to users on about:studies"
+    RISK_AI_TEXT = (
+        "Note: Selecting Yes will exclude all users that have opted out of "
+        "AI functionality."
+    )
+
     MONITORING_CARD_TITLE = "Enrollment Monitoring"
     MONITORING_SECTION_UNENROLLMENT = "Unenrollment"
     MONITORING_SECTION_SRM = "Sample Ratio Mismatch (SRM)"

--- a/experimenter/experimenter/nimbus_ui/context_processors.py
+++ b/experimenter/experimenter/nimbus_ui/context_processors.py
@@ -1,16 +1,19 @@
-from experimenter.experiments.constants import EXTERNAL_URLS
+from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 
 
 def nimbus_ui_constants(request):
     """
-    Context processor that makes NimbusUIConstants and EXTERNAL_URLS
-    available to all templates.
+    Context processor that makes NimbusUIConstants, EXTERNAL_URLS, and
+    RISK_QUESTIONS available to all templates.
 
     This allows templates to access UI constants directly via:
     {{ NimbusUIConstants.PROPERTY_NAME }}
+    {{ EXTERNAL_URLS.URL_KEY }}
+    {{ RISK_QUESTIONS.QUESTION_KEY }}
     """
     return {
         "NimbusUIConstants": NimbusUIConstants,
         "EXTERNAL_URLS": EXTERNAL_URLS,
+        "RISK_QUESTIONS": RISK_QUESTIONS,
     }

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -9,6 +9,11 @@
     <div class="text-secondary mb-1" style="font-size: 12px;">Observations &amp; Problem space</div>
     <div class="small text-body" style="white-space: pre-wrap;">{{ experiment.hypothesis|default:"—" }}</div>
   </div>
+  {# Public description #}
+  <div>
+    <div class="text-secondary mb-1" style="font-size: 12px;">Public description</div>
+    <div class="small text-body" style="white-space: pre-wrap;">{{ experiment.public_description|default:"—" }}</div>
+  </div>
   {# Application #}
   <div>
     <div class="text-secondary mb-1" style="font-size: 12px;">Application</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -29,7 +29,7 @@
         {% if form.public_description.errors %}
           <div class="text-danger small mt-1">{{ form.public_description.errors|join:", " }}</div>
         {% endif %}
-        <p class="form-text mb-0">This description will be public to users on about:studies</p>
+        <p class="form-text mb-0">{{ NimbusUIConstants.PUBLIC_DESCRIPTION_TEXT }}</p>
       </div>
       {# Application #}
       <div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -22,6 +22,15 @@
           <div class="text-danger small mt-1">{{ form.hypothesis.errors|join:", " }}</div>
         {% endif %}
       </div>
+      {# Public description #}
+      <div>
+        <label for="id_public_description" class="small text-body mb-1">Public description</label>
+        {{ form.public_description }}
+        {% if form.public_description.errors %}
+          <div class="text-danger small mt-1">{{ form.public_description.errors|join:", " }}</div>
+        {% endif %}
+        <p class="form-text mb-0">This description will be public to users on about:studies</p>
+      </div>
       {# Application #}
       <div>
         <label for="id_application" class="small text-body mb-1">Application</label>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
@@ -1,4 +1,13 @@
 <div class="d-flex flex-column gap-3" id="rollout-risks-body">
+  {# AI risk #}
+  <div class="d-flex flex-row gap-3">
+    <div class="text-secondary mb-1" style="font-size: 12px;">AI risk</div>
+    {% if experiment.risk_ai %}
+      <i class="fas fa-check text-success"></i>
+    {% else %}
+      <i class="fas fa-times text-danger"></i>
+    {% endif %}
+  </div>
   {# Brand perception impact #}
   <div class="d-flex flex-row gap-3">
     <div class="text-secondary mb-1" style="font-size: 12px;">Brand perception impact</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
@@ -14,6 +14,17 @@
       {{ documentation_link_form.link.as_hidden }}
     {% endfor %}
     <div class="d-flex flex-column gap-4">
+      {# AI risk #}
+      <div>
+        <label for="id_risk_ai" class="small text-body mb-2">
+          <div class="d-block fw-normal">
+            <div class="fw-bold">{{ RISK_QUESTIONS.AI }}</div>
+            <div class="text-secondary">Note: Selecting Yes will exclude all users that have opted out of AI functionality.</div>
+          </div>
+        </label>
+        {{ form.risk_ai }}
+        {% if form.risk_ai.errors %}<div class="text-danger small mt-1">{{ form.risk_ai.errors|join:", " }}</div>{% endif %}
+      </div>
       {#  Brand perception impact  #}
       <div>
         <label for="id_name" class="small text-body mb-2">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
@@ -19,7 +19,7 @@
         <label for="id_risk_ai" class="small text-body mb-2">
           <div class="d-block fw-normal">
             <div class="fw-bold">{{ RISK_QUESTIONS.AI }}</div>
-            <div class="text-secondary">Note: Selecting Yes will exclude all users that have opted out of AI functionality.</div>
+            <div class="text-secondary">{{ NimbusUIConstants.RISK_AI_TEXT }}</div>
           </div>
         </label>
         {{ form.risk_ai }}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -18,7 +18,7 @@
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Define</div>
       {# EXP-6681: Rollout Overview Form/Card #}
-      {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" subtitle="Name · Observations & Problem space · Important Links · Project Tags · Subscribers" show_edit_btn=True body_template="new/rollouts/overview/card.html" %}
+      {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" subtitle="Name · Observations & Problem Space · Public Description · Application · Important Links · Project Tags · Subscribers" show_edit_btn=True body_template="new/rollouts/overview/card.html" %}
 
       {# TODO EXP-6682: Rollout Risks Form/Card #}
       {% include "new/rollouts/detail_card.html" with card_id="risks" title="Risks" subtitle="Consider possible risks if the public interacts with your experiment" show_edit_btn=True body_template="new/rollouts/risks/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -12,7 +12,7 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
-from experimenter.experiments.constants import EXTERNAL_URLS
+from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
 from experimenter.experiments.models import (
     NimbusExperiment,
     NimbusRolloutPlanTemplate,
@@ -200,6 +200,7 @@ class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
         self.assertResponseUsesForm(response, RolloutOverviewForm)
+        self.assertContains(response, "Public description")
 
     @parameterized.expand(
         [
@@ -267,6 +268,7 @@ class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
         experiment.refresh_from_db()
         self.assertEqual(experiment.name, "updated name")
         self.assertEqual(experiment.hypothesis, "updated hypothesis")
+        self.assertEqual(experiment.public_description, "updated description")
         self.assertTrue(response.context["hx_swap_oob"])
 
     def test_post_invalid_returns_edit_form_with_errors(self):
@@ -303,6 +305,7 @@ class TestNewRisksUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/risks/edit_form.html")
         self.assertResponseUsesForm(response, RolloutRisksForm)
+        self.assertContains(response, RISK_QUESTIONS["AI"])
 
     def test_post_valid_saves_and_returns_display_card(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* We are missing the public description field in the overview card and the AI risk field in the risks card

This commit

* Adds the public description field to the overview card
* Adds the AI risk field to the risks card while following the same text format as the old UI

Fixes #16367

<img width="1723" height="869" alt="Screenshot 2026-07-20 at 2 41 26 PM" src="https://github.com/user-attachments/assets/025192f6-74a4-462d-98af-dd353a939870" />
<img width="1724" height="886" alt="Screenshot 2026-07-20 at 2 42 48 PM" src="https://github.com/user-attachments/assets/362dce76-e7f9-4f61-a6f1-2b26311f8566" />
<img width="1727" height="826" alt="Screenshot 2026-07-20 at 2 44 54 PM" src="https://github.com/user-attachments/assets/2390e00f-320d-42fc-ad1e-b80db861c0aa" />
