### PR TITLE
feat(nimbus): Add sidebar phases control in new rollouts UI

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -993,9 +993,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             elif rejection.old_status == self.Status.LIVE:
                 if rejection.old_status_next == self.Status.DISABLED:
                     flow_key = "DISABLE_ROLLOUT"
-                else:
+                elif self.is_rollout_with_phases:
                     flow_key = "ADVANCE_ROLLOUT_PHASE"
-            elif rejection.old_status == self.Status.DISABLED:
+                elif rejection.old_status_next == self.Status.LIVE:
+                    flow_key = "END_ENROLLMENT"
+                else:
+                    flow_key = "END_EXPERIMENT"
+            elif (
+                rejection.old_status == self.Status.DISABLED
+                and self.is_rollout_with_phases
+            ):
                 flow_key = "START_ROLLOUT_PHASE"
         else:
             if rejection.old_status == self.Status.DRAFT:
@@ -1354,19 +1361,25 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return None
 
     @property
-    def has_advanceable_rollout_phase(self):
+    def next_rollout_phase(self):
+        if self.rollout_phase_next_id is not None:
+            return self.rollout_phase_next
+
         phases = list(self.rollout_phases.all())
         if not phases:
-            return False
+            return None
 
         if self.rollout_phase_id is None:
-            next_phase = phases[0]
-        else:
-            phase_ids = [phase.id for phase in phases]
-            current_index = phase_ids.index(self.rollout_phase_id)
-            next_index = current_index + 1
-            next_phase = phases[next_index] if next_index < len(phases) else None
+            return phases[0]
 
+        phase_ids = [phase.id for phase in phases]
+        current_index = phase_ids.index(self.rollout_phase_id)
+        next_index = current_index + 1
+        return phases[next_index] if next_index < len(phases) else None
+
+    @property
+    def has_advanceable_rollout_phase(self):
+        next_phase = self.next_rollout_phase
         return bool(next_phase and next_phase.population_percent)
 
     @property
@@ -1421,7 +1434,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         today = timezone.now().date()
         current_phase = self.rollout_phase
-        next_phase = self.rollout_phase_next
+        next_phase = self.next_rollout_phase
 
         if not next_phase or not next_phase.population_percent:
             return
@@ -1444,17 +1457,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if not self.is_rollout_with_phases:
             return None
 
-        phases = list(self.rollout_phases.all())
-
-        if self.rollout_phase_next_id is not None:
-            next_phase = self.rollout_phase_next
-        elif self.rollout_phase_id is None:
-            next_phase = phases[0]
-        else:
-            phase_ids = [phase.id for phase in phases]
-            current_index = phase_ids.index(self.rollout_phase_id)
-            next_index = current_index + 1
-            next_phase = phases[next_index] if next_index < len(phases) else None
+        next_phase = self.next_rollout_phase
 
         if next_phase is None or not next_phase.population_percent:
             return None

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -987,13 +987,27 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             return None
 
         flow_key = None
