### PR TITLE
feat(nimbus): Map fields with Targeting context recorder

### DIFF
--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -272,6 +272,15 @@ def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]
             right = f"'{right.lower()}'"
         elif left in ("TRUE", "FALSE") and _is_json_string_expr(right):
             left = f"'{left.lower()}'"
+        # In JEXL, pref|preferenceValue returns null when the pref is not explicitly set.
+        # null != 'false' is true in JEXL — unset prefs should pass a != false check.
+        # JSON_VALUE returns NULL for unset prefs; NULL != 'false' is NULL in SQL (falsy),
+        # which would incorrectly exclude users on the browser default.
+        # Fix: (col IS NULL OR col != 'false') matches JEXL semantics.
+        if sql_op == "!=" and right in ("'false'", "'true'") and _is_json_string_expr(left):
+            return f"({left} IS NULL OR {left} != {right})"
+        if sql_op == "!=" and left in ("'false'", "'true'") and _is_json_string_expr(right):
+            return f"({right} IS NULL OR {left} != {right})"
         return f"{left} {sql_op} {right}"
     if op in arithmetic_ops:
         return f"({left} {arithmetic_ops[op]} {right})"

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -56,6 +56,10 @@ JEXL_TO_BQ_COLUMN = {
         "metrics.boolean.nimbus_targeting_context_user_prefers_reduced_motion"
     ),
     "usesFirefoxSync": "metrics.boolean.nimbus_targeting_context_uses_firefox_sync",
