### PR TITLE
feat(nimbus): add localization checkbox to new rollout audience UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -484,6 +484,9 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         (True, "Yes"),
         (False, "No"),
     )
+    is_localized = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
     localizations = forms.CharField(required=False, widget=forms.HiddenInput())
     channel = forms.ChoiceField(
         required=False,
@@ -578,6 +581,7 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "locales",
             "required_experiments_branches",
             "targeting_config_slug",
+            "is_localized",
             "localizations",
         ]
 
@@ -597,6 +601,17 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 "hx-trigger": "change",
                 "hx-select": "#first-run-fields",
                 "hx-target": "#first-run-fields",
+            }
+        )
+
+        self.fields["is_localized"].widget.attrs.update(
+            {
+                "hx-post": reverse(
+                    "nimbus-ui-new-update-audience", kwargs={"slug": self.instance.slug}
+                ),
+                "hx-trigger": "change",
+                "hx-select": "#rollout-audience-body",
+                "hx-target": "#rollout-audience-body",
             }
         )
 

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -240,6 +240,14 @@ class NewAudienceUpdateView(CardMixin, NewCardUpdateView):
     display_template = "new/rollouts/audience/card.html"
     template_name = "new/rollouts/audience/edit_form.html"
 
+    def render_valid_response(self):
+        self.object.refresh_from_db()
+
+        if "save" in self.request.POST:
+            return super().render_valid_response()
+
+        return self.render_to_response(self.get_context_data())
+
 
 class NewRolloutFeaturesUpdateView(CardMixin, NewCardUpdateView):
     form_class = RolloutFeaturesForm

--- a/experimenter/experimenter/nimbus_ui/static/js/new/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/edit_branches.js
@@ -17,6 +17,7 @@ import $ from "jquery";
 const BRANCHES_FORM_ID = "branches-form";
 const CONTENT_WITH_SIDEBAR_ID = "content-with-sidebar";
 const ROLLOUT_FEATURES_BODY_ID = "rollout-rollout-features-body";