-        if rejection.old_status == self.Status.DRAFT:
-            flow_key = "LAUNCH_ROLLOUT" if self.is_rollout else "LAUNCH_EXPERIMENT"
-        elif rejection.old_status == self.Status.LIVE:
-            if rejection.old_status_next == self.Status.LIVE:
-                flow_key = "END_ENROLLMENT"
-            else:
-                flow_key = "END_EXPERIMENT"
+        if self.is_rollout:
+            if rejection.old_status == self.Status.DRAFT:
+                flow_key = "LAUNCH_ROLLOUT"
+            elif rejection.old_status == self.Status.LIVE:
+                if rejection.old_status_next == self.Status.DISABLED:
+                    flow_key = "DISABLE_ROLLOUT"
+                else:
+                    flow_key = "ADVANCE_ROLLOUT_PHASE"
+            elif rejection.old_status == self.Status.DISABLED:
+                flow_key = "START_ROLLOUT_PHASE"
+        else:
+            if rejection.old_status == self.Status.DRAFT:
+                flow_key = "LAUNCH_EXPERIMENT"
+            elif rejection.old_status == self.Status.LIVE:
+                if rejection.old_status_next == self.Status.LIVE:
+                    flow_key = "END_ENROLLMENT"
+                else:
+                    flow_key = "END_EXPERIMENT"
+
+        if flow_key is None:
+            return None
 
         return {
             "action": NimbusUIConstants.ReviewRequestMessages[flow_key].value,
@@ -1318,6 +1332,42 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def is_rollout_with_phases(self):
         return self.is_rollout and self.rollout_phases.exists()
+
+    @property
+    def is_disabled(self):
+        return self.status == self.Status.DISABLED
+
+    @property
+    def is_rolling_out(self):
+        return self.is_rollout and (self.is_live_rollout or self.is_disabled)
+
+    @property
+    def has_pending_rollout_transition(self):
+        return self.is_rollout and self.publish_status != self.PublishStatus.IDLE
+
+    @property
+    def current_rollout_phase_display(self):
+        for number, phase in enumerate(self.annotated_rollout_phases(), start=1):
+            if phase.card_status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
+                phase.number = number
+                return phase
+        return None
+
+    @property
+    def has_advanceable_rollout_phase(self):
+        phases = list(self.rollout_phases.all())
+        if not phases:
+            return False
+
+        if self.rollout_phase_id is None:
+            next_phase = phases[0]
+        else:
+            phase_ids = [phase.id for phase in phases]
+            current_index = phase_ids.index(self.rollout_phase_id)
+            next_index = current_index + 1
+            next_phase = phases[next_index] if next_index < len(phases) else None
+
+        return bool(next_phase and next_phase.population_percent)
 
     @property
     def rollout_review_controls(self):
@@ -3062,6 +3112,13 @@ class NimbusRolloutPhase(models.Model):
             return 0
         return max(0, (timezone.now().date() - self.start_date).days)
 
+    @property
+    def days_elapsed_capped(self):
+        duration = self.duration_days
+        if duration is None:
+            return self.days_elapsed
+        return min(self.days_elapsed, duration)
+
 
 class NimbusRolloutPlanTemplate(models.Model):
     name = models.CharField("Rollout Plan Name", max_length=255, unique=True)
@@ -3581,6 +3638,7 @@ class NimbusChangeLog(FilterMixin, models.Model):
             new_status__in=(
                 NimbusExperiment.Status.DRAFT,
                 NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
             ),
             published_dto_changed=False,
         )

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5503,17 +5503,20 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Status.DRAFT,
                 None,
                 False,
+                False,
                 "LAUNCH_EXPERIMENT",
             ),
             (
                 NimbusExperiment.Status.DRAFT,
                 None,
                 True,
+                False,
                 "LAUNCH_ROLLOUT",
             ),
             (
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.LIVE,
+                False,
                 False,
                 "END_ENROLLMENT",
             ),
@@ -5521,11 +5524,13 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.COMPLETE,
                 False,
+                False,
                 "END_EXPERIMENT",
             ),
             (
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.LIVE,
+                True,
                 True,
                 "ADVANCE_ROLLOUT_PHASE",
             ),
@@ -5533,13 +5538,29 @@ class TestNimbusExperiment(TestCase):
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.Status.DISABLED,
                 True,
+                True,
                 "DISABLE_ROLLOUT",
             ),
             (
                 NimbusExperiment.Status.DISABLED,
                 NimbusExperiment.Status.LIVE,
                 True,
+                True,
                 "START_ROLLOUT_PHASE",
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.COMPLETE,
+                True,
+                False,
+                "END_EXPERIMENT",
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                True,
+                False,
+                "END_ENROLLMENT",
             ),
         ]
     )
@@ -5548,12 +5569,15 @@ class TestNimbusExperiment(TestCase):
         status,
         status_next,
         is_rollout,
+        with_phases,
         expected_flow_key,
     ):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             is_rollout=is_rollout,
         )
