### PR TITLE
Nova enabled targeting added based on the browser.nova.enabled pref

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -5176,6 +5176,17 @@ SMART_WINDOW_ONBOARDING_COMPLETE = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+NOVA_ENABLED = NimbusTargetingConfig(
+    name="Nova enabled",
+    slug="nova_enabled",
+    description="Nova is enabled",
+    targeting="'browser.nova.enabled'|preferenceValue",
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NOT_DEFAULT_BROWSER_PROFILE_7_DAYS_NO_ENTERPRISE = NimbusTargetingConfig(
     name="Not default browser, profile 7+ days, not first startup, no enterprise",
     slug="not_default_browser_profile_7_days_no_enterprise",


### PR DESCRIPTION
This is an advanced targeting that helps us target users who have Nova enabled in their Firefox.  

The targeting checks if the `browser.nova.enabled` pref is true. 