### PR TITLE
feat(nimbus): Add archive button to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -38,6 +38,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY = "10%"
     SRM_P_VALUE_THRESHOLD_DISPLAY = "0.001"
 
+    ARCHIVE_DISABLED_TOOLTIP = (
+        "Experiments can only be archived when in Draft or Complete."
+    )
+
     PUBLIC_DESCRIPTION_TEXT = "This description will be public to users on about:studies"
     RISK_AI_TEXT = (
         "Note: Selecting Yes will exclude all users that have opted out of "

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -12,6 +12,7 @@ from experimenter.nimbus_ui.filtersets import (
     TagSearchFilterSet,
     UserSearchFilterSet,
 )
+from experimenter.nimbus_ui.forms import ToggleArchiveForm
 from experimenter.nimbus_ui.new.forms import (
     AdvancePhaseReviewApproveRolloutForm,
     AdvancePhaseReviewRejectRolloutForm,
@@ -647,6 +648,18 @@ class NewCloneView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
             response.headers["HX-Redirect"] = reverse(
                 "new-nimbus-ui-rollout-detail", kwargs={"slug": self.object.slug}
             )
+        return response
+
+
+class NewToggleArchiveView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):
+    form_class = ToggleArchiveForm
+    template_name = "new/common/base.html"
+
+    def form_valid(self, form):
+        form.save()
+        response = HttpResponse()
+        if self.request.headers.get("HX-Request"):
+            response.headers["HX-Refresh"] = "true"
         return response
 
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -67,8 +67,25 @@
                             type="button"
                             data-bs-toggle="modal"
                             data-bs-target="#cloneModal">
-                      <i class="fa-regular fa-copy me-2"></i>Clone
+                      <i class="fa-regular fa-copy fa-fw me-2"></i>Clone
                     </button>
+                  </li>
+                  <li>
+                    <form hx-post="{% url 'nimbus-ui-new-toggle-archive' experiment.slug %}"
+                          class="d-flex align-items-center">
+                      {% csrf_token %}
+                      <button class="dropdown-item"
+                              type="submit"
+                              {% if not experiment.can_archive %}disabled{% endif %}>
+                        <i class="fa-regular fa-trash-can fa-fw me-2"></i>{{ experiment.is_archived|yesno:"Unarchive,Archive" }}
+                      </button>
+                      {% if not experiment.can_archive %}
+                        <i class="fa-regular fa-circle-question fa-sm text-secondary pe-3"
+                           data-bs-toggle="tooltip"
+                           data-bs-placement="left"
+                           title="{{ NimbusUIConstants.ARCHIVE_DISABLED_TOOLTIP }}"></i>
+                      {% endif %}
+                    </form>
                   </li>
                 </ul>
               </div>
@@ -78,6 +95,7 @@
                 <span class="badge rounded-pill fw-medium small"
                       style="background-color: #2AC3A2">Rollout</span>
               {% endif %}
+              {% if experiment.is_archived %}<span class="badge rounded-pill bg-danger fw-medium small">Archived</span>{% endif %}
               <button id="experiment-slug"
                       class="btn p-0 border-0 text-secondary d-flex align-items-center gap-1 small"
                       aria-label="Copy slug">

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1628,6 +1628,66 @@ class TestNewCloneView(AuthTestCase):
         self.assertEqual(response.context["experiment"], self.experiment)
 
 
+class TestNewToggleArchiveView(AuthTestCase):
+    def setUp(self):
+        super().setUp()
+        self.experiment = NimbusExperiment.objects.create(
+            slug="test-experiment",
+            name="Test Experiment",
+            owner=self.user,
+            is_archived=False,
+        )
+
+    def test_toggle_archive_status_to_archive(self):
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-toggle-archive", kwargs={"slug": self.experiment.slug}
+            ),
+            {"owner": self.user},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("HX-Refresh"), "true")
+
+        updated_experiment = NimbusExperiment.objects.get(slug=self.experiment.slug)
+        self.assertTrue(updated_experiment.is_archived)
+
+    def test_toggle_archive_status_to_unarchive(self):
+        self.experiment.is_archived = True
+        self.experiment.save()
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-toggle-archive", kwargs={"slug": self.experiment.slug}
+            ),
+            {"owner": self.user},
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get("HX-Refresh"), "true")
+
+        updated_experiment = NimbusExperiment.objects.get(slug=self.experiment.slug)
+        self.assertFalse(updated_experiment.is_archived)
+
+    def test_detail_page_renders_archive_button(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            reverse("nimbus-ui-new-toggle-archive", kwargs={"slug": experiment.slug}),
+        )
+        self.assertContains(response, "Archive")
+
+
 class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
     def test_detail_page_renders_toggle_checked(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -38,6 +38,7 @@ from experimenter.nimbus_ui.new.views import (
     NewSubscriberSearchView,
     NewSubscribeView,
     NewTagSearchView,
+    NewToggleArchiveView,
     NewToggleReviewSlackNotificationsView,
     NewUnsubscribeView,
     NimbusRolloutDetailView,
@@ -558,5 +559,10 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/toggle_review_slack_notifications/$",
         NewToggleReviewSlackNotificationsView.as_view(),
         name="nimbus-ui-new-toggle-review-slack-notifications",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/toggle-archive/$",
+        NewToggleArchiveView.as_view(),
+        name="nimbus-ui-new-toggle-archive",
     ),
 ]


### PR DESCRIPTION
Because

* The new UI is missing the archive button and functionality

This commit

* Adds an archive button

Fixes #16444


https://github.com/user-attachments/assets/ac053d99-71ee-46e7-b28e-5aebed872c8a

