### PR TITLE
feat(nimbus): update kinto jobs to handle new rollout disabled state

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -550,13 +550,27 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     class Filters:
         IS_LAUNCH_QUEUED = Q(
-            status=NimbusConstants.Status.DRAFT,
-            status_next=NimbusConstants.Status.LIVE,
+            Q(
+                status=NimbusConstants.Status.DRAFT,
+                status_next=NimbusConstants.Status.LIVE,
+            )
+            | Q(
+                is_rollout=True,
+                status=NimbusConstants.Status.DISABLED,
+                status_next=NimbusConstants.Status.LIVE,
+            ),
             publish_status=NimbusConstants.PublishStatus.APPROVED,
         )
         IS_LAUNCHING = Q(
-            status=NimbusConstants.Status.DRAFT,
-            status_next=NimbusConstants.Status.LIVE,
+            Q(
+                status=NimbusConstants.Status.DRAFT,
+                status_next=NimbusConstants.Status.LIVE,
+            )
+            | Q(
+                is_rollout=True,
+                status=NimbusConstants.Status.DISABLED,
+                status_next=NimbusConstants.Status.LIVE,
+            ),
             publish_status=NimbusConstants.PublishStatus.WAITING,
         )
         IS_UPDATE_QUEUED = Q(
@@ -570,13 +584,27 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             publish_status=NimbusConstants.PublishStatus.WAITING,
         )
         IS_END_QUEUED = Q(
-            status=NimbusConstants.Status.LIVE,
-            status_next=NimbusConstants.Status.COMPLETE,
+            Q(
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.COMPLETE,
+            )
+            | Q(
+                is_rollout=True,
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.DISABLED,
+            ),
             publish_status=NimbusConstants.PublishStatus.APPROVED,
         )
         IS_ENDING = Q(
-            status=NimbusConstants.Status.LIVE,
-            status_next=NimbusConstants.Status.COMPLETE,
+            Q(
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.COMPLETE,
+            )
+            | Q(
+                is_rollout=True,
+                status=NimbusConstants.Status.LIVE,
+                status_next=NimbusConstants.Status.DISABLED,
+            ),
             publish_status=NimbusConstants.PublishStatus.WAITING,
         )
         SHOULD_ALLOCATE_BUCKETS = Q(
@@ -1265,6 +1293,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def is_live_rollout(self):
         return self.is_rollout and (self.is_enrolling or self.is_observation)
 
+    @property
+    def is_rollout_with_phases(self):
+        return self.is_rollout and self.rollout_phases.exists()
+
     def annotated_rollout_phases(self):
         phases = list(self.rollout_phases.all())
         current_index = None
@@ -1283,26 +1315,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return phases
 
     def advance_rollout_phase(self):
-        phases = list(self.rollout_phases.all())
-        if not phases:
+        if not self.is_rollout_with_phases or self.rollout_phase_next_id is None:
             return
 
         today = timezone.now().date()
-        phase_ids = [phase.id for phase in phases]
+        current_phase = self.rollout_phase
+        next_phase = self.rollout_phase_next
 
-        if self.rollout_phase_next_id is not None:
-            current_phase = self.rollout_phase
-            next_phase = self.rollout_phase_next
-        elif self.rollout_phase_id is None:
-            current_phase = None
-            next_phase = phases[0]
-        else:
-            current_index = phase_ids.index(self.rollout_phase_id)
-            current_phase = phases[current_index]
-            next_index = current_index + 1
-            next_phase = phases[next_index] if next_index < len(phases) else None
-
-        if next_phase is not None and not next_phase.population_percent:
+        if not next_phase or not next_phase.population_percent:
             return
 
         resuming = self.status == NimbusExperiment.Status.DISABLED
@@ -1312,11 +1332,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 current_phase.start_date = current_phase.actual_start_date
             current_phase.save()
 
-        if next_phase is None:
-            self.rollout_phase_next = None
-            self.save()
-            return
-
         next_phase.actual_start_date = today
         next_phase.save()
         self.rollout_phase = next_phase
@@ -1324,12 +1339,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         self.population_percent = next_phase.population_percent
         self.save()
 
-    def stage_rollout_phase_advance(self, copy_current_if_missing=False):
-        phases = list(self.rollout_phases.all())
-        if not phases:
+    def stage_rollout_phase_advance(self):
+        if not self.is_rollout_with_phases:
             return None
 
-        current_phase = self.rollout_phase
+        phases = list(self.rollout_phases.all())
+
         if self.rollout_phase_next_id is not None:
             next_phase = self.rollout_phase_next
         elif self.rollout_phase_id is None:
@@ -1340,11 +1355,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             next_index = current_index + 1
             next_phase = phases[next_index] if next_index < len(phases) else None
 
-        if next_phase is None and copy_current_if_missing and current_phase is not None:
-            next_phase = self.rollout_phases.create(
-                population_percent=current_phase.population_percent
-            )
-
         if next_phase is None or not next_phase.population_percent:
             return None
 
@@ -1353,7 +1363,19 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         self.save(update_fields=["rollout_phase_next", "population_percent"])
         return next_phase
 
+    def revert_staged_rollout_phase_advance(self):
+        if not self.is_rollout_with_phases or self.rollout_phase_next_id is None:
+            return
+
+        self.rollout_phase_next = None
+        self.population_percent = (
+            self.rollout_phase.population_percent if self.rollout_phase else 0
+        )
+        self.save(update_fields=["rollout_phase_next", "population_percent"])
+
     def end_current_rollout_phase(self):
+        if not self.is_rollout_with_phases:
+            return
         current_phase = self.rollout_phase
         if current_phase is None:
             return
@@ -3526,6 +3548,7 @@ class NimbusChangeLog(FilterMixin, models.Model):
         REJECTED_FROM_KINTO = "Rejected from Remote Settings"
         LIVE = "Experiment is live"
         COMPLETED = "Experiment is complete"
+        DISABLED = "Rollout is disabled"
         RESULTS_UPDATED = "Experiment results updated"
         MONITORING_DATA_UPDATED = "Experiment monitoring data updated"
         HOLDBACK_ENROLLMENT_UPDATED = "Holdback enrollment period updated"

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -321,6 +321,44 @@ class TestNimbusExperimentManager(TestCase):
             [experiment_should_update],
         )
 
