### PR TITLE
feat(nimbus): Add nimbus-devtools support to new rollouts UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -125,8 +125,26 @@
                 Slug copied to clipboard!
               </div>
             </div>
+            <div id="json-copy-toast"
+                 class="toast hide text-bg-primary mb-1"
+                 role="alert"
+                 aria-live="assertive"
+                 aria-atomic="true">
+              <div class="toast-body">
+                <i class="fa-regular fa-circle-check"></i>
+                JSON copied to clipboard!
+              </div>
+            </div>
           </div>
         </div>
+        <template id="template-toast">
+          <div class="toast hide text-bg-primary mb-1"
+               role="alert"
+               aria-live="assertive"
+               aria-atomic="true">
+            <div class="toast-body"></div>
+          </div>
+        </template>
         {# Page content #}
         {% block main_content %}{% endblock %}
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -175,6 +175,14 @@
         {% endif %}
       </div>
     {% endif %}
+    {# Recipe JSON #}
+    <div>
+      <div class="text-secondary mb-1" style="font-size: 12px;">Recipe JSON</div>
+      <div data-nimbus-devtools-recipe-json>
+        {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+
+      </div>
+    </div>
   </div>
   {% if hx_swap_oob %}
     {% include "new/common/audience_overlap_warnings.html" with oob=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
@@ -73,12 +73,16 @@
             </div>
           {% endif %}
         {% endwith %}
-        {# about:studies opt-in URL for the rollout branch #}
-        <button type="button"
-                class="btn btn-primary d-inline-flex align-items-center justify-content-center"
-                onclick="navigator.clipboard.writeText('about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview');this.innerText='Copied';">
-          <i class="fa-regular fa-eye me-2" aria-hidden="true"></i>Preview link
-        </button>
+        {% if experiment.is_desktop %}
+          {# about:studies opt-in URL for the rollout branch #}
+          <button type="button"
+                  class="btn btn-primary d-inline-flex align-items-center justify-content-center"
+                  onclick="navigator.clipboard.writeText('about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview');this.innerText='Copied';">
+            <i class="fa-regular fa-eye me-2" aria-hidden="true"></i>Preview link
+          </button>
+          {% include "nimbus_devtools/opt_in_pane.html" %}
+
+        {% endif %}
       </div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -1,10 +1,11 @@
 {% extends "new/common/base.html" %}
 
 {% load static %}
-{% load nimbus_extras %}
+{% load nimbus_extras nimbus_devtools %}
 
 {% block title %}{{ experiment.name }}{% endblock %}
 {% block main_content %}
+  {% devtools_integration experiment "rollout" %}
   <div id="RolloutSummary" class="d-flex flex-column gap-4">
     {% include "new/common/audience_overlap_warnings.html" %}
 

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_devtools/opt_in_pane.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_devtools/opt_in_pane.html
@@ -1,0 +1,27 @@
+<div data-nimbus-devtools-opt-in-pane>
+  <div class="d-none rounded-3 border border-primary-subtle bg-primary-subtle p-3"
+       data-nimbus-devtools-required>
+    <div class="d-flex align-items-start gap-2 mb-2">
+      <i class="fa-solid fa-bolt text-primary mt-1" aria-hidden="true"></i>
+      <div class="small text-body">
+        Because you have <em>Nimbus Developer Tools</em> installed, you can opt-in with one click:
+      </div>
+    </div>
+    {% if experiment.is_rollout %}
+      <input type="hidden"
+             data-nimbus-devtools-force-enroll-branch-selector
+             value="{{ experiment.reference_branch.slug }}">
+    {% else %}
+      <select class="form-select form-select-sm mb-2"
+              data-nimbus-devtools-force-enroll-branch-selector>
+        {% for branch in experiment.branches.all %}
+          <option value="{{ branch.slug }}"
+                  {% if branch == experiment.reference_branch %}selected{% endif %}>{{ branch.name }}</option>
+        {% endfor %}
+      </select>
+    {% endif %}
+    <button class="btn btn-primary btn-sm w-100 d-inline-flex align-items-center justify-content-center"
+            type="button"
+            data-nimbus-devtools-enroll-button>Force Enroll</button>
+  </div>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -6,6 +6,7 @@
 {% block title %}{{ experiment.name }}{% endblock %}
 {% block main_content %}
   {% devtools_metadata experiment %}
+  {% devtools_integration experiment "summary" %}
   <div id="PageSummary" class="mt-3">
     {% include "nimbus_experiments/invalid_pages_warning.html" %}
     {% include "nimbus_experiments/audience_overlap_warnings.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -9,6 +9,7 @@
 {% block title %}{{ experiment.name }} - Branches{% endblock %}
 {% block main_content %}
   {% devtools_metadata experiment %}
+  {% devtools_integration experiment "branches" %}
   <div class="position-relative">
     <!-- Full form overlay -->
     <div id="htmx-loading-overlay"

--- a/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
+++ b/experimenter/experimenter/nimbus_ui/templatetags/nimbus_devtools.py
@@ -1,11 +1,13 @@
 from django import template
 from django.utils.html import json_script
 
+from experimenter.experiments.models import NimbusExperiment
+
 register = template.Library()
 
 
 @register.simple_tag
-def devtools_metadata(experiment):
+def devtools_metadata(experiment: NimbusExperiment) -> str:
     """Embed metadata about a given experiment in a page for nimbus-devtools to
     consume.
     """
@@ -16,4 +18,22 @@ def devtools_metadata(experiment):
             "localizations": experiment.localizations,
         },
         element_id="nimbus-devtools-experiment-metadata",
+    )
+
+
+@register.simple_tag
+def devtools_integration(experiment: NimbusExperiment, page: str) -> str:
+    """Embed metadata about a given experiment and the current page for
+    nimbus-devtools to consume.
+    """
+    return json_script(
+        {
+            "experimentMetadata": {
+                "application": experiment.application,
+                "isLocalized": experiment.is_localized,
+                "localizations": experiment.localizations,
+            },
+            "page": page,
+        },
+        element_id="nimbus-devtools-integration",
     )


### PR DESCRIPTION
Because:

- rollouts on the new UI aren't integrated with nimbus-devtools yet

This commit:

- wires devtools metadata, recipe JSON, force-enroll, message feature preview, and toasts into the new rollouts page

Fixes #16623
