### PR TITLE
feat(nimbus): Show pop sizing data on summary page and audience page

### DIFF
--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -516,6 +516,19 @@ def build_random_funnel_data(branches):
     return rows
 
 
+def build_random_sizing_data():
+    """Generate realistic sizing data for local development."""
+    eligible_count = random.randint(500_000, 90_000_000)
+    possible_warnings = [
+        "experiment.slug",
+        "activeExperiments",
+        "activeRollouts",
+        "enrollmentsMap",
+    ]
+    warnings = random.sample(possible_warnings, k=random.randint(0, 2))
+    return {"eligible_count": eligible_count, "warnings": warnings}
+
+
 def build_random_monitoring_data(branches):
     """Generate realistic monitoring data for a set of branch names."""
     total_enrollments = random.randint(5000, 50000)
@@ -1195,6 +1208,18 @@ class NimbusExperimentFactory(factory.django.DjangoModelFactory):
             experiment.monitoring_data = build_random_monitoring_data(
                 list(experiment.branches.all())
             )
+            experiment.save()
+
+        sizing_data = kwargs.get("sizing_data", _UNSET)
+        if sizing_data is not _UNSET:
+            experiment.sizing_data = sizing_data
+            experiment.save()
+        elif experiment.status in (
+            NimbusExperiment.Status.DRAFT,
+            NimbusExperiment.Status.LIVE,
+            NimbusExperiment.Status.COMPLETE,
+        ):
+            experiment.sizing_data = build_random_sizing_data()
             experiment.save()
 
         return NimbusExperiment.objects.get(id=experiment.id)

--- a/experimenter/experimenter/experiments/tests/factories.py
+++ b/experimenter/experimenter/experiments/tests/factories.py
@@ -518,7 +518,7 @@ def build_random_funnel_data(branches):
 
 def build_random_sizing_data():
     """Generate realistic sizing data for local development."""
