### PR TITLE
feat(nimbus): Add rollout plan template values

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -365,7 +365,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Set both a start and an end date or leave both blank."
     )
     ERROR_ROLLOUT_PHASE_LOCKED = "This rollout phase is locked and cannot be changed."
-    ROLLOUT_TEMPLATE_PLANS = {"Medium risk": [1, 10, 50, 100]}
+    ROLLOUT_TEMPLATE_PLANS = {
+        "Low risk": [100],
+        "Medium risk": [1, 10, 50, 100],
+        "High risk": [1, 2, 5, 10, 25, 50, 100],
+    }
     ROLLOUT_ADVANCE_OBSERVATIONS_LABEL = (
         "Move to next phase of rollout if these observations occur"
     )


### PR DESCRIPTION
Because

* We previously only had a phases template for medium risk rollouts

This commit

* Adds low and high risk rollout phases templates

Fixes #16593

<img width="1211" height="406" alt="Screenshot 2026-07-31 at 3 47 08 PM" src="https://github.com/user-attachments/assets/a575348c-fb33-4b9b-8e25-42c4b4e35f63" />
