### PR TITLE
feat(nimbus): Show single description link URL field for Fenix labs

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -143,6 +143,13 @@ class FirefoxLabs:
         self.supported_description_links = supported_description_links
 
     @property
+    def supports_arbitrary_description_links(self) -> bool:
+        """Return whether this application supports arbitrary keys in the
+        firefox_labs_description_links field.
+        """
+        return self.supported_description_links is FirefoxLabs.ARBITRARY_KEYS
+
+    @property
     def supports_groups(self) -> bool:
         """Whether this application supports the firefox_labs_groups field."""
         return self.groups is not None

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -1,3 +1,4 @@
+import json
 import random
 from collections import defaultdict
 from datetime import UTC, datetime
@@ -711,6 +712,10 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     firefox_labs_description_links = forms.CharField(
         required=False, widget=forms.HiddenInput()
     )
+    # An alternative field shown when the application only supports a single link.
+    firefox_labs_description_link = forms.CharField(
+        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+    )
     firefox_labs_group = forms.ChoiceField(
         required=False,
         widget=forms.Select(attrs={"class": "form-select"}),
@@ -815,6 +820,27 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         if firefox_labs := self.instance.application_config.firefox_labs:
             self.fields["firefox_labs_group"].choices = firefox_labs.group_choices
 
+            supported_link_keys = firefox_labs.supported_description_links
+            if (
+                not firefox_labs.supports_arbitrary_description_links
+                and len(supported_link_keys) == 1
+            ):
+                supported_link_key = supported_link_keys[0]
+                try:
+                    description_links = json.loads(
+                        self.instance.firefox_labs_description_links
+                    )
+                except Exception:
+                    description_links = None
+
+                if (
+                    description_links is not None
+                    and supported_link_key in description_links
+                ):
+                    self.fields[
+                        "firefox_labs_description_link"
+                    ].initial = description_links[supported_link_key]
+
         self.was_labs_opt_in = self.instance.is_firefox_labs_opt_in
 
     @property
@@ -833,7 +859,26 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         elif not cleaned_data["is_rollout"]:
             cleaned_data["is_firefox_labs_opt_in"] = False
 
-        if not cleaned_data["is_firefox_labs_opt_in"]:
+        firefox_labs = self.instance.application_config.firefox_labs
+
+        if (
+            cleaned_data["is_firefox_labs_opt_in"]
+            and not firefox_labs.supports_arbitrary_description_links
+            and len(firefox_labs.supported_description_links) == 1
+        ):
+            description_link_key = firefox_labs.supported_description_links[0]
+
+            if description_link := cleaned_data.pop(
+                "firefox_labs_description_link", ""
+            ).strip():
+                cleaned_data["firefox_labs_description_links"] = json.dumps(
+                    {
+                        description_link_key: description_link,
+                    }
+                )
+            else:
+                cleaned_data["firefox_labs_description_links"] = "null"
+        elif not cleaned_data["is_firefox_labs_opt_in"]:
             cleaned_data["firefox_labs_title"] = ""
             cleaned_data["firefox_labs_description"] = ""
             cleaned_data["firefox_labs_description_links"] = "null"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -220,7 +220,7 @@
                             {% endwith %}
                           </div>
                           <div class="col-8">
-                            <div class=" d-flex align-items-end">
+                            <div class="d-flex align-items-end">
                               {{ screenshot_form.description|add_error_class:"is-invalid" }}
                               <button type="button"
                                       id="delete-screenshot-{{ screenshot_form.instance.id }}"
@@ -383,10 +383,17 @@
               </div>
               <div class="row mb-3">
                 <div class="col">
-                  <label class="d-block">
-                    Description Links (JSON)
-                    {{ form.firefox_labs_description_links }}
-                  </label>
+                  {% if experiment.application_config.firefox_labs.supports_arbitrary_description_links %}
+                    <label class="d-block">
+                      Description Links (JSON)
+                      {{ form.firefox_labs_description_links }}
+                    </label>
+                  {% else %}
+                    <label class="d-block">Feedback Link</label>
+                    {{ form.firefox_labs_description_link }}
+                    <div class="form-text">This link will be the target of the "Share Feedback" button on your Firefox Labs entry.</div>
+                  {% endif %}
+                  {# There are no firefox_labs_description_link errors: the field is always validated as firefox_labs_description_links #}
                   {{ form.firefox_labs_description_links.errors }}
                   {% for error in validation_errors.firefox_labs_description_links %}
                     <div class="form-text text-danger">{{ error }}</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_forms.py
@@ -1,9 +1,13 @@
+from __future__ import annotations
+
 import datetime
 import io
 import json
+from typing import TYPE_CHECKING, Any
 from unittest.mock import patch
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.forms.models import model_to_dict
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
@@ -86,6 +90,21 @@ from experimenter.segments import Segments
 from experimenter.segments.tests.mock_segments import mock_get_segments
 from experimenter.slack.constants import SlackConstants
 from experimenter.targeting.constants import NimbusTargetingConfig
+
+if TYPE_CHECKING:
+    from django import forms
+    from django.db import models
+
+
+def get_modelform_data(
+    form_cls: type[forms.ModelForm],
+    instance: models.Model,
+) -> dict[str, Any]:
+    return model_to_dict(
+        instance,
+        fields=getattr(form_cls.Meta, "fields", None),
+        exclude=getattr(form_cls.Meta, "exclude", None),
+    )
 
 
 class RequestFormTestCase(TestCase):
@@ -4375,6 +4394,132 @@ class TestNimbusBranchesForm(RequestFormTestCase):
         experiment = form.save()
 
         self.assertFalse(experiment.is_first_run)
+
+    def test_fenix_firefox_labs_description_link(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                **get_modelform_data(NimbusBranchesForm, experiment),
+                "firefox_labs_description_links": "ignored",
+                "firefox_labs_description_link": "https://example.com",
+            },
+        )
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(
+            json.loads(experiment.firefox_labs_description_links),
+            {"feedback": "https://example.com"},
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                **get_modelform_data(NimbusBranchesForm, experiment),
+                "firefox_labs_description_links": "ignored",
+                "firefox_labs_description_link": "",
+            },
+        )
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(
+            experiment.firefox_labs_description_links,
+            "null",
+        )
+
+    def test_fenix_firefox_labs_description_link_bad_json(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_description_links="not JSON",
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                **get_modelform_data(NimbusBranchesForm, experiment),
+                "firefox_labs_description_link": "https://example.com",
+            },
+        )
+
+        self.assertIsNone(form.fields["firefox_labs_description_link"].initial)
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(
+            json.loads(experiment.firefox_labs_description_links),
+            {"feedback": "https://example.com"},
+        )
+
+    def test_desktop_firefox_labs_description_link(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_description_links=json.dumps(
+                {
+                    "test": "https://example.com",
+                }
+            ),
+            firefox_labs_group=NimbusExperiment.FirefoxLabs.Groups.CUSTOMIZE_BROWSING,
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                **get_modelform_data(NimbusBranchesForm, experiment),
+                "firefox_labs_description_link": "https://example.com",
+            },
+        )
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(
+            json.loads(experiment.firefox_labs_description_links),
+            {"test": "https://example.com"},
+        )
+
+        form = NimbusBranchesForm(
+            instance=experiment,
+            request=self.request,
+            data={
+                **get_modelform_data(NimbusBranchesForm, experiment),
+                "firefox_labs_description_link": "https://example.com",
+            },
+        )
+
+        experiment = form.save()
+
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(
+            json.loads(experiment.firefox_labs_description_links),
+            {"test": "https://example.com"},
+        )
 
 
 class TestNimbusBranchCreateForm(RequestFormTestCase):


### PR DESCRIPTION
Because:

- Firefox for Android only supports a single firefox_labs_description_link key ("feedback"); and
- the default UI for this field is a JSON editor

This commit:

- replaces the editor with an input for a single link for Fenix Labs; and
- this UI will work for future products that only support a single link (e.g., iOS if we ever build it).

Fixes #16695