+    # Only usable via |length transform; listed here so the context-coverage check passes
+    "userMonthlyActivity": (
+        "metrics.object.nimbus_targeting_context_user_monthly_activity"
+    ),
     # isWindows is not stored — derived from absence of isMac and isLinux
     "os.isWindows": (
         f"(NOT CAST(JSON_VALUE({_OS}, '$.isMac') AS BOOL)"
@@ -142,6 +146,10 @@ KNOWN_UNTRANSLATABLE = {
     "no_shortcuts_or_stories_opt_outs",
     "android_sdk_version",
     "install_referrer_response_utm_source",
+    # In Desktop targeting context but not yet confirmed in nimbus_targeting_context BQ
+    # schema — move to JEXL_TO_BQ_COLUMN once the column is verified to exist
+    "launchOnLoginAllowedByPolicy",
+    "launchOnLoginEnabled",
     # Standalone sub-fields accessed without parent (default PDF handler context)
     "pdf",
     "knownBrowser",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -56,6 +56,12 @@ JEXL_TO_BQ_COLUMN = {
         "metrics.boolean.nimbus_targeting_context_user_prefers_reduced_motion"
     ),
     "usesFirefoxSync": "metrics.boolean.nimbus_targeting_context_uses_firefox_sync",
+    "launchOnLoginAllowedByPolicy": (
+        "metrics.boolean.nimbus_targeting_context_launch_on_login_allowed_by_policy"
+    ),
+    "launchOnLoginEnabled": (
+        "metrics.boolean.nimbus_targeting_context_launch_on_login_enabled"
+    ),
     # Only usable via |length transform; listed here so the context-coverage check passes
     "userMonthlyActivity": (
         "metrics.object.nimbus_targeting_context_user_monthly_activity"
@@ -146,10 +152,6 @@ KNOWN_UNTRANSLATABLE = {
     "no_shortcuts_or_stories_opt_outs",
     "android_sdk_version",
     "install_referrer_response_utm_source",
-    # In Desktop targeting context but not yet confirmed in nimbus_targeting_context BQ
-    # schema — move to JEXL_TO_BQ_COLUMN once the column is verified to exist
-    "launchOnLoginAllowedByPolicy",
-    "launchOnLoginEnabled",
     # Standalone sub-fields accessed without parent (default PDF handler context)
     "pdf",
     "knownBrowser",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -62,7 +62,6 @@ JEXL_TO_BQ_COLUMN = {
     "launchOnLoginEnabled": (
         "metrics.boolean.nimbus_targeting_context_launch_on_login_enabled"
     ),
-    # Only usable via |length transform; listed here so the context-coverage check passes
     "userMonthlyActivity": (
         "metrics.object.nimbus_targeting_context_user_monthly_activity"
     ),

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -266,8 +266,8 @@ def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]
                 return f"NOT ({expr})" if is_filter_result else f"{expr} IS NULL"
             if sql_op == "!=":
                 return expr if is_filter_result else f"{expr} IS NOT NULL"
-        # JSON_VALUE returns STRING; comparing to a BOOL literal (TRUE/FALSE) is invalid.
-        # 'pref'|preferenceValue == false → JSON_VALUE(...) = 'false' (string comparison).
+        # JSON_VALUE returns STRING; comparing to a BOOL literal is invalid.
+        # 'pref'|preferenceValue == false → JSON_VALUE(...) = 'false'.
         if right in ("TRUE", "FALSE") and _is_json_string_expr(left):
             right = f"'{right.lower()}'"
         elif left in ("TRUE", "FALSE") and _is_json_string_expr(right):
@@ -277,9 +277,10 @@ def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]
         # JSON_VALUE returns NULL for unset prefs; NULL != 'false' is NULL in SQL (falsy),
         # which would incorrectly exclude users on the browser default.
         # Fix: (col IS NULL OR col != 'false') matches JEXL semantics.
-        if sql_op == "!=" and right in ("'false'", "'true'") and _is_json_string_expr(left):
+        _bool_strs = ("'false'", "'true'")
+        if sql_op == "!=" and right in _bool_strs and _is_json_string_expr(left):
             return f"({left} IS NULL OR {left} != {right})"
-        if sql_op == "!=" and left in ("'false'", "'true'") and _is_json_string_expr(right):
+        if sql_op == "!=" and left in _bool_strs and _is_json_string_expr(right):
             return f"({right} IS NULL OR {left} != {right})"
         return f"{left} {sql_op} {right}"
     if op in arithmetic_ops:
@@ -343,7 +344,7 @@ def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
         return None
 
     if node.name == "date":
-        # profileAgeCreated is stored as epoch ms — return column directly for arithmetic
+        # profileAgeCreated is epoch ms — return column directly for arithmetic
         if subject_path == "profileAgeCreated":
             return JEXL_TO_BQ_COLUMN["profileAgeCreated"]
         if subject_path == "currentDate":

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -345,8 +345,6 @@ def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
     if node.name == "length":
         # BigQuery has no JSON_ARRAY_LENGTH for STRING columns — metrics.object.*
         # columns are JSON strings, so use ARRAY_LENGTH(JSON_QUERY_ARRAY(...)).
-        if subject_path == "userMonthlyActivity":
-            return f"ARRAY_LENGTH(JSON_QUERY_ARRAY({_USER_MONTHLY_ACTIVITY_COL}))"
         subject_sql = _node_to_sql(node.subject, warnings)
         if subject_sql:
             return f"ARRAY_LENGTH(JSON_QUERY_ARRAY({subject_sql}))"

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -151,6 +151,19 @@ class TestJEXLToSQL(TestCase):
                 "false == 'browser.shell.checkDefaultBrowser'|preferenceValue",
                 f"'false' = JSON_VALUE({_PREF}, '$.browser__shell__checkDefaultBrowser')",
             ),
+            (
+                "pref_value_neq_bool_false",
+                # null != false is true in JEXL — unset prefs (NULL) must pass
+                "'app.shield.optoutstudies.enabled'|preferenceValue != false",
+                f"(JSON_VALUE({_PREF}, '$.app__shield__optoutstudies__enabled') IS NULL"
+                f" OR JSON_VALUE({_PREF}, '$.app__shield__optoutstudies__enabled') != 'false')",
+            ),
+            (
+                "pref_value_neq_bool_true",
+                "'some.pref'|preferenceValue != true",
+                f"(JSON_VALUE({_PREF}, '$.some__pref') IS NULL"
+                f" OR JSON_VALUE({_PREF}, '$.some__pref') != 'true')",
+            ),
         ]
     )
     def test_comparison_produces_correct_sql(self, _name, jexl, expected_sql):

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -165,6 +165,12 @@ class TestJEXLToSQL(TestCase):
                 f"(JSON_VALUE({_PREF}, '$.some__pref') IS NULL"
                 f" OR JSON_VALUE({_PREF}, '$.some__pref') != 'true')",
             ),
+            (
+                "pref_value_neq_bool_reversed",
+                "false != 'app.normandy.enabled'|preferenceValue",
+                f"(JSON_VALUE({_PREF}, '$.app__normandy__enabled') IS NULL"
+                f" OR 'false' != JSON_VALUE({_PREF}, '$.app__normandy__enabled'))",
+            ),
         ]
     )
     def test_comparison_produces_correct_sql(self, _name, jexl, expected_sql):

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -155,8 +155,9 @@ class TestJEXLToSQL(TestCase):
                 "pref_value_neq_bool_false",
                 # null != false is true in JEXL — unset prefs (NULL) must pass
                 "'app.shield.optoutstudies.enabled'|preferenceValue != false",
