### PR TITLE
feat(nimbus): Add links to the new rollouts sidebar

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -104,8 +104,10 @@
     </div>
   </div>
 </div>
-{# History & Help #}
+{# Links, History & Help #}
 <div class="d-flex flex-column gap-1">
+  {% include "new/common/sidebar_links.html" %}
+
   <a href="{% url 'nimbus-ui-history' experiment.slug %}"
      class="text-decoration-none d-flex align-items-center gap-2 rounded-2 pt-3 px-2 small text-body">
     <i class="fa-regular fa-clock text-body"></i>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_links.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_links.html
@@ -1,0 +1,79 @@
+{% load nimbus_extras %}
+
+<div class="dropdown"
+     id="sidebar-links"
+     {% if hx_swap_oob %}hx-swap-oob="true"{% endif %}>
+  <button class="border-0 bg-transparent text-decoration-none d-flex align-items-center justify-content-between w-100 gap-2 rounded-2 pt-3 px-2 small text-body"
+          type="button"
+          data-bs-toggle="dropdown"
+          data-bs-auto-close="outside"
+          aria-expanded="false">
+    <span class="d-flex align-items-center gap-2">
+      <i class="fa-regular fa-compass text-body"></i>
+      Links
+    </span>
+    <i class="fa-solid fa-chevron-down small text-body"></i>
+  </button>
+  <ul class="dropdown-menu w-100">
+    {% for title, link in NimbusUIConstants.SIDEBAR_COMMON_LINKS.items %}
+      <li>
+        <a class="dropdown-item d-flex align-items-center justify-content-between gap-2 small"
+           href="{{ link.url }}"
+           target="_blank"
+           rel="noopener noreferrer">
+          <span class="d-flex align-items-center gap-2">
+            <i class="{{ link.icon }} text-secondary" style="min-width: 16px;"></i>
+            {{ title }}
+          </span>
+          <i class="fa-regular fa-circle-question fa-sm text-secondary"
+             data-bs-toggle="tooltip"
+             data-bs-placement="left"
+             title="{{ link.tooltip }}"></i>
+        </a>
+      </li>
+    {% endfor %}
+    {% if experiment.is_started %}
+      <li>
+        <a class="dropdown-item d-flex align-items-center justify-content-between gap-2 small"
+           href="{{ experiment.monitoring_dashboard_url }}"
+           target="_blank"
+           rel="noopener noreferrer">
+          <span class="d-flex align-items-center gap-2">
+            <i class="fa-solid fa-chart-simple text-secondary"
+               style="min-width: 16px"></i>
+            Live Monitoring Dashboard
+          </span>
+          <i class="fa-regular fa-circle-question fa-sm text-secondary"
+             data-bs-toggle="tooltip"
+             data-bs-placement="left"
+             title="{{ NimbusUIConstants.LIVE_MONITOR_TOOLTIP }}"></i>
+        </a>
+      </li>
+      {% if experiment.rollout_monitoring_dashboard_url %}
+        <li>
+          <a class="dropdown-item d-flex align-items-center gap-2 small"
+             href="{{ experiment.rollout_monitoring_dashboard_url }}"
+             target="_blank"
+             rel="noopener noreferrer">
+            <i class="fa-solid fa-gauge-high text-secondary" style="min-width: 16px"></i>
+            Rollouts OpMon Dashboard
+          </a>
+        </li>
+      {% endif %}
+    {% endif %}
+    {% for documentation_link in experiment.documentation_links.all %}
+      {% if documentation_link.link %}
+        <li>
+          <a class="dropdown-item d-flex align-items-center gap-2 small"
+             href="{{ documentation_link.link }}"
+             target="_blank"
+             rel="noopener noreferrer">
+            <i class="fa-solid fa-arrow-up-right-from-square text-secondary"
+               style="min-width: 16px"></i>
+            {{ documentation_link.get_title_display }}
+          </a>
+        </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -79,5 +79,7 @@
     <h1 id="experiment-header-name"
         class="mb-0 fw-semibold fs-4 text-body"
         hx-swap-oob="true">{{ experiment.name }}</h1>
+    {% include "new/common/sidebar_links.html" with hx_swap_oob=True %}
+
   {% endif %}
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -198,3 +198,4 @@
     </div>
   </form>
 </div>
+{% include "new/common/sidebar_links.html" with hx_swap_oob=True %}


### PR DESCRIPTION
Because:

* The old UI had all the relevant links on the sidebar which we currently don’t have in the new UI

This commit:

* Groups the links into one sidebar dropdown including Performance Reports, Messaging Skylight, Live Monitoring, Rollouts OpMon, and all documentation links
* Refreshes it on overview save and link add/delete, so documentation links appear without a page reload

Fixes #16480


https://github.com/user-attachments/assets/72d9db00-d7b2-46cf-a729-3acb941b9f7d