-    eligible_count = random.randint(500_000, 90_000_000)
+    eligible_count = random.randint(10_000, 1_000_000)
     possible_warnings = [
         "experiment.slug",
         "activeExperiments",

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -22,6 +22,10 @@
       {% include "nimbus_experiments/detail_card_monitoring.html" %}
 
     {% endif %}
+    {% if experiment.is_draft %}
+      {% include "nimbus_experiments/detail_card_sizing.html" %}
+
+    {% endif %}
     {% include "nimbus_experiments/detail_card_overview.html" %}
     {% include "nimbus_experiments/detail_card_risk_mitigation.html" %}
     {% include "nimbus_experiments/detail_card_signoff.html" with edit=False experiment=experiment %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -22,7 +22,7 @@
       {% include "nimbus_experiments/detail_card_monitoring.html" %}
 
     {% endif %}
-    {% if experiment.is_draft %}
+    {% if experiment.is_draft or experiment.sizing_eligible_count is not None %}
       {% include "nimbus_experiments/detail_card_sizing.html" %}
 
     {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -40,7 +40,7 @@
           </div>
         </div>
       {% endif %}
-    {% else %}
+    {% elif experiment.is_draft %}
       <p class="text-muted mb-0">No sizing data available yet. Estimates are computed daily for Draft experiments.</p>
     {% endif %}
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -15,33 +15,33 @@
   </div>
 {% endblock %}
 {% block card_body %}
-  <div class="p-3">
-    {% if experiment.sizing_eligible_count is not None %}
-      <table class="table table-sm mb-0">
-        <tbody>
+  {% if experiment.sizing_eligible_count is not None %}
+    <table class="table table-striped mb-0" data-testid="sizing-callout">
+      <tbody>
+        <tr>
+          <th class="w-50">Estimated eligible clients</th>
+          <td>~{{ experiment.sizing_eligible_count|short_number }}</td>
+        </tr>
+        {% if experiment.sizing_enrolled_count is not None %}
           <tr>
-            <th class="w-50">Estimated eligible clients</th>
-            <td>~{{ experiment.sizing_eligible_count|short_number }}</td>
+            <th>Projected enrolled at {{ experiment.population_percent }}%</th>
+            <td>~{{ experiment.sizing_enrolled_count|short_number }}</td>
           </tr>
-          {% if experiment.sizing_enrolled_count is not None %}
-            <tr>
-              <th>Projected enrolled at {{ experiment.population_percent }}%</th>
-              <td>~{{ experiment.sizing_enrolled_count|short_number }}</td>
-            </tr>
-          {% endif %}
-        </tbody>
-      </table>
-      {% if experiment.sizing_warnings %}
-        <div class="alert alert-warning mt-3 mb-0 py-2">
-          <i class="fa-solid fa-triangle-exclamation me-1"></i>
-          <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
-          <div class="form-text text-muted mt-1">
-            These attributes couldn't be translated to SQL and were excluded from the estimate.
-          </div>
-        </div>
-      {% endif %}
-    {% elif experiment.is_draft %}
+        {% endif %}
+        {% if experiment.sizing_warnings %}
+          <tr>
+            <td colspan="2" class="text-warning-emphasis">
+              <i class="fa-solid fa-triangle-exclamation me-1"></i>
+              <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
+              <div class="form-text">These attributes couldn't be translated to SQL</div>
+            </td>
+          </tr>
+        {% endif %}
+      </tbody>
+    </table>
+  {% elif experiment.is_draft %}
+    <div class="p-3">
       <p class="text-muted mb-0">No sizing data available yet. Estimates are computed daily for Draft experiments.</p>
-    {% endif %}
-  </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -1,0 +1,47 @@
+{% extends "nimbus_experiments/detail_card_base.html" %}
+
+{% load nimbus_extras %}
+
+{% block card_id %}sizing{% endblock %}
+{% block card_anchor %}sizing{% endblock %}
+{% block card_header %}
+  <div class="d-flex align-items-center justify-content-between">
+    <h4 class="mb-0">
+      <a href="#sizing" class="text-decoration-none text-body">Audience Size Estimate</a>
+    </h4>
+    {% if experiment.sizing_data_updated_at %}
+      <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>
+    {% endif %}
+  </div>
+{% endblock %}
+{% block card_body %}
+  <div class="p-3">
+    {% if experiment.sizing_eligible_count is not None %}
+      <table class="table table-sm mb-0">
+        <tbody>
+          <tr>
+            <th class="w-50">Estimated eligible clients</th>
+            <td>~{{ experiment.sizing_eligible_count|short_number }}</td>
+          </tr>
+          {% if experiment.sizing_enrolled_count is not None %}
+            <tr>
+              <th>Projected enrolled at {{ experiment.population_percent }}%</th>
+              <td>~{{ experiment.sizing_enrolled_count|short_number }}</td>
+            </tr>
+          {% endif %}
+        </tbody>
+      </table>
+      {% if experiment.sizing_warnings %}
+        <div class="alert alert-warning mt-3 mb-0 py-2">
+          <i class="fa-solid fa-triangle-exclamation me-1"></i>
+          <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
+          <div class="form-text text-muted mt-1">
+            These attributes couldn't be translated to SQL and were excluded from the estimate.
+          </div>
+        </div>
+      {% endif %}
+    {% else %}
+      <p class="text-muted mb-0">No sizing data available yet. Estimates are computed daily for Draft experiments.</p>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -260,14 +260,18 @@
             </div>
           </div>
           {% if experiment.sizing_eligible_count is not None %}
-            <div class="alert alert-info mt-3 mb-0" role="alert" data-testid="sizing-callout">
+            <div class="alert alert-info mt-3 mb-0"
+                 role="alert"
+                 data-testid="sizing-callout">
               <div class="d-flex align-items-baseline justify-content-between mb-1">
                 <strong>Audience Size Estimate</strong>
                 {% if experiment.sizing_data_updated_at %}
                   <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>
                 {% endif %}
               </div>
-              <div>Estimated eligible clients: <strong>~{{ experiment.sizing_eligible_count|short_number }}</strong></div>
+              <div>
+                Estimated eligible clients: <strong>~{{ experiment.sizing_eligible_count|short_number }}</strong>
+              </div>
               {% if experiment.sizing_enrolled_count is not None %}
                 <div>
                   Projected enrolled at {{ experiment.population_percent }}%: <strong>~{{ experiment.sizing_enrolled_count|short_number }}</strong>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -259,6 +259,29 @@
               </div>
             </div>
           </div>
+          {% if experiment.sizing_eligible_count is not None %}
+            <div class="alert alert-info mt-3 mb-0" role="alert" data-testid="sizing-callout">
+              <div class="d-flex align-items-baseline justify-content-between mb-1">
+                <strong>Audience Size Estimate</strong>
+                {% if experiment.sizing_data_updated_at %}
+                  <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>
+                {% endif %}
+              </div>
+              <div>Estimated eligible clients: <strong>~{{ experiment.sizing_eligible_count|short_number }}</strong></div>
+              {% if experiment.sizing_enrolled_count is not None %}
+                <div>
+                  Projected enrolled at {{ experiment.population_percent }}%: <strong>~{{ experiment.sizing_enrolled_count|short_number }}</strong>
+                </div>
+              {% endif %}
+              {% if experiment.sizing_warnings %}
+                <div class="mt-2 text-warning-emphasis">
+                  <i class="fa-solid fa-triangle-exclamation me-1"></i>
+                  <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
+                  <div class="form-text">These attributes couldn't be translated to SQL</div>
+                </div>
+              {% endif %}
+            </div>
+          {% endif %}
         </div>
       </div>
       <div class="d-flex justify-content-end">

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1220,49 +1220,64 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         )
         self.assertEqual(response.context["segment_links"], expected_segment_links)
 
-    def test_shows_sizing_card_when_data_present(self):
-        self.experiment.sizing_data = {"eligible_count": 800000, "warnings": []}
-        self.experiment.sizing_data_updated_at = datetime.datetime.now(tz=datetime.UTC)
-        self.experiment.save()
+    @parameterized.expand(
+        [
+            (
+                "draft_with_data",
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                {"eligible_count": 800000, "warnings": []},
+                True,
+                False,
+            ),
+            (
+                "draft_with_warnings",
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                {"eligible_count": 800000, "warnings": ["activeRollouts"]},
+                True,
+                False,
+            ),
+            (
+                "draft_no_data",
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                None,
+                True,
+                True,
+            ),
+            (
+                "live_with_data",
+                NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+                {"eligible_count": 5000000, "warnings": []},
+                True,
+                False,
+            ),
+            (
+                "live_no_data",
+                NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+                None,
+                False,
+                False,
+            ),
+        ]
+    )
+    def test_sizing_card_display(
+        self, _name, lifecycle, sizing_data, shows_card, shows_no_data_message
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            sizing_data=sizing_data,
+        )
         response = self.client.get(
-            reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug})
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug})
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Audience Size Estimate")
-
-    def test_shows_sizing_card_with_no_data_message_for_draft(self):
-        self.experiment.sizing_data = None
-        self.experiment.save()
-        response = self.client.get(
-            reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug})
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Audience Size Estimate")
-        self.assertContains(response, "No sizing data available yet")
-
-    def test_shows_sizing_card_for_live_experiment_with_data(self):
-        live_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            sizing_data={"eligible_count": 5000000, "warnings": []},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
-        )
-        response = self.client.get(
-            reverse("nimbus-ui-detail", kwargs={"slug": live_experiment.slug})
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "Audience Size Estimate")
-        self.assertNotContains(response, "No sizing data available yet")
-
-    def test_hides_sizing_card_for_live_experiment_without_data(self):
-        live_experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            sizing_data=None,
-        )
-        response = self.client.get(
-            reverse("nimbus-ui-detail", kwargs={"slug": live_experiment.slug})
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "Audience Size Estimate")
+        if shows_card:
+            self.assertContains(response, "Audience Size Estimate")
+        else:
+            self.assertNotContains(response, "Audience Size Estimate")
+        if shows_no_data_message:
+            self.assertContains(response, "No sizing data available yet")
+        else:
+            self.assertNotContains(response, "No sizing data available yet")
 
     def test_qa_edit_mode_get_form(self):
         response = self.client.get(
@@ -3358,48 +3373,50 @@ class TestAudienceUpdateView(AuthTestCase):
         )
         self.assertTrue(experiment.is_sticky)
 