-                f"(JSON_VALUE({_PREF}, '$.app__shield__optoutstudies__enabled') IS NULL"
-                f" OR JSON_VALUE({_PREF}, '$.app__shield__optoutstudies__enabled') != 'false')",
+                f"(JSON_VALUE({_PREF}, '$.app__shield__optoutstudies__enabled')"
+                f" IS NULL OR JSON_VALUE({_PREF},"
+                f" '$.app__shield__optoutstudies__enabled') != 'false')",
             ),
             (
                 "pref_value_neq_bool_true",

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -65,6 +65,38 @@ class TestTargetingConfigs(TestCase):
                 f"JEXL_TO_BQ_COLUMN or KNOWN_UNTRANSLATABLE.",
             )
 
+    def test_desktop_targeting_context_fields_are_mapped(self):
+        """Every field in the Desktop targeting context must be in JEXL_TO_BQ_COLUMN
+        or KNOWN_UNTRANSLATABLE.
+
+        This test runs against the real (unversioned) Desktop targeting context file.
+        When an Update External Configs PR adds a new field to the recorded targeting
+        context, this test fails, requiring the SQL mapping to be updated in the same
+        PR before the field can be referenced in any targeting config.
+        """
+        desktop_fields = TargetingContextFields.for_application(Application.DESKTOP)
+
+        all_mapped_prefixes = {
+            key.split(".")[0] for key in JEXL_TO_BQ_COLUMN
+        } | set(JEXL_TO_BQ_COLUMN)
+        all_untranslatable_prefixes = {
+            key.split(".")[0] for key in KNOWN_UNTRANSLATABLE
+        } | set(KNOWN_UNTRANSLATABLE)
+
+        unmapped = [
+            field
+            for field in desktop_fields
+            if field not in all_mapped_prefixes
+            and field not in all_untranslatable_prefixes
+        ]
+
+        self.assertFalse(
+            unmapped,
+            f"Desktop targeting context fields not covered by JEXL_TO_BQ_COLUMN "
+            f"or KNOWN_UNTRANSLATABLE: {unmapped}. "
+            f"Add a mapping in jexl_to_sql.py or add to KNOWN_UNTRANSLATABLE.",
+        )
+
     @parameterized.expand([(t,) for t in TargetingConstants.TARGETING_CONFIGS.values()])
     def test_validate_targeting_config_fields(self, targeting_config):
         valid_fields = set()

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -76,9 +76,9 @@ class TestTargetingConfigs(TestCase):
         """
         desktop_fields = TargetingContextFields.for_application(Application.DESKTOP)
 
-        all_mapped_prefixes = {
-            key.split(".")[0] for key in JEXL_TO_BQ_COLUMN
-        } | set(JEXL_TO_BQ_COLUMN)
+        all_mapped_prefixes = {key.split(".")[0] for key in JEXL_TO_BQ_COLUMN} | set(
+            JEXL_TO_BQ_COLUMN
+        )
         all_untranslatable_prefixes = {
             key.split(".")[0] for key in KNOWN_UNTRANSLATABLE
         } | set(KNOWN_UNTRANSLATABLE)


### PR DESCRIPTION
Because

- When a new field is added to the Desktop targeting context (`ATTRIBUTE_TRANSFORMS)`, there's no automated check to ensure the SQL/JEXL mapping is updated at the same time. This means a new field could be referenced in a targeting config before the BigQuery translation is in place.

This commit

- Adds `test_desktop_targeting_context_fields_are_mapped `which reads the real` TargetingContextRecorder.sys.mjs` and asserts every field in ATTRIBUTE_TRANSFORMS is either in `JEXL_TO_BQ_COLUMN or KNOWN_UNTRANSLATABLE.` When an Update External Configs PR lands, CI fails if a new field has no mapping, requiring it to be added in the same PR.
- Adds` launchOnLoginAllowedByPolicy` and `launchOnLoginEnabled` to JEXL_TO_BQ_COLUMN (confirmed in BQ schema: metrics.boolean.nimbus_targeting_context_launch_on_login_*)
- Adds `userMonthlyActivity to JEXL_TO_BQ_COLUMN` so the context coverage check passes and the |length transform works via the generic path
- Fixes` pref|preferenceValue != false` translation — unset prefs are NULL in BigQuery but `null != false` is true in JEXL, so unset prefs should pass. Now generates (col IS NULL OR col != 'false')

Fixes #16506 