### PR TITLE
fix(nimbus): Rollouts can be stuck during review

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -934,6 +934,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ERROR_CANNOT_PAUSE_INVALID = "Cannot end enrollment at this time"
 
+    ERROR_CANNOT_UPDATE_ROLLOUT_NOT_DIRTY = (
+        "Cannot request an update: there are no unpublished changes"
+    )
+
     ERROR_CANNOT_PARSE_TARGETING = "Cannot parse targeting expression"
 
     ERROR_MOBILE_MESSAGING_EXPERIMENT_FIELD = (

--- a/experimenter/experimenter/experiments/migrations/0336_unwedge_rollout_update_review.py
+++ b/experimenter/experimenter/experiments/migrations/0336_unwedge_rollout_update_review.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def unwedge_rollout_update_review(apps, schema_editor):
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+    NimbusExperiment.objects.filter(
+        is_rollout=True,
+        status="Live",
+        status_next="Live",
+        publish_status="Review",
+        is_rollout_dirty=False,
+        is_paused=False,
+    ).update(publish_status="Idle", status_next=None)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0335_nimbusexperiment_sizing_data_updated_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            unwedge_rollout_update_review, migrations.RunPython.noop
+        ),
+    ]

--- a/experimenter/experimenter/experiments/tests/test_migrations.py
+++ b/experimenter/experimenter/experiments/tests/test_migrations.py
@@ -1,14 +1,14 @@
 from django_test_migrations.contrib.unittest_case import MigratorTestCase
 
 
-class TestClearMonitoringDataMigration(MigratorTestCase):
+class TestUnwedgeRolloutUpdateReviewMigration(MigratorTestCase):
     migrate_from = (
         "experiments",
-        "0326_alter_nimbusexperiment_next_steps_and_more",
+        "0335_nimbusexperiment_sizing_data_updated_at",
     )
     migrate_to = (
         "experiments",
-        "0327_clear_monitoring_data_non_live_complete",
+        "0336_unwedge_rollout_update_review",
     )
 
     def prepare(self):
@@ -22,32 +22,78 @@ class TestClearMonitoringDataMigration(MigratorTestCase):
             defaults={"email": "test@example.com"},
         )
 
-        self.monitoring_data = {"total_enrollments": 100, "total_unenrollments": 5}
-
-        for status in ("Draft", "Preview", "Live", "Complete"):
-            NimbusExperiment.objects.create(
-                slug=f"test-{status.lower()}",
-                name=f"Test {status}",
-                application="firefox-desktop",
-                owner=owner,
-                status=status,
-                monitoring_data=self.monitoring_data,
-            )
+        NimbusExperiment.objects.create(
+            slug="wedged",
+            name="Wedged rollout",
+            application="firefox-desktop",
+            owner=owner,
+            is_rollout=True,
+            status="Live",
+            status_next="Live",
+            publish_status="Review",
+            is_rollout_dirty=False,
+            is_paused=False,
+        )
+        NimbusExperiment.objects.create(
+            slug="dirty-update-review",
+            name="Legitimate dirty update review",
+            application="firefox-desktop",
+            owner=owner,
+            is_rollout=True,
+            status="Live",
+            status_next="Live",
+            publish_status="Review",
+            is_rollout_dirty=True,
+            is_paused=False,
+        )
+        NimbusExperiment.objects.create(
+            slug="paused-end-enrollment-review",
+            name="Legitimate paused end enrollment review",
+            application="firefox-desktop",
+            owner=owner,
+            is_rollout=True,
+            status="Live",
+            status_next="Live",
+            publish_status="Review",
+            is_rollout_dirty=False,
+            is_paused=True,
+        )
+        NimbusExperiment.objects.create(
+            slug="non-rollout-review",
+            name="Non-rollout experiment review",
+            application="firefox-desktop",
+            owner=owner,
+            is_rollout=False,
+            status="Live",
+            status_next="Live",
+            publish_status="Review",
+            is_rollout_dirty=False,
+            is_paused=False,
+        )
 
     def test_migration(self):
         NimbusExperiment = self.new_state.apps.get_model(
             "experiments", "NimbusExperiment"
         )
 