+        if with_phases:
+            NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=10)
 
         experiment.status = status
         experiment.status_next = status_next

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -5523,6 +5523,24 @@ class TestNimbusExperiment(TestCase):
                 False,
                 "END_EXPERIMENT",
             ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                True,
+                "ADVANCE_ROLLOUT_PHASE",
+            ),
+            (
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.DISABLED,
+                True,
+                "DISABLE_ROLLOUT",
+            ),
+            (
+                NimbusExperiment.Status.DISABLED,
+                NimbusExperiment.Status.LIVE,
+                True,
+                "START_ROLLOUT_PHASE",
+            ),
         ]
     )
     def test_rejection_block_from_rejection_changelog(
@@ -5559,6 +5577,25 @@ class TestNimbusExperiment(TestCase):
         )
         self.assertEqual(block["date"], experiment.changes.latest_rejection().changed_on)
         self.assertEqual(block["message"], "test message")
+
+    def test_rejection_block_is_none_for_unmapped_status(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=False,
+        )
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.status_next = None
+
+        for publish_status in (
+            NimbusExperiment.PublishStatus.REVIEW,
+            NimbusExperiment.PublishStatus.IDLE,
+        ):
+            experiment.publish_status = publish_status
+            experiment.save()
+            generate_nimbus_changelog(experiment, experiment.owner, "test message")
+
+        self.assertIsNotNone(experiment.changes.latest_rejection())
+        self.assertIsNone(experiment.rejection_block)
 
     def test_save_populates_firefox_min_version_parsed_with_bang_notation(self):
         experiment = NimbusExperimentFactory.create(firefox_min_version="95.!")
@@ -6922,6 +6959,23 @@ class TestNimbusRolloutPhase(TestCase):
         self.assertEqual(phase.duration_days, 5)
         self.assertEqual(phase.duration_display, "5 days")
 
+    def test_days_elapsed_capped(self):
+        today = timezone.now().date()
+        day = datetime.timedelta(days=1)
+
+        phase = NimbusRolloutPhaseFactory.build(
+            start_date=today - 3 * day, end_date=today + 3 * day
+        )
+        self.assertEqual(phase.days_elapsed_capped, 3)
+
+        phase = NimbusRolloutPhaseFactory.build(
+            start_date=today - 10 * day, end_date=today - day
+        )
+        self.assertEqual(phase.days_elapsed_capped, 9)
+
+        phase = NimbusRolloutPhaseFactory.build(start_date=today - 2 * day, end_date=None)
+        self.assertEqual(phase.days_elapsed_capped, 2)
+
     def test_duration_none_without_dates(self):
         phase = NimbusRolloutPhaseFactory.build(start_date=None, end_date=None)
         self.assertIsNone(phase.duration_days)
@@ -7404,3 +7458,113 @@ class TestRolloutReviewControls(TestCase):
         controls = experiment.rollout_review_controls
         self.assertEqual(controls["approve_url"], approve_url)
         self.assertEqual(controls["reject_url"], reject_url)
