### PR TITLE
feat(nimbus): Disable first run for Labs experiments

### DIFF
--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -721,6 +721,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     is_holdback = forms.BooleanField(
         required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
     )
+    is_first_run = forms.BooleanField(required=False, widget=forms.HiddenInput())
 
     update_on_change_fields = (
         "equal_branch_ratio",
@@ -746,6 +747,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "firefox_labs_description_links",
             "firefox_labs_group",
             "requires_restart",
+            "is_first_run",
             "is_holdback",
         )
         widgets = {
@@ -827,6 +829,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
         if not self.was_labs_opt_in and cleaned_data["is_firefox_labs_opt_in"]:
             cleaned_data["is_rollout"] = True
+            cleaned_data["is_first_run"] = False
         elif not cleaned_data["is_rollout"]:
             cleaned_data["is_firefox_labs_opt_in"] = False
 
@@ -1177,6 +1180,9 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
             for field_name in self.fields:
                 if field_name != "population_percent":
                     self.fields[field_name].disabled = True
+
+        if self.instance.is_firefox_labs_opt_in:
+            self.fields["is_first_run"].disabled = True
 
     def format_branch_choice(self, experiment_slug, experiment_name, branch_slug):
         if branch_slug is None:

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -26,6 +26,7 @@
           hx-target="#content-with-sidebar"
           hx-swap="innerHTML">
       {% csrf_token %}
+      {{ form.is_first_run }}
       <div class="card mb-3">
         <div class="card-header">
           <h4>Branches</h4>

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -3159,6 +3159,20 @@ class TestAudienceForm(RequestFormTestCase):
             msg="Channel choices did not match for desktop",
         )
 
+    def test_is_first_run_disabled_for_labs(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="",
+            firefox_labs_description="",
+            is_rollout=True,
+        )
+
+        form = AudienceForm(instance=experiment, request=self.request)
+
+        self.assertTrue(form.fields["is_first_run"].disabled)
+
 
 class TestNimbusBranchesForm(RequestFormTestCase):
     def test_branches_form_saves_branches(self):
@@ -4342,6 +4356,25 @@ class TestNimbusBranchesForm(RequestFormTestCase):
         self.assertEqual(
             expected_branch_ids, [branch_b.slug, branch_a.slug, branch_c.slug]
         )
+
+    def test_disables_first_run_when_becomes_lab(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            is_first_run=True,
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                "is_firefox_labs_opt_in": True,
+            },
+        )
+
+        experiment = form.save()
+
+        self.assertFalse(experiment.is_first_run)
 
 
 class TestNimbusBranchCreateForm(RequestFormTestCase):


### PR DESCRIPTION
Because:

- Firefox Labs does not support first run experiments

this commit:

- sets first run to false when experiments become Firefox Labs
- disables the first run field for Firefox Labs

Fixes #16261