-        self.assertIsNone(NimbusExperiment.objects.get(slug="test-draft").monitoring_data)
-        self.assertIsNone(
-            NimbusExperiment.objects.get(slug="test-preview").monitoring_data
-        )
-        self.assertEqual(
-            NimbusExperiment.objects.get(slug="test-live").monitoring_data,
-            self.monitoring_data,
-        )
-        self.assertEqual(
-            NimbusExperiment.objects.get(slug="test-complete").monitoring_data,
-            self.monitoring_data,
-        )
+        wedged = NimbusExperiment.objects.get(slug="wedged")
+        self.assertEqual(wedged.status, "Live")
+        self.assertIsNone(wedged.status_next)
+        self.assertEqual(wedged.publish_status, "Idle")
+        self.assertFalse(wedged.is_rollout_dirty)
+        self.assertFalse(wedged.is_paused)
+
+        dirty = NimbusExperiment.objects.get(slug="dirty-update-review")
+        self.assertEqual(dirty.status, "Live")
+        self.assertEqual(dirty.status_next, "Live")
+        self.assertEqual(dirty.publish_status, "Review")
+
+        paused = NimbusExperiment.objects.get(slug="paused-end-enrollment-review")
+        self.assertEqual(paused.status, "Live")
+        self.assertEqual(paused.status_next, "Live")
+        self.assertEqual(paused.publish_status, "Review")
+
+        non_rollout = NimbusExperiment.objects.get(slug="non-rollout-review")
+        self.assertEqual(non_rollout.status, "Live")
+        self.assertEqual(non_rollout.status_next, "Live")
+        self.assertEqual(non_rollout.publish_status, "Review")

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1809,6 +1809,16 @@ class LiveToUpdateRolloutForm(SlackNotificationMixin, UpdateStatusForm):
 
     slack_action = SlackConstants.SLACK_ACTION_UPDATE_REQUEST
 
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if self.instance and not self.instance.is_rollout_dirty:
+            raise forms.ValidationError(
+                NimbusExperiment.ERROR_CANNOT_UPDATE_ROLLOUT_NOT_DIRTY
+            )
+
+        return cleaned_data
+
     def get_changelog_message(self):
         return f"{self.request.user} requested review to update Audience"
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -2237,6 +2237,7 @@ class TestLiveToUpdateRolloutForm(
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_paused=False,
             is_rollout=True,
+            is_rollout_dirty=True,
         )
         form = LiveToUpdateRolloutForm(data={}, instance=experiment, request=self.request)
         self.assertTrue(form.is_valid(), form.errors)
@@ -2250,6 +2251,22 @@ class TestLiveToUpdateRolloutForm(
         changelog = experiment.changes.latest("changed_on")
         self.assertEqual(changelog.changed_by, self.user)
         self.assertIn("requested review to update Audience", changelog.message)
+
+    def test_invalid_when_rollout_not_dirty(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_paused=False,
+            is_rollout=True,
+            is_rollout_dirty=False,
+        )
+        form = LiveToUpdateRolloutForm(data={}, instance=experiment, request=self.request)
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            NimbusExperiment.ERROR_CANNOT_UPDATE_ROLLOUT_NOT_DIRTY,
+            form.errors["__all__"],
+        )
 
     @parameterized.expand(
         [
@@ -2293,6 +2310,7 @@ class TestLiveToUpdateRolloutForm(
             status_next=None,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            is_rollout_dirty=True,
             enable_review_slack_notifications=False,
         )
         form = LiveToUpdateRolloutForm(data={}, instance=experiment, request=self.request)
@@ -2311,6 +2329,7 @@ class TestLiveToUpdateRolloutForm(
             status_next=None,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            is_rollout_dirty=True,
             enable_review_slack_notifications=True,
         )
         form = LiveToUpdateRolloutForm(data={}, instance=experiment, request=self.request)

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -2776,6 +2776,7 @@ class TestLaunchViews(AuthTestCase):
             status_next=None,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            is_rollout_dirty=True,
         )
 
         response = self.client.post(
@@ -2788,6 +2789,23 @@ class TestLaunchViews(AuthTestCase):
 
         changelog = experiment.changes.latest("changed_on")
         self.assertIn("requested review to update Audience", changelog.message)
+
+    def test_live_to_update_rollout_view_does_not_transition_when_not_dirty(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+            is_rollout_dirty=False,
+        )
+
+        response = self.client.post(
+            reverse("nimbus-ui-live-to-update-rollout", kwargs={"slug": experiment.slug}),
+        )
+        self.assertEqual(response.status_code, 200)
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status_next, None)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
 
     def test_cancel_update_rollout_view_with_rejection(self):
         experiment = NimbusExperimentFactory.create(


### PR DESCRIPTION
Because

* A stale/duplicate "Request Update" POST can transition a rollout to `(Live, Live, Review, is_rollout_dirty=False)`, a state the summary page renders no working controls for, so the recipe cannot be advanced from the UI.
* The only existing guard was the button's client-side `disabled` attribute; `LiveToUpdateRolloutForm.clean()` never checked `is_rollout_dirty`.

This commit

* Adds a `clean()` to `LiveToUpdateRolloutForm` that rejects the transition when the rollout has no unpublished changes, with a new `ERROR_CANNOT_UPDATE_ROLLOUT_NOT_DIRTY` constant.
* Adds a data migration that resets already-wedged rollouts to `(Live, None, Idle)`, selecting only the precisely-wedged tuple so legitimate dirty update reviews and paused end-enrollment reviews are untouched.

Fixes #16516