### PR TITLE
fix(nimbus): Instantiate forms with current request in RenderDBResponseMixin et al.

### DIFF
--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -159,14 +159,14 @@ class RenderResponseMixin:
 class RenderDBResponseMixin:
     def form_valid(self, form):
         super().form_valid(form)
-        form = self.form_class(instance=self.object)
+        form = self.form_class(instance=self.object, request=self.request)
         return self.render_to_response(self.get_context_data(form=form))
 
 
 class RenderParentDBResponseMixin:
     def form_valid(self, form):
         super().form_valid(form)
-        form = super().form_class(instance=self.object)
+        form = super().form_class(instance=self.object, request=self.request)
         return self.render_to_response(self.get_context_data(form=form))
 
 


### PR DESCRIPTION
Because:

- we were not passing the current request to the form class, resulting in authentication errors when interacting with the development server directly

this commit:

- ensures we instantiate the forms with the correct request

Fixes #16587