### PR TITLE
feat(nimbus): split retention results into fixed weekly metrics

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -692,7 +692,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     DAILY_ACTIVE_USERS = "client_level_daily_active_users_v2"
     DAYS_OF_USE = "days_of_use"
-    RETENTION = "retained"
+    RETENTION_2_WEEKS = "week_2_retention"
+    RETENTION_4_WEEKS = "week_4_retention"
     RETENTION_3_DAYS = "active_in_last_3_days"
     RETENTION_3_DAYS_DESKTOP = "active_in_last_3_days_legacy"
     SEARCH_COUNT = "search_count"
@@ -710,8 +711,17 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     KPI_METRICS = [
         {
             "group": "other_metrics",
-            "slug": RETENTION,
+            "friendly_name": "Week 2 Retention",
+            "slug": RETENTION_2_WEEKS,
             "display_type": "percentage",
+            "description": "Users who were active in Firefox during the second week after enrollment.",  # noqa
+        },
+        {
+            "group": "other_metrics",
+            "friendly_name": "Week 4 Retention",
+            "slug": RETENTION_4_WEEKS,
+            "display_type": "percentage",
+            "description": "Users who were active in Firefox during the fourth week after enrollment.",  # noqa
         },
         {
             "group": "other_metrics",

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -668,7 +668,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     DAILY_ACTIVE_USERS = "client_level_daily_active_users_v2"
     DAYS_OF_USE = "days_of_use"
-    RETENTION = "retained"
+    RETENTION_2_WEEKS = "week_2_retention"
+    RETENTION_4_WEEKS = "week_4_retention"
     RETENTION_3_DAYS = "active_in_last_3_days"
     RETENTION_3_DAYS_DESKTOP = "active_in_last_3_days_legacy"
     SEARCH_COUNT = "search_count"
@@ -686,8 +687,17 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     KPI_METRICS = [
         {
             "group": "other_metrics",
-            "slug": RETENTION,
+            "friendly_name": "Week 2 Retention",
+            "slug": RETENTION_2_WEEKS,
             "display_type": "percentage",
+            "description": "Users who were active in Firefox during the second week after enrollment.",  # noqa
+        },
+        {
+            "group": "other_metrics",
+            "friendly_name": "Week 4 Retention",
+            "slug": RETENTION_4_WEEKS,
+            "display_type": "percentage",
+            "description": "Users who were active in Firefox during the fourth week after enrollment.",  # noqa
         },
         {
             "group": "other_metrics",

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -692,8 +692,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     DAILY_ACTIVE_USERS = "client_level_daily_active_users_v2"
     DAYS_OF_USE = "days_of_use"
-    RETENTION_2_WEEKS = "week_2_retention"
-    RETENTION_4_WEEKS = "week_4_retention"
+    RETENTION_WEEK_2 = "week_2_retention"
+    RETENTION_WEEK_4 = "week_4_retention"
     RETENTION_3_DAYS = "active_in_last_3_days"
     RETENTION_3_DAYS_DESKTOP = "active_in_last_3_days_legacy"
     SEARCH_COUNT = "search_count"
@@ -712,14 +712,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         {
             "group": "other_metrics",
             "friendly_name": "Week 2 Retention",
-            "slug": RETENTION_2_WEEKS,
+            "slug": RETENTION_WEEK_2,
             "display_type": "percentage",
             "description": "Users who were active in Firefox during the second week after enrollment.",  # noqa
         },
         {
             "group": "other_metrics",
             "friendly_name": "Week 4 Retention",
-            "slug": RETENTION_4_WEEKS,
+            "slug": RETENTION_WEEK_4,
             "display_type": "percentage",
             "description": "Users who were active in Firefox during the fourth week after enrollment.",  # noqa
         },

--- a/experimenter/experimenter/experiments/migrations/0339_force_weekly_retention_results_refetch.py
+++ b/experimenter/experimenter/experiments/migrations/0339_force_weekly_retention_results_refetch.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+
+BATCH_SIZE = 100
+
+
+def stored_analysis_start_time(results_data):
+    metadata = (results_data.get("v3") or {}).get("metadata")
+    return metadata.get("analysis_start_time") if isinstance(metadata, dict) else None
+
+
+def force_results_refetch(apps, schema_editor):
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+
+    stale_experiments = []
+    for experiment in NimbusExperiment.objects.exclude(results_data=None).iterator(
+        chunk_size=BATCH_SIZE
+    ):
+        if stored_analysis_start_time(experiment.results_data) is None:
+            continue
+
+        experiment.results_data["v3"]["metadata"]["analysis_start_time"] = None
+        stale_experiments.append(experiment)
+
+        if len(stale_experiments) == BATCH_SIZE:
+            NimbusExperiment.objects.bulk_update(stale_experiments, ["results_data"])
+            stale_experiments.clear()
+
+    NimbusExperiment.objects.bulk_update(stale_experiments, ["results_data"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0338_nimbusemail_rollout_phase_alter_nimbusemail_type"),
+    ]
+
+    operations = [
+        migrations.RunPython(force_results_refetch, migrations.RunPython.noop),
+    ]

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -647,6 +647,18 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
         for metric in outcome_metrics
     }
 
+    control_weekly_retention = {
+        f"week_{week}_retention": build_metric_data(branch_key="control")
+        for week in (3, 5, 6)
+    }
+    treatment_weekly_retention = {
+        slug: build_metric_data(
+            branch_key="treatment",
+            comparative_branch_data=control_weekly_retention[slug],
+        )
+        for slug in control_weekly_retention
+    }
+
     results = {
         "v3": {
             "overall": {
@@ -667,8 +679,13 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             },
                                         },
                                     },
-                                    "retained": (
-                                        control_retained := build_metric_data(
+                                    "week_2_retention": (
+                                        control_week_2_retention := build_metric_data(
+                                            branch_key="control"
+                                        )
+                                    ),
+                                    "week_4_retention": (
+                                        control_week_4_retention := build_metric_data(
                                             branch_key="control"
                                         )
                                     ),
@@ -682,6 +699,7 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             branch_key="control"
                                         )
                                     ),
+                                    **control_weekly_retention,
                                     **control_outcome_metrics,
                                 },
                                 "search_metrics": {
@@ -710,9 +728,13 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             },
                                         },
                                     },
-                                    "retained": build_metric_data(
+                                    "week_2_retention": build_metric_data(
                                         branch_key="treatment",
-                                        comparative_branch_data=control_retained,
+                                        comparative_branch_data=control_week_2_retention,
+                                    ),
+                                    "week_4_retention": build_metric_data(
+                                        branch_key="treatment",
+                                        comparative_branch_data=control_week_4_retention,
                                     ),
                                     "client_level_daily_active_users_v2": (
                                         build_metric_data(
@@ -724,6 +746,7 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                         branch_key="treatment",
                                         comparative_branch_data=control_three_day,
                                     ),
+                                    **treatment_weekly_retention,
                                     **treatment_outcome_metrics,
                                 },
                                 "search_metrics": {
@@ -755,8 +778,13 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             },
                                         },
                                     },
-                                    "retained": (
-                                        control_retained := build_metric_data(
+                                    "week_2_retention": (
+                                        control_week_2_retention := build_metric_data(
+                                            branch_key="control"
+                                        )
+                                    ),
+                                    "week_4_retention": (
+                                        control_week_4_retention := build_metric_data(
                                             branch_key="control"
                                         )
                                     ),
@@ -770,6 +798,7 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             branch_key="control"
                                         )
                                     ),
+                                    **control_weekly_retention,
                                     **control_outcome_metrics,
                                 },
                                 "search_metrics": {
@@ -798,9 +827,13 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                             },
                                         },
                                     },
-                                    "retained": build_metric_data(
+                                    "week_2_retention": build_metric_data(
                                         branch_key="treatment",
-                                        comparative_branch_data=control_retained,
+                                        comparative_branch_data=control_week_2_retention,
+                                    ),
+                                    "week_4_retention": build_metric_data(
+                                        branch_key="treatment",
+                                        comparative_branch_data=control_week_4_retention,
                                     ),
                                     "client_level_daily_active_users_v2": (
                                         build_metric_data(
@@ -812,6 +845,7 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                                         branch_key="treatment",
                                         comparative_branch_data=control_three_day,
                                     ),
+                                    **treatment_weekly_retention,
                                     **treatment_outcome_metrics,
                                 },
                                 "search_metrics": {
@@ -825,6 +859,12 @@ def build_random_results_data(primary_outcomes, secondary_outcomes, application)
                             "is_control": False,
                         },
                     },
