### PR TITLE
feat(nimbus): Add first_run_windows advanced targeting for all-install-type Windows first run

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -583,6 +583,21 @@ FIRST_RUN_MACOS = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FIRST_RUN_WINDOWS = NimbusTargetingConfig(
+    name="First start-up users on Windows",
+    slug="first_run_windows",
+    description=(
+        "First start-up users on Windows across all install types (stub, full, "
+        "MSI, MSIX, zip). Keyed on the first Nimbus update pass (isNonStubFirstRun) "
+        "rather than isFirstStartup, which is only set for stub installer runs."
+    ),
+    targeting=f"{NON_STUB_FIRST_RUN.targeting} && os.isWindows",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NOT_TCP_STUDY = NimbusTargetingConfig(
     name="Exclude users in the TCP revenue study",
     slug="not_tcp_study",


### PR DESCRIPTION
### Because

The default launch-on-login code for new Windows users moved out of the stub-installer first-startup path in Firefox 153 so all install types get it (Firefox bug 2038097), and 153 re-gated enablement on Nimbus (`browser.startup.windowsLaunchOnLogin.defaultEnabled` now defaults false). The existing default launch-on-login rollout targets `isFirstStartup`, which is only set for stub/full NSIS installer runs, so MSIX and zip first-runs would not enroll.

### This commit

Adds a `first_run_windows` advanced targeting config (`isNonStubFirstRun && os.isWindows`), mirroring the existing `first_run_macos`, so the rollout enrolls Windows first-run users across all install types (stub, full, MSI, MSIX, zip) with accurate enrollment stats. `TARGETING_CONFIGS` and the `TargetingConfig` enum are auto-generated from the config list, so no other registration is needed.

Fixes #16399

Context: Mozilla FXE-1510; Firefox bug 2038097; intended for the `default-launch-on-login-all-install-types-rollout` recipe.