### PR TITLE
feat(nimbus): add error text to form fields on rollouts page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -230,6 +230,10 @@ class RolloutSetupProgressMixin:
         field_errors = self.object.get_invalid_fields_errors(
             serializer_class=NimbusRolloutReviewSerializer
         )
+        validation_errors = {
+            field: self.flatten_errors(messages)
+            for field, messages in field_errors.items()
+        }
         error_keys = set(field_errors)
 
         field_to_section = {
@@ -266,6 +270,7 @@ class RolloutSetupProgressMixin:
 
         context["setup_issues"] = issues
         context["setup_issues_count"] = len(issues)
+        context["validation_errors"] = validation_errors
         return context
 
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/validation_errors.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/validation_errors.html
@@ -1,0 +1,5 @@
+{% for error in errors %}
+  <div class="small text-danger mt-1">
+    <i class="fa-solid fa-triangle-exclamation fa-xs me-1"></i>{{ error }}
+  </div>
+{% endfor %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -35,6 +35,13 @@
             {{ experiment.get_channel_display|default:"—" }}
           {% endif %}
         </div>
+        {% if experiment.is_desktop %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.channels %}
+
+        {% else %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.channel %}
+
+        {% endif %}
       </div>
       {# Version range #}
       <div>
@@ -42,12 +49,16 @@
         <div id="rollout-audience-min-version" class="small text-body">
           {{ experiment.get_firefox_min_version_display|default:"—" }}
         </div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_min_version %}
+
       </div>
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">Max Version</div>
         <div id="rollout-audience-max-version" class="small text-body">
           {{ experiment.get_firefox_max_version_display|default:"—" }}
         </div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_max_version %}
+
       </div>
       {# Locales / languages #}
       <div>
@@ -83,6 +94,15 @@
             {% endwith %}
           {% endif %}
         </div>
+        {% if experiment.is_desktop %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.locales %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_locales %}
+
+        {% else %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.languages %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_languages %}
+
+        {% endif %}
       </div>
       {# Countries #}
       <div>
@@ -99,16 +119,23 @@
             {% endif %}
           {% endwith %}
         </div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.countries %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_countries %}
+
       </div>
       {# Advanced targeting #}
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">Advanced targeting</div>
         <div id="rollout-audience-targeting" class="small text-body">{{ experiment.targeting_config_slug|default:"—" }}</div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.targeting_config_slug %}
+
       </div>
       {# Full targeting expression #}
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
         {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.targeting %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.non_field_errors %}
 
       </div>
       {# Required experiments #}
@@ -130,6 +157,8 @@
             —
           {% endif %}
         {% endwith %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.required_experiments_branches %}
+
       </div>
       {# Excluded experiments #}
       <div>
@@ -150,6 +179,8 @@
             —
           {% endif %}
         {% endwith %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.excluded_experiments_branches %}
+
       </div>
       {# Sticky enrollment #}
       <div>
@@ -159,6 +190,8 @@
         {% else %}
           <i id="rollout-audience-sticky" class="fas fa-times text-danger"></i>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.is_sticky %}
+
       </div>
       {# Localization #}
       <div>
@@ -168,6 +201,8 @@
         {% else %}
           <i id="rollout-audience-localized" class="fas fa-times text-danger"></i>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.is_localized %}
+
       </div>
       {% if experiment.is_localized %}
         <div>
@@ -178,6 +213,8 @@
           {% else %}
             —
           {% endif %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.localizations %}
+
         </div>
       {% endif %}
       {# Recipe JSON #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -52,6 +52,8 @@
           <div class="form-check mt-2">
             {{ form.exclude_locales|add_error_class:"is-invalid" }}
             <label class="form-check-label small text-body" for="id_exclude_locales">Exclude selected locales</label>
+            {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_locales %}
+
           </div>
           {% for error in form.locales.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
           {% for error in validation_errors.locales %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
@@ -61,6 +63,8 @@
           <div class="form-check mt-2">
             {{ form.exclude_languages|add_error_class:"is-invalid" }}
             <label class="form-check-label small text-body" for="id_exclude_languages">Exclude selected languages</label>
+            {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_languages %}
+
           </div>
           {% for error in form.languages.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
           {% for error in validation_errors.languages %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
@@ -72,6 +76,8 @@
         <div class="form-check mt-2">
           {{ form.exclude_countries|add_error_class:"is-invalid" }}
           <label class="form-check-label small text-body" for="id_exclude_countries">Exclude selected countries</label>
+          {% include "new/common/validation_errors.html" with errors=validation_errors.exclude_countries %}
+
         </div>
         {% for error in form.countries.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
         {% for error in validation_errors.countries %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
@@ -99,6 +105,9 @@
       {% for error in validation_errors.targeting_config_slug %}
         <div class="form-text text-danger">{{ error }}</div>
       {% endfor %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.targeting %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.non_field_errors %}
+
     </div>
     <div>
       <label for="id_name" class="small text-body mb-2">Include users from existing experiments</label>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -6,6 +6,8 @@
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">Name</div>
       <div id="rollout-overview-name" class="small text-body">{{ experiment.name|default:"—" }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.name %}
+
     </div>
     {# Observations & Problem space #}
     <div>
@@ -13,6 +15,8 @@
       <div id="rollout-overview-hypothesis"
            class="small text-body"
            style="white-space: pre-wrap">{{ experiment.hypothesis|default:"—" }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.hypothesis %}
+
     </div>
     {# Public description #}
     <div>
@@ -20,11 +24,15 @@
       <div id="rollout-overview-public-description"
            class="small text-body"
            style="white-space: pre-wrap">{{ experiment.public_description|default:"—" }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.public_description %}
+
     </div>
     {# Application #}
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">Application</div>
       <div class="small text-body">{{ experiment.get_application_display }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.application %}
+
     </div>
     {# Important Links #}
     <div>
@@ -48,6 +56,8 @@
       {% else %}
         <div class="small text-body">—</div>
       {% endif %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.documentation_links %}
+
     </div>
     {# Project Tags #}
     <div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -13,6 +13,8 @@
         </label>
         {{ form.name }}
         {% if form.name.errors %}<div class="text-danger small mt-1">{{ form.name.errors|join:", " }}</div>{% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.name %}
+
       </div>
       {# Observations & Problem space #}
       <div>
@@ -21,6 +23,8 @@
         {% if form.hypothesis.errors %}
           <div class="text-danger small mt-1">{{ form.hypothesis.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.hypothesis %}
+
       </div>
       {# Public description #}
       <div>
@@ -29,6 +33,8 @@
         {% if form.public_description.errors %}
           <div class="text-danger small mt-1">{{ form.public_description.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.public_description %}
+
         <p class="form-text mb-0">{{ NimbusUIConstants.PUBLIC_DESCRIPTION_TEXT }}</p>
       </div>
       {# Application #}
@@ -38,6 +44,8 @@
         {% if form.application.errors %}
           <div class="text-danger small mt-1">{{ form.application.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.application %}
+
         <p class="form-text mb-0">
           Rollouts can only target one Application at a time.
           <br>
@@ -87,6 +95,8 @@
                 hx-swap="outerHTML">
           <i class="fa-solid fa-plus me-1"></i>Add link
         </button>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.documentation_links %}
+
       </div>
       {# Project Tags — search input + pills #}
       {% include "new/rollouts/overview/tags_field.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/card.html
@@ -11,6 +11,8 @@
           {{ qa_status_display }}
         </span>
       {% endwith %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.qa_status %}
+
     </div>
     {# QA notes #}
     <div>
@@ -18,6 +20,8 @@
       <div id="rollout-qa-comment"
            class="small text-body"
            style="white-space: pre-wrap">{{ experiment.qa_comment|default:"—" }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.qa_comment %}
+
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
@@ -37,6 +37,8 @@
                 {% if form.qa_status.errors %}
                   <div class="text-danger small mt-1">{{ form.qa_status.errors|join:", " }}</div>
                 {% endif %}
+                {% include "new/common/validation_errors.html" with errors=validation_errors.qa_status %}
+
               </div>
             </div>
             <div class="mt-4">
@@ -45,6 +47,8 @@
               {% if form.qa_comment.errors %}
                 <div class="text-danger small mt-1">{{ form.qa_comment.errors|join:", " }}</div>
               {% endif %}
+              {% include "new/common/validation_errors.html" with errors=validation_errors.qa_comment %}
+
             </div>
           </div>
         </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
@@ -3,49 +3,79 @@
 {% block card %}
   <div class="d-flex flex-column gap-3" id="rollout-risks-body">
     {# AI risk #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">AI risk</div>
-      {% if experiment.risk_ai %}
-        <i id="rollout-risks-ai" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-risks-ai" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">AI risk</div>
+        {% if experiment.risk_ai is None %}
+          <span id="rollout-risks-ai" class="small text-body">—</span>
+        {% elif experiment.risk_ai %}
+          <i id="rollout-risks-ai" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-risks-ai" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.risk_ai %}
+
     </div>
     {# Brand perception impact #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">Brand perception impact</div>
-      {% if experiment.risk_brand %}
-        <i id="rollout-risks-brand" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-risks-brand" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">Brand perception impact</div>
+        {% if experiment.risk_brand is None %}
+          <span id="rollout-risks-brand" class="small text-body">—</span>
+        {% elif experiment.risk_brand %}
+          <i id="rollout-risks-brand" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-risks-brand" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.risk_brand %}
+
     </div>
     {# Revenue impact #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">Revenue impact</div>
-      {% if experiment.risk_revenue %}
-        <i id="rollout-risks-revenue" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-risks-revenue" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary" style="font-size: 12px;">Revenue impact</div>
+        {% if experiment.risk_revenue is None %}
+          <span id="rollout-risks-revenue" class="small text-body">—</span>
+        {% elif experiment.risk_revenue %}
+          <i id="rollout-risks-revenue" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-risks-revenue" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.risk_revenue %}
+
     </div>
     {# External vendor impact #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">External vendor impact</div>
-      {% if experiment.risk_partner_related %}
-        <i id="rollout-risks-partner-related" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-risks-partner-related" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">External vendor impact</div>
+        {% if experiment.risk_partner_related is None %}
+          <span id="rollout-risks-partner-related" class="small text-body">—</span>
+        {% elif experiment.risk_partner_related %}
+          <i id="rollout-risks-partner-related" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-risks-partner-related" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.risk_partner_related %}
+
     </div>
     {# Messaging impact #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">Messaging impact</div>
-      {% if experiment.risk_message %}
-        <i id="rollout-risks-message" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-risks-message" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">Messaging impact</div>
+        {% if experiment.risk_message is None %}
+          <span id="rollout-risks-message" class="small text-body">—</span>
+        {% elif experiment.risk_message %}
+          <i id="rollout-risks-message" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-risks-message" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.risk_message %}
+
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
@@ -24,6 +24,8 @@
         </label>
         {{ form.risk_ai }}
         {% if form.risk_ai.errors %}<div class="text-danger small mt-1">{{ form.risk_ai.errors|join:", " }}</div>{% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.risk_ai %}
+
       </div>
       {#  Brand perception impact  #}
       <div>
@@ -35,6 +37,8 @@
         {% if form.risk_brand.errors %}
           <div class="text-danger small mt-1">{{ form.risk_brand.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.risk_brand %}
+
       </div>
       {# Revenue impact #}
       <div>
@@ -46,6 +50,8 @@
         {% if form.risk_revenue.errors %}
           <div class="text-danger small mt-1">{{ form.risk_revenue.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.risk_revenue %}
+
       </div>
       {# External vendor impact #}
       <div>
@@ -57,6 +63,8 @@
         {% if form.risk_partner_related.errors %}
           <div class="text-danger small mt-1">{{ form.risk_partner_related.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.risk_partner_related %}
+
       </div>
       {# Messaging impact #}
       <div>
@@ -68,6 +76,8 @@
         {% if form.risk_message.errors %}
           <div class="text-danger small mt-1">{{ form.risk_message.errors|join:", " }}</div>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.risk_message %}
+
       </div>
     </div>
     {# Action buttons #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -6,6 +6,8 @@
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">Rollout experience</div>
       <div id="rollout-features-experience" class="small text-body">{{ experiment.takeaways_summary|default:"—" }}</div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.takeaways_summary %}
+
     </div>
     {# Feature configurations #}
     <div>
@@ -22,28 +24,40 @@
       {% empty %}
         <div class="small text-body">—</div>
       {% endfor %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.reference_branch %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.treatment_branches %}
+
     </div>
     {# Warn only on feature schema validation failure #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">Warn only on feature schema validation failure</div>
-      {% if experiment.warn_feature_schema %}
-        <i id="rollout-features-warn-schema" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-features-warn-schema" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">Warn only on feature schema validation failure</div>
+        {% if experiment.warn_feature_schema %}
+          <i id="rollout-features-warn-schema" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-features-warn-schema" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.warn_feature_schema %}
+
     </div>
     {# Prevent enrollment if prefs changed #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">
-        Prevent enrollment if users have changed any prefs set by this rollout
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">
+          Prevent enrollment if users have changed any prefs set by this rollout
+        </div>
+        {% if experiment.prevent_pref_conflicts %}
+          <i id="rollout-features-prevent-conflicts"
+             class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-features-prevent-conflicts"
+             class="fas fa-times text-danger"></i>
+        {% endif %}
       </div>
-      {% if experiment.prevent_pref_conflicts %}
-        <i id="rollout-features-prevent-conflicts"
-           class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-features-prevent-conflicts"
-           class="fas fa-times text-danger"></i>
-      {% endif %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.prevent_pref_conflicts %}
+
     </div>
     {# Rollout screenshots #}
     <div>
@@ -80,25 +94,34 @@
         {% else %}
           <i class="fas fa-times text-danger"></i>
         {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.is_firefox_labs_opt_in %}
+
       </div>
       {% if experiment.is_firefox_labs_opt_in %}
         <div>
           <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Title</div>
           <div class="small text-body">{{ experiment.firefox_labs_title|default:"—" }}</div>
+          {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_labs_title %}
+
         </div>
         <div>
           <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Description</div>
           <div class="small text-body">{{ experiment.firefox_labs_description|default:"—" }}</div>
+          {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_labs_description %}
+
         </div>
         <div>
           <div class="text-secondary mb-1" style="font-size: 12px;">Description Links</div>
           {% include "common/readonly_json.html" with json_content=experiment.firefox_labs_description_links|default:"null" %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_labs_description_links %}
 
         </div>
         {% if experiment.application_config.firefox_labs.supports_groups %}
           <div>
             <div class="text-secondary mb-1" style="font-size: 12px;">Firefox Labs Group</div>
             <div class="small text-body">{{ experiment.firefox_labs_group|default:"—" }}</div>
+            {% include "new/common/validation_errors.html" with errors=validation_errors.firefox_labs_group %}
+
           </div>
         {% endif %}
         <div>
@@ -108,6 +131,8 @@
           {% else %}
             <i class="fas fa-times text-danger"></i>
           {% endif %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.requires_restart %}
+
         </div>
       {% endif %}
     {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -21,6 +21,8 @@
       {% if form.rollout_experience.errors %}
         <div class="text-danger small mt-1">{{ form.rollout_experience.errors|join:", " }}</div>
       {% endif %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.takeaways_summary %}
+
     </div>
     <div>
       {#  Feature config  #}
@@ -70,6 +72,9 @@
           </div>
         {% endfor %}
       </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.reference_branch %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.treatment_branches %}
+
     {% endwith %}
     {#  Feature validation and pref conflict options  #}
     <div class="mt-4">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -105,6 +105,12 @@
         </table>
       {% endif %}
     {% endwith %}
+    {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_phases %}
+    {% include "new/common/validation_errors.html" with errors=validation_errors.population_percent %}
+    {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_enrollment %}
+    {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_duration %}
+    {% include "new/common/validation_errors.html" with errors=validation_errors.total_enrolled_clients %}
+
     <div class="d-flex gap-5">
       {# Move to next phase observations #}
       <div class="flex-fill">
@@ -114,6 +120,8 @@
         <div id="rollout-schedule-advance-observations" class="small text-body">
           {{ experiment.rollout_advance_observations|default:"—" }}
         </div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_advance_observations %}
+
       </div>
       {# Pause rollout observations #}
       <div class="flex-fill">
@@ -123,6 +131,8 @@
         <div id="rollout-schedule-pause-observations" class="small text-body">
           {{ experiment.rollout_pause_observations|default:"—" }}
         </div>
+        {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_pause_observations %}
+
       </div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -104,6 +104,11 @@
           Add phase
         </button>
       </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_phases %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.population_percent %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_enrollment %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_duration %}
+
     </div>
     {# Move to next phase observations #}
     <div>
@@ -114,6 +119,8 @@
       {% if form.rollout_advance_observations.errors %}
         <div class="text-danger small mt-1">{{ form.rollout_advance_observations.errors|join:", " }}</div>
       {% endif %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_advance_observations %}
+
     </div>
     {# Pause rollout observations #}
     <div class="mb-2">
@@ -124,6 +131,8 @@
       {% if form.rollout_pause_observations.errors %}
         <div class="text-danger small mt-1">{{ form.rollout_pause_observations.errors|join:", " }}</div>
       {% endif %}
+      {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_pause_observations %}
+
     </div>
     {# Action buttons #}
     <div class="d-flex align-items-center gap-2">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/card.html
@@ -3,31 +3,43 @@
 {% block card %}
   <div class="d-flex flex-column gap-3" id="rollout-signoff-body">
     {# QA sign-off #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">QA sign-off</div>
-      {% if experiment.qa_signoff %}
-        <i id="rollout-signoff-qa" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-signoff-qa" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">QA sign-off</div>
+        {% if experiment.qa_signoff %}
+          <i id="rollout-signoff-qa" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-signoff-qa" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.qa_signoff %}
+
     </div>
     {# VP sign-off #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">VP sign-off</div>
-      {% if experiment.vp_signoff %}
-        <i id="rollout-signoff-vp" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-signoff-vp" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">VP sign-off</div>
+        {% if experiment.vp_signoff %}
+          <i id="rollout-signoff-vp" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-signoff-vp" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.vp_signoff %}
+
     </div>
     {# Legal sign-off #}
-    <div class="d-flex flex-row gap-3">
-      <div class="text-secondary mb-1" style="font-size: 12px;">Legal sign-off</div>
-      {% if experiment.legal_signoff %}
-        <i id="rollout-signoff-legal" class="fas fa-check text-success"></i>
-      {% else %}
-        <i id="rollout-signoff-legal" class="fas fa-times text-danger"></i>
-      {% endif %}
+    <div>
+      <div class="d-flex flex-row gap-3">
+        <div class="text-secondary mb-1" style="font-size: 12px;">Legal sign-off</div>
+        {% if experiment.legal_signoff %}
+          <i id="rollout-signoff-legal" class="fas fa-check text-success"></i>
+        {% else %}
+          <i id="rollout-signoff-legal" class="fas fa-times text-danger"></i>
+        {% endif %}
+      </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.legal_signoff %}
+
     </div>
   </div>
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/edit_form.html
@@ -20,6 +20,8 @@
              href="https://experimenter.info/workflow/risk-mitigation#qa-sign-off">Learn more</a>
         </span>
       </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.qa_signoff %}
+
       {# VP sign-off #}
       <div class="d-flex flex-row align-items-center gap-2">
         <div class="form-check mb-0">
@@ -34,6 +36,8 @@
              href="https://experimenter.info/workflow/risk-mitigation#vp-sign-off">Learn more</a>
         </span>
       </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.vp_signoff %}
+
       {# Legal sign-off #}
       <div class="d-flex flex-row align-items-center gap-2">
         <div class="form-check mb-0">
@@ -50,6 +54,8 @@
              href="https://experimenter.info/workflow/risk-mitigation#legal-sign-off">Learn more</a>
         </span>
       </div>
+      {% include "new/common/validation_errors.html" with errors=validation_errors.legal_signoff %}
+
     </div>
     {# Action buttons #}
     <div class="d-flex align-items-center gap-2">


### PR DESCRIPTION
Because

- We were only showing field validation errors in the sidebar on the rollouts page

This commit

- Adds field error text directly next to impacted fields

Fixes #16693