+
+
+class TestRolloutSidebarStateHelpers(TestCase):
+    def live_rollout(self):
+        return NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+
+    def disabled_rollout(self):
+        experiment = self.live_rollout()
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.save()
+        return experiment
+
+    def test_is_rolling_out_when_live_rollout(self):
+        self.assertTrue(self.live_rollout().is_rolling_out)
+
+    def test_is_rolling_out_when_disabled_rollout(self):
+        self.assertTrue(self.disabled_rollout().is_rolling_out)
+
+    def test_is_rolling_out_false_when_draft(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        self.assertFalse(experiment.is_rolling_out)
+
+    def test_has_pending_rollout_transition_false_when_idle(self):
+        experiment = NimbusExperimentFactory.create(
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+        self.assertFalse(experiment.has_pending_rollout_transition)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.PublishStatus.REVIEW,),
+            (NimbusExperiment.PublishStatus.APPROVED,),
+            (NimbusExperiment.PublishStatus.WAITING,),
+        ]
+    )
+    def test_has_pending_rollout_transition_true_while_not_idle(self, publish_status):
+        experiment = NimbusExperimentFactory.create(
+            publish_status=publish_status,
+            is_rollout=True,
+        )
+        self.assertTrue(experiment.has_pending_rollout_transition)
+
+    def test_current_rollout_phase_display_returns_in_progress_phase(self):
+        experiment = self.live_rollout()
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (1, 10, 50)
+        ]
+        experiment.rollout_phase = phases[1]
+        experiment.save()
+
+        current = experiment.current_rollout_phase_display
+        self.assertEqual(current, phases[1])
+        self.assertEqual(current.number, 2)
+
+    def test_current_rollout_phase_display_none_when_no_current_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=10)
+        self.assertIsNone(experiment.current_rollout_phase_display)
+
+    def test_has_advanceable_rollout_phase_false_when_no_phases(self):
+        self.assertFalse(self.live_rollout().has_advanceable_rollout_phase)
+
+    def test_has_advanceable_rollout_phase_true_when_next_has_population(self):
+        experiment = self.live_rollout()
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (1, 10)
+        ]
+        experiment.rollout_phase = phases[0]
+        experiment.save()
+        self.assertTrue(experiment.has_advanceable_rollout_phase)
+
+    def test_has_advanceable_rollout_phase_false_on_last_phase(self):
+        experiment = self.live_rollout()
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (1, 10)
+        ]
+        experiment.rollout_phase = phases[1]
+        experiment.save()
+        self.assertFalse(experiment.has_advanceable_rollout_phase)
+
+    def test_has_advanceable_rollout_phase_false_when_next_has_zero_population(self):
+        experiment = self.live_rollout()
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (10, 0)
+        ]
+        experiment.rollout_phase = phases[0]
+        experiment.save()
+        self.assertFalse(experiment.has_advanceable_rollout_phase)

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -387,6 +387,18 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ROLLOUT_PREVIEW_BLOCKED_TOOLTIP = (
         "Resolve the detected setup issues before previewing"
     )
+    ROLLOUT_LIVE_MESSAGE = (
+        "This rollout is live. You can advance to the next phase to adjust its "
+        "population sizing, or disable it."
+    )
+    ROLLOUT_DISABLED_MESSAGE = (
+        "This rollout is currently disabled. You can re-enable it by starting the "
+        "next phase."
+    )
+    ROLLOUT_DUPLICATE_PHASE_MESSAGE = (
+        "There is no next phase to start. Your current phase will be copied and "
+        "rolled out again."
+    )
 
     class RolloutPhaseStatus:
         NOT_STARTED = "not_started"
@@ -424,6 +436,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         LAUNCH_ROLLOUT = "launch this rollout"
         UPDATE_ROLLOUT = "update this rollout"
         END_ROLLOUT = "end this rollout"
+        ADVANCE_ROLLOUT_PHASE = "advance this rollout to the next phase"
+        START_ROLLOUT_PHASE = "start the next phase of this rollout"
+        DISABLE_ROLLOUT = "disable this rollout"
 
     class CancelRequestMessages(Enum):
         END_ENROLLMENT = "Cancelled end enrollment request."

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -396,8 +396,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "next phase."
     )
     ROLLOUT_DUPLICATE_PHASE_MESSAGE = (
-        "There is no next phase to start. Your current phase will be copied and "
-        "rolled out again."
+        "There is no next phase to start. Accept to copy and launch the current "
+        "phase again, or cancel and add a new phase in the rollout schedule."
     )
 
     class RolloutPhaseStatus:

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -627,7 +627,7 @@ class NewRolloutScheduleUpdateView(NewCardUpdateView):
         return context
 
     def can_edit(self):
-        return True
+        return self.object.is_draft or self.object.is_rolling_out
 
 
 class NewRolloutPhaseCreateView(

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -80,7 +80,7 @@
     <h2 class="accordion-header">
       <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_preview %} collapsed{% endif %}"
               type="button"