+    def test_end_queue_includes_disabling_rollouts(self):
+        disabling_rollout = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.end_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [disabling_rollout],
+        )
+
+    def test_launch_queue_includes_reenabling_rollouts(self):
+        reenabling_rollout = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [reenabling_rollout],
+        )
+
     def test_update_queue_filters_by_collection(self):
         test_feature = NimbusFeatureConfigFactory.create(
             slug="test-feature",
@@ -513,6 +551,44 @@ class TestNimbusExperimentManager(TestCase):
                 )
             ),
             [pausing],
+        )
+
+    def test_waiting_to_end_includes_disabling_rollouts(self):
+        disabling_rollout = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_end_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [disabling_rollout],
+        )
+
+    def test_waiting_to_launch_includes_reenabling_rollouts(self):
+        reenabling_rollout = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+
+        self.assertEqual(
+            list(
+                NimbusExperiment.objects.waiting_to_launch_queue(
+                    [NimbusExperiment.Application.DESKTOP],
+                    settings.KINTO_COLLECTION_NIMBUS_DESKTOP,
+                )
+            ),
+            [reenabling_rollout],
         )
 
     def test_waiting_to_update_filters_by_collection(self):
@@ -6974,6 +7050,7 @@ class TestAdvanceRolloutPhase(TestCase):
 
     def test_advance_from_no_phase_starts_first_phase(self):
         today = timezone.now().date()
+        self.experiment.stage_rollout_phase_advance()
         self.experiment.advance_rollout_phase()
         self.experiment.refresh_from_db()
         self.phases[0].refresh_from_db()
@@ -7027,6 +7104,7 @@ class TestAdvanceRolloutPhase(TestCase):
         self.phases[1].save()
         self.experiment.rollout_phase = self.phases[0]
         self.experiment.save()
+        self.experiment.stage_rollout_phase_advance()
 
         self.experiment.advance_rollout_phase()
         self.experiment.refresh_from_db()
