### PR TITLE
feat(nimbus): Fix font in code blocks in rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -353,3 +353,10 @@
 .rollout-card-toggle[aria-expanded="true"] .chevron-icon {
   transform: rotate(90deg);
 }
+
+.rollout-page {
+  .cm-editor .cm-scroller {
+    font-family: var(--bs-font-monospace);
+    font-size: 0.875rem;
+  }
+}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -14,7 +14,7 @@
     <script src="{% static 'nimbus_ui/app.bundle.js' %}"></script>
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="m-0 p-0"
+  <body class="m-0 p-0 rollout-page"
         style="font-family: -apple-system, 'SF Pro', BlinkMacSystemFont, sans-serif">
     <div class="d-flex overflow-hidden" style="height: 100vh;">
       {# ── Sidebar ── #}


### PR DESCRIPTION
Because

* The default font doesn't match the rest of the design

This commit

* Adjusts the size of the font in the code blocks

Fixes #16455

<img width="1248" height="518" alt="Screenshot 2026-07-23 at 12 31 13 PM" src="https://github.com/user-attachments/assets/0e733da6-400f-42ba-8e81-7f0933f4c924" />
 
<img width="1264" height="172" alt="Screenshot 2026-07-23 at 12 31 21 PM" src="https://github.com/user-attachments/assets/fbc5b434-dc31-4cf4-a347-33a8e338fe2f" />
