### PR TITLE
feat(nimbus): add rollout set up & preview sidebar controls

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1450,9 +1450,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     def can_edit_audience(self):
         return self.is_draft or (self.is_live_rollout and self.is_enrolling)
 
-    def can_edit_schedule(self):
-        return self.is_draft or self.is_live_rollout
-
     def sidebar_links(self, current_path):
         return [
             {

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1144,7 +1144,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def is_preview_complete(self):
-        return self.preview_date is not None and not self.is_preview and not self.is_draft
+        return self.preview_date is not None and self.status not in (
+            self.Status.DRAFT,
+            self.Status.PREVIEW,
+        )
 
     @property
     def days_since_enrollment_start(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -983,7 +983,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         flow_key = None
         if rejection.old_status == self.Status.DRAFT:
-            flow_key = "LAUNCH_EXPERIMENT"
+            flow_key = "LAUNCH_ROLLOUT" if self.is_rollout else "LAUNCH_EXPERIMENT"
         elif rejection.old_status == self.Status.LIVE:
             if rejection.old_status_next == self.Status.LIVE:
                 flow_key = "END_ENROLLMENT"
@@ -1137,6 +1137,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 self._end_date = end_changelog.changed_on.date()
                 self.save()
                 return self._end_date
+
+    @property
+    def is_setup_complete(self):
+        return not self.is_draft
+
+    @property
+    def is_preview_complete(self):
+        return self.preview_date is not None and not self.is_preview and not self.is_draft
 
     @property
     def days_since_enrollment_start(self):
@@ -1302,6 +1310,35 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def is_rollout_with_phases(self):
         return self.is_rollout and self.rollout_phases.exists()
+
+    @property
+    def rollout_review_controls(self):
+        if self.publish_status != self.PublishStatus.REVIEW:
+            return None
+
+        transitions = {
+            (self.Status.DRAFT, self.Status.LIVE): {
+                "action_label": "Launch Rollout",
+                "approve_url": "nimbus-ui-new-draft-review-to-approve-rollout",
+                "reject_url": "nimbus-ui-new-draft-review-to-reject-rollout",
+            },
+            (self.Status.LIVE, self.Status.LIVE): {
+                "action_label": "Advance to Next Phase",
+                "approve_url": "nimbus-ui-new-approve-advance-phase-review-rollout",
+                "reject_url": "nimbus-ui-new-reject-advance-phase-review-rollout",
+            },
+            (self.Status.LIVE, self.Status.DISABLED): {
+                "action_label": "Disable Rollout",
+                "approve_url": "nimbus-ui-new-live-to-disabled-review-approve-rollout",
+                "reject_url": "nimbus-ui-new-live-to-disabled-review-reject-rollout",
+            },
+            (self.Status.DISABLED, self.Status.LIVE): {
+                "action_label": "Start Next Phase",
+                "approve_url": "nimbus-ui-new-disabled-to-live-review-approve-rollout",
+                "reject_url": "nimbus-ui-new-disabled-to-live-review-reject-rollout",
+            },
+        }
+        return transitions.get((self.status, self.status_next))
 
     def annotated_rollout_phases(self):
         phases = list(self.rollout_phases.all())

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7320,6 +7320,31 @@ class TestAdvanceRolloutPhase(TestCase):
         self.assertIsNone(cloned.rollout_phase_next)
 
 
+class TestIsPreviewComplete(TestCase):
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Status.DRAFT, True, False),
+            (NimbusExperiment.Status.PREVIEW, True, False),
+            (NimbusExperiment.Status.LIVE, True, True),
+            (NimbusExperiment.Status.COMPLETE, True, True),
+            (NimbusExperiment.Status.DISABLED, True, True),
+            (NimbusExperiment.Status.LIVE, False, False),
+        ]
+    )
+    def test_is_preview_complete(self, status, has_preview_change, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=True,
+        )
+        if has_preview_change:
+            NimbusChangeLogFactory.create(
+                experiment=experiment,
+                new_status=NimbusExperiment.Status.PREVIEW,
+            )
+
+        self.assertEqual(experiment.is_preview_complete, expected)
+
+
 class TestRolloutReviewControls(TestCase):
     def test_rollout_review_controls_none_when_not_in_review(self):
         experiment = NimbusExperimentFactory.create(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -6910,27 +6910,6 @@ class TestNimbusRolloutPhase(TestCase):
         phase.refresh_from_db()
         self.assertEqual(str(phase), "Rollout phase (25.0000%)")
 
-    def test_can_edit_schedule_draft(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            is_rollout=True,
-        )
-        self.assertTrue(experiment.can_edit_schedule())
-
-    def test_can_edit_schedule_live_rollout(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            is_rollout=True,
-        )
-        self.assertTrue(experiment.can_edit_schedule())
-
-    def test_can_edit_schedule_completed(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
-            is_rollout=True,
-        )
-        self.assertFalse(experiment.can_edit_schedule())
-
     def test_duration_days_and_display(self):
         phase = NimbusRolloutPhaseFactory.build(
             start_date=datetime.date(2026, 1, 1),

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5502,16 +5502,25 @@ class TestNimbusExperiment(TestCase):
             (
                 NimbusExperiment.Status.DRAFT,
                 None,
+                False,
                 "LAUNCH_EXPERIMENT",
+            ),
+            (
+                NimbusExperiment.Status.DRAFT,
+                None,
+                True,
+                "LAUNCH_ROLLOUT",
             ),
             (
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.LIVE,
+                False,
                 "END_ENROLLMENT",
             ),
             (
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.COMPLETE,
+                False,
                 "END_EXPERIMENT",
             ),
         ]
@@ -5520,10 +5529,12 @@ class TestNimbusExperiment(TestCase):
         self,
         status,
         status_next,
+        is_rollout,
         expected_flow_key,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=is_rollout,
         )
 
         experiment.status = status