@@ -7046,6 +7124,7 @@ class TestAdvanceRolloutPhase(TestCase):
         self.phases[1].population_percent = 0
         self.phases[1].save()
         self.experiment.rollout_phase = self.phases[0]
+        self.experiment.rollout_phase_next = self.phases[1]
         self.experiment.save()
 
         self.experiment.advance_rollout_phase()
@@ -7060,6 +7139,8 @@ class TestAdvanceRolloutPhase(TestCase):
     def test_advance_does_not_start_first_phase_with_zero_population(self):
         self.phases[0].population_percent = 0
         self.phases[0].save()
+        self.experiment.rollout_phase_next = self.phases[0]
+        self.experiment.save()
 
         self.experiment.advance_rollout_phase()
         self.experiment.refresh_from_db()
@@ -7073,7 +7154,9 @@ class TestAdvanceRolloutPhase(TestCase):
         self.phases[0].start_date = datetime.date(2099, 1, 1)
         self.phases[0].save()
 
+        self.experiment.stage_rollout_phase_advance()
         self.experiment.advance_rollout_phase()
+        self.experiment.stage_rollout_phase_advance()
         self.experiment.advance_rollout_phase()
         self.phases[0].refresh_from_db()
 
@@ -7081,7 +7164,7 @@ class TestAdvanceRolloutPhase(TestCase):
         self.assertEqual(self.phases[0].start_date, today)
         self.assertEqual(self.phases[0].end_date, today)
 
-    def test_advance_past_last_phase_clears_next(self):
+    def test_advance_past_last_phase_without_staged_phase_is_noop(self):
         self.experiment.rollout_phase = self.phases[2]
         self.experiment.save()
 
@@ -7089,7 +7172,7 @@ class TestAdvanceRolloutPhase(TestCase):
         self.experiment.refresh_from_db()
         self.phases[2].refresh_from_db()
 
-        self.assertEqual(self.phases[2].end_date, timezone.now().date())
+        self.assertIsNone(self.phases[2].end_date)
         self.assertEqual(self.experiment.rollout_phase, self.phases[2])
         self.assertIsNone(self.experiment.rollout_phase_next)
 
@@ -7138,7 +7221,7 @@ class TestAdvanceRolloutPhase(TestCase):
             self.experiment.population_percent, self.phases[2].population_percent
         )
 
-    def test_stage_advance_past_last_phase_without_copy_is_noop(self):
+    def test_stage_advance_past_last_phase_is_noop(self):
         self.experiment.rollout_phase = self.phases[2]
         self.experiment.save()
 
@@ -7146,23 +7229,7 @@ class TestAdvanceRolloutPhase(TestCase):
 
         self.assertIsNone(next_phase)
         self.assertIsNone(self.experiment.rollout_phase_next)
-
-    def test_stage_advance_past_last_phase_copies_current_when_requested(self):
-        self.experiment.rollout_phase = self.phases[2]
-        self.experiment.save()
-
-        next_phase = self.experiment.stage_rollout_phase_advance(
-            copy_current_if_missing=True
-        )
-        self.experiment.refresh_from_db()
-
-        self.assertIsNotNone(next_phase)
-        assert next_phase is not None
-        self.assertNotEqual(next_phase, self.phases[2])
-        self.assertEqual(next_phase.population_percent, self.phases[2].population_percent)
-        self.assertEqual(self.experiment.rollout_phase, self.phases[2])
-        self.assertEqual(self.experiment.rollout_phase_next, next_phase)
-        self.assertEqual(self.experiment.rollout_phases.count(), 4)
+        self.assertEqual(self.experiment.rollout_phases.count(), 3)
 
     def test_stage_advance_does_not_stage_zero_population_phase(self):
         self.phases[1].population_percent = 0
@@ -7216,6 +7283,16 @@ class TestAdvanceRolloutPhase(TestCase):
         self.experiment.end_current_rollout_phase()
 
         self.assertIsNone(self.experiment.rollout_phase)
