### PR TITLE
feat(nimbus): Add Firefox Labs opt-in to the new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -707,10 +707,37 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         queryset=NimbusFeatureConfig.objects.all(),
         widget=FeatureConfigMultiSelectWidget(attrs={}),
     )
+    is_firefox_labs_opt_in = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
+    firefox_labs_title = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+    firefox_labs_description = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+    )
+    firefox_labs_description_links = forms.CharField(
+        required=False, widget=forms.HiddenInput()
+    )
+    firefox_labs_group = forms.ChoiceField(
+        required=False,
+        widget=forms.Select(attrs={"class": "form-select"}),
+    )
+    requires_restart = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
 
     class Meta:
         model = NimbusExperiment
-        fields = ("feature_configs",)
+        fields = (
+            "feature_configs",
+            "is_firefox_labs_opt_in",
+            "firefox_labs_title",
+            "firefox_labs_description",
+            "firefox_labs_description_links",
+            "firefox_labs_group",
+            "requires_restart",
+        )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -762,6 +789,23 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         # will remain unused as rollouts donot have results data
         self.fields["rollout_experience"].initial = self.instance.takeaways_summary
 
+        if firefox_labs := self.instance.application_config.firefox_labs:
+            self.fields["firefox_labs_group"].choices = firefox_labs.group_choices
+
+        self.was_labs_opt_in = self.instance.is_firefox_labs_opt_in
+
+        self.fields["is_firefox_labs_opt_in"].widget.attrs.update(
+            {
+                "hx-post": reverse(
+                    "nimbus-ui-new-update-rollout-features",
+                    kwargs={"slug": self.instance.slug},
+                ),
+                "hx-trigger": "change",
+                "hx-select": "#rollout-rollout-features-body",
+                "hx-target": "#rollout-rollout-features-body",
+            }
+        )
+
     @property
     def errors(self):
         errors = super().errors
@@ -777,6 +821,18 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             and self.branch_feature_values.is_valid()
             and self.rollout_screenshots.is_valid()
         )
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if not cleaned_data.get("is_firefox_labs_opt_in"):
+            cleaned_data["firefox_labs_title"] = ""
+            cleaned_data["firefox_labs_description"] = ""
+            cleaned_data["firefox_labs_description_links"] = "null"
+            cleaned_data["firefox_labs_group"] = ""
+            cleaned_data["requires_restart"] = False
+
+        return cleaned_data
 
     @transaction.atomic
     def save(self, *args, **kwargs):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -45,6 +45,47 @@
         {% endif %}
       {% endwith %}
     </div>
