### PR TITLE
feat(nimbus): Add multi-profile exclusion to launch-on-login targeting.

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1291,15 +1291,17 @@ WINDOWS_LAUNCH_ON_LOGIN_ELIGIBLE_IMPROVED = NimbusTargetingConfig(
     slug="windows_launch_on_login_eligible_improved",
     description=(
         "Windows 10+ users whose profiles predate 6/16/2026, who don't already "
-        "have launch on login enabled, for whom LoL is not blocked by policy. "
-        "Excludes users running an MSIX build on Windows 10."
+        "have launch on login enabled, for whom LoL is not blocked by policy, "
+        "who are not running an MSIX build on Windows 10, and who are not using "
+        "a selectable profile group with more than 1 profile."
     ),
     targeting=(
         "os.isWindows && os.windowsVersion >= 10 && !launchOnLoginEnabled && "
         "launchOnLoginAllowedByPolicy && "
         "'browser.startup.windowsLaunchOnLogin.enabled'|preferenceValue && "
         "(!isMSIX || os.windowsBuildNumber >= 22000) && "
-        "profileAgeCreated < '2026-06-16'|date"
+        "profileAgeCreated < '2026-06-16'|date && "
+        "profileGroupProfileCount < 2"
     ),
     desktop_telemetry="",
     sticky_required=False,


### PR DESCRIPTION
Because:

- The experiment turns on LoL upon enrollment, and then shows an infobar (notifying users of the change and offering them a chance to turn it back off) the next time Firefox is launched by the launch-on-login startup item (it gets a launch flag indicating this). The problem is that the startup item operates at the level of the installation, not the profile. So users with selectable profiles could have LoL turned on while using Profile1, then switch to Profile2. Then we wouldn't be able to show them the infobar, because the messaging system doesn't know that they had LoL turned on by the experiment - that info only exists in Profile2. And the infobar is crucial, since turning this feature on without the user's express consent is only mitigated by the fact that we show them an infobar later. As long as the infobar shows, we're just previewing the feature for them. But if it doesn't show, we're not really respecting the user's autonomy.

This commit:

- Adds to the existing launch-on-login targeting expression to exclude users who have more than one selectable profile in their profile group.

Fixes #16696