### PR TITLE
feat(nimbus): add views for rollout state transitions

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -26,6 +26,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Cannot perform this action: experiment must be in state {required_state}, "
         "but is currently in state {current_state}."
     )
+    ERROR_INVALID_DISABLED_TRANSITION = (
+        "Cannot perform this action: only rollouts may be disabled."
+    )
 
     RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
     REVIEW_URL = "https://experimenter.info/getting-started/for-reviewers"

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from datetime import UTC, datetime
 from decimal import Decimal
 
 import markus
@@ -13,6 +14,7 @@ from django.utils.text import slugify
 
 from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
+from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchFeatureValue,
@@ -25,6 +27,10 @@ from experimenter.experiments.models import (
     NimbusRolloutPhase,
     NimbusRolloutPlanTemplate,
     Tag,
+)
+from experimenter.kinto.tasks import (
+    nimbus_check_kinto_push_queue_by_collection,
+    nimbus_synchronize_preview_experiments_in_kinto,
 )
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.nimbus_ui.forms import NimbusBranchScreenshotForm
@@ -959,6 +965,412 @@ class CollaboratorsForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def get_changelog_message(self):
         return f"{self.request.user} updated collaborators"
+
+
+class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    status = None
+    status_next = None
+    publish_status = None
+    is_paused = None
+
+    required_status = None
+    required_status_next = None
+    required_publish_status = None
+    required_is_paused = None
+
+    class Meta:
+        model = NimbusExperiment
+        fields = []
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        required_state = (
+            self.required_status,
+            self.required_status_next,
+            self.required_publish_status,
+            self.required_is_paused,
+        )
+        current_state = (
+            self.instance.status,
+            self.instance.status_next,
+            self.instance.publish_status,
+            self.instance.is_paused,
+        )
+
+        state_mismatch = (
+            self.required_status != self.instance.status
+            or self.required_status_next != self.instance.status_next
+            or self.required_publish_status != self.instance.publish_status
+            or (
+                self.required_is_paused is not None
+                and self.required_is_paused != self.instance.is_paused
+            )
+        )
+
+        if state_mismatch:
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_INVALID_STATE_TRANSITION.format(
+                    required_state=required_state,
+                    current_state=current_state,
+                )
+            )
+
+        if not self.instance.is_rollout and NimbusConstants.Status.DISABLED in (
+            *required_state,
+            *current_state,
+            self.status,
+            self.status_next,
+        ):
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_INVALID_DISABLED_TRANSITION
+            )
+
+        return cleaned_data
+
+    @transaction.atomic
+    def save(self, commit=True):
+        self.instance.status = self.status
+        self.instance.status_next = self.status_next
+        previous_publish_status = self.instance.publish_status
+        self.instance.publish_status = self.publish_status
+
+        if self.status == NimbusExperiment.Status.DRAFT:
+            self.instance.published_dto = None
+
+        if (
+            previous_publish_status == NimbusExperiment.PublishStatus.REVIEW
+            and self.publish_status != NimbusExperiment.PublishStatus.REVIEW
+        ):
+            last_review_request = self.instance.changes.latest_review_request()
+            if last_review_request is not None:
+                delta = datetime.now(UTC) - last_review_request.changed_on
+                delta_ms = int(delta.total_seconds() * 1000)
+                metrics.timing(
+                    "review_timing",
+                    value=delta_ms,
+                    tags=[f"status:{self.publish_status}"],
+                )
+
+        return super().save(commit=commit)
+
+
+# Draft to Live transitions
+
+
+class DraftReviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DRAFT
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.DRAFT
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested rollout launch without Preview"
+
+
+class DraftReviewApproveRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DRAFT
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.DRAFT
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.APPROVED
+
+    def get_changelog_message(self):
+        return f"{self.request.user} approved the review."
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.stage_rollout_phase_advance()
+        experiment.allocate_bucket_range()
+        nimbus_check_kinto_push_queue_by_collection.apply_async(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+        return experiment
+
+
+class DraftReviewRejectForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DRAFT
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.DRAFT
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    changelog_message = forms.CharField(
+        required=False, label="Changelog Message", max_length=1000
+    )
+
+    cancel_message = forms.CharField(
+        required=False, label="Cancel Message", max_length=1000
+    )
+
+    def get_changelog_message(self):
+        if self.cleaned_data.get("changelog_message"):
+            return (
+                f"{self.request.user} rejected the review with reason: "
+                f"{self.cleaned_data['changelog_message']}"
+            )
+        return f"{self.request.user} {self.cleaned_data['cancel_message']}"
+
+
+# Preview to Live transitions
+
+
+class PreviewReviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.PREVIEW
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.DRAFT
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested rollout launch from Preview"
+
+
+# Preview to Draft transitions
+
+
+class DraftToPreviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DRAFT
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.PREVIEW
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    def get_changelog_message(self):
+        return f"{self.request.user} launched rollout to Preview"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.allocate_bucket_range()
+        nimbus_synchronize_preview_experiments_in_kinto.apply_async(countdown=5)
+        return experiment
+
+
+class PreviewToDraftRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.PREVIEW
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.DRAFT
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    def get_changelog_message(self):
+        return f"{self.request.user} moved the rollout back to Draft"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        nimbus_synchronize_preview_experiments_in_kinto.apply_async(countdown=5)
+        return experiment
+
+
+# Phase advance transitions
+
+
+class AdvancePhaseReviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested review to advance rollout phase"
+
+
+class AdvancePhaseReviewApproveRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.APPROVED
+
+    def get_changelog_message(self):
+        return f"{self.request.user} approved the advance rollout phase review request"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.stage_rollout_phase_advance()
+        experiment.allocate_bucket_range()
+        nimbus_check_kinto_push_queue_by_collection.apply_async(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+        return experiment
+
+
+class AdvancePhaseReviewRejectRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    changelog_message = forms.CharField(
+        required=False, label="Changelog Message", max_length=1000
+    )
+
+    cancel_message = forms.CharField(
+        required=False, label="Cancel Message", max_length=1000
+    )
+
+    def get_changelog_message(self):
+        if self.cleaned_data.get("changelog_message"):
+            return (
+                f"{self.request.user} rejected the review with reason: "
+                f"{self.cleaned_data['changelog_message']}"
+            )
+        return f"{self.request.user} {self.cleaned_data['cancel_message']}"
+
+
+# Live to disabled transitions
+
+
+class LiveToDisabledReviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.DISABLED
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested review to disable rollout"
+
+
+class LiveToDisabledReviewApproveRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.DISABLED
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.DISABLED
+    publish_status = NimbusExperiment.PublishStatus.APPROVED
+
+    def get_changelog_message(self):
+        return f"{self.request.user} approved the disable rollout review request"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        nimbus_check_kinto_push_queue_by_collection.apply_async(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+        return experiment
+
+
+class LiveToDisabledReviewRejectRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.DISABLED
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    changelog_message = forms.CharField(
+        required=False, label="Changelog Message", max_length=1000
+    )
+
+    cancel_message = forms.CharField(
+        required=False, label="Cancel Message", max_length=1000
+    )
+
+    def get_changelog_message(self):
+        if self.cleaned_data.get("changelog_message"):
+            return (
+                f"{self.request.user} rejected the review with reason: "
+                f"{self.cleaned_data['changelog_message']}"
+            )
+        return f"{self.request.user} {self.cleaned_data['cancel_message']}"
+
+
+# Disabled to Live transitions
+
+
+class DisabledToLiveReviewRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DISABLED
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    status = NimbusExperiment.Status.DISABLED
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested review to re-enable rollout"
+
+
+class DisabledToLiveReviewApproveRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DISABLED
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.DISABLED
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.APPROVED
+
+    def get_changelog_message(self):
+        return f"{self.request.user} approved the re-enable rollout review request"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        experiment.stage_rollout_phase_advance(copy_current_if_missing=True)
+        experiment.allocate_bucket_range()
+        nimbus_check_kinto_push_queue_by_collection.apply_async(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+        return experiment
+
+
+class DisabledToLiveReviewRejectRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.DISABLED
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    status = NimbusExperiment.Status.DISABLED
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+
+    changelog_message = forms.CharField(
+        required=False, label="Changelog Message", max_length=1000
+    )
+    cancel_message = forms.CharField(
+        required=False, label="Cancel Message", max_length=1000
+    )
+
+    def get_changelog_message(self):
+        if self.cleaned_data.get("changelog_message"):
+            return (
+                f"{self.request.user} rejected the review with reason: "
+                f"{self.cleaned_data['changelog_message']}"
+            )
+        return f"{self.request.user} {self.cleaned_data['cancel_message']}"
 
 
 class RolloutPhaseForm(forms.ModelForm):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -1,21 +1,38 @@
 from django import forms
+from django.conf import settings
 from django.http import HttpResponse, HttpResponseRedirect
 from django.urls import reverse
 from django.views.generic import DetailView
 from django.views.generic.edit import UpdateView
 
 from experimenter.experiments.api.v5.serializers import NimbusRolloutReviewSerializer
+from experimenter.experiments.constants import EXTERNAL_URLS, RISK_QUESTIONS
 from experimenter.experiments.models import NimbusExperiment, Tag
 from experimenter.nimbus_ui.filtersets import (
     TagSearchFilterSet,
     UserSearchFilterSet,
 )
 from experimenter.nimbus_ui.new.forms import (
+    AdvancePhaseReviewApproveRolloutForm,
+    AdvancePhaseReviewRejectRolloutForm,
+    AdvancePhaseReviewRolloutForm,
     CollaboratorsForm,
+    DisabledToLiveReviewApproveRolloutForm,
+    DisabledToLiveReviewRejectRolloutForm,
+    DisabledToLiveReviewRolloutForm,
     DocumentationLinkCreateForm,
     DocumentationLinkDeleteForm,
+    DraftReviewApproveRolloutForm,
+    DraftReviewRejectForm,
+    DraftReviewRolloutForm,
+    DraftToPreviewRolloutForm,
+    LiveToDisabledReviewApproveRolloutForm,
+    LiveToDisabledReviewRejectRolloutForm,
+    LiveToDisabledReviewRolloutForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
+    PreviewReviewRolloutForm,
+    PreviewToDraftRolloutForm,
     RolloutAudienceForm,
     RolloutFeaturesForm,
     RolloutOverviewForm,
@@ -50,6 +67,12 @@ class RequestFormMixin:
         return kwargs
 
 
+class RenderResponseMixin:
+    def form_valid(self, form):
+        super().form_valid(form)
+        return self.render_to_response(self.get_context_data(form=form))
+
+
 class NimbusExperimentViewMixin:
     model = NimbusExperiment
     context_object_name = "experiment"
@@ -70,6 +93,63 @@ class NimbusExperimentViewMixin:
             context["slack_notifications_form"] = ToggleReviewSlackNotificationsForm(
                 instance=experiment
             )
+
+        return context
+
+
+def build_experiment_context(experiment):
+    outcome_doc_base_url = "https://mozilla.github.io/metric-hub/outcomes/"
+    primary_outcome_links = [
+        (
+            outcome,
+            f"{outcome_doc_base_url}{experiment.application.replace('-', '_')}/{outcome}",
+        )
+        for outcome in experiment.primary_outcomes
+    ]
+    secondary_outcome_links = [
+        (
+            outcome,
+            f"{outcome_doc_base_url}{experiment.application.replace('-', '_')}/{outcome}",
+        )
+        for outcome in experiment.secondary_outcomes
+    ]
+
+    segment_doc_base_url = "https://mozilla.github.io/metric-hub/segments/"
+    segment_links = [
+        (
+            segment,
+            # ruff prefers this implicit syntax for concatenating strings
+            f"{segment_doc_base_url}"
+            f"{experiment.application.replace('-', '_')}/"
+            f"#{segment}",
+        )
+        for segment in experiment.segments
+    ]
+    context = {
+        "RISK_QUESTIONS": RISK_QUESTIONS,
+        "EXTERNAL_URLS": EXTERNAL_URLS,
+        "primary_outcome_links": primary_outcome_links,
+        "secondary_outcome_links": secondary_outcome_links,
+        "segment_links": segment_links,
+        "uses_secure_collection": (
+            experiment.kinto_collection == settings.KINTO_COLLECTION_NIMBUS_SECURE
+        ),
+    }
+    return context
+
+
+class NimbusExperimentDetailView(
+    NimbusExperimentViewMixin,
+    CloneExperimentFormMixin,
+    UpdateView,
+):
+    template_name = "nimbus_experiments/detail.html"
+    fields = []
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        experiment_context = build_experiment_context(self.object)
+        context.update(experiment_context)
 
         return context
 
@@ -410,6 +490,88 @@ class NewAddSubscriberView(NewSubscriberView):
 
 class NewRemoveSubscriberView(NewSubscriberView):
     add = False
+
+
+class StatusUpdateView(RequestFormMixin, RenderResponseMixin, NimbusExperimentDetailView):
+    fields = None
+
+    def get_template_names(self):
+        if self.request.headers.get("HX-Request"):
+            fragment = self.request.GET.get("fragment") or self.request.POST.get(
+                "fragment"
+            )
+
+            if fragment == "progress_card":
+                return ["nimbus_experiments/launch_controls_v2.html"]
+
+        return [self.template_name]
+
+    def get_context_data(self, *, form=None, **kwargs):
+        context = super().get_context_data(form=form, **kwargs)
+        if self.request.method in ("POST", "PUT") and form and not form.is_valid():
+            context["update_status_form_errors"] = form.errors["__all__"]
+
+        return context
+
+
+class DraftToPreviewRolloutView(StatusUpdateView):
+    form_class = DraftToPreviewRolloutForm
+
+
+class DraftReviewRolloutView(StatusUpdateView):
+    form_class = DraftReviewRolloutForm
+
+
+class DraftReviewApproveRolloutView(StatusUpdateView):
+    form_class = DraftReviewApproveRolloutForm
+
+
+class DraftReviewRejectView(StatusUpdateView):
+    form_class = DraftReviewRejectForm
+
+
+class PreviewReviewRolloutView(StatusUpdateView):
+    form_class = PreviewReviewRolloutForm
+
+
+class PreviewToDraftRolloutView(StatusUpdateView):
+    form_class = PreviewToDraftRolloutForm
+
+
+class AdvancePhaseReviewRolloutView(StatusUpdateView):
+    form_class = AdvancePhaseReviewRolloutForm
+
+
+class AdvancePhaseReviewApproveRolloutView(StatusUpdateView):
+    form_class = AdvancePhaseReviewApproveRolloutForm
+
+
+class AdvancePhaseReviewRejectRolloutView(StatusUpdateView):
+    form_class = AdvancePhaseReviewRejectRolloutForm
+
+
+class LiveToDisabledReviewRolloutView(StatusUpdateView):
+    form_class = LiveToDisabledReviewRolloutForm
+
+
+class LiveToDisabledReviewApproveRolloutView(StatusUpdateView):
+    form_class = LiveToDisabledReviewApproveRolloutForm
+
+
+class LiveToDisabledReviewRejectRolloutView(StatusUpdateView):
+    form_class = LiveToDisabledReviewRejectRolloutForm
+
+
+class DisabledToLiveReviewRolloutView(StatusUpdateView):
+    form_class = DisabledToLiveReviewRolloutForm
+
+
+class DisabledToLiveReviewApproveRolloutView(StatusUpdateView):
+    form_class = DisabledToLiveReviewApproveRolloutForm
+
+
+class DisabledToLiveReviewRejectRolloutView(StatusUpdateView):
+    form_class = DisabledToLiveReviewRejectRolloutForm
 
 
 class NewRolloutScheduleUpdateView(NewCardUpdateView):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -1,10 +1,12 @@
 import datetime
 import json
+from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
+from parameterized import parameterized
 
 from experimenter.base.tests.factories import (
     CountryFactory,
@@ -22,17 +24,33 @@ from experimenter.experiments.tests.factories import (
     NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
+    NimbusRolloutPhaseFactory,
     NimbusVersionedSchemaFactory,
     TagFactory,
 )
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.nimbus_ui.new.forms import (
+    AdvancePhaseReviewApproveRolloutForm,
+    AdvancePhaseReviewRejectRolloutForm,
+    AdvancePhaseReviewRolloutForm,
     CollaboratorsForm,
+    DisabledToLiveReviewApproveRolloutForm,
+    DisabledToLiveReviewRejectRolloutForm,
+    DisabledToLiveReviewRolloutForm,
     DocumentationLinkCreateForm,
     DocumentationLinkDeleteForm,
+    DraftReviewApproveRolloutForm,
+    DraftReviewRejectForm,
+    DraftReviewRolloutForm,
+    DraftToPreviewRolloutForm,
+    LiveToDisabledReviewApproveRolloutForm,
+    LiveToDisabledReviewRejectRolloutForm,
+    LiveToDisabledReviewRolloutForm,
     NimbusBranchFeatureValueForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
+    PreviewReviewRolloutForm,
+    PreviewToDraftRolloutForm,
     RolloutAudienceForm,
     RolloutFeaturesForm,
     RolloutOverviewForm,
@@ -1220,6 +1238,546 @@ class TestTagAssignForm(RequestFormTestCase):
 
         tag_names = [tag.name for tag in form.fields["tags"].queryset]
         self.assertEqual(tag_names, ["A Tag", "M Tag", "Z Tag"])
+
+
+class TestRolloutStatusForms(RequestFormTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_preview_task = patch(
+            "experimenter.nimbus_ui.new.forms."
+            "nimbus_synchronize_preview_experiments_in_kinto.apply_async"
+        ).start()
+        self.mock_allocate_bucket_range = patch(
+            "experimenter.experiments.models.NimbusExperiment.allocate_bucket_range"
+        ).start()
+        self.mock_kinto_push_queue = patch(
+            "experimenter.nimbus_ui.new.forms."
+            "nimbus_check_kinto_push_queue_by_collection.apply_async"
+        ).start()
+        self.addCleanup(self.mock_preview_task.stop)
+        self.addCleanup(self.mock_allocate_bucket_range.stop)
+        self.addCleanup(self.mock_kinto_push_queue.stop)
+
+    @parameterized.expand(
+        [
+            # Draft -> Preview.
+            (
+                DraftToPreviewRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.PREVIEW,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "launched rollout to Preview",
+            ),
+            # Preview -> Draft.
+            (
+                PreviewToDraftRolloutForm,
+                NimbusExperiment.Status.PREVIEW,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "moved the rollout back to Draft",
+            ),
+            # Draft -> launch review.
+            (
+                DraftReviewRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                "requested rollout launch without Preview",
+            ),
+            # Approve launch review from Draft.
+            (
+                DraftReviewApproveRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.APPROVED,
+                "approved the review",
+            ),
+            # Reject launch review from Draft.
+            (
+                DraftReviewRejectForm,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "rejected the review",
+            ),
+            # Preview -> launch review.
+            (
+                PreviewReviewRolloutForm,
+                NimbusExperiment.Status.PREVIEW,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                "requested rollout launch from Preview",
+            ),
+            # Live -> phase-advance review.
+            (
+                AdvancePhaseReviewRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                "requested review to advance rollout phase",
+            ),
+            # Approve phase-advance review.
+            (
+                AdvancePhaseReviewApproveRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.APPROVED,
+                "approved the advance rollout phase review request",
+            ),
+            # Reject phase-advance review.
+            (
+                AdvancePhaseReviewRejectRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "rejected the review",
+            ),
+            # Live -> disable review.
+            (
+                LiveToDisabledReviewRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.PublishStatus.REVIEW,
+                "requested review to disable rollout",
+            ),
+            # Approve disable review.
+            (
+                LiveToDisabledReviewApproveRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.PublishStatus.APPROVED,
+                "approved the disable rollout review request",
+            ),
+            # Reject disable review.
+            (
+                LiveToDisabledReviewRejectRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "rejected the review",
+            ),
+            # Disabled -> re-enable review.
+            (
+                DisabledToLiveReviewRolloutForm,
+                NimbusExperiment.Status.DISABLED,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                "requested review to re-enable rollout",
+            ),
+            # Approve re-enable review.
+            (
+                DisabledToLiveReviewApproveRolloutForm,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.APPROVED,
+                "approved the re-enable rollout review request",
+            ),
+            # Reject re-enable review.
+            (
+                DisabledToLiveReviewRejectRolloutForm,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.DISABLED,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+                "rejected the review",
+            ),
+        ]
+    )
+    def test_valid_transition(
+        self,
+        form_class,
+        initial_status,
+        initial_status_next,
+        initial_publish_status,
+        expected_status,
+        expected_status_next,
+        expected_publish_status,
+        expected_changelog_message,
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=initial_status,
+            status_next=initial_status_next,
+            publish_status=initial_publish_status,
+            is_paused=False,
+            is_rollout=True,
+        )
+        form = form_class(
+            data={"changelog_message": "rejected the review"},
+            instance=experiment,
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, expected_status)
+        self.assertEqual(experiment.status_next, expected_status_next)
+        self.assertEqual(experiment.publish_status, expected_publish_status)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn(expected_changelog_message, changelog.message)
+
+    @parameterized.expand(
+        [
+            # Draft -> Preview.
+            (DraftToPreviewRolloutForm,),
+            # Preview -> Draft.
+            (PreviewToDraftRolloutForm,),
+            # Draft -> launch review.
+            (DraftReviewRolloutForm,),
+            # Approve launch review from Draft.
+            (DraftReviewApproveRolloutForm,),
+            # Reject launch review from Draft.
+            (DraftReviewRejectForm,),
+            # Preview -> launch review.
+            (PreviewReviewRolloutForm,),
+            # Live -> phase-advance review.
+            (AdvancePhaseReviewRolloutForm,),
+            # Approve phase-advance review.
+            (AdvancePhaseReviewApproveRolloutForm,),
+            # Reject phase-advance review.
+            (AdvancePhaseReviewRejectRolloutForm,),
+            # Live -> disable review.
+            (LiveToDisabledReviewRolloutForm,),
+            # Approve disable review.
+            (LiveToDisabledReviewApproveRolloutForm,),
+            # Reject disable review.
+            (LiveToDisabledReviewRejectRolloutForm,),
+            # Disabled -> re-enable review.
+            (DisabledToLiveReviewRolloutForm,),
+            # Approve re-enable review.
+            (DisabledToLiveReviewApproveRolloutForm,),
+            # Reject re-enable review.
+            (DisabledToLiveReviewRejectRolloutForm,),
+        ]
+    )
+    def test_invalid_publish_status_rejects_transition(self, form_class):
+        invalid_publish_status = (
+            NimbusExperiment.PublishStatus.REVIEW
+            if form_class.required_publish_status == NimbusExperiment.PublishStatus.IDLE
+            else NimbusExperiment.PublishStatus.IDLE
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=form_class.required_status,
+            status_next=form_class.required_status_next,
+            publish_status=invalid_publish_status,
+            is_paused=False,
+            is_rollout=True,
+        )
+        form = form_class(data={}, instance=experiment, request=self.request)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            "Cannot perform this action: experiment must be in state",
+            form.errors["__all__"][0],
+        )
+
+    @parameterized.expand(
+        [
+            # Reject launch review from Draft.
+            (DraftReviewRejectForm,),
+            # Reject phase-advance review.
+            (AdvancePhaseReviewRejectRolloutForm,),
+            # Reject disable review.
+            (LiveToDisabledReviewRejectRolloutForm,),
+            # Reject re-enable review.
+            (DisabledToLiveReviewRejectRolloutForm,),
+        ]
+    )
+    def test_reject_transition_uses_cancel_message_when_reason_is_blank(self, form_class):
+        experiment = NimbusExperimentFactory.create(
+            status=form_class.required_status,
+            status_next=form_class.required_status_next,
+            publish_status=form_class.required_publish_status,
+            is_rollout=True,
+        )
+        form = form_class(
+            data={"cancel_message": "cancelled the review"},
+            instance=experiment,
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertIn(
+            "cancelled the review",
+            experiment.changes.latest("changed_on").message,
+        )
+
+    def test_disabled_transition_is_rejected_for_non_rollout(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=False,
+        )
+        form = LiveToDisabledReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["__all__"],
+            [NimbusUIConstants.ERROR_INVALID_DISABLED_TRANSITION],
+        )
+
+    def test_draft_to_preview_side_effects(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_paused=False,
+            is_rollout=True,
+        )
+        form = DraftToPreviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        form.save()
+
+        self.mock_allocate_bucket_range.assert_called_once()
+        self.mock_preview_task.assert_called_once_with(countdown=5)
+
+    def test_preview_to_draft_resets_published_dto_and_syncs_preview(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.PREVIEW,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_paused=False,
+            is_rollout=True,
+            published_dto={"slug": "test-rollout"},
+        )
+        form = PreviewToDraftRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertIsNone(experiment.published_dto)
+        self.mock_preview_task.assert_called_once_with(countdown=5)
+
+    @patch("experimenter.nimbus_ui.new.forms.metrics")
+    def test_draft_review_approval_stages_phase_and_queues_kinto(self, mock_metrics):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            is_rollout=True,
+            population_percent=0,
+        )
+        first_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        form = DraftReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertIsNone(experiment.rollout_phase)
+        self.assertEqual(experiment.rollout_phase_next, first_phase)
+        self.assertEqual(experiment.population_percent, first_phase.population_percent)
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
+        )
+        self.mock_allocate_bucket_range.assert_called_once()
+        self.mock_kinto_push_queue.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+        mock_metrics.timing.assert_called_once()
+
+    def test_approve_phase_advance_stages_population_and_queues_kinto(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_paused=False,
+            is_rollout=True,
+            population_percent=10,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        next_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.rollout_phase = current_phase
+        experiment.save()
+        form = AdvancePhaseReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        next_phase.refresh_from_db()
+        self.assertEqual(experiment.rollout_phase, current_phase)
+        self.assertEqual(experiment.rollout_phase_next, next_phase)
+        self.assertEqual(experiment.population_percent, next_phase.population_percent)
+        self.assertIsNone(next_phase.actual_start_date)
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
+        )
+        self.mock_allocate_bucket_range.assert_called_once()
+        self.mock_kinto_push_queue.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+    def test_reject_phase_advance_clears_pending_transition(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+        form = AdvancePhaseReviewRejectRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+
+    def test_disable_approval_preserves_population_and_queues_kinto(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_paused=False,
+            is_rollout=True,
+            population_percent=25,
+        )
+        form = LiveToDisabledReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.population_percent, 25)
+        self.mock_allocate_bucket_range.assert_not_called()
+        self.mock_kinto_push_queue.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+    def test_reenable_approval_stages_existing_next_phase(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+            population_percent=0,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        next_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=50
+        )
+        experiment.rollout_phase = current_phase
+        experiment.save()
+        form = DisabledToLiveReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.rollout_phase, current_phase)
+        self.assertEqual(experiment.rollout_phase_next, next_phase)
+        self.assertEqual(experiment.population_percent, next_phase.population_percent)
+        self.mock_allocate_bucket_range.assert_called_once()
+        self.mock_kinto_push_queue.assert_called_once_with(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+
+    def test_reenable_approval_copies_current_phase_when_next_is_missing(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DISABLED,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+            population_percent=0,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=25
+        )
+        experiment.rollout_phase = current_phase
+        experiment.save()
+        form = DisabledToLiveReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+
+        self.assertEqual(experiment.rollout_phase, current_phase)
+        self.assertIsNotNone(experiment.rollout_phase_next)
+        self.assertNotEqual(experiment.rollout_phase_next, current_phase)
+        self.assertEqual(
+            experiment.rollout_phase_next.population_percent,
+            current_phase.population_percent,
+        )
+        self.assertEqual(experiment.rollout_phases.count(), 2)
 
 
 class TestRolloutPhaseForm(TestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1,10 +1,11 @@
 import datetime
 from decimal import Decimal
 from unittest import mock
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase
-from django.urls import reverse
+from django.urls import resolve, reverse
 from django.utils import timezone
 from parameterized import parameterized
 
@@ -51,6 +52,186 @@ class AuthTestCase(TestCase):
         super().setUp()
         self.user = UserFactory.create(email="user@example.com")
         self.client.defaults[settings.OPENIDC_EMAIL_HEADER] = self.user.email
+
+
+class TestRolloutStatusUpdateViews(AuthTestCase):
+    def setUp(self):
+        super().setUp()
+        self.mock_preview_task = patch(
+            "experimenter.nimbus_ui.new.forms."
+            "nimbus_synchronize_preview_experiments_in_kinto.apply_async"
+        ).start()
+        self.mock_allocate_bucket_range = patch(
+            "experimenter.experiments.models.NimbusExperiment.allocate_bucket_range"
+        ).start()
+        self.mock_kinto_push_queue = patch(
+            "experimenter.nimbus_ui.new.forms."
+            "nimbus_check_kinto_push_queue_by_collection.apply_async"
+        ).start()
+        self.addCleanup(self.mock_preview_task.stop)
+        self.addCleanup(self.mock_allocate_bucket_range.stop)
+        self.addCleanup(self.mock_kinto_push_queue.stop)
+
+    @parameterized.expand(
+        [
+            # Draft -> Preview
+            (
+                "nimbus-ui-new-draft-to-preview-rollout",
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.PREVIEW,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+            ),
+            # Draft -> Review
+            (
+                "nimbus-ui-new-draft-to-review-rollout",
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
+            # Preview -> Draft
+            (
+                "nimbus-ui-new-preview-to-draft-rollout",
+                NimbusExperiment.Status.PREVIEW,
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+            ),
+            # Live -> Live
+            (
+                "nimbus-ui-new-advance-phase-review-rollout",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
+            # Live -> Disabled
+            (
+                "nimbus-ui-new-live-to-disabled-rollout",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
+            # Disabled -> Live
+            (
+                "nimbus-ui-new-disabled-to-live-rollout",
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
+        ]
+    )
+    def test_valid_submission(
+        self,
+        url_name,
+        initial_status,
+        expected_status,
+        expected_status_next,
+        expected_publish_status,
+    ):
+        form_class = resolve(
+            reverse(url_name, kwargs={"slug": "test"})
+        ).func.view_class.form_class
+        experiment = NimbusExperimentFactory.create(
+            status=initial_status,
+            status_next=form_class.required_status_next,
+            publish_status=form_class.required_publish_status,
+            is_rollout=True,
+        )
+
+        response = self.client.post(reverse(url_name, kwargs={"slug": experiment.slug}))
+
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status, expected_status)
+        self.assertEqual(experiment.status_next, expected_status_next)
+        self.assertEqual(experiment.publish_status, expected_publish_status)
+
+    @parameterized.expand(
+        [
+            # Approve Draft -> Live review.
+            (
+                "nimbus-ui-new-draft-review-to-approve-rollout",
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.APPROVED,
+            ),
+            # Reject Draft -> Live review.
+            (
+                "nimbus-ui-new-draft-review-to-reject-rollout",
+                NimbusExperiment.Status.DRAFT,
+                None,
+                NimbusExperiment.PublishStatus.IDLE,
+            ),
+        ]
+    )
+    def test_draft_review_submission(
+        self,
+        url_name,
+        expected_status,
+        expected_status_next,
+        expected_publish_status,
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+
+        response = self.client.post(reverse(url_name, kwargs={"slug": experiment.slug}))
+
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status, expected_status)
+        self.assertEqual(experiment.status_next, expected_status_next)
+        self.assertEqual(experiment.publish_status, expected_publish_status)
+
+    def test_htmx_progress_card_renders_fragment(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_paused=False,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse(
+                "nimbus-ui-new-live-to-disabled-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+            {"fragment": "progress_card"},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "nimbus_experiments/launch_controls_v2.html")
+
+    def test_invalid_submission_adds_status_form_errors_to_context(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_paused=False,
+            is_rollout=True,
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-live-to-disabled-rollout",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(
+            "Cannot perform this action: experiment must be in state",
+            response.context["update_status_form_errors"][0],
+        )
 
 
 class NewViewTestMixin:

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -2,6 +2,19 @@ from django.urls import re_path
 from django.views.generic import RedirectView
 
 from experimenter.nimbus_ui.new.views import (
+    AdvancePhaseReviewApproveRolloutView,
+    AdvancePhaseReviewRejectRolloutView,
+    AdvancePhaseReviewRolloutView,
+    DisabledToLiveReviewApproveRolloutView,
+    DisabledToLiveReviewRejectRolloutView,
+    DisabledToLiveReviewRolloutView,
+    DraftReviewApproveRolloutView,
+    DraftReviewRejectView,
+    DraftReviewRolloutView,
+    DraftToPreviewRolloutView,
+    LiveToDisabledReviewApproveRolloutView,
+    LiveToDisabledReviewRejectRolloutView,
+    LiveToDisabledReviewRolloutView,
     NewAddSubscriberView,
     NewAddTagView,
     NewAudienceUpdateView,
@@ -27,6 +40,8 @@ from experimenter.nimbus_ui.new.views import (
     NewToggleReviewSlackNotificationsView,
     NewUnsubscribeView,
     NimbusRolloutDetailView,
+    PreviewReviewRolloutView,
+    PreviewToDraftRolloutView,
 )
 from experimenter.nimbus_ui.views import (
     ApproveEndEnrollmentView,
@@ -311,6 +326,81 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/approve-update-rollout/$",
         ApproveUpdateRolloutView.as_view(),
         name="nimbus-ui-approve-update-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/draft-to-preview-rollout/$",
+        DraftToPreviewRolloutView.as_view(),
+        name="nimbus-ui-new-draft-to-preview-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/draft-to-review-rollout/$",
+        DraftReviewRolloutView.as_view(),
+        name="nimbus-ui-new-draft-to-review-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/draft-review-to-approve-rollout/$",
+        DraftReviewApproveRolloutView.as_view(),
+        name="nimbus-ui-new-draft-review-to-approve-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/draft-review-to-reject-rollout/$",
+        DraftReviewRejectView.as_view(),
+        name="nimbus-ui-new-draft-review-to-reject-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/preview-review-rollout/$",
+        PreviewReviewRolloutView.as_view(),
+        name="nimbus-ui-new-preview-review-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/preview-to-draft-rollout/$",
+        PreviewToDraftRolloutView.as_view(),
+        name="nimbus-ui-new-preview-to-draft-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/advance-phase-review-rollout/$",
+        AdvancePhaseReviewRolloutView.as_view(),
+        name="nimbus-ui-new-advance-phase-review-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/approve-advance-phase-review-rollout/$",
+        AdvancePhaseReviewApproveRolloutView.as_view(),
+        name="nimbus-ui-new-approve-advance-phase-review-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/reject-advance-phase-review-rollout/$",
+        AdvancePhaseReviewRejectRolloutView.as_view(),
+        name="nimbus-ui-new-reject-advance-phase-review-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-disabled-rollout/$",
+        LiveToDisabledReviewRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-disabled-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-disabled-review-approve-rollout/$",
+        LiveToDisabledReviewApproveRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-disabled-review-approve-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-disabled-review-reject-rollout/$",
+        LiveToDisabledReviewRejectRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-disabled-review-reject-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/disabled-to-live-rollout/$",
+        DisabledToLiveReviewRolloutView.as_view(),
+        name="nimbus-ui-new-disabled-to-live-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/disabled-to-live-review-approve-rollout/$",
+        DisabledToLiveReviewApproveRolloutView.as_view(),
+        name="nimbus-ui-new-disabled-to-live-review-approve-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/disabled-to-live-review-reject-rollout/$",
+        DisabledToLiveReviewRejectRolloutView.as_view(),
+        name="nimbus-ui-new-disabled-to-live-review-reject-rollout",
     ),
     re_path(
         r"^(?P<slug>[\w-]+)/results/$",


### PR DESCRIPTION
Because

- Rollout lifecycle forms need dedicated endpoints so users can perform each supported state transition

This commit

- Adds views and URL routes for rollout launch, phase advancement, disabling, and re-enabling transitions
- Maps each endpoint to the appropriate request, approval, or rejection form
- Adds view and URL tests for successful submissions and validation errors

Fixes #16408