+                },
+            },
+            "other_metrics": {
+                "other_metrics": {
+                    slug: " ".join(word.title() for word in slug.split("_"))
+                    for slug in control_weekly_retention
                 },
             },
         },

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -97,3 +97,83 @@ class TestUnwedgeRolloutUpdateReviewMigration(MigratorTestCase):
         self.assertEqual(non_rollout.status, "Live")
         self.assertEqual(non_rollout.status_next, "Live")
         self.assertEqual(non_rollout.publish_status, "Review")
+
+
+class TestForceWeeklyRetentionResultsRefetchMigration(MigratorTestCase):
+    migrate_from = (
+        "experiments",
+        "0338_nimbusemail_rollout_phase_alter_nimbusemail_type",
+    )
+    migrate_to = (
+        "experiments",
+        "0339_force_weekly_retention_results_refetch",
+    )
+
+    def prepare(self):
+        User = self.old_state.apps.get_model("auth", "User")
+        NimbusExperiment = self.old_state.apps.get_model(
+            "experiments", "NimbusExperiment"
+        )
+
+        owner, _ = User.objects.get_or_create(
+            username="test@example.com",
+            defaults={"email": "test@example.com"},
+        )
+
+        NimbusExperiment.objects.create(
+            slug="with-analysis-start-time",
+            name="With analysis start time",
+            application="firefox-desktop",
+            owner=owner,
+            results_data={
+                "v3": {
+                    "metadata": {
+                        "analysis_start_time": "2026-07-01T00:00:00+00:00",
+                        "outcomes": {},
+                    },
+                    "overall": {},
+                }
+            },
+        )
+        NimbusExperiment.objects.create(
+            slug="without-metadata",
+            name="Without metadata",
+            application="firefox-desktop",
+            owner=owner,
+            results_data={"v3": {"overall": {}}},
+        )
+        NimbusExperiment.objects.create(
+            slug="null-metadata",
+            name="Null metadata",
+            application="firefox-desktop",
+            owner=owner,
+            results_data={"v3": {"metadata": None, "overall": {}}},
+        )
+        NimbusExperiment.objects.create(
+            slug="no-results",
+            name="No results",
+            application="firefox-desktop",
+            owner=owner,
+            results_data=None,
+        )
+
+    def test_migration(self):
+        NimbusExperiment = self.new_state.apps.get_model(
+            "experiments", "NimbusExperiment"
+        )
+
+        cleared = NimbusExperiment.objects.get(slug="with-analysis-start-time")
+        self.assertIsNone(cleared.results_data["v3"]["metadata"]["analysis_start_time"])
+        self.assertEqual(cleared.results_data["v3"]["metadata"]["outcomes"], {})
+        self.assertEqual(cleared.results_data["v3"]["overall"], {})
+
+        untouched = NimbusExperiment.objects.get(slug="without-metadata")
+        self.assertEqual(untouched.results_data, {"v3": {"overall": {}}})
+
+        null_metadata = NimbusExperiment.objects.get(slug="null-metadata")
+        self.assertEqual(
+            null_metadata.results_data, {"v3": {"metadata": None, "overall": {}}}
+        )
+
+        no_results = NimbusExperiment.objects.get(slug="no-results")
+        self.assertIsNone(no_results.results_data)

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -281,9 +281,9 @@ def get_experiment_data(experiment: NimbusExperiment):
                 raw_data[window][AnalysisBasis.EXPOSURES] = {}
 
         for segment, segment_data in segment_points_enrollments.items():
-            raw_segment_data = JetstreamData(segment_data)
-            raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = raw_segment_data
-            data = raw_segment_data.model_copy(deep=True)
+            data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
+                segment_data
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -301,36 +301,11 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
-                weekly_data = (
+                data.append_retention_data(
                     raw_data.get(AnalysisWindow.WEEKLY, {})
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
-                week_2_retention = data.get_retention_by_window(
-                    2,
-                    weekly_data,
-                    Metric.RETENTION,
-                )
-                has_retention = any(
-                    point.metric == Metric.RETENTION for point in weekly_data or []
-                )
-
-                if has_retention and not week_2_retention and segment == Segment.ALL:
-                    runtime_errors.append(
-                        AnalysisError(
-                            experiment=experiment.slug,
-                            filename="experimenter/jetstream/client.py",
-                            func_name="get_experiment_data",
-                            log_level="WARNING",
-                            message=(
-                                "Week 2 retention is unavailable because this "
-                                "experiment did not run long enough."
-                            ),
-                            metric=Metric.RETENTION,
-                            timestamp=timezone.now(),
-                        )
-                    )
-                data.extend(week_2_retention)
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -344,12 +319,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
-                data.replace_retention_weeks(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.ENROLLMENTS, {})
-                    .get(segment)
-                )
-
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -377,9 +346,9 @@ def get_experiment_data(experiment: NimbusExperiment):
             experiment_data[window][AnalysisBasis.ENROLLMENTS][segment] = transformed_data
 
         for segment, segment_data in segment_points_exposures.items():
-            raw_segment_data = JetstreamData(segment_data)
-            raw_data[window][AnalysisBasis.EXPOSURES][segment] = raw_segment_data
-            data = raw_segment_data.model_copy(deep=True)
+            data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
+                segment_data
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -415,12 +384,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
-                data.replace_retention_weeks(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.EXPOSURES, {})
-                    .get(segment)
-                )
-
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -477,17 +440,14 @@ def get_experiment_data(experiment: NimbusExperiment):
                     errors_experiment_overall.append(err)
 
     for e in runtime_errors:
-        if isinstance(e, AnalysisError):
-            analysis_error = e
-        else:
-            analysis_error = AnalysisError(
-                experiment=experiment.slug,
-                filename="experimenter/jetstream/client.py",
-                func_name="load_data_from_gcs",
-                log_level="WARNING",
-                message=e,
-                timestamp=timezone.now(),
-            )
+        analysis_error = AnalysisError(
+            experiment=experiment.slug,
+            filename="experimenter/jetstream/client.py",
+            func_name="load_data_from_gcs",
+            log_level="WARNING",
+            message=e,
+            timestamp=timezone.now(),
+        )
         errors_experiment_overall.append(analysis_error.model_dump())
 
     errors_by_metric["experiment"] = errors_experiment_overall

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -346,6 +346,11 @@ def get_experiment_data(experiment: NimbusExperiment):
             data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
                 segment_data
             )
+            data.separate_weekly_retention_data(
+                raw_data.get(AnalysisWindow.WEEKLY, {})
+                .get(AnalysisBasis.ENROLLMENTS, {})
+                .get(segment)
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -363,11 +368,6 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
-                data.append_retention_data(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.ENROLLMENTS, {})
-                    .get(segment)
-                )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -399,6 +399,8 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
+                data.remove_retention_data()
+
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
@@ -410,6 +412,11 @@ def get_experiment_data(experiment: NimbusExperiment):
         for segment, segment_data in segment_points_exposures.items():
             data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
                 segment_data
+            )
+            data.separate_weekly_retention_data(
+                raw_data.get(AnalysisWindow.WEEKLY, {})
+                .get(AnalysisBasis.EXPOSURES, {})
+                .get(segment)
             )
             (
                 result_metrics,
@@ -428,11 +435,6 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto Jetstream data
                 data.append_population_percentages()
-                data.append_retention_data(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.EXPOSURES, {})
-                    .get(segment)
-                )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -464,6 +466,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.EXPOSURES, {})
                     .get(segment)
                 )
+                data.remove_retention_data()
 
                 ResultsObjectModel = create_results_object_model(data)
 

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -343,9 +343,9 @@ def get_experiment_data(experiment: NimbusExperiment):
                 raw_data[window][AnalysisBasis.EXPOSURES] = {}
 
         for segment, segment_data in segment_points_enrollments.items():