+
+    def test_end_current_rollout_phase_is_noop_without_phases(self):
+        legacy_rollout = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+
+        legacy_rollout.end_current_rollout_phase()
+
+        self.assertFalse(legacy_rollout.rollout_phases.exists())
 
     def test_end_current_rollout_phase_replaces_estimated_end_date(self):
         previous_end_date = timezone.now().date() - datetime.timedelta(days=1)

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -117,6 +117,7 @@ def handle_pending_review(applications, collection):
         if experiment.should_timeout:
             with transaction.atomic():
                 experiment.publish_status = NimbusExperiment.PublishStatus.REVIEW
+                experiment.revert_staged_rollout_phase_advance()
                 if experiment.status == experiment.Status.DRAFT:
                     experiment.published_date = None
                 experiment.save()
@@ -153,6 +154,7 @@ def handle_rejection(applications, kinto_client):
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
             experiment.status_next = None
             experiment.is_paused = False
+            experiment.revert_staged_rollout_phase_advance()
             if experiment.status == experiment.Status.DRAFT:
                 experiment.published_date = None
             experiment.save()
@@ -203,6 +205,8 @@ def handle_launching_experiments(applications, records, collection):
             published_record.pop("last_modified")
 
             with transaction.atomic():
+                if experiment.is_rollout_with_phases and experiment.rollout_phase_next_id:
+                    experiment.advance_rollout_phase()
                 experiment.status = NimbusExperiment.Status.LIVE
                 experiment.status_next = None
                 experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -246,6 +250,11 @@ def handle_updating_experiments(applications, records, collection):
         if published_record != stored_record:
             logger.info(f"{experiment} is updated in Kinto".format(experiment=experiment))
             with transaction.atomic():
+                next_status = experiment.status_next
+                if experiment.is_rollout_with_phases and experiment.rollout_phase_next_id:
+                    experiment.advance_rollout_phase()
+                if next_status == NimbusExperiment.Status.LIVE:
+                    experiment.status = next_status
                 experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
                 experiment.status_next = None
                 experiment.published_dto = published_record
@@ -289,38 +298,54 @@ def handle_ending_experiments(applications, records, collection):
         applications, collection
     ):
         if experiment.slug not in records:
