### PR TITLE
fix(nimbus): reduce redundant queries on the new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -67,6 +67,13 @@ class RequestFormMixin:
         return kwargs
 
 
+class PrefetchExperimentQuerysetMixin:
+    def get_queryset(self):
+        if self.request.method in ("GET", "HEAD"):
+            return NimbusExperiment.objects.with_related()
+        return super().get_queryset()
+
+
 class RenderResponseMixin:
     def form_valid(self, form):
         super().form_valid(form)
@@ -261,6 +268,7 @@ class RolloutSetupProgressMixin:
 
 
 class NimbusRolloutDetailView(
+    PrefetchExperimentQuerysetMixin,
     RolloutSetupProgressMixin,
     NimbusExperimentViewMixin,
     CloneExperimentFormMixin,
@@ -285,6 +293,7 @@ class CardMixin:
 
 
 class NewCardUpdateView(
+    PrefetchExperimentQuerysetMixin,
     RolloutSetupProgressMixin,
     NimbusExperimentViewMixin,
     RequestFormMixin,


### PR DESCRIPTION
Because

* The new rollouts UI detail and edit-card pages make many repeated database queries. The with_related() prefetching added in #16534 was not being used by these views, so related data such as branches, feature values, screenshots, and documentation links was queried repeatedly.

This commit

* Adds PrefetchExperimentQuerysetMixin, which uses with_related() for GET and HEAD requests, matching the old UI.
* Applies it to NimbusRolloutDetailView and the NewCardUpdateView base used by rollout edit cards.

Fixes #16554