-              {% if experiment.is_preview or experiment.is_preview_complete %}data-bs-toggle="collapse" data-bs-target="#sidebar-preview" aria-controls="sidebar-preview" aria-expanded="{% if experiment.is_preview %}true{% else %}false{% endif %}
+              {% if experiment.preview_date and not experiment.is_draft %}data-bs-toggle="collapse" data-bs-target="#sidebar-preview" aria-controls="sidebar-preview" aria-expanded="{% if experiment.is_preview %}true{% else %}false{% endif %}
               "
               {% else %}
               aria-expanded="false"
@@ -95,7 +95,7 @@
         {% endif %}
         <span class="d-flex flex-column">
           <span>Preview</span>
-          {% if experiment.is_preview or experiment.is_preview_complete %}
+          {% if experiment.preview_date and not experiment.is_draft %}
             <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
               {{ experiment.preview_date|date:"M j, Y" }}
               <span class="text-body-tertiary">|</span>
@@ -109,7 +109,7 @@
          id="sidebar-preview"
          data-bs-parent="#accordion-preview">
       <div class="accordion-body pt-0 px-3 pb-3">
-        {% if experiment.is_preview or experiment.is_preview_complete %}
+        {% if experiment.preview_date and not experiment.is_draft %}
           <div class="d-flex flex-column gap-3">
             <p class="mb-0 text-secondary" style="font-size: 12px;">
               {{ NimbusUIConstants.ROLLOUT_PREVIEW_MESSAGE }}
@@ -139,6 +139,84 @@
                       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                       {% if not experiment.is_preview %}disabled{% endif %}>Request Enrollment</button>
             </div>
