### PR TITLE
chore(nimbus): copied NimbusBranchScreenshotForm into new/forms.py

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -35,7 +35,6 @@ from experimenter.kinto.tasks import (
     nimbus_synchronize_preview_experiments_in_kinto,
 )
 from experimenter.nimbus_ui.constants import NimbusUIConstants
-from experimenter.nimbus_ui.forms import NimbusBranchScreenshotForm
 from experimenter.slack.constants import SlackConstants
 from experimenter.slack.tasks import (
     add_emoji_to_message_async,
@@ -410,6 +409,21 @@ class RolloutBranchFeatureValueForm(NimbusBranchFeatureValueForm):
         return self.cleaned_data.get("feature_config") or (
             self.instance.feature_config if self.instance.feature_config_id else None
         )
+
+
+class NimbusBranchScreenshotForm(forms.ModelForm):
+    image = forms.ImageField(
+        required=False,
+        widget=forms.FileInput(attrs={"class": "form-control"}),
+    )
+    description = forms.CharField(
+        required=False,
+        widget=forms.TextInput(attrs={"class": "form-control"}),
+    )
+
+    class Meta:
+        model = NimbusBranchScreenshot
+        fields = ("image", "description")
 
 
 RolloutBranchFeatureValueFormSet = inlineformset_factory(


### PR DESCRIPTION
Because

- Instead of having a cross dependency between forms.py and new/forms.py where we would import existing forms from the old file into the new, we decided that a better pattern would be to simply copy over any required forms in the new file. 
- we missed doing this with `NimbusBranchScreenshotForm`.

This commit

- Copies `NimbusBranchScreenshotForm` into `new/forms.py`

Fixes #16636