### PR TITLE
perf(nimbus): reduce redundant queries on Nimbus UI experiment edit pages

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -58,12 +58,15 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
         return (
             super()
             .get_queryset()
+            .select_related(
+                "reference_branch",
+                "bucket_range",
+                "bucket_range__isolation_group",
+            )
             .prefetch_related(
                 "locales",
                 "languages",
                 "countries",
-                "bucket_range",
-                "bucket_range__isolation_group",
                 Prefetch(
                     "bucket_range__isolation_group__bucket_ranges",
                     queryset=NimbusBucketRange.objects.filter(
@@ -72,13 +75,13 @@ class NimbusExperimentManager(models.Manager["NimbusExperiment"]):
                     ),
                     to_attr="desktop_group_id_ranges",
                 ),
-                "reference_branch",
                 "branches",
                 "branches__feature_values",
                 "branches__feature_values__feature_config",
                 "branches__screenshots",
                 "feature_configs",
                 "documentation_links",
+                "tags",
             )
         )
 

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1231,7 +1231,9 @@ class AudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 branch.child_experiment.name,
                 branch.branch_slug,
             )[0]
-            for branch in getattr(self.instance, field_name)
+            for branch in getattr(self.instance, field_name).select_related(
+                "child_experiment"
+            )
         ]
 
     def save_experiments_branches(self, field_name, model):

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_dropdown.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_dropdown.html
@@ -1,5 +1,5 @@
 <div class="dropdown dropup position-static">
-  {% include "common/tag_button.html" with tag_count=experiment.tags.count %}
+  {% include "common/tag_button.html" with tag_count=experiment.tags.all|length %}
 
   <div class="dropdown-menu p-2 shadow-sm border rounded-2"
        style="min-width:180px;
@@ -23,7 +23,7 @@
                  name="tags"
                  id="tag-{{ tag.id }}"
                  value="{{ tag.id }}"
-                 {% if tag in experiment.tags.all %}checked{% endif %}>
+                 {% if tag.id in experiment_tag_ids %}checked{% endif %}>
           <label class="form-check-label d-flex align-items-center"
                  for="tag-{{ tag.id }}">
             <span class="me-1" style="color: {{ tag.color }}">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_response.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/assign_tags_response.html
@@ -1,5 +1,5 @@
 <!-- This updates the dropdown button -->
-{% include "common/tag_button.html" with tag_count=experiment.tags.count %}
+{% include "common/tag_button.html" with tag_count=experiment.tags.all|length %}
 
 <!-- This updates the tags display using out-of-band swap -->
 {% include "nimbus_experiments/experiment_tags.html" with hx_swap_oob=True show_status_badges=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -19,7 +19,7 @@
       <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
     {% endif %}
   {% endif %}
-  {% if experiment.tags.exists %}
+  {% if experiment.tags.all %}
     {% for tag in experiment.tags.all %}
       <span class="badge rounded-pill"
             style="background-color: {{ tag.color }};

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -171,10 +171,22 @@ class RenderParentDBResponseMixin:
 
 
 class PrefetchExperimentQuerysetMixin:
+    _cached_object = None
+
     def get_queryset(self):
         if self.request.method in ("GET", "HEAD"):
             return NimbusExperiment.objects.with_related()
         return super().get_queryset()
+
+    def get_object(self, queryset=None):
+        if self.request.method not in ("GET", "HEAD"):
+            return super().get_object(queryset=queryset)
+        if queryset is None and self._cached_object is not None:
+            return self._cached_object
+        obj = super().get_object(queryset=queryset)
+        if queryset is None:
+            self._cached_object = obj
+        return obj
 
 
 class NimbusExperimentViewMixin:
@@ -191,6 +203,9 @@ class NimbusExperimentViewMixin:
             else []
         )
         context["all_tags"] = Tag.objects.all().order_by("name")
+        context["experiment_tag_ids"] = (
+            {tag.id for tag in experiment.tags.all()} if experiment else set()
+        )
         context["create_form"] = NimbusExperimentCreateForm()
 
         return context


### PR DESCRIPTION
Because

* The experiment edit pages (overview/branches/metrics/audience) issued ~130-180 DB queries per request from several N+1 patterns, making them slow to render.
* The tag dropdown re-queried the experiment's tags once per global tag; the fully prefetched experiment was loaded three times per request; and selected required/excluded relations plus forward-FK relations were fetched one query at a time.

This commit

* Prefetches the experiment's tags and precomputes a tag-id set for the sidebar dropdown so it no longer re-queries per tag.
* Memoizes get_object() per request (GET/HEAD only) so the prefetched experiment loads once instead of three times.
* Uses select_related for the required/excluded child_experiment lookups and for the reference_branch and bucket_range forward FKs.

Fixes #16564