+          </div>
+        {% endif %}
+      </div>
+    </div>
+  </div>
+</div>
+<div class="accordion accordion-flush rounded-3 bg-body-secondary"
+     style="--bs-accordion-btn-active-color: var(--bs-body-color);
+            --bs-accordion-btn-active-bg: transparent;
+            --bs-accordion-active-color: var(--bs-body-color)"
+     id="accordion-rollout">
+  <div class="accordion-item border-0 bg-transparent rounded-3">
+    <h2 class="accordion-header">
+      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_rolling_out %} collapsed{% endif %}"
+              type="button"
+              {% if experiment.is_rolling_out %}data-bs-toggle="collapse" data-bs-target="#sidebar-rollout" aria-expanded="true" aria-controls="sidebar-rollout"{% else %}aria-expanded="false" aria-disabled="true"{% endif %}>
+        <i class="fa-solid fa-rocket text-secondary me-2 align-self-start mt-1"></i>
+        <span class="d-flex flex-column">
+          <span>Rollout</span>
+          {% if experiment.start_date %}
+            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
+              {{ experiment.start_date|date:"M j, Y" }}
+              <span class="text-body-tertiary">|</span>
+              {% if experiment.is_disabled %}
+                Disabled
+              {% else %}
+                In Progress
+              {% endif %}
+            </span>
+          {% endif %}
+        </span>
+      </button>
+    </h2>
+    <div class="accordion-collapse collapse{% if experiment.is_rolling_out %} show{% endif %}"
+         id="sidebar-rollout"
+         data-bs-parent="#accordion-rollout">
+      <div class="accordion-body pt-0 px-3 pb-3">
+        {% if experiment.is_rolling_out %}
+          <div class="d-flex flex-column gap-3">
+            {% with phase=experiment.current_rollout_phase_display %}
+              {% if phase %}
+                <div>
+                  <div class="small fw-semibold text-body mb-0">Phase {{ phase.number }}</div>
+                  <div class="text-secondary d-flex flex-wrap align-items-center gap-1"
+                       style="font-size: 12px">
+                    {% if phase.duration_days %}
+                      <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
+                    {% else %}
+                      <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
+                    {% endif %}
+                    <span class="text-body-tertiary">|</span>
+                    <span>{{ phase.population_percent|floatformat:"-2" }}% population</span>
+                  </div>
+                  <div class="progress mt-1 bg-body"
+                       style="height: 6px"
+                       role="progressbar"
+                       aria-label="Phase {{ phase.number }} progress">
+                    <div class="progress-bar {% if experiment.is_disabled %}bg-secondary{% else %}bg-primary{% endif %}"
+                         style="width: {% if phase.duration_days %}{% widthratio phase.days_elapsed_capped phase.duration_days 100 %}{% else %}0{% endif %}%">
+                    </div>
+                  </div>
+                </div>
+              {% endif %}
+            {% endwith %}
+            <p class="text-secondary mb-0" style="font-size: 12px;">
+              {% if experiment.is_disabled %}
+                {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
+              {% else %}
+                {{ NimbusUIConstants.ROLLOUT_LIVE_MESSAGE }}
+              {% endif %}
+            </p>
+            <a href="#rollout-card-schedule"
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+              <i class="fa-regular fa-clock text-secondary"></i>
+              Rollout Schedule
+            </a>
+            {% include "new/common/sidebar_rollout_actions.html" %}
+
           </div>
         {% endif %}
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -31,11 +31,14 @@
                  data-testid="rejection-notice">
               <p class="small text-secondary text-break mb-0">
                 {{ rejection.email }} rejected the request to
-                {{ rejection.action }} on {{ rejection.date|date:"M j, Y" }}:
+                {{ rejection.action }} on {{ rejection.date|date:"M j, Y" }}
+                {% if rejection.message %}:{% endif %}
               </p>
-              <p class="small text-danger-emphasis text-break bg-danger-subtle border-start border-danger border-3 rounded-end p-2 mb-0">
-                {{ rejection.message }}
-              </p>
+              {% if rejection.message %}
+                <p class="small text-danger-emphasis text-break bg-danger-subtle border-start border-danger border-3 rounded-end p-2 mb-0">
+                  {{ rejection.message }}
+                </p>
+              {% endif %}
             </div>
           {% endif %}
           {% if timed_out %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -1,0 +1,72 @@
+<div id="sidebar-rollout-actions"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  {% if experiment.is_rolling_out %}
+    {% with transition_pending=experiment.has_pending_rollout_transition %}
+      <div class="d-flex flex-column gap-2">
+        {% if experiment.is_disabled %}
+          {% if experiment.has_advanceable_rollout_phase %}
+            {# Disabled to Live #}
+            <button type="button"
+                    id="rollout-resume-btn"
+                    class="btn btn-primary btn-sm w-100"
+                    hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-disabled-elt="this"
+                    {% if transition_pending %}disabled{% endif %}>Start next phase</button>
+          {% else %}
+            {# Disabled to Live #}
+            <div class="collapse show rollout-resume-swap" id="rollout-resume-trigger">
+              <button type="button"
+                      id="rollout-resume-btn"
+                      class="btn btn-primary btn-sm w-100"
+                      data-bs-toggle="collapse"
+                      data-bs-target=".rollout-resume-swap"
+                      aria-expanded="false"
+                      aria-controls="rollout-duplicate-phase-confirm"
+                      {% if transition_pending %}disabled{% endif %}>Start next phase</button>
+            </div>
+            <div class="collapse rollout-resume-swap"
+                 id="rollout-duplicate-phase-confirm">
+              <p style="font-size: 12px;">{{ NimbusUIConstants.ROLLOUT_DUPLICATE_PHASE_MESSAGE }}</p>
+              <div class="d-flex flex-column gap-2">
+                <button type="button"
+                        id="rollout-duplicate-phase-cancel-btn"
+                        class="btn btn-secondary btn-sm w-100"
+                        data-bs-toggle="collapse"
+                        data-bs-target=".rollout-resume-swap"
+                        aria-expanded="false"
+                        aria-controls="rollout-resume-trigger">Cancel</button>
+                <button type="button"
+                        id="rollout-duplicate-phase-accept-btn"
+                        class="btn btn-success btn-sm w-100"
+                        hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}"
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                        hx-disabled-elt="this"
+                        {% if transition_pending %}disabled{% endif %}>Accept</button>
+              </div>
+            </div>
+          {% endif %}
+        {% else %}
+          {# Live to Disabled #}
+          <button type="button"
+                  id="rollout-disable-btn"
+                  class="btn btn-secondary btn-sm w-100"
+                  hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}"
+                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                  hx-disabled-elt="this"
+                  {% if transition_pending %}disabled{% endif %}>Disable rollout</button>
+          {# Live to Live phase advance #}
+          <button type="button"
+                  id="rollout-next-phase-btn"
+                  class="btn btn-primary btn-sm w-100"
+                  hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
+                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                  hx-disabled-elt="this"
+                  {% if transition_pending or not experiment.has_advanceable_rollout_phase %}disabled{% endif %}>
+            Start next phase
+          </button>
+        {% endif %}
+      </div>
+    {% endwith %}
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -12,6 +12,10 @@
       {% include "new/rollouts/detail_card.html" with card_id="monitoring" title=NimbusUIConstants.MONITORING_CARD_TITLE subtitle="Enrollment funnel and branch health" show_edit_btn=False body_template="new/rollouts/monitoring/card.html" %}
 
     {% endif %}
+    {% if experiment.is_rolling_out %}
+      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" subtitle="Gradually increase the rollout population in phases" show_edit_btn=True body_template="new/rollouts/schedule/card.html" %}
+
+    {% endif %}
     {% if experiment.is_preview %}
       <div class="d-flex flex-column gap-2" id="rollout-preview-section">
         {% include "new/rollouts/detail_card.html" with card_id="preview" title="Preview links & testing details" subtitle="Rollout experience" show_edit_btn=False body_template="new/rollouts/preview/card.html" %}
@@ -41,8 +45,11 @@
       <div class="small fw-medium mb-1 text-secondary">Build</div>
       {# TODO EXP-6685: Rollout Features Form/Card #}
       {% include "new/rollouts/detail_card.html" with card_id="rollout-features" title="Rollout Features" subtitle="Describe the rollout experience" show_edit_btn=experiment.is_draft body_template="new/rollouts/rollout_features/card.html" %}
-      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" subtitle="Gradually increase the rollout population in phases" show_edit_btn=True body_template="new/rollouts/schedule/card.html" %}
 
+      {% if not experiment.is_rolling_out %}
+        {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" subtitle="Gradually increase the rollout population in phases" show_edit_btn=experiment.is_draft body_template="new/rollouts/schedule/card.html" %}
+
+      {% endif %}
     </div>
     {# ── Check ── #}
     <div class="d-flex flex-column gap-2">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -39,11 +39,22 @@
                 {# Estimated Duration #}
                 <td class="small">
                   {% if phase.card_status == "in_progress" %}
-                    {% if phase.end_date %}
+                    {% if experiment.is_disabled %}
+                      <div class="d-flex align-items-center gap-1 text-secondary mb-1">
+                        <span>Disabled</span>
+                        {% if phase.actual_start_date %}
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>Started {{ phase.actual_start_date|date:"M j, Y" }}</span>
+                        {% endif %}
+                      </div>
+                      <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
+                        <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
+                      </div>
+                    {% elif phase.end_date %}
                       <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                         <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
                         <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>Ending on {{ phase.end_date|date:"M j, Y" }}</span>
+                        <span>End on {{ phase.end_date|date:"M j, Y" }}</span>
                       </div>
                       <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
                         <div class="progress-bar"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -110,4 +110,8 @@
       </div>
     </div>
   </div>
+  {% if hx_swap_oob and experiment.is_rolling_out %}
+    {% include "new/common/sidebar_rollout_actions.html" with oob=True %}
+
+  {% endif %}
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1350,6 +1350,20 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
 
+    def test_get_locked_when_not_draft_or_rolling_out(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
+        )
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.url,
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+        )
+
     def test_get_shows_builtin_plan(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,


### PR DESCRIPTION
Because

* We need controls in the sidebar to move to the next phase or disable
* We need to give user the option to duplicate previous phase if there is no next phase and current phase is disabled

This commit

* Adds all the remaining sidebar controls
* Ensures buttons are disabled when they should be
* Provides user with the relevant tips

Fixes #16583