-            raw_segment_data = JetstreamData(segment_data)
-            raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = raw_segment_data
-            data = raw_segment_data.model_copy(deep=True)
+            data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
+                segment_data
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -363,36 +363,11 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
-                weekly_data = (
+                data.append_retention_data(
                     raw_data.get(AnalysisWindow.WEEKLY, {})
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
-                week_2_retention = data.get_retention_by_window(
-                    2,
-                    weekly_data,
-                    Metric.RETENTION,
-                )
-                has_retention = any(
-                    point.metric == Metric.RETENTION for point in weekly_data or []
-                )
-
-                if has_retention and not week_2_retention and segment == Segment.ALL:
-                    runtime_errors.append(
-                        AnalysisError(
-                            experiment=experiment.slug,
-                            filename="experimenter/jetstream/client.py",
-                            func_name="get_experiment_data",
-                            log_level="WARNING",
-                            message=(
-                                "Week 2 retention is unavailable because this "
-                                "experiment did not run long enough."
-                            ),
-                            metric=Metric.RETENTION,
-                            timestamp=timezone.now(),
-                        )
-                    )
-                data.extend(week_2_retention)
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -406,12 +381,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
-                data.replace_retention_weeks(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.ENROLLMENTS, {})
-                    .get(segment)
-                )
-
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -439,9 +408,9 @@ def get_experiment_data(experiment: NimbusExperiment):
             experiment_data[window][AnalysisBasis.ENROLLMENTS][segment] = transformed_data
 
         for segment, segment_data in segment_points_exposures.items():
-            raw_segment_data = JetstreamData(segment_data)
-            raw_data[window][AnalysisBasis.EXPOSURES][segment] = raw_segment_data
-            data = raw_segment_data.model_copy(deep=True)
+            data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
+                segment_data
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -477,12 +446,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                 data.append_conversion_count(primary_metrics_set)
 
             elif data and window == AnalysisWindow.WEEKLY:
-                data.replace_retention_weeks(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.EXPOSURES, {})
-                    .get(segment)
-                )
-
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -539,17 +502,14 @@ def get_experiment_data(experiment: NimbusExperiment):
                     errors_experiment_overall.append(err)
 
     for e in runtime_errors:
-        if isinstance(e, AnalysisError):
-            analysis_error = e
-        else:
-            analysis_error = AnalysisError(
-                experiment=experiment.slug,
-                filename="experimenter/jetstream/client.py",
-                func_name="load_data_from_gcs",
-                log_level="WARNING",
-                message=e,
-                timestamp=timezone.now(),
-            )
+        analysis_error = AnalysisError(
+            experiment=experiment.slug,
+            filename="experimenter/jetstream/client.py",
+            func_name="load_data_from_gcs",
+            log_level="WARNING",
+            message=e,
+            timestamp=timezone.now(),
+        )
         errors_experiment_overall.append(analysis_error.model_dump())
 
     errors_by_metric["experiment"] = errors_experiment_overall

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -284,6 +284,11 @@ def get_experiment_data(experiment: NimbusExperiment):
             data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
                 segment_data
             )
+            data.separate_weekly_retention_data(
+                raw_data.get(AnalysisWindow.WEEKLY, {})
+                .get(AnalysisBasis.ENROLLMENTS, {})
+                .get(segment)
+            )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -301,11 +306,6 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto the incoming Jetstream data
                 data.append_population_percentages()
-                data.append_retention_data(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.ENROLLMENTS, {})
-                    .get(segment)
-                )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -337,6 +337,8 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
+                data.remove_retention_data()
+
                 ResultsObjectModel = create_results_object_model(data)
 
                 data = ResultsObjectModel(result_metrics, data, experiment, window)
@@ -348,6 +350,11 @@ def get_experiment_data(experiment: NimbusExperiment):
         for segment, segment_data in segment_points_exposures.items():
             data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
                 segment_data
+            )
+            data.separate_weekly_retention_data(
+                raw_data.get(AnalysisWindow.WEEKLY, {})
+                .get(AnalysisBasis.EXPOSURES, {})
+                .get(segment)
             )
             (
                 result_metrics,
@@ -366,11 +373,6 @@ def get_experiment_data(experiment: NimbusExperiment):
             if data and window == AnalysisWindow.OVERALL:
                 # Append some values onto Jetstream data
                 data.append_population_percentages()
-                data.append_retention_data(
-                    raw_data.get(AnalysisWindow.WEEKLY, {})
-                    .get(AnalysisBasis.EXPOSURES, {})
-                    .get(segment)
-                )
                 # Append 3-day retention from daily data
                 data.append_retention_3_days(
                     raw_data.get(AnalysisWindow.DAILY, {})
@@ -402,6 +404,7 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.EXPOSURES, {})
                     .get(segment)
                 )
+                data.remove_retention_data()
 
                 ResultsObjectModel = create_results_object_model(data)
 

--- a/experimenter/experimenter/jetstream/client.py
+++ b/experimenter/experimenter/jetstream/client.py
@@ -343,14 +343,15 @@ def get_experiment_data(experiment: NimbusExperiment):
                 raw_data[window][AnalysisBasis.EXPOSURES] = {}
 
         for segment, segment_data in segment_points_enrollments.items():
-            data = raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = JetstreamData(
-                segment_data
-            )
-            data.separate_weekly_retention_data(
-                raw_data.get(AnalysisWindow.WEEKLY, {})
-                .get(AnalysisBasis.ENROLLMENTS, {})
-                .get(segment)
-            )
+            raw_segment_data = JetstreamData(segment_data)
+            raw_data[window][AnalysisBasis.ENROLLMENTS][segment] = raw_segment_data
+            data = raw_segment_data.model_copy(deep=True)
+            if data:
+                data.separate_weekly_retention_data(
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.ENROLLMENTS, {})
+                    .get(segment)
+                )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -399,7 +400,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.ENROLLMENTS, {})
                     .get(segment)
                 )
-                data.remove_retention_data()
 
                 ResultsObjectModel = create_results_object_model(data)
 
@@ -410,14 +410,15 @@ def get_experiment_data(experiment: NimbusExperiment):
             experiment_data[window][AnalysisBasis.ENROLLMENTS][segment] = transformed_data
 
         for segment, segment_data in segment_points_exposures.items():
-            data = raw_data[window][AnalysisBasis.EXPOSURES][segment] = JetstreamData(
-                segment_data
-            )
-            data.separate_weekly_retention_data(
-                raw_data.get(AnalysisWindow.WEEKLY, {})
-                .get(AnalysisBasis.EXPOSURES, {})
-                .get(segment)
-            )
+            raw_segment_data = JetstreamData(segment_data)
+            raw_data[window][AnalysisBasis.EXPOSURES][segment] = raw_segment_data
+            data = raw_segment_data.model_copy(deep=True)
+            if data:
+                data.separate_weekly_retention_data(
+                    raw_data.get(AnalysisWindow.WEEKLY, {})
+                    .get(AnalysisBasis.EXPOSURES, {})
+                    .get(segment)
+                )
             (
                 result_metrics,
                 primary_metrics_set,
@@ -466,7 +467,6 @@ def get_experiment_data(experiment: NimbusExperiment):
                     .get(AnalysisBasis.EXPOSURES, {})
                     .get(segment)
                 )
-                data.remove_retention_data()
 
                 ResultsObjectModel = create_results_object_model(data)
 

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -158,6 +158,8 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
         ]
 
     def separate_weekly_retention_data(self, weekly_data):
+        # Replace "retained" with one week_N_retention metric per week in "weekly_data",
+        # skipping week 1. Points are copied so the shared "weekly_data" is untouched.
         retention_data = []
 
         for jetstream_data_point in weekly_data or []:

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -78,7 +78,6 @@ GROUPED_METRICS = {
     Group.SEARCH: SEARCH_METRICS,
     Group.USAGE: USAGE_METRICS,
 }
-RETENTION_2_WEEKS_WINDOW_INDEX = 2
 RETENTION_3_DAYS_WINDOW_INDEX = 4
 RETENTION_3_DAYS_METRICS = (Metric.RETENTION_3_DAYS, Metric.RETENTION_3_DAYS_LEGACY)
 
@@ -154,28 +153,18 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
             jetstream_data_point
             for jetstream_data_point in data
             if jetstream_data_point.window_index == str(window_index)
-            and jetstream_data_point.metric == metric.value
+            and jetstream_data_point.metric == metric
         ]
 
     def append_retention_data(self, weekly_data):
-        # Only use two-week retention data.
-        retention_data = self.get_retention_by_window(
-            RETENTION_2_WEEKS_WINDOW_INDEX, weekly_data, Metric.RETENTION
-        )
+        # Try to get the two-week retention data. If it doesn't
+        # exist (experiment was too short), settle for 1 week.
+        retention_data = self.get_retention_by_window(2, weekly_data, Metric.RETENTION)
+        if len(retention_data) == 0:
+            retention_data = self.get_retention_by_window(
+                1, weekly_data, Metric.RETENTION
+            )
 
-        self.extend(retention_data)
-
-    def replace_retention_weeks(self, weekly_data):
-        # Remove all weekly retention data except for week 2.
-        retention_data = self.get_retention_by_window(
-            RETENTION_2_WEEKS_WINDOW_INDEX, weekly_data, Metric.RETENTION
-        )
-
-        self.root = [
-            jetstream_data_point
-            for jetstream_data_point in self.root
-            if jetstream_data_point.metric != Metric.RETENTION
-        ]
         self.extend(retention_data)
 
     def get_retention_3_days_by_window(self, window_index, daily_data):