-    def test_shows_sizing_callout_when_data_present(self):
+    @parameterized.expand(
+        [
+            (
+                "with_data_and_warnings",
+                {"eligible_count": 500000, "warnings": ["activeRollouts"]},
+                True,
+                True,
+            ),
+            (
+                "with_data_no_warnings",
+                {"eligible_count": 1000000, "warnings": []},
+                True,
+                False,
+            ),
+            (
+                "no_data",
+                None,
+                False,
+                False,
+            ),
+        ]
+    )
+    def test_sizing_callout_display(
+        self, _name, sizing_data, shows_callout, shows_warnings
+    ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
             population_percent=10,
-            sizing_data={"eligible_count": 500000, "warnings": ["activeRollouts"]},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
+            sizing_data=sizing_data,
         )
         response = self.client.get(
             reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
         )
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "sizing-callout")
-        self.assertContains(response, "Audience Size Estimate")
-        self.assertContains(response, "Estimate excludes")
-
-    def test_hides_sizing_callout_when_no_data(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            sizing_data=None,
-        )
-        response = self.client.get(
-            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertNotContains(response, "sizing-callout")
-
-    def test_shows_sizing_callout_without_warnings(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            application=NimbusExperiment.Application.DESKTOP,
-            population_percent=5,
-            sizing_data={"eligible_count": 1000000, "warnings": []},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
-        )
-        response = self.client.get(
-            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "sizing-callout")
-        self.assertNotContains(response, "Estimate excludes")
+        if shows_callout:
+            self.assertContains(response, "sizing-callout")
+            self.assertContains(response, "Audience Size Estimate")
+        else:
+            self.assertNotContains(response, "sizing-callout")
+        if shows_warnings:
+            self.assertContains(response, "Estimate excludes")
+        else:
+            self.assertNotContains(response, "Estimate excludes")
 
 
 class TestSaveAndContinueMixin(AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1222,9 +1222,7 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
 
     def test_shows_sizing_card_when_data_present(self):
         self.experiment.sizing_data = {"eligible_count": 800000, "warnings": []}
-        self.experiment.sizing_data_updated_at = datetime.datetime.now(
-            tz=datetime.timezone.utc
-        )
+        self.experiment.sizing_data_updated_at = datetime.datetime.now(tz=datetime.UTC)
         self.experiment.save()
         response = self.client.get(
             reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug})
@@ -1246,7 +1244,7 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         live_experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             sizing_data={"eligible_count": 5000000, "warnings": []},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
         )
         response = self.client.get(
             reverse("nimbus-ui-detail", kwargs={"slug": live_experiment.slug})
@@ -3366,7 +3364,7 @@ class TestAudienceUpdateView(AuthTestCase):
             application=NimbusExperiment.Application.DESKTOP,
             population_percent=10,
             sizing_data={"eligible_count": 500000, "warnings": ["activeRollouts"]},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
         )
         response = self.client.get(
             reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
@@ -3394,7 +3392,7 @@ class TestAudienceUpdateView(AuthTestCase):
             application=NimbusExperiment.Application.DESKTOP,
             population_percent=5,
             sizing_data={"eligible_count": 1000000, "warnings": []},
-            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.UTC),
         )
         response = self.client.get(
             reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1225,14 +1225,14 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
             (
                 "draft_with_data",
                 NimbusExperimentFactory.Lifecycles.CREATED,
-                {"eligible_count": 800000, "warnings": []},
+                {"eligible_count": 12_345, "warnings": []},
                 True,
                 False,
             ),
             (
                 "draft_with_warnings",
                 NimbusExperimentFactory.Lifecycles.CREATED,
-                {"eligible_count": 800000, "warnings": ["activeRollouts"]},
+                {"eligible_count": 12_345, "warnings": ["activeRollouts"]},
                 True,
                 False,
             ),
@@ -1246,7 +1246,7 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
             (
                 "live_with_data",
                 NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-                {"eligible_count": 5000000, "warnings": []},
+                {"eligible_count": 98_765, "warnings": []},
                 True,
                 False,
             ),
@@ -3377,13 +3377,13 @@ class TestAudienceUpdateView(AuthTestCase):
         [
             (
                 "with_data_and_warnings",
-                {"eligible_count": 500000, "warnings": ["activeRollouts"]},
+                {"eligible_count": 34_567, "warnings": ["activeRollouts"]},
                 True,
                 True,
             ),
             (
                 "with_data_no_warnings",
-                {"eligible_count": 1000000, "warnings": []},
+                {"eligible_count": 87_654, "warnings": []},
                 True,
                 False,
             ),

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1242,6 +1242,30 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         self.assertContains(response, "Audience Size Estimate")
         self.assertContains(response, "No sizing data available yet")
 
+    def test_shows_sizing_card_for_live_experiment_with_data(self):
+        live_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            sizing_data={"eligible_count": 5000000, "warnings": []},
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": live_experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Audience Size Estimate")
+        self.assertNotContains(response, "No sizing data available yet")
+
+    def test_hides_sizing_card_for_live_experiment_without_data(self):
+        live_experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            sizing_data=None,
+        )
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": live_experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Audience Size Estimate")
+
     def test_qa_edit_mode_get_form(self):
         response = self.client.get(
             reverse("nimbus-ui-update-qa-status", kwargs={"slug": self.experiment.slug}),

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1220,6 +1220,28 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
         )
         self.assertEqual(response.context["segment_links"], expected_segment_links)
 
