### PR TITLE
feat(nimbus): Reference Resource IDs on mobile in Labs

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -349,7 +349,12 @@
               <div class="row mb-3">
                 <div class="col">
                   <label class="d-block">
-                    The title to display in Firefox Labs (Fluent ID)
+                    The title to display in Firefox Labs
+                    {% if experiment.is_mobile %}
+                      (Resource ID)
+                    {% else %}
+                      (Fluent ID)
+                    {% endif %}
                     {{ form.firefox_labs_title }}
                   </label>
                   {{ form.firefox_labs_title.errors }}
@@ -361,7 +366,12 @@
               <div class="row mb-3">
                 <div class="col">
                   <label class="d-block">
-                    The description to display in Firefox Labs (Fluent ID)
+                    The description to display in Firefox Labs
+                    {% if experiment.is_mobile %}
+                      (Resource ID)
+                    {% else %}
+                      (Fluent ID)
+                    {% endif %}
                     {{ form.firefox_labs_description }}
                   </label>
                   {{ form.firefox_labs_description.errors }}


### PR DESCRIPTION
Because:

- mobile does not have Fluent -- instead translations are done via resource IDs;
- the Firefox Labs forms reference Fluent IDs explicitly; and
- mobile now has Firefox Labs

this commit:

- Updates the labels to reference "Resource ID" on mobile and "Fluent ID" on Desktop

Fixes #16632