@@ -185,7 +174,7 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
                 self.get_retention_by_window(window_index, daily_data, metric)
             )
         return retention_data
-
+    
     def append_retention_3_days(self, daily_data):
         # Extract the 3-day retention data (window index 4)
         # without falling back to earlier windows
@@ -306,11 +295,10 @@ class ResultsObjectModelBase(BaseModel):
 
                 # Need window index for weekly DataPoint objects and for storing
                 # significance for each window. Overall should always be 1 because
-                # there is only ever one overall window, except retained data which
-                # is pulled from week 2.
+                # there is only ever one overall window.
                 window_index = (
                     "1"
-                    if window == AnalysisWindow.OVERALL and metric != Metric.RETENTION
+                    if window == AnalysisWindow.OVERALL
                     else jetstream_data_point.window_index
                 )
 

--- a/experimenter/experimenter/jetstream/models.py
+++ b/experimenter/experimenter/jetstream/models.py
@@ -28,6 +28,7 @@ class BranchComparison(StrEnum):
 
 class Metric(StrEnum):
     RETENTION = "retained"
+    WEEKLY_RETENTION = "week_{}_retention"
     RETENTION_3_DAYS = "active_in_last_3_days"
     RETENTION_3_DAYS_LEGACY = "active_in_last_3_days_legacy"
     SEARCH = "search_count"
@@ -156,16 +157,29 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
             and jetstream_data_point.metric == metric
         ]
 
-    def append_retention_data(self, weekly_data):
-        # Try to get the two-week retention data. If it doesn't
-        # exist (experiment was too short), settle for 1 week.
-        retention_data = self.get_retention_by_window(2, weekly_data, Metric.RETENTION)
-        if len(retention_data) == 0:
-            retention_data = self.get_retention_by_window(
-                1, weekly_data, Metric.RETENTION
-            )
+    def separate_weekly_retention_data(self, weekly_data):
+        retention_data = []
 
+        for jetstream_data_point in weekly_data or []:
+            if (
+                jetstream_data_point.metric == Metric.RETENTION
+                and jetstream_data_point.window_index != "1"
+            ):
+                retention_data_point = jetstream_data_point.model_copy()
+                retention_data_point.metric = Metric.WEEKLY_RETENTION.format(
+                    retention_data_point.window_index
+                )
+                retention_data.append(retention_data_point)
+
+        self.remove_retention_data()
         self.extend(retention_data)
+
+    def remove_retention_data(self):
+        self.root = [
+            jetstream_data_point
+            for jetstream_data_point in self.root
+            if jetstream_data_point.metric != Metric.RETENTION
+        ]
 
     def get_retention_3_days_by_window(self, window_index, daily_data):
         retention_data = []
@@ -174,7 +188,7 @@ class JetstreamData(RootModel[JetstreamDataPoint]):
                 self.get_retention_by_window(window_index, daily_data, metric)
             )
         return retention_data
-    
+
     def append_retention_3_days(self, daily_data):
         # Extract the 3-day retention data (window index 4)
         # without falling back to earlier windows

--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -402,9 +402,9 @@ class ExperimentResultsManager:
             )
 
             match kpi["slug"]:
-                case NimbusConstants.RETENTION_2_WEEKS:
+                case NimbusConstants.RETENTION_WEEK_2:
                     kpi["displayed_window"] = "Week 2"
-                case NimbusConstants.RETENTION_4_WEEKS:
+                case NimbusConstants.RETENTION_WEEK_4:
                     kpi["displayed_window"] = "Week 4"
                 case (
                     NimbusConstants.RETENTION_3_DAYS
@@ -558,8 +558,8 @@ class ExperimentResultsManager:
         remaining_metrics = self.get_remaining_metrics_metadata(
             exclude_slugs=[
                 *all_outcome_metric_slugs,
-                NimbusConstants.RETENTION_2_WEEKS,
-                NimbusConstants.RETENTION_4_WEEKS,
+                NimbusConstants.RETENTION_WEEK_2,
+                NimbusConstants.RETENTION_WEEK_4,
             ],
             analysis_basis=analysis_basis,
             segment=segment,

--- a/experimenter/experimenter/jetstream/results_manager.py
+++ b/experimenter/experimenter/jetstream/results_manager.py
@@ -401,21 +401,22 @@ class ExperimentResultsManager:
                 kpi["slug"], kpi["group"], analysis_basis, segment, reference_branch
             )
 
-            if (
-                kpi["slug"] == NimbusConstants.RETENTION_3_DAYS
-                or kpi["slug"] == NimbusConstants.RETENTION_3_DAYS_DESKTOP
-            ):
-                kpi["displayed_window"] = "Day 4"
-            # TODO: EXP-5498 - We are still unclear on the best window to show for weekly
-            # retention, so for now we are defaulting to showing whatever window the
-            # latest results data is available for. Once we have clarity, we can
-            # hardcode a displayed_window value like we do for 3DR.
-            # if kpi["slug"] == NimbusConstants.RETENTION:
-            #     kpi["displayed_window"] = "Week 2"
+            match kpi["slug"]:
+                case NimbusConstants.RETENTION_2_WEEKS:
+                    kpi["displayed_window"] = "Week 2"
+                case NimbusConstants.RETENTION_4_WEEKS:
+                    kpi["displayed_window"] = "Week 4"
+                case (
+                    NimbusConstants.RETENTION_3_DAYS
+                    | NimbusConstants.RETENTION_3_DAYS_DESKTOP
+                ):
+                    kpi["displayed_window"] = "Day 4"
 
     def get_remaining_metrics_metadata(
         self, exclude_slugs=None, analysis_basis=None, segment=None, reference_branch=None
     ):
+        from experimenter.jetstream.models import Metric
+
         analysis_data = (
             self.experiment.results_data.get("v3", {})
             if self.experiment.results_data
@@ -425,11 +426,15 @@ class ExperimentResultsManager:
         metadata = analysis_data.get("metadata", {})
         metrics_metadata = metadata.get("metrics", {}) if metadata else {}
         defaults = []
+        retention_prefix, retention_suffix = Metric.WEEKLY_RETENTION.split("{}")
 
         for group, default_metrics in other_metrics.items():
             for slug, metric_friendly_name in default_metrics.items():
                 if exclude_slugs and slug in exclude_slugs:
                     continue
+                retention_week = slug.removeprefix(retention_prefix).removesuffix(
+                    retention_suffix
+                )
                 defaults.append(
                     {
                         "slug": slug,
@@ -451,6 +456,10 @@ class ExperimentResultsManager:
                         "has_data": self.metric_has_data(
                             slug, group, analysis_basis, segment, reference_branch
                         ),
+                        "displayed_window": (f"Week {retention_week}")
+                        if slug.startswith(retention_prefix)
+                        and slug.endswith(retention_suffix)
+                        else None,
                     }
                 )
 
@@ -547,7 +556,11 @@ class ExperimentResultsManager:
             }
 
         remaining_metrics = self.get_remaining_metrics_metadata(
-            exclude_slugs=all_outcome_metric_slugs,
+            exclude_slugs=[
+                *all_outcome_metric_slugs,
+                NimbusConstants.RETENTION_2_WEEKS,
+                NimbusConstants.RETENTION_4_WEEKS,
+            ],
             analysis_basis=analysis_basis,
             segment=segment,
             reference_branch=reference_branch,

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -133,7 +133,6 @@ class JetstreamTestData:
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.lower = -5.0
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.metric = Metric.RETENTION
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.statistic = Statistic.BINOMIAL
-        VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.window_index = "2"
 
         CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW = (
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_copy()
@@ -218,9 +217,9 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C.model_copy(update={"window_index": "2"}),
+            DATA_POINT_C,
             SignificanceData(
-                daily={"2": Significance.NEGATIVE.value}, weekly={}, overall={}
+                daily={"1": Significance.NEGATIVE.value}, weekly={}, overall={}
             ),
             comparison_to_branch="control",
         )
@@ -235,8 +234,8 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C.model_copy(update={"window_index": "2"}),
-            SignificanceData(weekly={"2": Significance.NEGATIVE.value}, overall={}),
+            DATA_POINT_C,
+            SignificanceData(weekly={"1": Significance.NEGATIVE.value}, overall={}),
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_CONTROL = cls.get_difference_metric_data(
@@ -250,15 +249,15 @@ class JetstreamTestData:
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D.model_copy(update={"window_index": "2"}),
-            SignificanceData(weekly={}, overall={"2": Significance.NEGATIVE.value}),
+            DATA_POINT_D,
+            SignificanceData(weekly={}, overall={"1": Significance.NEGATIVE.value}),
             is_retention=True,
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B.model_copy(update={"window_index": "2"}),
+            DATA_POINT_B,
             SignificanceData(
-                daily={"2": Significance.NEUTRAL.value}, weekly={}, overall={}
+                daily={"1": Significance.NEUTRAL.value}, weekly={}, overall={}
             ),
             comparison_to_branch="variant",
         )
@@ -277,8 +276,8 @@ class JetstreamTestData:
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B.model_copy(update={"window_index": "2"}),
-            SignificanceData(weekly={"2": Significance.NEUTRAL.value}, overall={}),
+            DATA_POINT_B,
+            SignificanceData(weekly={"1": Significance.NEUTRAL.value}, overall={}),
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_POSITIVE_VARIANT = cls.get_difference_metric_data(
@@ -292,8 +291,8 @@ class JetstreamTestData:
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E.model_copy(update={"window_index": "2"}),
-            SignificanceData(weekly={}, overall={"2": Significance.NEUTRAL.value}),
+            DATA_POINT_E,
+            SignificanceData(weekly={}, overall={"1": Significance.NEUTRAL.value}),
             is_retention=True,
             comparison_to_branch="variant",
         )
@@ -1538,7 +1537,6 @@ class ZeroJetstreamTestData(JetstreamTestData):
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.lower = 0.0
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.metric = Metric.RETENTION
         VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.statistic = Statistic.BINOMIAL
-        VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.window_index = "2"
 
         CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW = (
             VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_copy()
@@ -1608,7 +1606,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C.model_copy(update={"window_index": "2"}),
+            DATA_POINT_C,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="control",
         )
@@ -1623,7 +1621,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_C.model_copy(update={"window_index": "2"}),
+            DATA_POINT_C,
             SignificanceData(weekly={}, overall={}),
             comparison_to_branch="control",
         )
@@ -1638,13 +1636,13 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL = cls.get_difference_metric_data(
-            DATA_POINT_D.model_copy(update={"window_index": "2"}),
+            DATA_POINT_D,
             SignificanceData(weekly={}, overall={}),
             is_retention=True,
             comparison_to_branch="control",
         )
         DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B.model_copy(update={"window_index": "2"}),
+            DATA_POINT_B,
             SignificanceData(daily={}, weekly={}, overall={}),
             comparison_to_branch="variant",
         )