-            logger.info(
-                f"{experiment.slug} status is being updated to complete".format(
-                    experiment=experiment
-                )
+            is_disabling_rollout = (
+                experiment.is_rollout_with_phases
+                and experiment.status_next == NimbusExperiment.Status.DISABLED
             )
+            next_status = (
+                NimbusExperiment.Status.DISABLED
+                if is_disabling_rollout
+                else NimbusExperiment.Status.COMPLETE
+            )
+            logger.info(f"{experiment.slug} status is being updated to {next_status}")
 
             with transaction.atomic():
-                experiment.status = NimbusExperiment.Status.COMPLETE
+                experiment.status = next_status
                 experiment.status_next = None
                 experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
                 experiment.is_rollout_dirty = False
                 experiment.save()
 
+                if is_disabling_rollout:
+                    experiment.end_current_rollout_phase()
+
                 generate_nimbus_changelog(
                     experiment,
                     get_kinto_user(),
-                    message=NimbusChangeLog.Messages.COMPLETED,
+                    message=(
+                        NimbusChangeLog.Messages.DISABLED
+                        if is_disabling_rollout
+                        else NimbusChangeLog.Messages.COMPLETED
+                    ),
                 )
 
-                experiment.update_computed_end_date()
+                if not is_disabling_rollout:
+                    experiment.update_computed_end_date()
 
-            _send_slack_alert_success_message(
-                experiment,
-                NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
-                SlackConstants.SLACK_EXPERIMENT_ENDED_MESSAGE,
-                SlackConstants.SLACK_OPERATION_EXPERIMENT_ENDING,
-                lambda slug: SlackConstants.SLACK_LOG_EXPERIMENT_ENDING_SENT.format(
-                    experiment=slug
-                ),
+            if not is_disabling_rollout:
+                _send_slack_alert_success_message(
+                    experiment,
+                    NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+                    SlackConstants.SLACK_EXPERIMENT_ENDED_MESSAGE,
+                    SlackConstants.SLACK_OPERATION_EXPERIMENT_ENDING,
+                    lambda slug: SlackConstants.SLACK_LOG_EXPERIMENT_ENDING_SENT.format(
+                        experiment=slug
+                    ),
+                )
+
+            logger.info(
+                f"{experiment.slug} {'disabled' if is_disabling_rollout else 'ended'}"
             )
-
-            logger.info(f"{experiment.slug} ended")
 
 
 def handle_waiting_experiments(applications, records, collection):
@@ -328,6 +353,7 @@ def handle_waiting_experiments(applications, records, collection):
         with transaction.atomic():
             experiment.status_next = None
             experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+            experiment.revert_staged_rollout_phase_advance()
             if experiment.status == experiment.Status.DRAFT:
                 experiment.published_date = None
 

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -19,6 +19,7 @@ from experimenter.experiments.models import (
 from experimenter.experiments.tests.factories import (
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
+    NimbusRolloutPhaseFactory,
 )
 from experimenter.kinto import tasks
 from experimenter.kinto.client import KINTO_REVIEW_STATUS, KINTO_ROLLBACK_STATUS
@@ -1109,9 +1110,37 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertEqual(
             launching_experiment.computed_end_date, launching_experiment.proposed_end_date
         )
-        self.assertEqual(
-            launching_experiment.computed_end_date, launching_experiment.proposed_end_date
+
+    def test_remote_settings_launch_approval_commits_staged_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
         )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.stage_rollout_phase_advance()
+
+        self.assertIsNone(experiment.rollout_phase)
+        self.assertEqual(experiment.rollout_phase_next, phase)
+
+        tasks.handle_launching_experiments(
+            [NimbusExperiment.Application.DESKTOP],
+            {
+                experiment.slug: {
+                    "id": experiment.slug,
+                    "last_modified": 1,
+                }
+            },
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        phase.refresh_from_db()
+        self.assertEqual(experiment.rollout_phase, phase)
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(phase.actual_start_date, timezone.now().date())
 
     @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
     def test_launching_experiment_live_handles_slack_notification_error(
@@ -1189,6 +1218,189 @@ class TestNimbusCheckKintoPushQueueByCollection(
             updating_experiment.publish_status, NimbusExperiment.PublishStatus.IDLE
         )
         self.assertIn("updated_field", updating_experiment.published_dto)
+
+    def test_remote_settings_update_approval_commits_staged_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            published_dto={"id": "previous-record"},
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        next_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.rollout_phase = current_phase
+        experiment.population_percent = current_phase.population_percent
+        experiment.save()
+        experiment.stage_rollout_phase_advance()
+
+        self.assertEqual(experiment.rollout_phase, current_phase)
+        self.assertEqual(experiment.rollout_phase_next, next_phase)
+
+        tasks.handle_updating_experiments(
+            [NimbusExperiment.Application.DESKTOP],
+            {
+                experiment.slug: {
+                    "id": experiment.slug,
+                    "last_modified": 1,
+                }
+            },
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        current_phase.refresh_from_db()
+        next_phase.refresh_from_db()
+        self.assertEqual(experiment.rollout_phase, next_phase)
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(current_phase.end_date, timezone.now().date())
+        self.assertEqual(next_phase.actual_start_date, timezone.now().date())
+
+    def test_remote_settings_rejection_reverts_staged_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=25)
+        experiment.rollout_phase = current_phase
+        experiment.population_percent = current_phase.population_percent
+        experiment.save()
+        experiment.stage_rollout_phase_advance()
+
+        self.mock_kinto_client.collection = experiment.kinto_collection
+        self.mock_kinto_client.get_rejected_collection_data.return_value = {
+            "last_reviewer_comment": "Rejected"
+        }
+        tasks.handle_rejection(
+            [NimbusExperiment.Application.DESKTOP], self.mock_kinto_client
+        )
+
+        experiment.refresh_from_db()
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(experiment.population_percent, current_phase.population_percent)
+
+    @override_settings(KINTO_REVIEW_TIMEOUT=0)
+    def test_remote_settings_timeout_reverts_staged_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=25)
+        experiment.rollout_phase = current_phase
+        experiment.population_percent = current_phase.population_percent
+        experiment.save()
+        experiment.stage_rollout_phase_advance()
+
+        tasks.handle_pending_review(
+            [NimbusExperiment.Application.DESKTOP], experiment.kinto_collection
+        )
+
+        experiment.refresh_from_db()
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(experiment.population_percent, current_phase.population_percent)
+
+    def test_remote_settings_disable_approval_disables_and_ends_current_phase(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            published_dto={"id": "previous-record"},
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=25,
+            actual_start_date=timezone.now().date(),
+        )
+        experiment.rollout_phase = current_phase
+        experiment.save()
+
+        tasks.handle_ending_experiments(
+            [NimbusExperiment.Application.DESKTOP],
+            {},
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        current_phase.refresh_from_db()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.DISABLED)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertEqual(current_phase.end_date, timezone.now().date())
+
+    def test_remote_settings_legacy_rollout_ending_uses_completion_flow(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            published_dto={"id": "previous-record"},
+        )
+
+        tasks.handle_ending_experiments(
+            [NimbusExperiment.Application.DESKTOP],
+            {},
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.COMPLETE)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertTrue(
+            experiment.changes.filter(message=NimbusChangeLog.Messages.COMPLETED).exists()
+        )
+
+    def test_remote_settings_reenable_approval_advances_phase_and_sets_live(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.WAITING,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            published_dto={"id": "previous-record"},
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        next_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.rollout_phase = current_phase
+        experiment.rollout_phase_next = next_phase
+        experiment.save()
+
+        tasks.handle_launching_experiments(
+            [NimbusExperiment.Application.DESKTOP],
+            {
+                experiment.slug: {
+                    "id": experiment.slug,
+                    "last_modified": 1,
+                }
+            },
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        next_phase.refresh_from_db()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.rollout_phase, next_phase)
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(next_phase.actual_start_date, timezone.now().date())
 
     @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
     def test_updating_paused_experiment_sends_enrollment_ended_notification(

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -29,6 +29,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_INVALID_DISABLED_TRANSITION = (
         "Cannot perform this action: only rollouts may be disabled."
     )
+    ERROR_INVALID_PHASELESS_ROLLOUT_DISABLED_TRANSITION = (
+        "Cannot perform this action: only rollouts with phases may be disabled."
+    )
+    ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE = (
+        "Cannot duplicate the final phase because this rollout has no current phase."
+    )
 
     RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
     REVIEW_URL = "https://experimenter.info/getting-started/for-reviewers"

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1323,6 +1323,14 @@ class LiveToDisabledReviewRolloutForm(UpdateStatusForm):
     status_next = NimbusExperiment.Status.DISABLED
     publish_status = NimbusExperiment.PublishStatus.REVIEW
 
+    def clean(self):
+        cleaned_data = super().clean()
+        if not self.instance.is_rollout_with_phases:
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_INVALID_PHASELESS_ROLLOUT_DISABLED_TRANSITION
+            )
+        return cleaned_data
+
     def get_changelog_message(self):
         return f"{self.request.user} requested review to disable rollout"
 
@@ -1391,6 +1399,36 @@ class DisabledToLiveReviewRolloutForm(UpdateStatusForm):
         return f"{self.request.user} requested review to re-enable rollout"
 
 
+class DisabledToLiveDuplicatePhaseReviewRolloutForm(DisabledToLiveReviewRolloutForm):
+    def get_changelog_message(self):
+        return (
+            f"{self.request.user} duplicated the final rollout phase and requested "
+            "review to re-enable rollout"
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if self.instance.rollout_phase_id is None:
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE
+            )
+        return cleaned_data
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = NimbusExperiment.objects.select_for_update().get(pk=self.instance.pk)
+        self.instance = experiment
+        if (
+            experiment.rollout_phase_next_id is None
+            and experiment.rollout_phase
+            and experiment.rollout_phase == experiment.rollout_phases.last()
+        ):
+            experiment.rollout_phases.create(
+                population_percent=experiment.rollout_phase.population_percent
+            )
+        return super().save(commit=commit)
+
+
 class DisabledToLiveReviewApproveRolloutForm(UpdateStatusForm):
     required_status = NimbusExperiment.Status.DISABLED
     required_status_next = NimbusExperiment.Status.LIVE
@@ -1406,7 +1444,7 @@ class DisabledToLiveReviewApproveRolloutForm(UpdateStatusForm):
     @transaction.atomic
     def save(self, commit=True):
         experiment = super().save(commit=commit)
-        experiment.stage_rollout_phase_advance(copy_current_if_missing=True)
+        experiment.stage_rollout_phase_advance()
         experiment.allocate_bucket_range()
         nimbus_check_kinto_push_queue_by_collection.apply_async(
             countdown=5, args=[experiment.kinto_collection]

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -17,6 +17,7 @@ from experimenter.nimbus_ui.new.forms import (
     AdvancePhaseReviewRejectRolloutForm,
     AdvancePhaseReviewRolloutForm,
     CollaboratorsForm,
+    DisabledToLiveDuplicatePhaseReviewRolloutForm,
     DisabledToLiveReviewApproveRolloutForm,
     DisabledToLiveReviewRejectRolloutForm,
     DisabledToLiveReviewRolloutForm,
@@ -565,6 +566,10 @@ class LiveToDisabledReviewRejectRolloutView(StatusUpdateView):
 
 class DisabledToLiveReviewRolloutView(StatusUpdateView):
     form_class = DisabledToLiveReviewRolloutForm
+
+
+class DisabledToLiveDuplicatePhaseReviewRolloutView(StatusUpdateView):
+    form_class = DisabledToLiveDuplicatePhaseReviewRolloutForm
 
 
 class DisabledToLiveReviewApproveRolloutView(StatusUpdateView):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -34,6 +34,7 @@ from experimenter.nimbus_ui.new.forms import (
     AdvancePhaseReviewRejectRolloutForm,
     AdvancePhaseReviewRolloutForm,
     CollaboratorsForm,
+    DisabledToLiveDuplicatePhaseReviewRolloutForm,
     DisabledToLiveReviewApproveRolloutForm,
     DisabledToLiveReviewRejectRolloutForm,
     DisabledToLiveReviewRolloutForm,
@@ -1537,6 +1538,8 @@ class TestRolloutStatusForms(RequestFormTestCase):
             is_paused=False,
             is_rollout=True,
         )
+        if form_class is LiveToDisabledReviewRolloutForm:
+            NimbusRolloutPhaseFactory.create(experiment=experiment)
         form = form_class(
             data={"changelog_message": "rejected the review"},
             instance=experiment,
@@ -1658,6 +1661,23 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.assertEqual(
             form.errors["__all__"],
             [NimbusUIConstants.ERROR_INVALID_DISABLED_TRANSITION],
+        )
+
+    def test_disabled_transition_is_rejected_for_rollout_without_phases(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        form = LiveToDisabledReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["__all__"],
+            [NimbusUIConstants.ERROR_INVALID_PHASELESS_ROLLOUT_DISABLED_TRANSITION],
         )
 
     def test_draft_to_preview_side_effects(self):
@@ -1841,35 +1861,85 @@ class TestRolloutStatusForms(RequestFormTestCase):
             countdown=5, args=[experiment.kinto_collection]
         )
 
-    def test_reenable_approval_copies_current_phase_when_next_is_missing(self):
+    def test_duplicate_phase_reenable_copies_final_phase(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DISABLED,
-            status_next=NimbusExperiment.Status.LIVE,
-            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
-            population_percent=0,
         )
-        current_phase = NimbusRolloutPhaseFactory.create(
-            experiment=experiment, population_percent=25
+        final_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=25,
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 1, 15),
+            actual_start_date=datetime.date(2026, 1, 2),
         )
-        experiment.rollout_phase = current_phase
+        experiment.rollout_phase = final_phase
         experiment.save()
-        form = DisabledToLiveReviewApproveRolloutForm(
+        form = DisabledToLiveDuplicatePhaseReviewRolloutForm(
             data={}, instance=experiment, request=self.request
         )
 
         self.assertTrue(form.is_valid(), form.errors)
 
         experiment = form.save()
+        duplicated_phase = experiment.rollout_phases.last()
 
-        self.assertEqual(experiment.rollout_phase, current_phase)
-        self.assertIsNotNone(experiment.rollout_phase_next)
-        self.assertNotEqual(experiment.rollout_phase_next, current_phase)
+        self.assertNotEqual(duplicated_phase, final_phase)
         self.assertEqual(
-            experiment.rollout_phase_next.population_percent,
-            current_phase.population_percent,
+            duplicated_phase.population_percent, final_phase.population_percent
         )
+        self.assertIsNone(duplicated_phase.start_date)
+        self.assertIsNone(duplicated_phase.end_date)
+        self.assertIsNone(duplicated_phase.actual_start_date)
+        self.assertEqual(experiment.status, NimbusExperiment.Status.DISABLED)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertIn(
+            "duplicated the final rollout phase and requested review to re-enable",
+            experiment.changes.latest("changed_on").message,
+        )
+
+    def test_duplicate_phase_reenable_request_does_not_duplicate_if_existing_next_phase(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=50)
+        experiment.rollout_phase = current_phase
+        experiment.save()
+        form = DisabledToLiveDuplicatePhaseReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        form.save()
+
         self.assertEqual(experiment.rollout_phases.count(), 2)
+
+    def test_duplicate_phase_reenable_request_requires_current_phase(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        form = DisabledToLiveDuplicatePhaseReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            NimbusUIConstants.ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE,
+            form.errors["__all__"],
+        )
 
 
 class TestRolloutPhaseForm(TestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -141,6 +141,8 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             publish_status=form_class.required_publish_status,
             is_rollout=True,
         )
+        if url_name == "nimbus-ui-new-live-to-disabled-rollout":
+            NimbusRolloutPhaseFactory.create(experiment=experiment)
 
         response = self.client.post(reverse(url_name, kwargs={"slug": experiment.slug}))
 
@@ -232,6 +234,61 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             "Cannot perform this action: experiment must be in state",
             response.context["update_status_form_errors"][0],
         )
+
+    def test_duplicate_phase_resume_submission_creates_phase_and_requests_review(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        final_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.rollout_phase = final_phase
+        experiment.save()
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-disabled-to-live-duplicate-phase-rollout",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+        duplicated_phase = experiment.rollout_phases.last()
+        self.assertEqual(experiment.rollout_phases.count(), 2)
+        self.assertNotEqual(duplicated_phase, final_phase)
+        self.assertEqual(
+            duplicated_phase.population_percent, final_phase.population_percent
+        )
+        self.assertEqual(experiment.status, NimbusExperiment.Status.DISABLED)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+
+    def test_duplicate_phase_resume_submission_without_current_phase_is_invalid(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-disabled-to-live-duplicate-phase-rollout",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            NimbusUIConstants.ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE,
+            response.context["update_status_form_errors"],
+        )
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.rollout_phases.count(), 0)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
 
 
 class NewViewTestMixin:

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -5,6 +5,7 @@ from experimenter.nimbus_ui.new.views import (
     AdvancePhaseReviewApproveRolloutView,
     AdvancePhaseReviewRejectRolloutView,
     AdvancePhaseReviewRolloutView,
+    DisabledToLiveDuplicatePhaseReviewRolloutView,
     DisabledToLiveReviewApproveRolloutView,
     DisabledToLiveReviewRejectRolloutView,
     DisabledToLiveReviewRolloutView,
@@ -392,6 +393,11 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/disabled-to-live-rollout/$",
         DisabledToLiveReviewRolloutView.as_view(),
         name="nimbus-ui-new-disabled-to-live-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/disabled-to-live-duplicate-phase-rollout/$",
+        DisabledToLiveDuplicatePhaseReviewRolloutView.as_view(),
+        name="nimbus-ui-new-disabled-to-live-duplicate-phase-rollout",
     ),
     re_path(
         r"^new/(?P<slug>[\w-]+)/disabled-to-live-review-approve-rollout/$",


### PR DESCRIPTION
Because

- Disabling and re-enabling rollouts require dedicated RS unpublish and publish workflows

This commit

- Updates Kinto jobs and queryset filters to route disabling through the unpublish queue and re-enabling through the publish queue
- Finalizes rollout statuses and phases only after Remote Settings confirmation
- Adds tests for the new queue and approval behavior

Fixes #16412 