### PR TITLE
feat(nimbus): Add explore matching audiences to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -2,6 +2,13 @@
 
 {% block card %}
   <div class="d-flex flex-column gap-3" id="rollout-audience-body">
+    {# Explore matching audiences #}
+    <div class="mt-1">
+      <a href="{{ experiment.audience_url }}"
+         class="small text-decoration-none"
+         target="_blank"
+         rel="noopener noreferrer"><i class="fa-solid fa-users me-2"></i>Explore matching audiences</a>
+    </div>
     {# Channel / channels #}
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -2,6 +2,13 @@
 {% load widget_tweaks %}
 
 <div id="rollout-audience-body">
+  {# Explore matching audiences #}
+  <div class="d-flex justify-content-end mb-2">
+    <a href="{{ experiment.audience_url }}"
+       class="small text-decoration-none"
+       target="_blank"
+       rel="noopener noreferrer"><i class="fa-solid fa-users me-2"></i>Explore matching audiences</a>
+  </div>
   <form hx-post="{% url 'nimbus-ui-new-update-audience' experiment.slug %}"
         hx-target="#rollout-audience-body"
         hx-swap="outerHTML"


### PR DESCRIPTION
Because

*  the new rollouts UI is missing the button to explore matching audiences

This commit

* adds the button to the top of the audience card

Fixes #16453 

<img width="1336" height="373" alt="Screenshot 2026-07-22 at 5 56 13 PM" src="https://github.com/user-attachments/assets/cdefbdb3-dd44-40bf-975d-293ba2781397" />

<img width="1258" height="584" alt="Screenshot 2026-07-23 at 9 57 20 AM" src="https://github.com/user-attachments/assets/acff8153-f9fc-49a5-9c55-b1fcd16c4826" />