+    def test_shows_sizing_card_when_data_present(self):
+        self.experiment.sizing_data = {"eligible_count": 800000, "warnings": []}
+        self.experiment.sizing_data_updated_at = datetime.datetime.now(
+            tz=datetime.timezone.utc
+        )
+        self.experiment.save()
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Audience Size Estimate")
+
+    def test_shows_sizing_card_with_no_data_message_for_draft(self):
+        self.experiment.sizing_data = None
+        self.experiment.save()
+        response = self.client.get(
+            reverse("nimbus-ui-detail", kwargs={"slug": self.experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Audience Size Estimate")
+        self.assertContains(response, "No sizing data available yet")
+
     def test_qa_edit_mode_get_form(self):
         response = self.client.get(
             reverse("nimbus-ui-update-qa-status", kwargs={"slug": self.experiment.slug}),
@@ -3313,6 +3335,49 @@ class TestAudienceUpdateView(AuthTestCase):
             experiment.targeting_config_slug, NimbusExperiment.TargetingConfig.FIRST_RUN
         )
         self.assertTrue(experiment.is_sticky)
+
+    def test_shows_sizing_callout_when_data_present(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            population_percent=10,
+            sizing_data={"eligible_count": 500000, "warnings": ["activeRollouts"]},
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        response = self.client.get(
+            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "sizing-callout")
+        self.assertContains(response, "Audience Size Estimate")
+        self.assertContains(response, "Estimate excludes")
+
+    def test_hides_sizing_callout_when_no_data(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            sizing_data=None,
+        )
+        response = self.client.get(
+            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "sizing-callout")
+
+    def test_shows_sizing_callout_without_warnings(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            population_percent=5,
+            sizing_data={"eligible_count": 1000000, "warnings": []},
+            sizing_data_updated_at=datetime.datetime.now(tz=datetime.timezone.utc),
+        )
+        response = self.client.get(
+            reverse("nimbus-ui-update-audience", kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "sizing-callout")
+        self.assertNotContains(response, "Estimate excludes")
 
 
 class TestSaveAndContinueMixin(AuthTestCase):


### PR DESCRIPTION
Because

- Experimenter needs to surface the population size estimates written by `bigquery-etl `so experiment owners can see eligible client counts before launching and after go-live.

This commit

- Adds a sizing callout on the Audience edit page showing estimated eligible clients, projected enrollment at the current population %, and a warning if any targeting attributes were excluded from the estimate
- Adds a read-only sizing card on the experiment detail page — shown for Draft experiments (with a "no data yet" fallback) and for Live/Complete experiments when data exists
- `Auto-populates sizing_data i`n the factory for local dev

Fixes #16626 