### PR TITLE
fix(nimbus): anchor holdback enrollment end date

### DIFF
--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -179,10 +179,25 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
         }
 
     def _holdback_enrollment_end(self, obj):
-        if obj.is_holdback and not obj.end_date and not obj.actual_enrollment_end_date:
-            return datetime.date.today() - datetime.timedelta(
+        # A holdback's analysis window is anchored on its most recent weekly rerun
+        # (do_rerun_timestamp), NOT on today, so the enrollment period steps weekly
+        # (7, 14, 21, ...) instead of drifting by a day on every API read. Before the
+        # first rerun is triggered there is no complete window yet, so emit nothing;
+        # this keeps jetstream from analyzing (and computing overall) prematurely.
+        # do_rerun_timestamp is a UTC datetime, matching jetstream's UTC clock, so
+        # the resulting endDate also lands in the past (today-1 or earlier).
+        if (
+            obj.is_holdback
+            and not obj.end_date
+            and not obj.actual_enrollment_end_date
+            and obj.do_rerun_timestamp
+            and obj.start_date
+        ):
+            enrollment_end = obj.do_rerun_timestamp.date() - datetime.timedelta(
                 days=settings.HOLDBACK_OBSERVATION_DAYS
             )
+            if enrollment_end > obj.start_date:
+                return enrollment_end
         return None
 
     def get_enrollmentEndDate(self, obj):

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.conf import settings
 from django.test import TestCase
+from django.utils import timezone
 from parameterized import parameterized
 
 from experimenter.base.tests.factories import LocaleFactory
@@ -419,23 +420,45 @@ class TestNimbusExperimentSerializer(TestCase):
             self.assertEqual(serializer.data["localizations"], expected)
 
     def test_holdback_serializer_overrides(self):
-        today = datetime.date.today()
-        start = today - datetime.timedelta(days=50)
-        expected_enrollment_end = today - datetime.timedelta(days=21)
+        # The window is anchored on the weekly rerun (do_rerun_timestamp), not on
+        # today. A holdback 35 days in (its 5th weekly rerun) reports a 14-day
+        # enrollment (35 - 21 observation), and endDate is the rerun date.
+        rerun = timezone.now()
+        rerun_date = rerun.date()
+        start = rerun_date - datetime.timedelta(days=35)
+        expected_enrollment_end = rerun_date - datetime.timedelta(days=21)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_holdback=True,
             _start_date=start,
         )
+        experiment.do_rerun = True
+        experiment.do_rerun_timestamp = rerun
+        experiment.save()
+
         serializer = NimbusExperimentSerializer(experiment)
         data = serializer.data
 
         self.assertEqual(data["enrollmentEndDate"], expected_enrollment_end.isoformat())
-        self.assertEqual(data["endDate"], today.isoformat())
-        self.assertEqual(
-            data["proposedEnrollment"],
-            (expected_enrollment_end - start).days,
+        self.assertEqual(data["endDate"], rerun_date.isoformat())
+        self.assertEqual(data["proposedEnrollment"], 14)
+
+    def test_holdback_serializer_no_window_before_first_rerun(self):
+        # Until the first weekly rerun is triggered (do_rerun_timestamp is None),
+        # the serializer emits no enrollment/end window so jetstream does not
+        # analyze the holdback (or compute overall) prematurely.
+        start = timezone.now().date() - datetime.timedelta(days=20)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_holdback=True,
+            _start_date=start,
         )
+        self.assertIsNone(experiment.do_rerun_timestamp)
+
+        data = NimbusExperimentSerializer(experiment).data
+
+        self.assertIsNone(data["enrollmentEndDate"])
+        self.assertIsNone(data["endDate"])
 
     def test_non_holdback_proposed_enrollment_uses_model_value(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

- Holdback experiments only produced Day-20 results and never the overall window. The v8 API computed a live holdback's `enrollmentEndDate`/`endDate`/`proposedEnrollment` from `today` on every read, which caused two problems:
  - `endDate` was set to `today`, but jetstream (UTC) only computes the `OVERALL` window once `endDate` is in the past, so overall was never produced.
  - the enrollment period drifted by a day on every request (showing 10 days) instead of stepping weekly, and a window was emitted from day 1, so jetstream analyzed the holdback before it was rerun-eligible.

This commit

- Anchors the holdback enrollment/end window on `do_rerun_timestamp` (the weekly-cadence source of truth set by `update_holdback_enrollment_period`) instead of `today`, so the window steps weekly (enrollment 7, 14, 21, ...) and only advances when a rerun actually fires.
- Emits no window until the first rerun is triggered, so jetstream no longer analyzes (or computes overall for) a holdback before it's rerun-eligible.
- Yields a past `endDate`, so jetstream computes the overall window per its `end_date + 1` logic.
- Guards `enrollmentEndDate` from preceding `start_date`, and updates/adds serializer tests for the weekly cadence and the pre-first-rerun case.

Fixes #16689
Fixes #16690