### PR TITLE
feat(nimbus): Add toggle for slack notifications to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1218,6 +1218,18 @@ class ToggleReviewSlackNotificationsForm(NimbusChangeLogFormMixin, forms.ModelFo
     class Meta:
         model = NimbusExperiment
         fields = ["enable_review_slack_notifications"]
+        widgets = {
+            "enable_review_slack_notifications": forms.CheckboxInput(
+                attrs={"class": "form-check-input m-0"}
+            ),
+        }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.is_complete:
+            self.fields["enable_review_slack_notifications"].widget.attrs["disabled"] = (
+                True
+            )
 
     def get_changelog_message(self):
         status = (

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1212,3 +1212,17 @@ class UnsubscribeForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def get_changelog_message(self):
         return f"{self.request.user} removed subscriber"
+
+
+class ToggleReviewSlackNotificationsForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    class Meta:
+        model = NimbusExperiment
+        fields = ["enable_review_slack_notifications"]
+
+    def get_changelog_message(self):
+        status = (
+            "enabled"
+            if self.cleaned_data.get("enable_review_slack_notifications")
+            else "disabled"
+        )
+        return f"{self.request.user} {status} review Slack notifications"

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1224,13 +1224,6 @@ class ToggleReviewSlackNotificationsForm(NimbusChangeLogFormMixin, forms.ModelFo
             ),
         }
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        if self.instance.is_complete:
-            self.fields["enable_review_slack_notifications"].widget.attrs["disabled"] = (
-                True
-            )
-
     def get_changelog_message(self):
         status = (
             "enabled"

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -31,6 +31,7 @@ from experimenter.nimbus_ui.new.forms import (
     RolloutSignoffForm,
     SubscribeForm,
     TagAssignForm,
+    ToggleReviewSlackNotificationsForm,
     UnsubscribeForm,
 )
 
@@ -448,3 +449,15 @@ class NewSubscribeView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
 
 class NewUnsubscribeView(NewSubscribeView):
     form_class = UnsubscribeForm
+
+
+class NewToggleReviewSlackNotificationsView(
+    NimbusExperimentViewMixin, RequestFormMixin, UpdateView
+):
+    model = NimbusExperiment
+    form_class = ToggleReviewSlackNotificationsForm
+    template_name = "new/common/slack_notifications_toggle.html"
+
+    def form_valid(self, form):
+        self.object = form.save()
+        return self.render_to_response(self.get_context_data())

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -66,6 +66,11 @@ class NimbusExperimentViewMixin:
         context["all_tags"] = Tag.objects.all().order_by("name")
         context["create_form"] = NimbusExperimentCreateForm()
 
+        if experiment and experiment.slug:
+            context["slack_notifications_form"] = ToggleReviewSlackNotificationsForm(
+                instance=experiment
+            )
+
         return context
 
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -82,6 +82,10 @@
               <div class="small text-secondary mt-1">Updated {{ experiment.latest_change.changed_on|timesince }} ago</div>
             {% endif %}
           </div>
+          <div class="align-self-end">
+            {% include "new/common/slack_notifications_toggle.html" %}
+
+          </div>
         </div>
         {# Toast container #}
         <div class="position-fixed top-0 end-0 m-3 w-auto z-3">

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
@@ -1,0 +1,29 @@
+<form id="slack-notifications-toggle-form"
+      class="d-flex align-items-center">
+  {% csrf_token %}
+  <input type="hidden" name="enable_review_slack_notifications" value="false">
+  <div class="form-check form-switch d-flex align-items-center m-0"
+       {% if experiment.is_complete %}data-bs-toggle="tooltip" data-bs-placement="left" title="Disabled because experiment is complete"{% endif %}>
+    <label for="slack-notifications-toggle"
+           class="form-check-label text-secondary small me-2 mb-0"
+           style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %};
+                  {% if experiment.is_complete %}opacity: 0.5{% endif %}">
+      <i class="fa-solid fa-bell me-1"></i>
+      <span>Enable review Slack notifications</span>
+    </label>
+    <input type="checkbox"
+           id="slack-notifications-toggle"
+           name="enable_review_slack_notifications"
+           value="true"
+           {% if experiment.enable_review_slack_notifications %}checked{% endif %}
+           {% if experiment.is_complete %}disabled{% endif %}
+           hx-trigger="change"
+           hx-post="{% url 'nimbus-ui-new-toggle-review-slack-notifications' experiment.slug %}"
+           hx-include="#slack-notifications-toggle-form"
+           hx-target="#slack-notifications-toggle-form"
+           hx-swap="outerHTML"
+           class="form-check-input m-0"
+           role="switch"
+           style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %}">
+  </div>
+</form>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
@@ -1,29 +1,17 @@
 <form id="slack-notifications-toggle-form"
+      hx-post="{% url 'nimbus-ui-new-toggle-review-slack-notifications' experiment.slug %}"
+      hx-trigger="change"
+      hx-target="#slack-notifications-toggle-form"
+      hx-swap="outerHTML"
       class="d-flex align-items-center">
   {% csrf_token %}
-  <input type="hidden" name="enable_review_slack_notifications" value="false">
-  <div class="form-check form-switch d-flex align-items-center m-0"
+  <div class="form-check form-switch d-flex align-items-center m-0{% if experiment.is_complete %} opacity-50{% endif %}"
        {% if experiment.is_complete %}data-bs-toggle="tooltip" data-bs-placement="left" title="Disabled because experiment is complete"{% endif %}>
-    <label for="slack-notifications-toggle"
-           class="form-check-label text-secondary small me-2 mb-0"
-           style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %};
-                  {% if experiment.is_complete %}opacity: 0.5{% endif %}">
+    <label for="{{ slack_notifications_form.enable_review_slack_notifications.id_for_label }}"
+           class="form-check-label text-secondary small me-2 mb-0">
       <i class="fa-solid fa-bell me-1"></i>
       <span>Enable review Slack notifications</span>
     </label>