@@ -1659,7 +1657,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_B.model_copy(update={"window_index": "2"}),
+            DATA_POINT_B,
             SignificanceData(weekly={}, overall={}),
             comparison_to_branch="variant",
         )
@@ -1674,7 +1672,7 @@ class ZeroJetstreamTestData(JetstreamTestData):
             comparison_to_branch="variant",
         )
         DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT = cls.get_difference_metric_data(
-            DATA_POINT_E.model_copy(update={"window_index": "2"}),
+            DATA_POINT_E,
             SignificanceData(weekly={}, overall={}),
             is_retention=True,
             comparison_to_branch="variant",

--- a/experimenter/experimenter/jetstream/tests/constants.py
+++ b/experimenter/experimenter/jetstream/tests/constants.py
@@ -657,8 +657,6 @@ class JetstreamTestData:
             VARIANT_DATA_DEFAULT_METRIC_ROW_DAU_IMPACT.model_dump(exclude_none=True),
             VARIANT_DATA_DEFAULT_METRIC_ROW_BINOMIAL.model_dump(exclude_none=True),
             VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
-            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
-            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
             BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
             VARIANT_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
         ]
@@ -676,10 +674,6 @@ class JetstreamTestData:
             EXPOSURES_VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(
                 exclude_none=True
             ),
-            EXPOSURES_VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(
-                exclude_none=True
-            ),
-            EXPOSURES_CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
             EXPOSURES_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
             VARIANT_EXPOSURES_BROKEN_STATISTIC_DATA_ROW.model_dump(exclude_none=True),
         ]
@@ -786,11 +780,6 @@ class JetstreamTestData:
                             exclude_none=True
                         ),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
@@ -820,11 +809,6 @@ class JetstreamTestData:
                         "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
@@ -847,11 +831,6 @@ class JetstreamTestData:
                             exclude_none=True
                         ),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
@@ -881,11 +860,6 @@ class JetstreamTestData:
                         "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
                 },
@@ -912,11 +886,6 @@ class JetstreamTestData:
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "default_browser_action": EMPTY_METRIC_DATA.model_dump(
                             exclude_none=True
-                        ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
                         ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
@@ -948,11 +917,6 @@ class JetstreamTestData:
                         ),
                         "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
                             exclude_none=True
-                        ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
                         ),
                         "custom_metric": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                     },
@@ -1133,8 +1097,6 @@ class JetstreamTestData:
             CONTROL_DATA_ROW.model_dump(exclude_none=True),
             VARIANT_DATA_ROW.model_dump(exclude_none=True),
             VARIANT_POSITIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
-            VARIANT_NEGATIVE_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
-            CONTROL_NEUTRAL_SIGNIFICANCE_DATA_ROW.model_dump(exclude_none=True),
         ]
         DAILY_EXPOSURES_DATA = [
             EXPOSURES_CONTROL_DATA_ROW.model_dump(exclude_none=True),
@@ -1221,11 +1183,6 @@ class JetstreamTestData:
                         "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
                         "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_DAILY_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
@@ -1248,23 +1205,12 @@ class JetstreamTestData:
                         "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_DAILY_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
         }
 
         FORMATTED_DAILY_EXPOSURES_DATA = deepcopy(FORMATTED_DAILY_BASE)
-        del FORMATTED_DAILY_EXPOSURES_DATA["control"]["branch_data"][Group.OTHER][
-            "retained"
-        ]
-        del FORMATTED_DAILY_EXPOSURES_DATA["variant"]["branch_data"][Group.OTHER][
-            "retained"
-        ]
         del FORMATTED_DAILY_EXPOSURES_DATA["control"]["branch_data"][Group.SEARCH][
             "search_count"
         ]
@@ -1323,11 +1269,6 @@ class JetstreamTestData:
                         "identity": ABSOLUTE_METRIC_DATA_A.model_dump(exclude_none=True),
                         "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
@@ -1350,19 +1291,12 @@ class JetstreamTestData:
                         "another_count": ABSOLUTE_METRIC_DATA_A.model_dump(
                             exclude_none=True
                         ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_WEEKLY_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
         }
 
         WEEKLY_EXPOSURES_DATA = deepcopy(WEEKLY_BASE)
-        del WEEKLY_EXPOSURES_DATA["control"]["branch_data"][Group.OTHER]["retained"]
-        del WEEKLY_EXPOSURES_DATA["variant"]["branch_data"][Group.OTHER]["retained"]
         del WEEKLY_EXPOSURES_DATA["control"]["branch_data"][Group.SEARCH]["search_count"]
         del WEEKLY_EXPOSURES_DATA["variant"]["branch_data"][Group.SEARCH]["search_count"]
 
@@ -1407,11 +1341,6 @@ class JetstreamTestData:
                         ),
                         "some_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
                         "another_count": EMPTY_METRIC_DATA.model_dump(exclude_none=True),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_NEUTRAL_VARIANT.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
@@ -1436,19 +1365,12 @@ class JetstreamTestData:
                         "another_count": ABSOLUTE_METRIC_DATA_F.model_dump(
                             exclude_none=True
                         ),
-                        "retained": (
-                            DIFFERENCE_METRIC_DATA_OVERALL_NEGATIVE_CONTROL.model_dump(
-                                exclude_none=True
-                            )
-                        ),
                     },
                 },
             },
         }
 
         OVERALL_EXPOSURES_DATA = deepcopy(OVERALL_BASE)
-        del OVERALL_EXPOSURES_DATA["control"]["branch_data"][Group.OTHER]["retained"]
-        del OVERALL_EXPOSURES_DATA["variant"]["branch_data"][Group.OTHER]["retained"]
         del OVERALL_EXPOSURES_DATA["control"]["branch_data"][Group.SEARCH]["search_count"]
         del OVERALL_EXPOSURES_DATA["variant"]["branch_data"][Group.SEARCH]["search_count"]
 

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -61,6 +61,21 @@ class TestJetstreamData(TestCase):
 
         self.assertIn(retention, data)
 