+    {# Firefox Labs #}
+    {% if experiment.application_config.firefox_labs %}
+      <hr class="my-1 text-body-tertiary">
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Is this a Firefox Labs rollout?</div>
+        {% if experiment.is_firefox_labs_opt_in %}
+          <i class="fas fa-check text-success"></i>
+        {% else %}
+          <i class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% if experiment.is_firefox_labs_opt_in %}
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Title</div>
+          <div class="small text-body">{{ experiment.firefox_labs_title|default:"—" }}</div>
+        </div>
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Description</div>
+          <div class="small text-body">{{ experiment.firefox_labs_description|default:"—" }}</div>
+        </div>
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">Description Links</div>
+          {% include "common/readonly_json.html" with json_content=experiment.firefox_labs_description_links|default:"null" %}
+
+        </div>
+        {% if experiment.application_config.firefox_labs.supports_groups %}
+          <div>
+            <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Group</div>
+            <div class="small text-body">{{ experiment.firefox_labs_group|default:"—" }}</div>
+          </div>
+        {% endif %}
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">Requires restart?</div>
+          {% if experiment.requires_restart %}
+            <i class="fas fa-check text-success"></i>
+          {% else %}
+            <i class="fas fa-times text-danger"></i>
+          {% endif %}
+        </div>
+      {% endif %}
+    {% endif %}
   </div>
   {% if hx_swap_oob %}
     {% include "new/common/audience_overlap_warnings.html" with oob=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -131,6 +131,71 @@
         </div>
       {% endwith %}
     </div>
+    {#  Firefox Labs  #}
+    {% if experiment.application_config.firefox_labs %}
+      <hr class="my-4 text-body-tertiary">
+      <div>
+        <div class="form-check">
+          {{ form.is_firefox_labs_opt_in }}
+          <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
+        </div>
+        {% for error in validation_errors.is_firefox_labs_opt_in %}
+          <div class="form-text text-danger">{{ error }}</div>
+        {% endfor %}
+        {% if experiment.is_firefox_labs_opt_in %}
+          <div class="mt-4">
+            <label class="small text-body mb-2 d-block">
+              The title to display in Firefox Labs (Fluent ID)
+              {{ form.firefox_labs_title }}
+            </label>
+            {{ form.firefox_labs_title.errors }}
+            {% for error in validation_errors.firefox_labs_title %}
+              <div class="form-text text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          <div class="mt-4">
+            <label class="small text-body mb-2 d-block">
+              The description to display in Firefox Labs (Fluent ID)
+              {{ form.firefox_labs_description }}
+            </label>
+            {{ form.firefox_labs_description.errors }}
+            {% for error in validation_errors.firefox_labs_description %}
+              <div class="form-text text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          <div class="mt-4">
+            <label class="small text-body mb-2 d-block">
+              Description Links (JSON)
+              {{ form.firefox_labs_description_links }}
+            </label>
+            {{ form.firefox_labs_description_links.errors }}
+            {% for error in validation_errors.firefox_labs_description_links %}
+              <div class="form-text text-danger">{{ error }}</div>
+            {% endfor %}
+          </div>
+          {% if experiment.application_config.firefox_labs.supports_groups %}
+            <div class="mt-4">
+              <label class="small text-body mb-2 d-block">
+                Firefox Labs Group
+                {{ form.firefox_labs_group }}
+              </label>
+              {{ form.firefox_labs_group.errors }}
+              {% for error in validation_errors.firefox_labs_group %}
+                <div class="form-text text-danger">{{ error }}</div>
+              {% endfor %}
+            </div>
+          {% endif %}
+          <div class="mt-4">
+            <div class="form-check">
+              {{ form.requires_restart }}
+              <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+            </div>
+            {{ form.requires_restart.errors }}
+            {% for error in validation_errors.requires_restart %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+          </div>
+        {% endif %}
+      </div>
+    {% endif %}
   </div>
 </div>
 {# Action buttons #}
@@ -147,5 +212,5 @@
 </div>
 {% block extrascripts %}
   {% if branch_form_data %}{{ branch_form_data|json_script:"branch-form-data" }}{% endif %}
-  <script src="{% static 'nimbus_ui/edit_branches.bundle.js' %}"></script>
+  <script src="{% static 'nimbus_ui/new_edit_branches.bundle.js' %}"></script>
 {% endblock extrascripts %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -940,6 +940,98 @@ class TestRolloutFeaturesForm(RequestFormTestCase):
         self.assertFalse(form.is_valid())
         self.assertIn("rollout_screenshots", form.errors)
 
+    def test_form_saves_firefox_labs_fields(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+            takeaways_summary="",
+        )
+
+        labs_title = "labs-title-id"
+        labs_description = "labs-description-id"
+        labs_description_links = '{"link1": "https://example.com"}'
+        labs_group = NimbusExperiment.FirefoxLabs.Groups.CUSTOMIZE_BROWSING
+        requires_restart = True
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+                "is_firefox_labs_opt_in": True,
+                "firefox_labs_title": labs_title,
+                "firefox_labs_description": labs_description,
+                "firefox_labs_description_links": labs_description_links,
+                "firefox_labs_group": labs_group,
+                "requires_restart": requires_restart,
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(experiment.firefox_labs_title, labs_title)
+        self.assertEqual(experiment.firefox_labs_description, labs_description)
+        self.assertEqual(
+            experiment.firefox_labs_description_links, labs_description_links
+        )
+        self.assertEqual(experiment.firefox_labs_group, labs_group)
+        self.assertTrue(experiment.requires_restart)
+
+    def test_form_clears_firefox_labs_fields_when_opt_out(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[],
+            takeaways_summary="",
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="labs-title-id",
+            firefox_labs_description="labs-description-id",
+            firefox_labs_description_links='{"link1": "https://example.com"}',
+            firefox_labs_group=NimbusExperiment.FirefoxLabs.Groups.CUSTOMIZE_BROWSING,
+            requires_restart=True,
+        )
+
+        form = RolloutFeaturesForm(
+            instance=experiment,
+            data={
+                "rollout_experience": "Updated rollout experience",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "branch-feature-value-MIN_NUM_FORMS": "0",
+                "branch-feature-value-MAX_NUM_FORMS": "1000",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+                "rollout-screenshots-MIN_NUM_FORMS": "0",
+                "rollout-screenshots-MAX_NUM_FORMS": "1000",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+        experiment = form.save()
+        experiment.refresh_from_db()
+
+        self.assertFalse(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(experiment.firefox_labs_title, "")
+        self.assertEqual(experiment.firefox_labs_description, "")
+        self.assertEqual(experiment.firefox_labs_description_links, "null")
+        self.assertEqual(experiment.firefox_labs_group, "")
+        self.assertFalse(experiment.requires_restart)
+
 
 class TestRolloutScreenshotCreateForm(RequestFormTestCase):
     def test_form_creates_empty_screenshot_and_logs_change(self):


### PR DESCRIPTION
Because:

* The old UI let users mark a rollout as a Firefox Labs rollout so we need the same in the new UI

This commit:

* Adds the Firefox Labs fields to the features card
* Reveals the additional fields when "Is this a Firefox Labs rollout?" is checked

Fixes #16474


https://github.com/user-attachments/assets/8764ff25-b44f-4536-9f1a-ba086b176c07

