### PR TITLE
chore(project): add 7-day Dependabot cooldown to dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -17,6 +19,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -26,6 +30,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -35,6 +41,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -44,6 +52,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -53,6 +63,8 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "*"
         update-types:
@@ -65,3 +77,5 @@ updates:
     schedule:
       interval: weekly
     target-branch: main
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Because

* A compromised package version is usually detected and yanked within days of release, so bumping to a brand-new release risks pulling in a malicious-then-yanked version before it is caught.
* Delaying version-update PRs mitigates this supply-chain attack window.

This commit

* Adds a 7-day cooldown (default-days: 7) to all 7 entries in .github/dependabot.yml.
* Cooldown applies to version updates only, not security updates.

Fixes #16513