+const ROLLOUT_AUDIENCE_BODY_ID = "rollout-audience-body";
 const EDIT_BRANCHES_INIT_FLAG = "__nimbusEditBranchesInitialized";
 
 const setupCodemirror = (selector, textarea, extraExtensions) => {
@@ -159,6 +160,7 @@ $(() => {
       if (
         event.detail.target.id === BRANCHES_FORM_ID ||
         event.detail.target.id === ROLLOUT_FEATURES_BODY_ID ||
+        event.detail.target.id === ROLLOUT_AUDIENCE_BODY_ID ||
         event.detail.target.id === CONTENT_WITH_SIDEBAR_ID
       ) {
         initializeAllEditors();

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -148,16 +148,26 @@
         <i class="fas fa-times text-danger"></i>
       {% endif %}
     </div>
-    {# Localization substitutions #}
+    {# Localization #}
     <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Localization Substitutions</div>
-      {% if experiment.localizations %}
-        {% include "nimbus_experiments/readonly_feature_value.html" with json_content=experiment.localizations %}
-
+      <div class="text-secondary mb-1" style="font-size: 12px;">Is this a localized rollout?</div>
+      {% if experiment.is_localized %}
+        <i class="fas fa-check text-success"></i>
       {% else %}
-        —
+        <i class="fas fa-times text-danger"></i>
       {% endif %}
     </div>
+    {% if experiment.is_localized %}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Localization Substitutions</div>
+        {% if experiment.localizations %}
+          {% include "nimbus_experiments/readonly_feature_value.html" with json_content=experiment.localizations %}
+
+        {% else %}
+          —
+        {% endif %}
+      </div>
+    {% endif %}
   </div>
   {% if hx_swap_oob %}
     {% include "new/common/audience_overlap_warnings.html" with oob=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -127,15 +127,25 @@
       {% for error in validation_errors.is_sticky %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
     </div>
     <div>
-      <label class="small text-body mb-2">Localization Substitutions</label>
-      {{ form.localizations|add_error_class:"is-invalid" }}
-      {% for error in form.localizations.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
-      {% for error in validation_errors.localizations %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+      <div class="form-check">
+        {{ form.is_localized }}
+        <label class="form-check-label" for="id_is_localized">Is this a localized rollout?</label>
+      </div>
+      {% for error in form.is_localized.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+      {% for error in validation_errors.is_localized %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+      {% if form.is_localized.value %}
+        <div class="mt-3">
+          <label class="small text-body mb-2" for="id_localizations">Localization Substitutions</label>
+          {{ form.localizations|add_error_class:"is-invalid" }}
+          {% for error in form.localizations.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+          {% for error in validation_errors.localizations %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+        </div>
+      {% endif %}
     </div>
   </div>
   {# Action buttons #}
   <div class="d-flex align-items-center gap-2">
-    <button type="submit" class="btn btn-primary btn-sm">Save</button>
+    <button type="submit" name="save" value="True" class="btn btn-primary btn-sm">Save</button>
     <button type="button"
             class="btn btn-outline-secondary btn-sm"
             hx-get="{{ cancel_url }}"
@@ -147,5 +157,5 @@
 </div>
 {% block extrascripts %}
   {% if branch_form_data %}{{ branch_form_data|json_script:"branch-form-data" }}{% endif %}
-  <script src="{% static 'nimbus_ui/edit_branches.bundle.js' %}"></script>
+  <script src="{% static 'nimbus_ui/new_edit_branches.bundle.js' %}"></script>
 {% endblock extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -488,6 +488,31 @@ class TestRolloutAudienceForm(RequestFormTestCase):
             form.get_changelog_message(), f"{self.request.user} updated audience"
         )
 
+    def test_saves_localization_fields(self):
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.BETA],
+            is_localized=False,
+            localizations="",
+        )
+
+        form = RolloutAudienceForm(
+            instance=experiment,
+            data=self._audience_data(
+                is_localized=True,
+                localizations='{"en-US": {}}',
+            ),
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        self.assertTrue(experiment.is_localized)
+        self.assertEqual(experiment.localizations, '{"en-US": {}}')
+
     def test_check_rollout_dirty_does_not_set_flag_for_non_rollout(self):
         experiment = NimbusExperimentFactory.create(
             is_rollout=False,

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -117,6 +117,7 @@ class NewViewTestMixin:
                 if targeting_config_slugs
                 else NimbusExperiment.TargetingConfig.NO_TARGETING
             ),
+            "is_localized": False,
         }
         data.update(overrides)
         return data
@@ -518,6 +519,7 @@ class TestNewAudienceUpdateView(NewViewTestMixin, AuthTestCase):
                 locales=[locale.id],
                 is_sticky=True,
                 targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+                save="True",
             ),
         )
 
@@ -532,6 +534,60 @@ class TestNewAudienceUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(
             experiment.targeting_config_slug, NimbusExperiment.TargetingConfig.FIRST_RUN
         )
+
+    def test_get_renders_is_localized_checkbox(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Is this a localized rollout?")
+        self.assertContains(response, 'id="id_is_localized"')
+
+    def test_post_toggling_is_localized_saves_and_returns_edit_form(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_localized=False,
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.audience_data(is_localized=True),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/audience/edit_form.html")
+        experiment.refresh_from_db()
+        self.assertTrue(experiment.is_localized)
+        self.assertContains(response, "Localization Substitutions")
+
+    def test_post_save_persists_localization_fields_and_returns_card(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_localized=False,
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.audience_data(
+                is_localized=True,
+                localizations='{"en-US": {}}',
+                save="True",
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/audience/card.html")
+        experiment.refresh_from_db()
+        self.assertTrue(experiment.is_localized)
+        self.assertEqual(experiment.localizations, '{"en-US": {}}')
 
 
 class TestNewRolloutFeaturesUpdateView(AuthTestCase):


### PR DESCRIPTION
Because

* the audience card provided the localization substitutions editor but not the "Is this localized?" toggle that the old UI had

This commit

* adds the is_localized checkbox to the audience card and gates the substitutions editor on the submitted value
* follows the pattern of the features card

Fixes #16447



https://github.com/user-attachments/assets/c3408fc5-aade-4c23-a039-795d6645485f