-    <input type="checkbox"
-           id="slack-notifications-toggle"
-           name="enable_review_slack_notifications"
-           value="true"
-           {% if experiment.enable_review_slack_notifications %}checked{% endif %}
-           {% if experiment.is_complete %}disabled{% endif %}
-           hx-trigger="change"
-           hx-post="{% url 'nimbus-ui-new-toggle-review-slack-notifications' experiment.slug %}"
-           hx-include="#slack-notifications-toggle-form"
-           hx-target="#slack-notifications-toggle-form"
-           hx-swap="outerHTML"
-           class="form-check-input m-0"
-           role="switch"
-           style="cursor: {% if experiment.is_complete %}not-allowed{% else %}pointer{% endif %}">
+    {{ slack_notifications_form.enable_review_slack_notifications }}
   </div>
 </form>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
@@ -5,8 +5,7 @@
       hx-swap="outerHTML"
       class="d-flex align-items-center">
   {% csrf_token %}
-  <div class="form-check form-switch d-flex align-items-center m-0{% if experiment.is_complete %} opacity-50{% endif %}"
-       {% if experiment.is_complete %}data-bs-toggle="tooltip" data-bs-placement="left" title="Disabled because experiment is complete"{% endif %}>
+  <div class="form-check form-switch d-flex align-items-center m-0">
     <label for="{{ slack_notifications_form.enable_review_slack_notifications.id_for_label }}"
            class="form-check-label text-secondary small me-2 mb-0">
       <i class="fa-solid fa-bell me-1"></i>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1374,19 +1374,6 @@ class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
         )
         self.assertContains(response, "checked")
 
-    def test_detail_page_renders_toggle_disabled_when_complete(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
-        )
-        self.assertTrue(experiment.is_complete)
-
-        response = self.client.get(
-            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "disabled")
-
     def test_post_enables_slack_notifications(self):
         experiment = NimbusExperimentFactory.create(
             enable_review_slack_notifications=False

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1353,6 +1353,40 @@ class TestNewUnsubscribeView(AuthTestCase):
 
 
 class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
+    def test_detail_page_renders_toggle_checked(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            enable_review_slack_notifications=True,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'name="enable_review_slack_notifications"')
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-toggle-review-slack-notifications",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+        self.assertContains(response, "checked")
+
+    def test_detail_page_renders_toggle_disabled_when_complete(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+        )
+        self.assertTrue(experiment.is_complete)
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "disabled")
+
     def test_post_enables_slack_notifications(self):
         experiment = NimbusExperimentFactory.create(
             enable_review_slack_notifications=False
@@ -1381,7 +1415,7 @@ class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
                 "nimbus-ui-new-toggle-review-slack-notifications",
                 kwargs={"slug": experiment.slug},
             ),
-            {"enable_review_slack_notifications": "false"},
+            {},
         )
 
         self.assertEqual(response.status_code, 200)

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1350,3 +1350,40 @@ class TestNewUnsubscribeView(AuthTestCase):
             response,
             reverse("nimbus-ui-new-subscribe", kwargs={"slug": experiment.slug}),
         )
+
+
+class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
+    def test_post_enables_slack_notifications(self):
+        experiment = NimbusExperimentFactory.create(
+            enable_review_slack_notifications=False
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-toggle-review-slack-notifications",
+                kwargs={"slug": experiment.slug},
+            ),
+            {"enable_review_slack_notifications": "true"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/common/slack_notifications_toggle.html")
+        experiment.refresh_from_db()
+        self.assertTrue(experiment.enable_review_slack_notifications)
+
+    def test_post_disables_slack_notifications(self):
+        experiment = NimbusExperimentFactory.create(
+            enable_review_slack_notifications=True
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-toggle-review-slack-notifications",
+                kwargs={"slug": experiment.slug},
+            ),
+            {"enable_review_slack_notifications": "false"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+        self.assertFalse(experiment.enable_review_slack_notifications)

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -24,6 +24,7 @@ from experimenter.nimbus_ui.new.views import (
     NewSubscriberSearchView,
     NewSubscribeView,
     NewTagSearchView,
+    NewToggleReviewSlackNotificationsView,
     NewUnsubscribeView,
     NimbusRolloutDetailView,
 )
@@ -456,5 +457,10 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/unsubscribe/$",
         NewUnsubscribeView.as_view(),
         name="nimbus-ui-new-unsubscribe",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/toggle_review_slack_notifications/$",
+        NewToggleReviewSlackNotificationsView.as_view(),
+        name="nimbus-ui-new-toggle-review-slack-notifications",
     ),
 ]


### PR DESCRIPTION
Because

* users need to be able to enable/disable slack notifications in new rollouts UI

This commit

* adds a toggle to the top of the rollouts page
* follows same code patterns used in the old UI

Fixes #16450

<img width="1723" height="323" alt="Screenshot 2026-07-22 at 4 18 31 PM" src="https://github.com/user-attachments/assets/075beaa9-7939-4e9b-acd1-1e5a70a19421" />
<img width="1721" height="348" alt="Screenshot 2026-07-22 at 4 18 38 PM" src="https://github.com/user-attachments/assets/c555d5a1-e858-4f5d-ab3d-898dd4234942" />