+    def test_append_retention_3_days_extracts_legacy_data(self):
+        retention = JetstreamDataPoint(
+            metric=Metric.RETENTION_3_DAYS_LEGACY,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="4",
+        )
+
+        data = JetstreamData([])
+        data.append_retention_3_days([retention])
+
+        self.assertIn(retention, data)
+
     def test_remove_retention_data(self):
         retained = JetstreamDataPoint(
             metric=Metric.RETENTION,
@@ -107,6 +122,22 @@ class TestJetstreamData(TestCase):
                 (Metric.WEEKLY_RETENTION.format(6), "6", 0.6),
             ],
         )
+
+    def test_separate_weekly_retention_data_ignores_week_1_only_data(self):
+        week_1_retention = JetstreamDataPoint(
+            metric=Metric.RETENTION,
+            statistic=Statistic.BINOMIAL,
+            branch="control",
+            point=0.65,
+            segment=Segment.ALL,
+            window_index="1",
+        )
+        identity = JetstreamTestData.get_identity_row()
+        data = JetstreamData([identity])
+
+        data.separate_weekly_retention_data(JetstreamData([week_1_retention]))
+
+        self.assertEqual(data.root, [identity])
 
     def test_replace_retention_3_days_replaces_existing_entries(self):
         existing_retention_1 = JetstreamDataPoint(

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -61,74 +61,52 @@ class TestJetstreamData(TestCase):
 
         self.assertIn(retention, data)
 
-    def test_append_retention_data_ignores_week_1_only_data(self):
-        week_1_retention = JetstreamDataPoint(
+    def test_remove_retention_data(self):
+        retained = JetstreamDataPoint(
             metric=Metric.RETENTION,
             statistic=Statistic.BINOMIAL,
             branch="control",
             point=0.65,
             segment=Segment.ALL,
-            window_index="1",
         )
+        identity = JetstreamTestData.get_identity_row()
+        data = JetstreamData([retained, identity])
 
-        data = JetstreamData([])
-        data.append_retention_data([week_1_retention])
+        data.remove_retention_data()
 
-        self.assertNotIn(week_1_retention, data)
+        self.assertEqual(data.root, [identity])
 
-    def test_append_retention_data_uses_week_2_data(self):
-        week_2_retention = JetstreamDataPoint(
-            metric=Metric.RETENTION,
-            statistic=Statistic.BINOMIAL,
-            branch="control",
-            point=0.65,
-            segment=Segment.ALL,
-            window_index="2",
-        )
-
-        data = JetstreamData([])
-        data.append_retention_data([week_2_retention])
-
-        self.assertIn(week_2_retention, data)
-
-    def test_replace_retention_replaces_existing_entries(self):
-        existing_retention_1 = JetstreamDataPoint(
-            metric=Metric.RETENTION,
-            statistic=Statistic.BINOMIAL,
-            branch="control",
-            point=0.5,
-            segment=Segment.ALL,
-            window_index="1",
-        )
-        kept_retention = JetstreamDataPoint(
-            metric=Metric.RETENTION,
-            statistic=Statistic.BINOMIAL,
-            branch="control",
-            point=0.25,
-            segment=Segment.ALL,
-            window_index="2",
-        )
-        existing_retention_2 = JetstreamDataPoint(
-            metric=Metric.RETENTION,
-            statistic=Statistic.BINOMIAL,
-            branch="control",
-            point=0.25,
-            segment=Segment.ALL,
-            window_index="3",
-        )
-
-        data = JetstreamData(
+    def test_separate_weekly_retention_data_splits_retention_by_week(self):
+        weekly_data = JetstreamData(
             [
-                existing_retention_1,
-                kept_retention,
-                existing_retention_2,
+                JetstreamDataPoint(
+                    metric=Metric.RETENTION,
+                    statistic=Statistic.BINOMIAL,
+                    branch="control",
+                    point=week / 10,
+                    segment=Segment.ALL,
+                    window_index=str(week),
+                )
+                for week in (1, 2, 3, 4, 5, 6)
             ]
         )
-        data.replace_retention_weeks(data)
+        transformed_data = JetstreamData([])
 
-        self.assertNotIn(existing_retention_1, data)
-        self.assertNotIn(existing_retention_2, data)
-        self.assertIn(kept_retention, data)
+        transformed_data.separate_weekly_retention_data(weekly_data)
+
+        self.assertEqual(
+            [
+                (point.metric, point.window_index, point.point)
+                for point in transformed_data
+            ],
+            [
+                (Metric.WEEKLY_RETENTION.format(2), "2", 0.2),
+                (Metric.WEEKLY_RETENTION.format(3), "3", 0.3),
+                (Metric.WEEKLY_RETENTION.format(4), "4", 0.4),
+                (Metric.WEEKLY_RETENTION.format(5), "5", 0.5),
+                (Metric.WEEKLY_RETENTION.format(6), "6", 0.6),
+            ],
+        )
 
     def test_replace_retention_3_days_replaces_existing_entries(self):
         existing_retention_1 = JetstreamDataPoint(

--- a/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
+++ b/experimenter/experimenter/jetstream/tests/test_jetstream_data.py
@@ -61,21 +61,6 @@ class TestJetstreamData(TestCase):
 
         self.assertIn(retention, data)
 
-    def test_append_retention_3_days_extracts_legacy_data(self):
-        retention = JetstreamDataPoint(
-            metric=Metric.RETENTION_3_DAYS_LEGACY,
-            statistic=Statistic.BINOMIAL,
-            branch="control",
-            point=0.65,
-            segment=Segment.ALL,
-            window_index="4",
-        )
-
-        data = JetstreamData([])
-        data.append_retention_3_days([retention])
-
-        self.assertIn(retention, data)
-
     def test_append_retention_data_ignores_week_1_only_data(self):
         week_1_retention = JetstreamDataPoint(
             metric=Metric.RETENTION,

--- a/experimenter/experimenter/jetstream/tests/test_results_manager.py
+++ b/experimenter/experimenter/jetstream/tests/test_results_manager.py
@@ -933,8 +933,8 @@ class TestExperimentResultsManager(TestCase):
                         "all": {
                             "branch-a": {
                                 "branch_data": {
-                                    "other_metrics": {
-                                        "retained": {
+                                    "search_metrics": {
+                                        "search_count": {
                                             "absolute": {
                                                 "all": [
                                                     {
@@ -978,8 +978,8 @@ class TestExperimentResultsManager(TestCase):
                             },
                             "branch-b": {
                                 "branch_data": {
-                                    "other_metrics": {
-                                        "retained": {
+                                    "search_metrics": {
+                                        "search_count": {
                                             "absolute": {
                                                 "all": [
                                                     {
@@ -1035,7 +1035,7 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertIn("Notable Changes", metric_areas)
         self.assertIn(
-            "retained",
+            "search_count",
             [metric["slug"] for metric in metric_areas["Notable Changes"]["metrics"]],
         )
 
@@ -1299,9 +1299,26 @@ class TestExperimentResultsManager(TestCase):
                 [
                     {
                         "group": "other_metrics",
-                        "friendly_name": "Retention",
-                        "slug": "retained",
-                        "description": "Retention description",
+                        "friendly_name": "Week 2 Retention",
+                        "slug": "week_2_retention",
+                        "displayed_window": "Week 2",
+                        "description": (
+                            "Users who were active in Firefox during the second week "
+                            "after enrollment."
+                        ),
+                        "display_type": "percentage",
+                        "overall_change": MetricSignificance.NEUTRAL,
+                        "has_data": False,
+                    },
+                    {
+                        "group": "other_metrics",
+                        "friendly_name": "Week 4 Retention",
+                        "slug": "week_4_retention",
+                        "displayed_window": "Week 4",
+                        "description": (
+                            "Users who were active in Firefox during the fourth week "
+                            "after enrollment."
+                        ),
                         "display_type": "percentage",
                         "overall_change": MetricSignificance.NEUTRAL,
                         "has_data": False,
@@ -1339,9 +1356,26 @@ class TestExperimentResultsManager(TestCase):
                 [
                     {
                         "group": "other_metrics",
-                        "friendly_name": "Retention",
-                        "slug": "retained",
-                        "description": "Retention description",
+                        "friendly_name": "Week 2 Retention",
+                        "displayed_window": "Week 2",
+                        "slug": "week_2_retention",
+                        "description": (
+                            "Users who were active in Firefox during the second week "
+                            "after enrollment."
+                        ),
+                        "display_type": "percentage",
+                        "overall_change": MetricSignificance.NEUTRAL,
+                        "has_data": False,
+                    },
+                    {
+                        "group": "other_metrics",
+                        "friendly_name": "Week 4 Retention",
+                        "displayed_window": "Week 4",
+                        "slug": "week_4_retention",
+                        "description": (
+                            "Users who were active in Firefox during the fourth week "
+                            "after enrollment."
+                        ),
                         "display_type": "percentage",
                         "overall_change": MetricSignificance.NEUTRAL,
                         "has_data": False,
@@ -1396,9 +1430,19 @@ class TestExperimentResultsManager(TestCase):
                             "friendly_name": "Search Count",
                             "description": "Search Count description",
                         },
-                        "retained": {
-                            "friendly_name": "Retention",
-                            "description": "Retention description",
+                        "week_2_retention": {
+                            "friendly_name": "Week 2 Retention",
+                            "description": (
+                                "Users who were active in Firefox during the second "
+                                "week after enrollment."
+                            ),
+                        },
+                        "week_4_retention": {
+                            "friendly_name": "Week 4 Retention",
+                            "description": (
+                                "Users who were active in Firefox during the fourth "
+                                "week after enrollment."
+                            ),
                         },
                         "active_in_last_3_days_legacy": {
                             "friendly_name": "3-Day Retention",
@@ -1549,7 +1593,8 @@ class TestExperimentResultsManager(TestCase):
                 },
                 "other_metrics": {
                     "other_metrics": {
-                        "retained": "2 Week Retention",
+                        "retained": "Week 2 Retention",
+                        "week_6_retention": "Week 6 Retention",
                         "search_count": "Search Count",
                     }
                 },
@@ -1564,6 +1609,10 @@ class TestExperimentResultsManager(TestCase):
 
         self.assertIn("retained", metric_slugs)
         self.assertNotIn("search_count", metric_slugs)
+        weekly_retention = next(
+            metric for metric in remaining_metrics if metric["slug"] == "week_6_retention"
+        )
+        self.assertEqual(weekly_retention["displayed_window"], "Week 6")
 
     @parameterized.expand(
         [
@@ -2888,7 +2937,8 @@ class TestExperimentResultsManager(TestCase):
                 NimbusExperiment.Application.DESKTOP,
                 [
                     "client_level_daily_active_users_v2",
-                    "retained",
+                    "week_2_retention",
+                    "week_4_retention",
                     "search_count",
                     "active_in_last_3_days_legacy",
                 ],
@@ -2897,7 +2947,8 @@ class TestExperimentResultsManager(TestCase):
                 NimbusExperiment.Application.FENIX,
                 [
                     "client_level_daily_active_users_v2",
-                    "retained",
+                    "week_2_retention",
+                    "week_4_retention",
                     "search_count",
                     "active_in_last_3_days",
                 ],
@@ -2906,7 +2957,8 @@ class TestExperimentResultsManager(TestCase):
                 NimbusExperiment.Application.IOS,
                 [
                     "client_level_daily_active_users_v2",
-                    "retained",
+                    "week_2_retention",
+                    "week_4_retention",
                     "search_count",
                     "active_in_last_3_days",
                 ],

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -35,7 +35,7 @@ from experimenter.jetstream.client import (
     get_stored_analysis_start_time,
     has_missing_expected_results,
 )
-from experimenter.jetstream.models import AnalysisWindow, Group
+from experimenter.jetstream.models import AnalysisWindow, Group, Metric
 from experimenter.jetstream.tests import mock_valid_outcomes
 from experimenter.jetstream.tests.constants import (
     JetstreamTestData,
@@ -1067,6 +1067,61 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             mock_get_metadata.return_value = None
             mock_get_errors.return_value = None
             tasks.fetch_experiment_data(experiment.id)
+
+    def test_results_data_includes_weekly_retention_in_overall_window(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+        experiment.reference_branch.slug = "control"
+        experiment.reference_branch.save()
+
+        def mock_jetstream_data_by_window(_, window):
+            if window == AnalysisWindow.WEEKLY:
+                return [
+                    {
+                        "metric": Metric.RETENTION,
+                        "statistic": "binomial",
+                        "branch": "control",
+                        "point": week / 10,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": str(week),
+                    }
+                    for week in (1, 2, 4)
+                ]
+            if window == AnalysisWindow.OVERALL:
+                return [
+                    {
+                        "metric": "identity",
+                        "statistic": "count",
+                        "branch": "control",
+                        "point": 10,
+                        "segment": "all",
+                        "analysis_basis": "enrollments",
+                        "window_index": "1",
+                    }
+                ]
+            return []
+
+        with (
+            patch("experimenter.jetstream.client.get_data") as mock_get_data,
+            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
+            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
+        ):
+            mock_get_data.side_effect = mock_jetstream_data_by_window
+            mock_get_metadata.return_value = None
+            mock_get_errors.return_value = None
+            tasks.fetch_experiment_data(experiment.id)
+
+        experiment.refresh_from_db()
+        overall_metrics = experiment.results_data["v3"]["overall"]["enrollments"]["all"][
+            "control"
+        ]["branch_data"][Group.OTHER]
+
+        self.assertIn(Metric.WEEKLY_RETENTION.format(2), overall_metrics)
+        self.assertIn(Metric.WEEKLY_RETENTION.format(4), overall_metrics)
+        self.assertNotIn(Metric.WEEKLY_RETENTION.format(1), overall_metrics)
+        self.assertNotIn(Metric.RETENTION, overall_metrics)
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -20,7 +20,7 @@ from experimenter.jetstream.client import (
     get_featmon_slugs,
     get_monitoring_data,
 )
-from experimenter.jetstream.models import AnalysisWindow, Group, Metric
+from experimenter.jetstream.models import AnalysisWindow, Group
 from experimenter.jetstream.tests import mock_valid_outcomes
 from experimenter.jetstream.tests.constants import (
     JetstreamTestData,
@@ -1052,61 +1052,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             mock_get_metadata.return_value = None
             mock_get_errors.return_value = None
             tasks.fetch_experiment_data(experiment.id)
-
-    def test_results_data_warns_when_week_2_retention_is_missing(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-        )
-        experiment.reference_branch.slug = "control"
-        experiment.reference_branch.save()
-
-        def mock_jetstream_data_by_window(_, window):
-            if window == AnalysisWindow.WEEKLY:
-                return [
-                    {
-                        "metric": Metric.RETENTION,
-                        "statistic": "binomial",
-                        "branch": "control",
-                        "point": 0.5,
-                        "segment": "all",
-                        "analysis_basis": "enrollments",
-                        "window_index": "1",
-                    }
-                ]
-            if window == AnalysisWindow.OVERALL:
-                return [
-                    {
-                        "metric": "identity",
-                        "statistic": "count",
-                        "branch": "control",
-                        "point": 10,
-                        "segment": "all",
-                        "analysis_basis": "enrollments",
-                        "window_index": "1",
-                    }
-                ]
-            return []
-
-        with (
-            patch("experimenter.jetstream.client.get_data") as mock_get_data,
-            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
-            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
-        ):
-            mock_get_data.side_effect = mock_jetstream_data_by_window
-            mock_get_metadata.return_value = None
-            mock_get_errors.return_value = None
-
-            tasks.fetch_experiment_data(experiment.id)
-
-        experiment.refresh_from_db()
-        errors = experiment.results_data["v3"]["errors"]["experiment"]
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0]["metric"], Metric.RETENTION)
-        self.assertEqual(
-            errors[0]["message"],
-            "Week 2 retention is unavailable because this experiment did not run "
-            "long enough.",
-        )
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/jetstream/tests/test_tasks.py
+++ b/experimenter/experimenter/jetstream/tests/test_tasks.py
@@ -35,7 +35,7 @@ from experimenter.jetstream.client import (
     get_stored_analysis_start_time,
     has_missing_expected_results,
 )
-from experimenter.jetstream.models import AnalysisWindow, Group, Metric
+from experimenter.jetstream.models import AnalysisWindow, Group
 from experimenter.jetstream.tests import mock_valid_outcomes
 from experimenter.jetstream.tests.constants import (
     JetstreamTestData,
@@ -1067,61 +1067,6 @@ class TestFetchJetstreamDataTask(MockSizingDataMixin, TestCase):
             mock_get_metadata.return_value = None
             mock_get_errors.return_value = None
             tasks.fetch_experiment_data(experiment.id)
-
-    def test_results_data_warns_when_week_2_retention_is_missing(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-        )
-        experiment.reference_branch.slug = "control"
-        experiment.reference_branch.save()
-
-        def mock_jetstream_data_by_window(_, window):
-            if window == AnalysisWindow.WEEKLY:
-                return [
-                    {
-                        "metric": Metric.RETENTION,
-                        "statistic": "binomial",
-                        "branch": "control",
-                        "point": 0.5,
-                        "segment": "all",
-                        "analysis_basis": "enrollments",
-                        "window_index": "1",
-                    }
-                ]
-            if window == AnalysisWindow.OVERALL:
-                return [
-                    {
-                        "metric": "identity",
-                        "statistic": "count",
-                        "branch": "control",
-                        "point": 10,
-                        "segment": "all",
-                        "analysis_basis": "enrollments",
-                        "window_index": "1",
-                    }
-                ]
-            return []
-
-        with (
-            patch("experimenter.jetstream.client.get_data") as mock_get_data,
-            patch("experimenter.jetstream.client.get_metadata") as mock_get_metadata,
-            patch("experimenter.jetstream.client.get_analysis_errors") as mock_get_errors,
-        ):
-            mock_get_data.side_effect = mock_jetstream_data_by_window
-            mock_get_metadata.return_value = None
-            mock_get_errors.return_value = None
-
-            tasks.fetch_experiment_data(experiment.id)
-
-        experiment.refresh_from_db()
-        errors = experiment.results_data["v3"]["errors"]["experiment"]
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0]["metric"], Metric.RETENTION)
-        self.assertEqual(
-            errors[0]["message"],
-            "Week 2 retention is unavailable because this experiment did not run "
-            "long enough.",
-        )
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/metric_popout.html
@@ -106,7 +106,7 @@
             </div>
           </div>
           {% with weekly_metric_data=all_weekly_metric_data|dict_get:metric_info.slug %}
-            {% if weekly_metric_data.has_weekly_data and not metric_info.slug in NimbusUIConstants.HIDDEN_WEEKLY_METRICS %}
+            {% if weekly_metric_data.has_weekly_data and not metric_info.slug in hidden_weekly_metrics %}
               <div class="border border-1 rounded py-4 px-5 rounded-4">
                 <h2 class="fs-6 fw-bold">Weekly breakdown</h2>
                 <div class="d-flex mt-3">
@@ -168,7 +168,7 @@
             {% endif %}
           {% endwith %}
           {% with daily_metric_data=all_daily_metric_data|dict_get:metric_info.slug %}
-            {% if daily_metric_data.has_daily_data and not metric_info.slug in NimbusUIConstants.HIDDEN_DAILY_METRICS %}
+            {% if daily_metric_data.has_daily_data and not metric_info.slug in hidden_daily_metrics %}
               <div class="border border-1 rounded py-4 px-5 rounded-4">
                 <h2 class="fs-6 fw-bold">Daily breakdown</h2>
                 <div class="d-flex mt-3">

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -34,6 +34,7 @@ from experimenter.experiments.tests.factories import (
     NimbusVersionedSchemaFactory,
     TagFactory,
 )
+from experimenter.jetstream.models import Metric
 from experimenter.kinto.tasks import (
     nimbus_check_kinto_push_queue_by_collection,
     nimbus_synchronize_preview_experiments_in_kinto,
@@ -3326,6 +3327,42 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["experiment"], experiment)
         self.assertTemplateUsed(response, "nimbus_experiments/results.html")
+
+    @patch("experimenter.nimbus_ui.views.ExperimentResultsManager.get_metric_data")
+    def test_results_view_hides_weekly_retention_metric_breakdowns(
+        self, mock_get_metric_data
+    ):
+        retention_slug = Metric.WEEKLY_RETENTION.format(6)
+        mock_get_metric_data.return_value = {
+            "Other Metrics": {
+                "metrics": [
+                    {
+                        "slug": retention_slug,
+                        "group": "other_metrics",
+                        "has_data": False,
+                    },
+                    {
+                        "slug": "days_of_use",
+                        "group": "other_metrics",
+                        "has_data": False,
+                    },
+                ],
+                "data": {},
+                "label_details": None,
+            }
+        }
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-results", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertIn(retention_slug, response.context["hidden_weekly_metrics"])
+        self.assertIn(retention_slug, response.context["hidden_daily_metrics"])
+        self.assertNotIn("days_of_use", response.context["hidden_weekly_metrics"])
+        self.assertNotIn("days_of_use", response.context["hidden_daily_metrics"])
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -37,6 +37,7 @@ from experimenter.experiments.tests.factories import (
     NimbusVersionedSchemaFactory,
     TagFactory,
 )
+from experimenter.jetstream.models import Metric
 from experimenter.kinto.tasks import (
     nimbus_check_kinto_push_queue_by_collection,
     nimbus_synchronize_preview_experiments_in_kinto,
@@ -3717,6 +3718,42 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["experiment"], experiment)
         self.assertTemplateUsed(response, "nimbus_experiments/results.html")
+
+    @patch("experimenter.nimbus_ui.views.ExperimentResultsManager.get_metric_data")
+    def test_results_view_hides_weekly_retention_metric_breakdowns(
+        self, mock_get_metric_data
+    ):
+        retention_slug = Metric.WEEKLY_RETENTION.format(6)
+        mock_get_metric_data.return_value = {
+            "Other Metrics": {
+                "metrics": [
+                    {
+                        "slug": retention_slug,
+                        "group": "other_metrics",
+                        "has_data": False,
+                    },
+                    {
+                        "slug": "days_of_use",
+                        "group": "other_metrics",
+                        "has_data": False,
+                    },
+                ],
+                "data": {},
+                "label_details": None,
+            }
+        }
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-results", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertIn(retention_slug, response.context["hidden_weekly_metrics"])
+        self.assertIn(retention_slug, response.context["hidden_daily_metrics"])
+        self.assertNotIn("days_of_use", response.context["hidden_weekly_metrics"])
+        self.assertNotIn("days_of_use", response.context["hidden_daily_metrics"])
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -21,6 +21,7 @@ from experimenter.experiments.models import (
     NimbusVersionedSchema,
     Tag,
 )
+from experimenter.jetstream.models import Metric
 from experimenter.jetstream.results_manager import ExperimentResultsManager
 from experimenter.nimbus_ui.constants import (
     METRICS_MIN_BOUNDS_WIDTH,
@@ -833,6 +834,26 @@ class ResultsView(NimbusExperimentViewMixin, DetailView):
             window=displayed_window,
         )
         context["metric_area_data"] = all_metrics
+
+        metric_slugs = {
+            metric["slug"]
+            for area_data in all_metrics.values()
+            for metric in area_data.get("metrics", [])
+        }
+        retention_prefix, retention_suffix = Metric.WEEKLY_RETENTION.split("{}")
+        weekly_retention_slugs = {
+            slug
+            for slug in metric_slugs
+            if slug.startswith(retention_prefix) and slug.endswith(retention_suffix)
+        }
+        context["hidden_weekly_metrics"] = {
+            *NimbusUIConstants.HIDDEN_WEEKLY_METRICS,
+            *weekly_retention_slugs,
+        }
+        context["hidden_daily_metrics"] = {
+            *NimbusUIConstants.HIDDEN_DAILY_METRICS,
+            *weekly_retention_slugs,
+        }
 
         context["ask_experimenter_slack_link"] = settings.ASK_EXPERIMENTER_SLACK_LINK
 

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -21,6 +21,7 @@ from experimenter.experiments.models import (
     NimbusVersionedSchema,
     Tag,
 )
+from experimenter.jetstream.models import Metric
 from experimenter.jetstream.results_manager import ExperimentResultsManager
 from experimenter.nimbus_ui.constants import (
     METRICS_MIN_BOUNDS_WIDTH,
@@ -846,6 +847,26 @@ class ResultsView(PrefetchExperimentQuerysetMixin, NimbusExperimentViewMixin, De
             window=displayed_window,
         )
         context["metric_area_data"] = all_metrics
+
+        metric_slugs = {
+            metric["slug"]
+            for area_data in all_metrics.values()
+            for metric in area_data.get("metrics", [])
+        }
+        retention_prefix, retention_suffix = Metric.WEEKLY_RETENTION.split("{}")
+        weekly_retention_slugs = {
+            slug
+            for slug in metric_slugs
+            if slug.startswith(retention_prefix) and slug.endswith(retention_suffix)
+        }
+        context["hidden_weekly_metrics"] = {
+            *NimbusUIConstants.HIDDEN_WEEKLY_METRICS,
+            *weekly_retention_slugs,
+        }
+        context["hidden_daily_metrics"] = {
+            *NimbusUIConstants.HIDDEN_DAILY_METRICS,
+            *weekly_retention_slugs,
+        }
 
         context["ask_experimenter_slack_link"] = settings.ASK_EXPERIMENTER_SLACK_LINK
 


### PR DESCRIPTION
Because

- The existing retention metric only represented Week 2 preventing users from viewing retention for other weeks

This commit

- Splits retention into fixed weekly metrics, gives each metric the correct displayed window, and hides unrelated breakdowns

Fixes #16421 