### PR TITLE
fix(nimbus): use feature test fixture for fml loader tests

### DIFF
--- a/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
+++ b/experimenter/experimenter/features/tests/test_nimbus_fml_loader.py
@@ -138,14 +138,15 @@ class TestNimbusFmlLoader(TestCase):
         result = loader.fml_client()
         self.assertIsInstance(result, FmlClient)
 
+    @mock_fml_versioned_features
     def test_get_fml_errors_fetches_client_inspector_and_error(
         self,
     ):
         loader = self.create_loader()
         test_blob = json.dumps({"features": {"new-feature": {"enabled": "false"}}})
 
-        result = loader.get_fml_errors(test_blob, "cookie-banners")
-        expected_error = 'Invalid property "features"; did you mean "sections-enabled"?'
+        result = loader.get_fml_errors(test_blob, "unified-search", "119.0.0")
+        expected_error = 'Invalid property "features"; did you mean "enabled"?'
         self.assertIn(expected_error, result[0].message)
 
     @mock_fml_features


### PR DESCRIPTION
Because

* The test loaded the checked-in fenix release manifest and hardcoded the feature id `cookie-banners`, which upstream Fenix has deleted.
* Every "Update External Configs" bot PR now fails with an IndexError once the manifest refresh drops that feature.

This commit

* Points the test at the versioned test fixture manifest via `mock_fml_versioned_features`, so it no longer reads a live manifest.
* Uses the fixture's `unified-search` feature, which yields the same shape of FML "did you mean" hint.

Fixes #16708