@@ -7328,3 +7339,64 @@ class TestAdvanceRolloutPhase(TestCase):
 
         self.assertIsNone(cloned.rollout_phase)
         self.assertIsNone(cloned.rollout_phase_next)
+
+
+class TestRolloutReviewControls(TestCase):
+    def test_rollout_review_controls_none_when_not_in_review(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        self.assertIsNone(experiment.rollout_review_controls)
+
+    def test_rollout_review_controls_none_for_unmatched_review_state(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+        self.assertIsNone(experiment.rollout_review_controls)
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.Status.LIVE,
+                "nimbus-ui-new-draft-review-to-approve-rollout",
+                "nimbus-ui-new-draft-review-to-reject-rollout",
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                "nimbus-ui-new-approve-advance-phase-review-rollout",
+                "nimbus-ui-new-reject-advance-phase-review-rollout",
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                "nimbus-ui-new-live-to-disabled-review-approve-rollout",
+                "nimbus-ui-new-live-to-disabled-review-reject-rollout",
+            ),
+            (
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                "nimbus-ui-new-disabled-to-live-review-approve-rollout",
+                "nimbus-ui-new-disabled-to-live-review-reject-rollout",
+            ),
+        ]
+    )
+    def test_rollout_review_controls_maps_state_to_urls(
+        self, status, status_next, approve_url, reject_url
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            status_next=status_next,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+        controls = experiment.rollout_review_controls
+        self.assertEqual(controls["approve_url"], approve_url)
+        self.assertEqual(controls["reject_url"], reject_url)

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -371,6 +371,14 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ROLLOUT_PAUSE_OBSERVATIONS_LABEL = "Pause rollout if these observations occur"
     ROLLOUT_PHASE_FIELDS = ("start_date", "end_date", "population_percent")
+    ROLLOUT_PREVIEW_MESSAGE = (
+        "This rollout is in Preview mode and is live for testing now. It can take up "
+        "to an hour before clients receive the preview. When you're ready, request "
+        "enrollment to launch."
+    )
+    ROLLOUT_PREVIEW_BLOCKED_TOOLTIP = (
+        "Resolve the detected setup issues before previewing"
+    )
 
     class RolloutPhaseStatus:
         NOT_STARTED = "not_started"

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -389,11 +389,17 @@ class NewQAUpdateView(CardMixin, NewCardUpdateView):
     display_template = "new/rollouts/qa/card.html"
     template_name = "new/rollouts/qa/edit_form.html"
 
+    def can_edit(self):
+        return True
+
 
 class NewSignoffUpdateView(CardMixin, NewCardUpdateView):
     form_class = RolloutSignoffForm
     display_template = "new/rollouts/signoff/card.html"
     template_name = "new/rollouts/signoff/edit_form.html"
+
+    def can_edit(self):
+        return True
 
 
 class NewDocumentationLinkCreateView(RenderParentDBResponseMixin, NewOverviewUpdateView):
@@ -621,7 +627,7 @@ class NewRolloutScheduleUpdateView(NewCardUpdateView):
         return context
 
     def can_edit(self):
-        return self.object.can_edit_schedule()
+        return True
 
 
 class NewRolloutPhaseCreateView(

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -278,6 +278,11 @@ class NimbusRolloutDetailView(
 ):
     template_name = "new/rollouts/rollout_detail.html"
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context.update(build_experiment_context(self.object))
+        return context
+
 
 class CardMixin:
     form_class: type[forms.ModelForm]
@@ -526,6 +531,15 @@ class StatusUpdateView(RequestFormMixin, RenderResponseMixin, NimbusExperimentDe
             context["update_status_form_errors"] = form.errors["__all__"]
 
         return context
+
+    def form_valid(self, form):
+        if self.request.headers.get("HX-Request"):
+            form.save()
+            response = HttpResponse()
+            response.headers["HX-Refresh"] = "true"
+            return response
+
+        return super().form_valid(form)
 
 
 class DraftToPreviewRolloutView(StatusUpdateView):

--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -354,6 +354,10 @@
   transform: rotate(90deg);
 }
 
+.accordion-button[aria-disabled="true"] {
+  cursor: not-allowed;
+}
+
 .rollout-page {
   .cm-editor .cm-scroller {
     font-family: var(--bs-font-monospace);

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -17,9 +17,7 @@
               aria-expanded="{% if experiment.is_draft %}true{% else %}false{% endif %}"
               aria-controls="sidebar-setup">
         {% if experiment.is_setup_complete %}
-          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1"
-                style="width: 18px;
-                       height: 18px">
+          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
             <i class="fa-solid fa-check" style="font-size: 10px"></i>
           </span>
         {% else %}
@@ -89,9 +87,7 @@
               aria-disabled="true"
               {% endif %}>
         {% if experiment.is_preview_complete %}
-          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1"
-                style="width: 18px;
-                       height: 18px">
+          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
             <i class="fa-solid fa-check" style="font-size: 10px"></i>
           </span>
         {% else %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -1,3 +1,7 @@
+{% load nimbus_extras %}
+
+{% include "new/common/sidebar_review_controls.html" %}
+
 {# Set up card #}
 <div class="accordion accordion-flush rounded-3 bg-body-secondary"
      style="--bs-accordion-btn-active-color: var(--bs-body-color);
@@ -6,17 +10,34 @@
      id="accordion-setup">
   <div class="accordion-item border-0 bg-transparent rounded-3">
     <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small"
+      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_draft %} collapsed{% endif %}"
               type="button"
               data-bs-toggle="collapse"
               data-bs-target="#sidebar-setup"
-              aria-expanded="true"
+              aria-expanded="{% if experiment.is_draft %}true{% else %}false{% endif %}"
               aria-controls="sidebar-setup">
-        <i class="fa-regular fa-pen-to-square text-secondary me-2"></i>
-        Set up
+        {% if experiment.is_setup_complete %}
+          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1"
+                style="width: 18px;
+                       height: 18px">
+            <i class="fa-solid fa-check" style="font-size: 10px"></i>
+          </span>
+        {% else %}
+          <i class="fa-regular fa-pen-to-square text-secondary me-2 align-self-start mt-1"></i>
+        {% endif %}
+        <span class="d-flex flex-column">
+          <span>Set up</span>
+          {% if experiment.draft_date %}
+            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
+              {{ experiment.draft_date|date:"M j, Y" }}
+              <span class="text-body-tertiary">|</span>
+              {% with days=experiment.draft_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+            </span>
+          {% endif %}
+        </span>
       </button>
     </h2>
-    <div class="accordion-collapse collapse show"
+    <div class="accordion-collapse collapse{% if experiment.is_draft %} show{% endif %}"
          id="sidebar-setup"
          data-bs-parent="#accordion-setup">
       <div class="accordion-body pt-0 px-3 pb-3">
@@ -45,11 +66,8 @@
             <a href="#rollout-card-qa"
                class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">7</span>QA</a>
           {% endfor %}
-          <div class="d-flex align-items-center justify-content-center gap-2 rounded-2 mt-2 py-2 px-3 fw-semibold small text-white bg-primary opacity-50"
-               style="cursor: not-allowed">
-            <i class="fa-regular fa-eye"></i>
-            Preview
-          </div>
+          {% include "new/common/sidebar_preview_button.html" %}
+
         </div>
       </div>
     </div>
@@ -62,45 +80,72 @@
      id="accordion-preview">
   <div class="accordion-item border-0 bg-transparent rounded-3">
     <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small collapsed"
+      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_preview %} collapsed{% endif %}"
               type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#sidebar-preview"
+              {% if experiment.is_preview or experiment.is_preview_complete %}data-bs-toggle="collapse" data-bs-target="#sidebar-preview" aria-controls="sidebar-preview" aria-expanded="{% if experiment.is_preview %}true{% else %}false{% endif %}
+              "
+              {% else %}
               aria-expanded="false"
-              aria-controls="sidebar-preview">
-        <i class="fa-regular fa-eye text-secondary me-2"></i>
-        Preview
+              aria-disabled="true"
+              {% endif %}>
+        {% if experiment.is_preview_complete %}
+          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1"
+                style="width: 18px;
+                       height: 18px">
+            <i class="fa-solid fa-check" style="font-size: 10px"></i>
+          </span>
+        {% else %}
+          <i class="fa-regular fa-eye text-secondary me-2 align-self-start mt-1"></i>
+        {% endif %}
+        <span class="d-flex flex-column">
+          <span>Preview</span>
+          {% if experiment.is_preview or experiment.is_preview_complete %}
+            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
+              {{ experiment.preview_date|date:"M j, Y" }}
+              <span class="text-body-tertiary">|</span>
+              {% with days=experiment.preview_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+            </span>
+          {% endif %}
+        </span>
       </button>
     </h2>
-    <div class="accordion-collapse collapse"
+    <div class="accordion-collapse collapse{% if experiment.is_preview %} show{% endif %}"
          id="sidebar-preview"
          data-bs-parent="#accordion-preview">
-      <div class="accordion-body pt-0 px-3 pb-3"></div>
-    </div>
-  </div>
-</div>
-{# Rollout nav card — EXP-6688 #}
-<div class="accordion accordion-flush rounded-3 bg-body-secondary"
-     style="--bs-accordion-btn-active-color: var(--bs-body-color);
-            --bs-accordion-btn-active-bg: transparent;
-            --bs-accordion-active-color: var(--bs-body-color)"
-     id="accordion-rollout">
-  <div class="accordion-item border-0 bg-transparent rounded-3">
-    <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small collapsed"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#sidebar-rollout"
-              aria-expanded="false"
-              aria-controls="sidebar-rollout">
-        <i class="fa-solid fa-rocket text-secondary me-2"></i>
-        Rollout
-      </button>
-    </h2>
-    <div class="accordion-collapse collapse"
-         id="sidebar-rollout"
-         data-bs-parent="#accordion-rollout">
-      <div class="accordion-body pt-0 px-3 pb-3">{# TODO EXP-6688: Rollout content #}</div>
+      <div class="accordion-body pt-0 px-3 pb-3">
+        {% if experiment.is_preview or experiment.is_preview_complete %}
+          <div class="d-flex flex-column gap-3">
+            <p class="mb-0 text-secondary" style="font-size: 12px;">
+              {{ NimbusUIConstants.ROLLOUT_PREVIEW_MESSAGE }}
+              <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="text-decoration-none">Learn more</a>
+            </p>
+            <a href="#rollout-card-preview"
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+              <i class="fa-regular fa-eye text-secondary"></i>
+              Preview and testing details
+            </a>
+            <div class="d-flex flex-column gap-2">
+              {# Preview to Draft #}
+              <button type="button"
+                      id="rollout-back-to-setup-btn"
+                      class="btn btn-secondary btn-sm w-100"
+                      hx-post="{% url 'nimbus-ui-new-preview-to-draft-rollout' experiment.slug %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      {% if not experiment.is_preview %}disabled{% endif %}>Back to Set Up</button>
+              {# Preview to Review #}
+              <button type="button"
+                      id="rollout-request-enrollment-btn"
+                      class="btn btn-primary btn-sm w-100"
+                      hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      {% if not experiment.is_preview %}disabled{% endif %}>Request Enrollment</button>
+            </div>
+          </div>
+        {% endif %}
+      </div>
     </div>
   </div>
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -1,0 +1,22 @@
+<div id="sidebar-preview-button" {% if oob %}hx-swap-oob="true"{% endif %}>
+  {% if experiment.is_draft and not setup_issues_count %}
+    <button type="button"
+            id="rollout-preview-btn"
+            class="btn btn-primary btn-sm w-100 mt-2 d-flex align-items-center justify-content-center gap-2"
+            hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
+            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+      <i class="fa-regular fa-eye"></i>
+      Preview
+    </button>
+  {% else %}
+    <span class="d-inline-block w-100 mt-2"
+          {% if experiment.is_draft and setup_issues_count %} data-bs-toggle="tooltip" data-bs-title="{{ NimbusUIConstants.ROLLOUT_PREVIEW_BLOCKED_TOOLTIP }}"{% endif %}>
+      <button type="button"
+              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
+              disabled>
+        <i class="fa-regular fa-eye"></i>
+        Preview
+      </button>
+    </span>
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -1,0 +1,124 @@
+{% load nimbus_extras %}
+
+{% with controls=experiment.rollout_review_controls timed_out=experiment.should_show_timeout_message rejection=experiment.rejection_block %}
+  {% if controls or experiment|should_show_remote_settings_pending:user or timed_out or rejection %}
+    <div class="accordion accordion-flush rounded-3 bg-body-secondary"
+         style="--bs-accordion-btn-active-color: var(--bs-body-color);
+                --bs-accordion-btn-active-bg: transparent;
+                --bs-accordion-active-color: var(--bs-body-color)">
+      <div class="accordion-item border-0 bg-transparent rounded-3">
+        <h2 class="accordion-header">
+          <div class="accordion-button bg-transparent shadow-none fw-semibold text-body small pb-1"
+               style="cursor: default;
+                      --bs-accordion-btn-icon: none;
+                      --bs-accordion-btn-active-icon: none">
+            {% if controls %}
+              <i class="fa-regular fa-hourglass-half text-secondary me-2"></i>
+              Review requested
+            {% elif rejection %}
+              <i class="fa-solid fa-circle-xmark text-secondary me-2"></i>
+              Review rejected
+            {% else %}
+              <i class="fa-solid fa-cloud-arrow-up text-secondary me-2"></i>
+              Action required
+            {% endif %}
+          </div>
+        </h2>
+        <div class="accordion-body pt-0 px-3 pb-3">
+          {% if rejection %}
+            <div class="d-flex flex-column gap-1 mb-2"
+                 id="rollout-rejection-notice"
+                 data-testid="rejection-notice">
+              <p class="small text-secondary text-break mb-0">
+                {{ rejection.email }} rejected the request to
+                {{ rejection.action }} on {{ rejection.date|date:"M j, Y" }}:
+              </p>
+              <p class="small text-danger-emphasis text-break bg-danger-subtle border-start border-danger border-3 rounded-end p-2 mb-0">
+                {{ rejection.message }}
+              </p>
+            </div>
+          {% endif %}
+          {% if timed_out %}
+            <p class="small text-danger-emphasis bg-danger-subtle border-start border-danger border-3 rounded-end p-2 my-2">
+              The Remote Settings request timed out. Please go through the approval
+              flow to {{ experiment.review_messages }} again.
+            </p>
+          {% endif %}
+          {% if controls %}
+            {% can_review_experiment experiment as user_can_review %}
+            <p class="small text-secondary mb-2">
+              {{ experiment.latest_review_requested_by }} requested to
+              {{ controls.action_label|lower }}.
+            </p>
+            {% if user_can_review %}
+              {% if uses_secure_collection %}
+                <p class="small text-body mb-2">
+                  <strong>Note:</strong> This must be reviewed by a member of the
+                  Release Management Team.
+                </p>
+              {% endif %}
+              <div class="d-flex flex-column gap-2">
+                <button type="button"
+                        id="rollout-review-reject-btn"
+                        class="btn btn-secondary btn-sm w-100"
+                        data-bs-toggle="collapse"
+                        data-bs-target="#rollout-reject-form"
+                        aria-expanded="false"
+                        aria-controls="rollout-reject-form">Reject</button>
+                <button type="button"
+                        id="rollout-review-approve-btn"
+                        class="btn btn-primary btn-sm w-100"
+                        hx-post="{% url controls.approve_url experiment.slug %}"
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>Approve</button>
+              </div>
+              <div class="collapse mt-2" id="rollout-reject-form">
+                <label for="rollout-reject-message" class="form-label small mb-1">
+                  You are rejecting the request to {{ controls.action_label|lower }}.
+                  Please provide a reason:
+                </label>
+                <textarea id="rollout-reject-message"
+                          name="changelog_message"
+                          class="form-control form-control-sm mb-2"
+                          rows="3"></textarea>
+                <button type="button"
+                        id="rollout-review-submit-reject-btn"
+                        class="btn btn-danger btn-sm w-100"
+                        hx-post="{% url controls.reject_url experiment.slug %}"
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                        hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'
+                        hx-include="#rollout-reject-message">Submit Rejection</button>
+              </div>
+            {% else %}
+              <p class="small text-body mb-2">
+                Ask someone on your team with
+                <a href="{{ NimbusUIConstants.REVIEW_URL }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="text-decoration-none">review privileges</a>
+                or a qualified reviewer to {{ controls.action_label|lower }}.
+              </p>
+              <p class="small text-body mb-2">
+                If you don't have a team reviewer, paste the experiment URL in
+                <strong>#ask-experimenter</strong> and ask for a review.
+              </p>
+              <a href="#"
+                 class="small text-decoration-none"
+                 onclick="navigator.clipboard.writeText(window.location.href).then(() => alert('URL copied to clipboard!')); return false;">
+                Click here to copy the URL to send them.
+              </a>
+            {% endif %}
+          {% elif experiment|should_show_remote_settings_pending:user %}
+            <p class="small text-secondary mb-2">
+              Review this change in Remote Settings to
+              {{ experiment.remote_settings_pending_message }}.
+            </p>
+            <a href="{{ experiment.review_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="btn btn-primary btn-sm w-100">Open Remote Settings</a>
+          {% endif %}
+        </div>
+      </div>
+    </div>
+  {% endif %}
+{% endwith %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -60,14 +60,14 @@
               <div class="d-flex flex-column gap-2">
                 <button type="button"
                         id="rollout-review-reject-btn"
-                        class="btn btn-secondary btn-sm w-100"
+                        class="btn btn-danger btn-sm w-100"
                         data-bs-toggle="collapse"
                         data-bs-target="#rollout-reject-form"
                         aria-expanded="false"
                         aria-controls="rollout-reject-form">Reject</button>
                 <button type="button"
                         id="rollout-review-approve-btn"
-                        class="btn btn-primary btn-sm w-100"
+                        class="btn btn-success btn-sm w-100"
                         hx-post="{% url controls.approve_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>Approve</button>
               </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
@@ -1,5 +1,6 @@
 {% if hx_swap_oob %}
   {% include "new/common/setup_progress.html" with oob=True %}
   {% include "new/common/setup_issues_modal.html" with oob=True %}
+  {% include "new/common/sidebar_preview_button.html" with oob=True %}
 
 {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -18,10 +18,10 @@
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Define</div>
       {# EXP-6681: Rollout Overview Form/Card #}
-      {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" subtitle="Name · Observations & Problem Space · Public Description · Application · Important Links · Project Tags · Subscribers" show_edit_btn=True body_template="new/rollouts/overview/card.html" %}
+      {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" subtitle="Name · Observations & Problem Space · Public Description · Application · Important Links · Project Tags · Subscribers" show_edit_btn=experiment.is_draft body_template="new/rollouts/overview/card.html" %}
 
       {# TODO EXP-6682: Rollout Risks Form/Card #}
-      {% include "new/rollouts/detail_card.html" with card_id="risks" title="Risks" subtitle="Consider possible risks if the public interacts with your experiment" show_edit_btn=True body_template="new/rollouts/risks/card.html" %}
+      {% include "new/rollouts/detail_card.html" with card_id="risks" title="Risks" subtitle="Consider possible risks if the public interacts with your experiment" show_edit_btn=experiment.is_draft body_template="new/rollouts/risks/card.html" %}
       {% include "new/rollouts/detail_card.html" with card_id="signoff" title="Sign-Offs" subtitle="QA, VP, and Legal Sign-offs" show_edit_btn=True body_template="new/rollouts/signoff/card.html" %}
 
     </div>
@@ -29,14 +29,14 @@
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Configure</div>
       {# TODO EXP-6683: Rollout Audience Form/Card #}
-      {% include "new/rollouts/detail_card.html" with card_id="audience" title="Audience" subtitle="Branch treatment details" show_edit_btn=True body_template="new/rollouts/audience/card.html" %}
+      {% include "new/rollouts/detail_card.html" with card_id="audience" title="Audience" subtitle="Branch treatment details" show_edit_btn=experiment.is_draft body_template="new/rollouts/audience/card.html" %}
 
     </div>
     {# ── Build ── #}
     <div class="d-flex flex-column gap-2">
       <div class="small fw-medium mb-1 text-secondary">Build</div>
       {# TODO EXP-6685: Rollout Features Form/Card #}
-      {% include "new/rollouts/detail_card.html" with card_id="rollout-features" title="Rollout Features" subtitle="Describe the rollout experience" show_edit_btn=True body_template="new/rollouts/rollout_features/card.html" %}
+      {% include "new/rollouts/detail_card.html" with card_id="rollout-features" title="Rollout Features" subtitle="Describe the rollout experience" show_edit_btn=experiment.is_draft body_template="new/rollouts/rollout_features/card.html" %}
       {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" subtitle="Gradually increase the rollout population in phases" show_edit_btn=True body_template="new/rollouts/schedule/card.html" %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_extras.py
@@ -70,6 +70,13 @@ def parse_version(version_str):
     return "No Version"
 
 
+@register.filter
+def days_since(value):
+    if value is None:
+        return None
+    return (date.today() - value).days
+
+
 @register.filter(name="remove_underscores")
 def remove_underscores(value):
     """Replace underscores in the string with spaces."""

--- a/experimenter/experimenter/nimbus_ui/tests/test_filters.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_filters.py
@@ -32,6 +32,7 @@ from experimenter.nimbus_ui.templatetags.nimbus_extras import (
     application_icon_info,
     channel_icon_info,
     choices_with_icons,
+    days_since,
     dict_get,
     experiment_date_progress,
     format_json,
@@ -1908,3 +1909,17 @@ class TestFormatPValue(TestCase):
     )
     def test_format_p_value(self, _name, value, expected):
         self.assertEqual(format_p_value(value), expected)
+
+
+class TestDaysSince(TestCase):
+    def test_returns_none_for_none(self):
+        self.assertIsNone(days_since(None))
+
+    def test_returns_days_elapsed(self):
+        import datetime
+
+        from django.utils import timezone
+
+        self.assertEqual(
+            days_since(timezone.now().date() - datetime.timedelta(days=5)), 5
+        )

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1468,16 +1468,6 @@ class TestNewRolloutPhaseCreateView(AuthTestCase):
         self.assertEqual(response.context["form"].rollout_phases.total_form_count(), 1)
         self.assertEqual(experiment.rollout_phases.count(), 1)
 
-    def test_post_on_non_editable_experiment_redirects(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-        )
-        response = self.client.post(
-            reverse(self.url_name, kwargs={"slug": experiment.slug}),
-            {"rollout_phases-TOTAL_FORMS": "0", "rollout_phases-INITIAL_FORMS": "0"},
-        )
-        self.assertIn("HX-Redirect", response.headers)
-
 
 class TestNewRolloutPhaseDeleteView(AuthTestCase):
     url_name = "nimbus-ui-new-delete-rollout-phase"

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -4,7 +4,7 @@ from unittest import mock
 from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.urls import resolve, reverse
 from django.utils import timezone
 from parameterized import parameterized
@@ -152,6 +152,45 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
         self.assertEqual(experiment.status, expected_status)
         self.assertEqual(experiment.status_next, expected_status_next)
         self.assertEqual(experiment.publish_status, expected_publish_status)
+
+    def test_htmx_transition_refreshes_page(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-draft-to-preview-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+            HTTP_HX_REQUEST="true",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers["HX-Refresh"], "true")
+
+    def test_non_htmx_transition_renders_response(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-draft-to-preview-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn("HX-Refresh", response.headers)
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.PREVIEW)
 
     @parameterized.expand(
         [
@@ -565,6 +604,47 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, screenshot_1.image.url)
         self.assertContains(response, screenshot_2.image.url)
+
+    @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
+    def test_sidebar_shows_approve_control_for_dev_reviewer(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
+            **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="rollout-review-approve-btn"')
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-draft-review-to-approve-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+
+    @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
+    def test_sidebar_shows_remote_settings_link_when_approved(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
+            **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Open Remote Settings")
 
 
 class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):


### PR DESCRIPTION
Because

* we need sidebar controls for moving between set up and preview

This commit

* adds the set up control which unlocks the preview button once there are no setup issues
* adds the preview controls to request enrollment or move back to set up
* adds the review controls card allowing the launch approve/reject flow and the RS link and timeout message

Fixes #16582


https://github.com/user-attachments/assets/a65c577e-8ff5-47c0-b20e-b5362be70851

<img width="1711" height="946" alt="Screenshot 2026-07-31 at 11 32 06 AM" src="https://github.com/user-attachments/assets/551938cf-34b0-4e75-8f75-72fee0c4259d" />
<img width="1721" height="955" alt="Screenshot 2026-07-31 at 3 15 18 PM" src="https://github.com/user-attachments/assets/27aa2274-dfc8-4376-b650-b6a5b6133108" />

