### PR TITLE
feat(nimbus): add slack notifications for rollout state changes

### DIFF
--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -195,6 +195,10 @@ def handle_launching_experiments(applications, records, collection):
         applications, collection
     ):
         if experiment.slug in records:
+            is_reenabling_rollout = (
+                experiment.is_rollout_with_phases
+                and experiment.status == NimbusExperiment.Status.DISABLED
+            )
             logger.info(
                 f"{experiment} status is being updated to live".format(
                     experiment=experiment
@@ -221,15 +225,26 @@ def handle_launching_experiments(applications, records, collection):
 
                 experiment.update_computed_end_date()
 
-            _send_slack_alert_success_message(
-                experiment,
-                NimbusConstants.AlertType.LAUNCH_REQUEST,
-                SlackConstants.SLACK_LAUNCH_SUCCESS_MESSAGE,
-                SlackConstants.SLACK_OPERATION_LAUNCH_SUCCESS,
-                lambda slug: SlackConstants.SLACK_LOG_LAUNCH_SUCCESS_SENT.format(
-                    experiment=slug
-                ),
-            )
+            if is_reenabling_rollout:
+                _send_slack_alert_success_message(
+                    experiment,
+                    NimbusConstants.AlertType.LAUNCH_REQUEST,
+                    SlackConstants.SLACK_ROLLOUT_REENABLED_MESSAGE,
+                    SlackConstants.SLACK_OPERATION_ROLLOUT_REENABLE_SUCCESS,
+                    lambda slug: SlackConstants.SLACK_LOG_ROLLOUT_REENABLE_SENT.format(
+                        experiment=slug
+                    ),
+                )
+            else:
+                _send_slack_alert_success_message(
+                    experiment,
+                    NimbusConstants.AlertType.LAUNCH_REQUEST,
+                    SlackConstants.SLACK_LAUNCH_SUCCESS_MESSAGE,
+                    SlackConstants.SLACK_OPERATION_LAUNCH_SUCCESS,
+                    lambda slug: SlackConstants.SLACK_LOG_LAUNCH_SUCCESS_SENT.format(
+                        experiment=slug
+                    ),
+                )
 
             logger.info(f"{experiment.slug} launched")
 
@@ -249,6 +264,10 @@ def handle_updating_experiments(applications, records, collection):
 
         if published_record != stored_record:
             logger.info(f"{experiment} is updated in Kinto".format(experiment=experiment))
+            is_advancing_rollout_phase = (
+                experiment.is_rollout_with_phases
+                and experiment.rollout_phase_next_id is not None
+            )
             with transaction.atomic():
                 next_status = experiment.status_next
                 if experiment.is_rollout_with_phases and experiment.rollout_phase_next_id:
@@ -269,7 +288,19 @@ def handle_updating_experiments(applications, records, collection):
 
                 experiment.update_computed_end_date()
 
-            if experiment.is_paused:
+            if is_advancing_rollout_phase:
+                _send_slack_alert_success_message(
+                    experiment,
+                    NimbusConstants.AlertType.UPDATE_REQUEST,
+                    SlackConstants.SLACK_ROLLOUT_PHASE_ADVANCED_MESSAGE,
+                    SlackConstants.SLACK_OPERATION_ROLLOUT_PHASE_ADVANCE_SUCCESS,
+                    lambda slug: (
+                        SlackConstants.SLACK_LOG_ROLLOUT_PHASE_ADVANCE_SENT.format(
+                            experiment=slug
+                        )
+                    ),
+                )
+            elif experiment.is_paused:
                 _send_slack_alert_success_message(
                     experiment,
                     NimbusConstants.AlertType.END_ENROLLMENT_REQUEST,
@@ -332,7 +363,17 @@ def handle_ending_experiments(applications, records, collection):
                 if not is_disabling_rollout:
                     experiment.update_computed_end_date()
 
-            if not is_disabling_rollout:
+            if is_disabling_rollout:
+                _send_slack_alert_success_message(
+                    experiment,
+                    NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+                    SlackConstants.SLACK_ROLLOUT_DISABLED_MESSAGE,
+                    SlackConstants.SLACK_OPERATION_ROLLOUT_DISABLE_SUCCESS,
+                    lambda slug: SlackConstants.SLACK_LOG_ROLLOUT_DISABLE_SENT.format(
+                        experiment=slug
+                    ),
+                )
+            else:
                 _send_slack_alert_success_message(
                     experiment,
                     NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1158,7 +1158,9 @@ class TestNimbusCheckKintoPushQueueByCollection(
         NimbusAlert.objects.create(
             experiment=launching_experiment,
             alert_type=NimbusConstants.AlertType.LAUNCH_REQUEST,
-            message="🚀 Requests launch",
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_LAUNCH_REQUEST
+            ],
             slack_thread_id="1234567890.123456",
         )
 
@@ -1193,7 +1195,9 @@ class TestNimbusCheckKintoPushQueueByCollection(
         NimbusAlert.objects.create(
             experiment=updating_experiment,
             alert_type=NimbusConstants.AlertType.UPDATE_REQUEST,
-            message="🔄 Requests update",
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_UPDATE_REQUEST
+            ],
             slack_thread_id="1234567890.123456",
         )
 
@@ -1219,7 +1223,10 @@ class TestNimbusCheckKintoPushQueueByCollection(
         )
         self.assertIn("updated_field", updating_experiment.published_dto)
 
-    def test_remote_settings_update_approval_commits_staged_rollout_phase(self):
+    @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
+    def test_remote_settings_update_approval_commits_staged_rollout_phase(
+        self, mock_send_message
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
             application=NimbusExperiment.Application.DESKTOP,
@@ -1236,6 +1243,14 @@ class TestNimbusCheckKintoPushQueueByCollection(
         experiment.population_percent = current_phase.population_percent
         experiment.save()
         experiment.stage_rollout_phase_advance()
+        alert = NimbusAlert.objects.create(
+            experiment=experiment,
+            alert_type=NimbusConstants.AlertType.UPDATE_REQUEST,
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST
+            ],
+            slack_thread_id="1234567890.123456",
+        )
 
         self.assertEqual(experiment.rollout_phase, current_phase)
         self.assertEqual(experiment.rollout_phase_next, next_phase)
@@ -1258,6 +1273,15 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertIsNone(experiment.rollout_phase_next)
         self.assertEqual(current_phase.end_date, timezone.now().date())
         self.assertEqual(next_phase.actual_start_date, timezone.now().date())
+        self.assertEqual(
+            mock_send_message.call_args.args[:4],
+            (
+                experiment.id,
+                alert.slack_thread_id,
+                SlackConstants.SLACK_ROLLOUT_PHASE_ADVANCED_MESSAGE,
+                SlackConstants.SLACK_OPERATION_ROLLOUT_PHASE_ADVANCE_SUCCESS,
+            ),
+        )
 
     def test_remote_settings_rejection_reverts_staged_rollout_phase(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1310,7 +1334,10 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertIsNone(experiment.rollout_phase_next)
         self.assertEqual(experiment.population_percent, current_phase.population_percent)
 
-    def test_remote_settings_disable_approval_disables_and_ends_current_phase(self):
+    @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
+    def test_remote_settings_disable_approval_disables_and_ends_current_phase(
+        self, mock_send_message
+    ):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
             status_next=NimbusExperiment.Status.DISABLED,
@@ -1326,6 +1353,14 @@ class TestNimbusCheckKintoPushQueueByCollection(
         )
         experiment.rollout_phase = current_phase
         experiment.save()
+        alert = NimbusAlert.objects.create(
+            experiment=experiment,
+            alert_type=NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_DISABLE_ROLLOUT_REQUEST
+            ],
+            slack_thread_id="1234567890.123456",
+        )
 
         tasks.handle_ending_experiments(
             [NimbusExperiment.Application.DESKTOP],
@@ -1339,6 +1374,15 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertIsNone(experiment.status_next)
         self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
         self.assertEqual(current_phase.end_date, timezone.now().date())
+        self.assertEqual(
+            mock_send_message.call_args.args[:4],
+            (
+                experiment.id,
+                alert.slack_thread_id,
+                SlackConstants.SLACK_ROLLOUT_DISABLED_MESSAGE,
+                SlackConstants.SLACK_OPERATION_ROLLOUT_DISABLE_SUCCESS,
+            ),
+        )
 
     def test_remote_settings_legacy_rollout_ending_uses_completion_flow(self):
         experiment = NimbusExperimentFactory.create(
@@ -1364,7 +1408,10 @@ class TestNimbusCheckKintoPushQueueByCollection(
             experiment.changes.filter(message=NimbusChangeLog.Messages.COMPLETED).exists()
         )
 
-    def test_remote_settings_reenable_approval_advances_phase_and_sets_live(self):
+    @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
+    def test_remote_settings_reenable_approval_advances_phase_and_sets_live(
+        self, mock_send_message
+    ):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DISABLED,
             status_next=NimbusExperiment.Status.LIVE,
@@ -1382,6 +1429,14 @@ class TestNimbusCheckKintoPushQueueByCollection(
         experiment.rollout_phase = current_phase
         experiment.rollout_phase_next = next_phase
         experiment.save()
+        alert = NimbusAlert.objects.create(
+            experiment=experiment,
+            alert_type=NimbusConstants.AlertType.LAUNCH_REQUEST,
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_REENABLE_ROLLOUT_REQUEST
+            ],
+            slack_thread_id="1234567890.123456",
+        )
 
         tasks.handle_launching_experiments(
             [NimbusExperiment.Application.DESKTOP],
@@ -1401,6 +1456,15 @@ class TestNimbusCheckKintoPushQueueByCollection(
         self.assertEqual(experiment.rollout_phase, next_phase)
         self.assertIsNone(experiment.rollout_phase_next)
         self.assertEqual(next_phase.actual_start_date, timezone.now().date())
+        self.assertEqual(
+            mock_send_message.call_args.args[:4],
+            (
+                experiment.id,
+                alert.slack_thread_id,
+                SlackConstants.SLACK_ROLLOUT_REENABLED_MESSAGE,
+                SlackConstants.SLACK_OPERATION_ROLLOUT_REENABLE_SUCCESS,
+            ),
+        )
 
     @mock.patch("experimenter.kinto.tasks.send_threaded_success_message")
     def test_updating_paused_experiment_sends_enrollment_ended_notification(
@@ -1418,7 +1482,9 @@ class TestNimbusCheckKintoPushQueueByCollection(
         NimbusAlert.objects.create(
             experiment=paused_experiment,
             alert_type=NimbusConstants.AlertType.END_ENROLLMENT_REQUEST,
-            message="⏸️ Requests end enrollment",
+            message=SlackConstants.SLACK_FORM_ACTIONS[
+                SlackConstants.SLACK_ACTION_END_ENROLLMENT_REQUEST
+            ],
             slack_thread_id="1234567890.123456",
         )
 

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 import markus
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from django.forms import inlineformset_factory
@@ -16,6 +17,7 @@ from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.changelog_utils import generate_nimbus_changelog
 from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
+    NimbusAlert,
     NimbusBranch,
     NimbusBranchFeatureValue,
     NimbusBranchScreenshot,
@@ -34,6 +36,12 @@ from experimenter.kinto.tasks import (
 )
 from experimenter.nimbus_ui.constants import NimbusUIConstants
 from experimenter.nimbus_ui.forms import NimbusBranchScreenshotForm
+from experimenter.slack.constants import SlackConstants
+from experimenter.slack.tasks import (
+    add_emoji_to_message_async,
+    nimbus_send_slack_notification,
+    remove_emoji_from_message_async,
+)
 from experimenter.targeting.constants import NimbusTargetingConfig
 
 metrics = markus.get_metrics("experimenter.nimbus_ui_forms")
@@ -84,6 +92,73 @@ class NimbusChangeLogFormMixin:
             experiment, self.request.user, self.get_changelog_message()
         )
         metrics.incr("changelog_form.save", tags=[f"form:{type(self).__name__}"])
+        return experiment
+
+
+class SlackNotificationMixin:
+    slack_action = None
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        if self.slack_action:
+            if experiment.enable_review_slack_notifications:
+                action_text = SlackConstants.SLACK_FORM_ACTIONS[self.slack_action]
+
+                # Call synchronously to get message timestamp and channel ID
+                result = nimbus_send_slack_notification(
+                    experiment_id=experiment.id,
+                    email_addresses=experiment.notification_emails,
+                    action_text=action_text,
+                    requesting_user_email=self.request.user.email,
+                    link_url=experiment.experiment_url,
+                )
+                if result:
+                    message_ts, channel_id = result
+                    alert_type = SlackConstants.SLACK_ACTION_TO_ALERT_TYPE[
+                        self.slack_action
+                    ]
+                    NimbusAlert.objects.create(
+                        experiment=experiment,
+                        alert_type=alert_type,
+                        message=action_text,
+                        slack_thread_id=message_ts,
+                        slack_channel_id=channel_id,
+                    )
+                    add_emoji_to_message_async.delay(
+                        experiment.id,
+                        alert_type,
+                        SlackConstants.EmojiReaction.PENDING,
+                    )
+                    if (
+                        experiment.kinto_collection
+                        == settings.KINTO_COLLECTION_NIMBUS_SECURE
+                    ):
+                        add_emoji_to_message_async.delay(
+                            experiment.id,
+                            alert_type,
+                            SlackConstants.EmojiReaction.SECURE,
+                        )
+        return experiment
+
+
+class CancelRequestMixin:
+    cancel_request_alert_type = None
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        if self.cancel_request_alert_type:
+            remove_emoji_from_message_async.delay(
+                experiment.id,
+                self.cancel_request_alert_type,
+                SlackConstants.EmojiReaction.PENDING,
+            )
+            add_emoji_to_message_async.delay(
+                experiment.id,
+                self.cancel_request_alert_type,
+                SlackConstants.EmojiReaction.CANCEL,
+            )
         return experiment
 
 
@@ -1188,7 +1263,7 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
 # Draft to Live transitions
 
 
-class DraftReviewRolloutForm(UpdateStatusForm):
+class DraftReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.DRAFT
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1196,6 +1271,8 @@ class DraftReviewRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    slack_action = SlackConstants.SLACK_ACTION_LAUNCH_REQUEST
 
     def get_changelog_message(self):
         return f"{self.request.user} requested rollout launch without Preview"
@@ -1221,11 +1298,21 @@ class DraftReviewApproveRolloutForm(UpdateStatusForm):
         nimbus_check_kinto_push_queue_by_collection.apply_async(
             countdown=5, args=[experiment.kinto_collection]
         )
+        remove_emoji_from_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        add_emoji_to_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
 
         return experiment
 
 
-class DraftReviewRejectForm(UpdateStatusForm):
+class DraftReviewRejectForm(CancelRequestMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.DRAFT
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1233,6 +1320,7 @@ class DraftReviewRejectForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
+    cancel_request_alert_type = NimbusConstants.AlertType.LAUNCH_REQUEST
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000
@@ -1254,7 +1342,7 @@ class DraftReviewRejectForm(UpdateStatusForm):
 # Preview to Live transitions
 
 
-class PreviewReviewRolloutForm(UpdateStatusForm):
+class PreviewReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.PREVIEW
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1262,6 +1350,8 @@ class PreviewReviewRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DRAFT
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
+
+    slack_action = SlackConstants.SLACK_ACTION_LAUNCH_REQUEST
 
     def get_changelog_message(self):
         return f"{self.request.user} requested rollout launch from Preview"
@@ -1312,7 +1402,7 @@ class PreviewToDraftRolloutForm(UpdateStatusForm):
 # Phase advance transitions
 
 
-class AdvancePhaseReviewRolloutForm(UpdateStatusForm):
+class AdvancePhaseReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1320,6 +1410,7 @@ class AdvancePhaseReviewRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
+    slack_action = SlackConstants.SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST
 
     def get_changelog_message(self):
         return f"{self.request.user} requested review to advance rollout phase"
@@ -1345,11 +1436,21 @@ class AdvancePhaseReviewApproveRolloutForm(UpdateStatusForm):
         nimbus_check_kinto_push_queue_by_collection.apply_async(
             countdown=5, args=[experiment.kinto_collection]
         )
+        remove_emoji_from_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.UPDATE_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        add_emoji_to_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.UPDATE_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
 
         return experiment
 
 
-class AdvancePhaseReviewRejectRolloutForm(UpdateStatusForm):
+class AdvancePhaseReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1357,6 +1458,7 @@ class AdvancePhaseReviewRejectRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
+    cancel_request_alert_type = NimbusConstants.AlertType.UPDATE_REQUEST
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000
@@ -1378,7 +1480,7 @@ class AdvancePhaseReviewRejectRolloutForm(UpdateStatusForm):
 # Live to disabled transitions
 
 
-class LiveToDisabledReviewRolloutForm(UpdateStatusForm):
+class LiveToDisabledReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1386,6 +1488,7 @@ class LiveToDisabledReviewRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.DISABLED
     publish_status = NimbusExperiment.PublishStatus.REVIEW
+    slack_action = SlackConstants.SLACK_ACTION_DISABLE_ROLLOUT_REQUEST
 
     def clean(self):
         cleaned_data = super().clean()
@@ -1417,11 +1520,21 @@ class LiveToDisabledReviewApproveRolloutForm(UpdateStatusForm):
         nimbus_check_kinto_push_queue_by_collection.apply_async(
             countdown=5, args=[experiment.kinto_collection]
         )
+        remove_emoji_from_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        add_emoji_to_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
 
         return experiment
 
 
-class LiveToDisabledReviewRejectRolloutForm(UpdateStatusForm):
+class LiveToDisabledReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = NimbusExperiment.Status.DISABLED
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1429,6 +1542,7 @@ class LiveToDisabledReviewRejectRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.LIVE
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
+    cancel_request_alert_type = NimbusConstants.AlertType.END_EXPERIMENT_REQUEST
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000
@@ -1450,7 +1564,7 @@ class LiveToDisabledReviewRejectRolloutForm(UpdateStatusForm):
 # Disabled to Live transitions
 
 
-class DisabledToLiveReviewRolloutForm(UpdateStatusForm):
+class DisabledToLiveReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.DISABLED
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1458,6 +1572,7 @@ class DisabledToLiveReviewRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DISABLED
     status_next = NimbusExperiment.Status.LIVE
     publish_status = NimbusExperiment.PublishStatus.REVIEW
+    slack_action = SlackConstants.SLACK_ACTION_REENABLE_ROLLOUT_REQUEST
 
     def get_changelog_message(self):
         return f"{self.request.user} requested review to re-enable rollout"
@@ -1513,10 +1628,20 @@ class DisabledToLiveReviewApproveRolloutForm(UpdateStatusForm):
         nimbus_check_kinto_push_queue_by_collection.apply_async(
             countdown=5, args=[experiment.kinto_collection]
         )
+        remove_emoji_from_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        add_emoji_to_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
         return experiment
 
 
-class DisabledToLiveReviewRejectRolloutForm(UpdateStatusForm):
+class DisabledToLiveReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.DISABLED
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1524,6 +1649,7 @@ class DisabledToLiveReviewRejectRolloutForm(UpdateStatusForm):
     status = NimbusExperiment.Status.DISABLED
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
+    cancel_request_alert_type = NimbusConstants.AlertType.LAUNCH_REQUEST
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -13,7 +13,9 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
+from experimenter.experiments.constants import NimbusConstants
 from experimenter.experiments.models import (
+    NimbusAlert,
     NimbusBranchFeatureValue,
     NimbusExperiment,
     NimbusExperimentBranchThroughExcluded,
@@ -63,6 +65,7 @@ from experimenter.nimbus_ui.new.forms import (
     TagAssignForm,
 )
 from experimenter.openidc.tests.factories import UserFactory
+from experimenter.slack.constants import SlackConstants
 from experimenter.targeting.constants import NimbusTargetingConfig
 
 
@@ -73,6 +76,29 @@ class RequestFormTestCase(TestCase):
         request_factory = RequestFactory()
         self.request = request_factory.get(reverse("nimbus-ui-create"))
         self.request.user = self.user
+
+
+class SlackNotificationMockMixin:
+    def setUp(self):
+        super().setUp()
+        self.mock_slack_task = patch(
+            "experimenter.nimbus_ui.new.forms.nimbus_send_slack_notification"
+        ).start()
+        self.mock_slack_task.return_value = ("1234567890.123456", "C123456")
+        self.addCleanup(self.mock_slack_task.stop)
+
+
+class SlackEmojiMockMixin:
+    def setUp(self):
+        super().setUp()
+        self.mock_emoji_task = patch(
+            "experimenter.slack.tasks.add_emoji_to_message_async.delay"
+        ).start()
+        self.mock_remove_emoji_task = patch(
+            "experimenter.slack.tasks.remove_emoji_from_message_async.delay"
+        ).start()
+        self.addCleanup(self.mock_emoji_task.stop)
+        self.addCleanup(self.mock_remove_emoji_task.stop)
 
 
 class TestNimbusExperimentCreateForm(RequestFormTestCase):
@@ -1438,7 +1464,9 @@ class TestTagAssignForm(RequestFormTestCase):
         self.assertEqual(tag_names, ["A Tag", "M Tag", "Z Tag"])
 
 
-class TestRolloutStatusForms(RequestFormTestCase):
+class TestRolloutStatusForms(
+    SlackEmojiMockMixin, SlackNotificationMockMixin, RequestFormTestCase
+):
     def setUp(self):
         super().setUp()
         self.mock_preview_task = patch(
@@ -1720,16 +1748,30 @@ class TestRolloutStatusForms(RequestFormTestCase):
     @parameterized.expand(
         [
             # Reject launch review from Draft.
-            (DraftReviewRejectForm,),
+            (
+                DraftReviewRejectForm,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+            ),
             # Reject phase-advance review.
-            (AdvancePhaseReviewRejectRolloutForm,),
+            (
+                AdvancePhaseReviewRejectRolloutForm,
+                NimbusConstants.AlertType.UPDATE_REQUEST,
+            ),
             # Reject disable review.
-            (LiveToDisabledReviewRejectRolloutForm,),
+            (
+                LiveToDisabledReviewRejectRolloutForm,
+                NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            ),
             # Reject re-enable review.
-            (DisabledToLiveReviewRejectRolloutForm,),
+            (
+                DisabledToLiveReviewRejectRolloutForm,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+            ),
         ]
     )
-    def test_reject_transition_uses_cancel_message_when_reason_is_blank(self, form_class):
+    def test_reject_transition_uses_cancel_message_and_updates_slack_reaction(
+        self, form_class, alert_type
+    ):
         experiment = NimbusExperimentFactory.create(
             status=form_class.required_status,
             status_next=form_class.required_status_next,
@@ -1749,6 +1791,16 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.assertIn(
             "cancelled the review",
             experiment.changes.latest("changed_on").message,
+        )
+        self.mock_remove_emoji_task.assert_called_once_with(
+            experiment.id,
+            alert_type,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id,
+            alert_type,
+            SlackConstants.EmojiReaction.CANCEL,
         )
 
     def test_disabled_transition_is_rejected_for_non_rollout(self):
@@ -1851,6 +1903,16 @@ class TestRolloutStatusForms(RequestFormTestCase):
             countdown=5, args=[experiment.kinto_collection]
         )
         mock_metrics.timing.assert_called_once()
+        self.mock_remove_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
 
     def test_approve_phase_advance_stages_population_and_queues_kinto(self):
         experiment = NimbusExperimentFactory.create(
@@ -1890,6 +1952,16 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.mock_allocate_bucket_range.assert_called_once()
         self.mock_kinto_push_queue.assert_called_once_with(
             countdown=5, args=[experiment.kinto_collection]
+        )
+        self.mock_remove_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.UPDATE_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.UPDATE_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
         )
 
     def test_reject_phase_advance_clears_pending_transition(self):
@@ -1933,6 +2005,16 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.mock_kinto_push_queue.assert_called_once_with(
             countdown=5, args=[experiment.kinto_collection]
         )
+        self.mock_remove_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
 
     def test_reenable_approval_stages_existing_next_phase(self):
         experiment = NimbusExperimentFactory.create(
@@ -1964,6 +2046,16 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.mock_allocate_bucket_range.assert_called_once()
         self.mock_kinto_push_queue.assert_called_once_with(
             countdown=5, args=[experiment.kinto_collection]
+        )
+        self.mock_remove_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id,
+            NimbusConstants.AlertType.LAUNCH_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
         )
 
     def test_duplicate_phase_reenable_copies_final_phase(self):
@@ -2044,6 +2136,128 @@ class TestRolloutStatusForms(RequestFormTestCase):
         self.assertIn(
             NimbusUIConstants.ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE,
             form.errors["__all__"],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "draft_launch",
+                DraftReviewRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                SlackConstants.SLACK_ACTION_LAUNCH_REQUEST,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+            ),
+            (
+                "preview_launch",
+                PreviewReviewRolloutForm,
+                NimbusExperiment.Status.PREVIEW,
+                SlackConstants.SLACK_ACTION_LAUNCH_REQUEST,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+            ),
+            (
+                "advance_phase",
+                AdvancePhaseReviewRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                SlackConstants.SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST,
+                NimbusConstants.AlertType.UPDATE_REQUEST,
+            ),
+            (
+                "disable",
+                LiveToDisabledReviewRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                SlackConstants.SLACK_ACTION_DISABLE_ROLLOUT_REQUEST,
+                NimbusConstants.AlertType.END_EXPERIMENT_REQUEST,
+            ),
+            (
+                "reenable",
+                DisabledToLiveReviewRolloutForm,
+                NimbusExperiment.Status.DISABLED,
+                SlackConstants.SLACK_ACTION_REENABLE_ROLLOUT_REQUEST,
+                NimbusConstants.AlertType.LAUNCH_REQUEST,
+            ),
+        ]
+    )
+    def test_review_request_sends_slack_notification(
+        self, name, form_class, status, slack_action, alert_type
+    ):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+            enable_review_slack_notifications=True,
+        )
+        if form_class is LiveToDisabledReviewRolloutForm:
+            NimbusRolloutPhaseFactory.create(experiment=experiment)
+        form = form_class(data={}, instance=experiment, request=self.request)
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        form.save()
+
+        self.mock_slack_task.assert_called_once()
+        self.assertEqual(
+            self.mock_slack_task.call_args.kwargs["action_text"],
+            SlackConstants.SLACK_FORM_ACTIONS[slack_action],
+        )
+        alert = NimbusAlert.objects.get(experiment=experiment, alert_type=alert_type)
+        self.assertEqual(alert.slack_thread_id, "1234567890.123456")
+        self.assertEqual(alert.slack_channel_id, "C123456")
+        self.mock_emoji_task.assert_called_once_with(
+            experiment.id, alert_type, SlackConstants.EmojiReaction.PENDING
+        )
+
+    def test_review_request_does_not_send_slack_notification_when_disabled(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+            enable_review_slack_notifications=False,
+        )
+        form = AdvancePhaseReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        form.save()
+
+        self.mock_slack_task.assert_not_called()
+        self.assertFalse(NimbusAlert.objects.filter(experiment=experiment).exists())
+
+    @patch("experimenter.slack.tasks.add_emoji_to_message_async.delay")
+    @patch("experimenter.nimbus_ui.new.forms.nimbus_send_slack_notification")
+    def test_adds_lock_emoji_for_secure_collection(
+        self, mock_send_slack, mock_emoji_task
+    ):
+        mock_send_slack.return_value = ("1234567890.123456", "C123456")
+
+        secure_feature = NimbusFeatureConfigFactory.create(
+            slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+            enable_review_slack_notifications=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[secure_feature],
+        )
+        form = DraftReviewRolloutForm(data={}, instance=experiment, request=self.request)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        form.save()
+
+        emoji_calls = [call[0] for call in mock_emoji_task.call_args_list]
+        alert_type = NimbusConstants.AlertType.LAUNCH_REQUEST
+        self.assertIn(
+            (experiment.id, alert_type, SlackConstants.EmojiReaction.PENDING),
+            emoji_calls,
+        )
+        self.assertIn(
+            (experiment.id, alert_type, SlackConstants.EmojiReaction.SECURE),
+            emoji_calls,
         )
 
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -69,9 +69,17 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             "experimenter.nimbus_ui.new.forms."
             "nimbus_check_kinto_push_queue_by_collection.apply_async"
         ).start()
+        self.mock_emoji_task = patch(
+            "experimenter.slack.tasks.add_emoji_to_message_async.delay"
+        ).start()
+        self.mock_remove_emoji_task = patch(
+            "experimenter.slack.tasks.remove_emoji_from_message_async.delay"
+        ).start()
         self.addCleanup(self.mock_preview_task.stop)
         self.addCleanup(self.mock_allocate_bucket_range.stop)
         self.addCleanup(self.mock_kinto_push_queue.stop)
+        self.addCleanup(self.mock_emoji_task.stop)
+        self.addCleanup(self.mock_remove_emoji_task.stop)
 
     @parameterized.expand(
         [

--- a/experimenter/experimenter/slack/constants.py
+++ b/experimenter/experimenter/slack/constants.py
@@ -11,12 +11,20 @@ class SlackConstants:
     SLACK_ACTION_UPDATE_REQUEST = "update_request"
     SLACK_ACTION_END_ENROLLMENT_REQUEST = "end_enrollment_request"
     SLACK_ACTION_END_EXPERIMENT_REQUEST = "end_experiment_request"
+    SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST = "advance_rollout_phase_request"
+    SLACK_ACTION_DISABLE_ROLLOUT_REQUEST = "disable_rollout_request"
+    SLACK_ACTION_REENABLE_ROLLOUT_REQUEST = "reenable_rollout_request"
 
     # Slack operation names for logging
     SLACK_OPERATION_LAUNCH_SUCCESS = "launch success notification"
     SLACK_OPERATION_UPDATE_SUCCESS = "update success notification"
     SLACK_OPERATION_ENROLLMENT_ENDING = "enrollment ending notification"
     SLACK_OPERATION_EXPERIMENT_ENDING = "experiment ending notification"
+    SLACK_OPERATION_ROLLOUT_PHASE_ADVANCE_SUCCESS = (
+        "rollout phase advance success notification"
+    )
+    SLACK_OPERATION_ROLLOUT_DISABLE_SUCCESS = "rollout disable success notification"
+    SLACK_OPERATION_ROLLOUT_REENABLE_SUCCESS = "rollout re-enable success notification"
 
     # Slack form action text mappings
     SLACK_FORM_ACTIONS = {
@@ -24,6 +32,9 @@ class SlackConstants:
         SLACK_ACTION_UPDATE_REQUEST: "🔄 Requests update",
         SLACK_ACTION_END_ENROLLMENT_REQUEST: "⏸️ Requests end enrollment",
         SLACK_ACTION_END_EXPERIMENT_REQUEST: "🛑 Requests end experiment",
+        SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST: "⏩ Requests rollout phase advance",
+        SLACK_ACTION_DISABLE_ROLLOUT_REQUEST: "⏸️ Requests disable rollout",
+        SLACK_ACTION_REENABLE_ROLLOUT_REQUEST: "▶️ Requests re-enable rollout",
     }
 
     # Slack email action text mappings
@@ -42,6 +53,13 @@ class SlackConstants:
         SLACK_ACTION_END_EXPERIMENT_REQUEST: (
             NimbusConstants.AlertType.END_EXPERIMENT_REQUEST
         ),
+        SLACK_ACTION_ADVANCE_ROLLOUT_PHASE_REQUEST: (
+            NimbusConstants.AlertType.UPDATE_REQUEST
+        ),
+        SLACK_ACTION_DISABLE_ROLLOUT_REQUEST: (
+            NimbusConstants.AlertType.END_EXPERIMENT_REQUEST
+        ),
+        SLACK_ACTION_REENABLE_ROLLOUT_REQUEST: (NimbusConstants.AlertType.LAUNCH_REQUEST),
     }
 
     # Slack emoji reaction names
@@ -76,6 +94,16 @@ class SlackConstants:
     SLACK_EXPERIMENT_ENDED_MESSAGE = (
         "🛑 ✅ *{name}* has ended\n📊 View experiment: <{url}|{slug}>"
     )
+    SLACK_ROLLOUT_PHASE_ADVANCED_MESSAGE = (
+        "⏩ ✅ *{name}* advanced to its next phase\n📊 View rollout: <{url}|{slug}>"
+    )
+    SLACK_ROLLOUT_DISABLED_MESSAGE = (
+        "⏸️ ✅ *{name}* is now disabled\n📊 View rollout: <{url}|{slug}>"
+    )
+    SLACK_ROLLOUT_REENABLED_MESSAGE = (
+        "▶️ ✅ *{name}* is now live again and advanced to its next phase\n"
+        "📊 View rollout: <{url}|{slug}>"
+    )
     SLACK_RESULTS_READY_MESSAGE = "📈 {window} analysis results are now available"
     SLACK_ANALYSIS_ERRORS_MESSAGE = "⚠️ Analysis errors detected:\n{error_lines}"
     SLACK_UNENROLLMENT_SPIKE_MESSAGE = (
@@ -109,6 +137,15 @@ class SlackConstants:
     )
     SLACK_LOG_EXPERIMENT_ENDING_SENT = (
         "Sent experiment ending notification for {experiment}"
+    )
+    SLACK_LOG_ROLLOUT_PHASE_ADVANCE_SENT = (
+        "Sent rollout phase advance success notification for {experiment}"
+    )
+    SLACK_LOG_ROLLOUT_DISABLE_SENT = (
+        "Sent rollout disable success notification for {experiment}"
+    )
+    SLACK_LOG_ROLLOUT_REENABLE_SENT = (
+        "Sent rollout re-enable success notification for {experiment}"
     )
     SLACK_LOG_EYES_EMOJI_ADDED = "Added eyes emoji to launch message for {experiment}"
     SLACK_LOG_DM_SENT = "DM sent to user {user_id}"


### PR DESCRIPTION
Because

- Rollout state transitions were not sending slack notifications

This commit

- Adds Slack notifications for rollout launch, phase advance, disable, and re-enable transitions using the existing experiment notification structure and alert types

Fixes #16532