### PR TITLE
feat(nimbus): Add windowed targeting for newtab 153.3 (Jun-05) to pre-154.8 (Jul-16)

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -5000,6 +5000,23 @@ FX_153_3_TO_PRE_154_JUL16_TRAINHOP_WIDGETS_ANY_FOUR_ENGAGED = NimbusTargetingCon
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+FX_153_3_TO_PRE_154_JUL16_TRAINHOP = NimbusTargetingConfig(
+    name="New Tab Fx153 Jun-05 Trainhop (older than Jul-16)",
+    slug="153-0605-thru-pre-154-0716-trainhop",
+    description=(
+        "Users on a New Tab train hop from 153.3.20260605.21338 (Jun-05) up to but "
+        "NOT including 154.8.20260716.43450 (Jul-16)"
+    ),
+    targeting=(
+        f"{FX_153_3_TRAINHOP.targeting} "
+        f"&& newtabAddonVersion|versionCompare('154.8.20260716.43450') < 0"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 FX_153_3_TRAINHOP_ANY_WIDGET_ENABLED = NimbusTargetingConfig(
     name="New Tab Fx153 Jun-05 Trainhop, any of 4 widgets enabled",
     slug="any-widget-enabled-153-0605-trainhop",


### PR DESCRIPTION
Adds advanced targeting for Desktop release users on a New Tab train hop from 153.3.20260605.21338 up to but not including 154.8.20260716.43450, with no engagement/widget criteria (non-engager counterpart for non-US/DE rollouts).

Fixes mozilla#16466
