### PR TITLE
feat(nimbus): Add Enrollment Monitoring to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -55,6 +55,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
 
     MONITORING_CARD_TITLE = "Enrollment Monitoring"
+    MONITORING_EXPERIMENT_ENDED_MESSAGE = (
+        "This experiment has ended. Monitoring data reflects the last update "
+        "before the experiment concluded."
+    )
     MONITORING_SECTION_UNENROLLMENT = "Unenrollment"
     MONITORING_SECTION_SRM = "Sample Ratio Mismatch (SRM)"
     MONITORING_SRM_SUBTITLE = "branches enrolling at unexpected ratios may indicate a bug"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/monitoring/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/monitoring/card.html
@@ -1,0 +1,132 @@
+{% extends "new/common/card_base.html" %}
+
+{% block card %}
+  <div class="d-flex flex-column gap-4">
+    {% if experiment.monitoring_data_updated_at %}
+      <div class="text-secondary" style="font-size: 12px;">
+        Last updated: {{ experiment.monitoring_data_updated_at|date:"N j, Y" }}
+      </div>
+    {% endif %}
+    {% if experiment.is_complete %}
+      <div class="alert alert-secondary small mb-0 border-0 border-start border-secondary border-4 rounded-0"
+           role="alert">{{ NimbusUIConstants.MONITORING_EXPERIMENT_ENDED_MESSAGE }}</div>
+    {% endif %}
+    {% with funnel=experiment.enrollment_funnel_stages summary=experiment.monitoring_summary %}
+      {% if funnel %}
+        <section>
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <h6 class="small fw-semibold text-body mb-0">Enrollment Funnel</h6>
+            {% for stage in funnel.stages %}
+              {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}
+                <span class="badge rounded-pill fw-normal small text-warning-emphasis bg-warning-subtle d-inline-flex align-items-center gap-1">
+                  <i class="fa-solid fa-triangle-exclamation"></i>
+                  Feature Conflict {{ stage.pct|floatformat:0 }}%
+                </span>
+              {% endif %}
+            {% endfor %}
+          </div>
+          <table class="table align-middle mb-0">
+            <thead>
+              <tr style="font-size: 12px;">
+                <th class="text-secondary fw-normal">Stage</th>
+                <th class="text-secondary fw-normal text-end">Clients</th>
+                <th class="text-secondary fw-normal text-end">% of Evaluated</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="small fw-semibold text-body">
+                <td>Evaluated (total)</td>
+                <td class="text-end">{{ funnel.total }}</td>
+                <td class="text-end"
+                    style="background: linear-gradient(to left, rgba(var(--bs-secondary-rgb), 0.15) 100%, transparent 0%)">
+                  100%
+                </td>
+              </tr>
+              {% for stage in funnel.stages %}
+                <tr class="small text-body">
+                  <td {% if stage.reason == "FeatureConflict" and stage.pct >= 25 %}class="fw-semibold"{% endif %}>
+                    <span class="badge rounded-pill fw-normal bg-{{ stage.color }}-subtle text-{{ stage.color }}-emphasis me-1">{{ stage.status }}</span>
+                    {{ stage.label }}
+                    {% if stage.conflict_slugs %}
+                      —
+                      {% for slug in stage.conflict_slugs %}
+                        <a href="{% url 'nimbus-ui-detail' slug=slug %}">{{ slug }}</a>
+                        {% if not forloop.last %},{% endif %}
+                      {% endfor %}
+                    {% endif %}
+                    {% if stage.has_null_conflict %}
+                      <span class="text-secondary">(conflict slug unavailable on iOS/Fenix)</span>
+                    {% endif %}
+                  </td>
+                  <td class="text-end">{{ stage.client_count }}</td>
+                  <td class="text-end"
+                      style="background: linear-gradient(to left, rgba(var(--bs-{{ stage.color }}-rgb), 0.15) {{ stage.pct|floatformat:1 }}%, transparent 0%)">
+                    {{ stage.pct|floatformat:1 }}%
+                  </td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </section>
+      {% endif %}
+      {% if summary %}
+        <section>
+          <div class="d-flex align-items-center gap-2 mb-2">
+            <h6 class="small fw-semibold text-body mb-0">Branch Health</h6>
+            {% if summary.is_unenrollment_spike %}
+              <span class="badge rounded-pill fw-normal small text-warning-emphasis bg-warning-subtle d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-triangle-exclamation"></i>
+                Unenrollment Spike {{ summary.unenrollment_rate|floatformat:1 }}%
+              </span>
+            {% else %}
+              <span class="badge rounded-pill fw-normal small text-success-emphasis bg-success-subtle d-inline-flex align-items-center gap-1">
+                <i class="fa-solid fa-circle-check"></i>
+                Unenrollment {{ summary.unenrollment_rate|floatformat:1 }}%
+              </span>
+            {% endif %}
+          </div>
+          <table class="table align-middle mb-0">
+            <thead>
+              <tr style="font-size: 12px;">
+                <th class="text-secondary fw-normal">Branch</th>
+                <th class="text-secondary fw-normal text-end">Enrolled</th>
+                <th class="text-secondary fw-normal text-end">Unenrolled</th>
+                <th class="text-secondary fw-normal text-end">Top Unenroll Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr class="small fw-semibold text-body">
+                <td>Total</td>
+                <td class="text-end">{{ summary.total_enrollments }}</td>
+                <td class="text-end">{{ summary.total_unenrollments }}</td>
+                <td></td>
+              </tr>
+              {% for branch in summary.branches %}
+                <tr class="small text-body">
+                  <td>{{ branch.name }}</td>
+                  <td class="text-end">{{ branch.enrollments }}</td>
+                  <td class="text-end">{{ branch.unenrollments }}</td>
+                  <td class="text-end">{{ branch.top_reason|default:"—" }}</td>
+                </tr>
+              {% empty %}
+                <tr>
+                  <td colspan="4" class="small text-secondary">No branch data available</td>
+                </tr>
+              {% endfor %}
+            </tbody>
+          </table>
+        </section>
+      {% endif %}
+    {% endwith %}
+    <div class="d-flex align-items-center justify-content-between mb-1">
+      <a href="{{ experiment.monitoring_dashboard_url }}"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="small text-decoration-none">{{ NimbusUIConstants.MONITORING_DASHBOARD_LINK_TEXT }}</a>
+      <a href="{{ NimbusUIConstants.VALIDATING_EXPERIMENTS_URL }}"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="small text-decoration-none">Learn more</a>
+    </div>
+  </div>
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -8,6 +8,10 @@
   <div id="RolloutSummary" class="d-flex flex-column gap-4">
     {% include "new/common/audience_overlap_warnings.html" %}
 
+    {% if experiment.monitoring_data %}
+      {% include "new/rollouts/detail_card.html" with card_id="monitoring" title=NimbusUIConstants.MONITORING_CARD_TITLE subtitle="Enrollment funnel and branch health" show_edit_btn=False body_template="new/rollouts/monitoring/card.html" %}
+
+    {% endif %}
     {% if experiment.is_preview %}
       <div class="d-flex flex-column gap-2" id="rollout-preview-section">
         {% include "new/rollouts/detail_card.html" with card_id="preview" title="Preview links & testing details" subtitle="Rollout experience" show_edit_btn=False body_template="new/rollouts/preview/card.html" %}


### PR DESCRIPTION
Because:

* The new rollouts page didn’t have enrollment monitoring

This commit:

* Adds the enrollment monitoring card to the new rollouts page following the same format as the old UI
* Removes experiment-specific details that do not apply to rollouts

Fixes #16592

<img width="1264" height="962" alt="Screenshot 2026-08-03 at 8 44 31 PM" src="https://github.com/user-attachments/assets/aa4a5119-ad14-4e0c-9e87-468863ec6cf4" />
