### PR TITLE
fix(nimbus): Fix Rollout Features card rendering in new UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1079,6 +1079,7 @@ class RolloutScreenshotDeleteForm(RolloutFeaturesForm):
             "screenshot_id",
             *RolloutFeaturesForm.Meta.fields,
         ]
+        widgets = RolloutFeaturesForm.Meta.widgets
 
     @transaction.atomic
     def save(self, *args, **kwargs):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -18,6 +18,8 @@
 
           {% endif %}
         {% endfor %}
+      {% empty %}
+        <div class="small text-body">—</div>
       {% endfor %}
     </div>
     {# Warn only on feature schema validation failure #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -140,7 +140,7 @@
             </div>
           {% endfor %}
         </div>
-        <div>
+        <div {% if rollout_screenshots|length %}class="mt-2"{% endif %}>
           <button type="button"
                   class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small"
                   hx-post="{% url 'nimbus-ui-new-create-rollout-screenshot' experiment.slug %}"


### PR DESCRIPTION
Because

* Currently adding a screenshot and then deleting it causes the UI to render incorrectly

This commit

* Fixes the Prevent Enrollment screenshot rendering bug
* Fixes spacing in Features card

Fixes #16703