### PR TITLE
fix(nimbus): Fix explore matching audience placement

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -647,19 +647,25 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         queryset=Locale.objects.all().order_by("code"),
         widget=MultiSelectWidget(),
     )
-    exclude_locales = forms.BooleanField(required=False)
+    exclude_locales = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
     languages = forms.ModelMultipleChoiceField(
         required=False,
         queryset=Language.objects.all().order_by("code"),
         widget=MultiSelectWidget(),
     )
-    exclude_languages = forms.BooleanField(required=False)
+    exclude_languages = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
     countries = forms.ModelMultipleChoiceField(
         required=False,
         queryset=Country.objects.all().order_by("code"),
         widget=MultiSelectWidget(),
     )
-    exclude_countries = forms.BooleanField(required=False)
+    exclude_countries = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
     targeting_config_slug = forms.ChoiceField(
         required=False,
         label="",

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -1,190 +1,192 @@
 {% extends "new/common/card_base.html" %}
 
 {% block card %}
-  <div class="d-flex flex-column gap-3" id="rollout-audience-body">
+  <div id="rollout-audience-body">
     {# Explore matching audiences #}
-    <div class="mt-1">
+    <div class="mb-3">
       <a href="{{ experiment.audience_url }}"
          class="small text-decoration-none"
          target="_blank"
          rel="noopener noreferrer"><i class="fa-solid fa-users me-2"></i>Explore matching audiences</a>
     </div>
-    {# Channel / channels #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">
-        {% if experiment.is_desktop %}
-          Channels
-        {% else %}
-          Channel
-        {% endif %}
+    <div class="d-flex flex-column gap-3">
+      {# Channel / channels #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">
+          {% if experiment.is_desktop %}
+            Channels
+          {% else %}
+            Channel
+          {% endif %}
+        </div>
+        <div id="rollout-audience-channel" class="small text-body">
+          {% if experiment.is_desktop %}
+            {% with experiment.channels as channels %}
+              {% if channels %}
+                {% for channel in channels %}
+                  {{ channel|capfirst }}
+                  {% if not forloop.last %},{% endif %}
+                {% endfor %}
+              {% else %}
+                —
+              {% endif %}
+            {% endwith %}
+          {% else %}
+            {{ experiment.get_channel_display|default:"—" }}
+          {% endif %}
+        </div>
       </div>
-      <div id="rollout-audience-channel" class="small text-body">
-        {% if experiment.is_desktop %}
-          {% with experiment.channels as channels %}
-            {% if channels %}
-              {% for channel in channels %}
-                {{ channel|capfirst }}
+      {# Version range #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Min Version</div>
+        <div id="rollout-audience-min-version" class="small text-body">
+          {{ experiment.get_firefox_min_version_display|default:"—" }}
+        </div>
+      </div>
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Max Version</div>
+        <div id="rollout-audience-max-version" class="small text-body">
+          {{ experiment.get_firefox_max_version_display|default:"—" }}
+        </div>
+      </div>
+      {# Locales / languages #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">
+          {% if experiment.is_desktop %}
+            Locales
+          {% else %}
+            Languages
+          {% endif %}
+        </div>
+        <div id="rollout-audience-locales-languages" class="small text-body">
+          {% if experiment.is_desktop %}
+            {% with experiment.locales.all as locales %}
+              {% if locales %}
+                {% for locale in locales %}
+                  {{ locale.code }}
+                  {% if not forloop.last %},{% endif %}
+                {% endfor %}
+              {% else %}
+                —
+              {% endif %}
+            {% endwith %}
+          {% else %}
+            {% with experiment.languages.all as languages %}
+              {% if languages %}
+                {% for language in languages %}
+                  {{ language.code }}
+                  {% if not forloop.last %},{% endif %}
+                {% endfor %}
+              {% else %}
+                —
+              {% endif %}
+            {% endwith %}
+          {% endif %}
+        </div>
+      </div>
+      {# Countries #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Countries</div>
+        <div id="rollout-audience-countries" class="small text-body">
+          {% with experiment.countries.all as countries %}
+            {% if countries %}
+              {% for country in countries %}
+                {{ country.code }}
                 {% if not forloop.last %},{% endif %}
               {% endfor %}
             {% else %}
               —
             {% endif %}
           {% endwith %}
-        {% else %}
-          {{ experiment.get_channel_display|default:"—" }}
-        {% endif %}
+        </div>
       </div>
-    </div>
-    {# Version range #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Min Version</div>
-      <div id="rollout-audience-min-version" class="small text-body">
-        {{ experiment.get_firefox_min_version_display|default:"—" }}
+      {# Advanced targeting #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Advanced targeting</div>
+        <div id="rollout-audience-targeting" class="small text-body">{{ experiment.targeting_config_slug|default:"—" }}</div>
       </div>
-    </div>
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Max Version</div>
-      <div id="rollout-audience-max-version" class="small text-body">
-        {{ experiment.get_firefox_max_version_display|default:"—" }}
+      {# Full targeting expression #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
+        {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
+
       </div>
-    </div>
-    {# Locales / languages #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">
-        {% if experiment.is_desktop %}
-          Locales
-        {% else %}
-          Languages
-        {% endif %}
-      </div>
-      <div id="rollout-audience-locales-languages" class="small text-body">
-        {% if experiment.is_desktop %}
-          {% with experiment.locales.all as locales %}
-            {% if locales %}
-              {% for locale in locales %}
-                {{ locale.code }}
-                {% if not forloop.last %},{% endif %}
-              {% endfor %}
-            {% else %}
-              —
-            {% endif %}
-          {% endwith %}
-        {% else %}
-          {% with experiment.languages.all as languages %}
-            {% if languages %}
-              {% for language in languages %}
-                {{ language.code }}
-                {% if not forloop.last %},{% endif %}
-              {% endfor %}
-            {% else %}
-              —
-            {% endif %}
-          {% endwith %}
-        {% endif %}
-      </div>
-    </div>
-    {# Countries #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Countries</div>
-      <div id="rollout-audience-countries" class="small text-body">
-        {% with experiment.countries.all as countries %}
-          {% if countries %}
-            {% for country in countries %}
-              {{ country.code }}
-              {% if not forloop.last %},{% endif %}
+      {# Required experiments #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing experiments</div>
+        {% with experiment.required_experiments_branches.all as required_branches %}
+          {% if required_branches %}
+            {% for branch in required_branches %}
+              <a href="{% url 'nimbus-ui-detail' branch.child_experiment.slug %}"
+                 target="_blank"
+                 class="small"
+                 rel="noopener noreferrer">
+                {{ branch.child_experiment.name }}
+                ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
+              </a>
+              <br>
             {% endfor %}
           {% else %}
             —
           {% endif %}
         {% endwith %}
       </div>
-    </div>
-    {# Advanced targeting #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Advanced targeting</div>
-      <div id="rollout-audience-targeting" class="small text-body">{{ experiment.targeting_config_slug|default:"—" }}</div>
-    </div>
-    {# Full targeting expression #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
-      {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
-
-    </div>
-    {# Required experiments #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing experiments</div>
-      {% with experiment.required_experiments_branches.all as required_branches %}
-        {% if required_branches %}
-          {% for branch in required_branches %}
-            <a href="{% url 'nimbus-ui-detail' branch.child_experiment.slug %}"
-               target="_blank"
-               class="small"
-               rel="noopener noreferrer">
-              {{ branch.child_experiment.name }}
-              ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
-            </a>
-            <br>
-          {% endfor %}
-        {% else %}
-          —
-        {% endif %}
-      {% endwith %}
-    </div>
-    {# Excluded experiments #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Exclude users from other experiments/rollouts</div>
-      {% with experiment.excluded_experiments_branches.all as excluded_branches %}
-        {% if excluded_branches %}
-          {% for branch in excluded_branches %}
-            <a href="{% url 'nimbus-ui-detail' branch.child_experiment.slug %}"
-               target="_blank"
-               rel="noopener noreferrer"
-               class="small">
-              {{ branch.child_experiment.name }}
-              ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
-            </a>
-            <br>
-          {% endfor %}
-        {% else %}
-          —
-        {% endif %}
-      {% endwith %}
-    </div>
-    {# Sticky enrollment #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Apply sticky enrollment?</div>
-      {% if experiment.is_sticky %}
-        <i id="rollout-audience-sticky" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-audience-sticky" class="fas fa-times text-danger"></i>
-      {% endif %}
-    </div>
-    {# Localization #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Is this a localized rollout?</div>
-      {% if experiment.is_localized %}
-        <i id="rollout-audience-localized" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-audience-localized" class="fas fa-times text-danger"></i>
-      {% endif %}
-    </div>
-    {% if experiment.is_localized %}
+      {# Excluded experiments #}
       <div>
-        <div class="text-secondary mb-1" style="font-size: 12px;">Localization Substitutions</div>
-        {% if experiment.localizations %}
-          {% include "nimbus_experiments/readonly_feature_value.html" with json_content=experiment.localizations %}
-
+        <div class="text-secondary mb-1" style="font-size: 12px;">Exclude users from other experiments/rollouts</div>
+        {% with experiment.excluded_experiments_branches.all as excluded_branches %}
+          {% if excluded_branches %}
+            {% for branch in excluded_branches %}
+              <a href="{% url 'nimbus-ui-detail' branch.child_experiment.slug %}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="small">
+                {{ branch.child_experiment.name }}
+                ({{ branch.branch_slug|add:" branch"|default:"All branches" }})
+              </a>
+              <br>
+            {% endfor %}
+          {% else %}
+            —
+          {% endif %}
+        {% endwith %}
+      </div>
+      {# Sticky enrollment #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Apply sticky enrollment?</div>
+        {% if experiment.is_sticky %}
+          <i id="rollout-audience-sticky" class="fas fa-check text-success"></i>
         {% else %}
-          —
+          <i id="rollout-audience-sticky" class="fas fa-times text-danger"></i>
         {% endif %}
       </div>
-    {% endif %}
-    {# Recipe JSON #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Recipe JSON</div>
-      <div data-nimbus-devtools-recipe-json>
-        {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+      {# Localization #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Is this a localized rollout?</div>
+        {% if experiment.is_localized %}
+          <i id="rollout-audience-localized" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-audience-localized" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% if experiment.is_localized %}
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">Localization Substitutions</div>
+          {% if experiment.localizations %}
+            {% include "nimbus_experiments/readonly_feature_value.html" with json_content=experiment.localizations %}
 
+          {% else %}
+            —
+          {% endif %}
+        </div>
+      {% endif %}
+      {# Recipe JSON #}
+      <div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Recipe JSON</div>
+        <div data-nimbus-devtools-recipe-json>
+          {% include "common/readonly_json.html" with json_content=experiment.recipe_json %}
+
+        </div>
       </div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -3,7 +3,7 @@
 
 <div id="rollout-audience-body">
   {# Explore matching audiences #}
-  <div class="d-flex justify-content-end mb-2">
+  <div class="mb-2">
     <a href="{{ experiment.audience_url }}"
        class="small text-decoration-none"
        target="_blank"
@@ -49,19 +49,19 @@
         {% if experiment.is_desktop %}
           <label for="id_locales" class="small text-body mb-2">Locales</label>
           {{ form.locales|add_class:"form-control"|add_error_class:"is-invalid" }}
-          <label for="id_exclude_locales" class="form-label mt-2">
+          <div class="form-check mt-2">
             {{ form.exclude_locales|add_error_class:"is-invalid" }}
-            Exclude selected locales
-          </label>
+            <label class="form-check-label small text-body" for="id_exclude_locales">Exclude selected locales</label>
+          </div>
           {% for error in form.locales.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
           {% for error in validation_errors.locales %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
         {% else %}
           <label for="id_languages" class="small text-body mb-2">Languages</label>
           {{ form.languages|add_class:"form-control"|add_error_class:"is-invalid" }}
-          <label for="id_exclude_languages" class="form-label mt-2">
+          <div class="form-check mt-2">
             {{ form.exclude_languages|add_error_class:"is-invalid" }}
-            Exclude selected languages
-          </label>
+            <label class="form-check-label small text-body" for="id_exclude_languages">Exclude selected languages</label>
+          </div>
           {% for error in form.languages.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
           {% for error in validation_errors.languages %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
         {% endif %}
@@ -69,10 +69,10 @@
       <div class="col">
         <label for="id_countries" class="small text-body mb-2">Countries</label>
         {{ form.countries|add_class:"form-control"|add_error_class:"is-invalid" }}
-        <label for="id_exclude_countries" class="form-label mt-2">
+        <div class="form-check mt-2">
           {{ form.exclude_countries|add_error_class:"is-invalid" }}
-          Exclude selected countries
-        </label>
+          <label class="form-check-label small text-body" for="id_exclude_countries">Exclude selected countries</label>
+        </div>
         {% for error in form.countries.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
         {% for error in validation_errors.countries %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
       </div>
@@ -136,7 +136,7 @@
     <div>
       <div class="form-check">
         {{ form.is_localized }}
-        <label class="form-check-label" for="id_is_localized">Is this a localized rollout?</label>
+        <label class="form-check-label small text-body" for="id_is_localized">Is this a localized rollout?</label>
       </div>
       {% for error in form.is_localized.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
       {% for error in validation_errors.is_localized %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}


### PR DESCRIPTION
Because

* We need to keep Explore matching audience in the same position in both edit and closed states
* We also need to fix the styling of the checkboxes in the audience card

This commit

* Keeps both aligned on the left side
* Fixes the styling in the audience card

Fixes #16702