### PR TITLE
feat(nimbus): Replace message risk question with message review process

### DIFF
--- a/.github/workflows/experimenter-mozcloud-pr-preview.yaml
+++ b/.github/workflows/experimenter-mozcloud-pr-preview.yaml
@@ -1,10 +1,8 @@
-name: Experimenter -- Build, Tag and Push Container Images to GAR Repository
+name: Experimenter -- PR Preview
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch: {}
+  pull_request:
+    types: [labeled, unlabeled, synchronize]
 
 env:
   PROJECT_ID: moz-fx-experimenter-prod-6cd5
@@ -13,8 +11,11 @@ env:
 jobs:
   build_and_push:
     if: >
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch'
+      (
+        github.event_name == 'pull_request' &&
+        contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -23,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           fetch-tags: true
           fetch-depth: 0
@@ -41,31 +42,13 @@ jobs:
             ./scripts/store_git_info.sh
             make build_prod
 
-      - name: Generate MozCloud Tag
-        if: steps.check-paths.outputs.should-run == 'true'
-        id: mozcloud-tag
-        shell: bash
-        env:
-          REF_TYPE: ${{ github.ref_type }}
-          REF_NAME: ${{ github.ref_name }}
-        run: |
-          if [[ "${REF_TYPE}" == "tag" ]]; then
-            tag="${REF_NAME}"
-          else
-            tag="sha-$(git rev-parse --short=9 HEAD)"
-          fi
-
-          echo "Setting IMAGE_TAG=${tag} as output"
-          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
-
       - name: Tag image(s) for GAR
         if: steps.check-paths.outputs.should-run == 'true'
         id: meta
         shell: bash
-        env:
-          IMAGE_TAG: ${{ steps.mozcloud-tag.outputs.image_tag }}
         run: |
-          docker tag experimenter:deploy "${IMAGE_BASE}:latest"
+          IMAGE_TAG="$(git rev-parse --short=10 HEAD)"
+
           docker tag experimenter:deploy "${IMAGE_BASE}:${IMAGE_TAG}"
           echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
 
@@ -74,7 +57,6 @@ jobs:
         uses: mozilla-it/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           image_tags: |-
-            ${{ env.IMAGE_BASE }}:latest
             ${{ env.IMAGE_BASE }}:${{ steps.meta.outputs.image_tag }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ env.PROJECT_ID }}

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -452,8 +452,6 @@ class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
             flags.append("Revenue")
         if obj.risk_brand:
             flags.append("Brand")
-        if obj.risk_message:
-            flags.append("Message")
         if obj.risk_ai:
             flags.append("AI")
         return flags
@@ -630,11 +628,6 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         error_messages={"null": NimbusConstants.ERROR_REQUIRED_QUESTION},
     )
     risk_brand = serializers.BooleanField(
-        required=True,
-        allow_null=False,
-        error_messages={"null": NimbusConstants.ERROR_REQUIRED_QUESTION},
-    )
-    risk_message = serializers.BooleanField(
         required=True,
         allow_null=False,
         error_messages={"null": NimbusConstants.ERROR_REQUIRED_QUESTION},

--- a/experimenter/experimenter/experiments/changelog_utils.py
+++ b/experimenter/experimenter/experiments/changelog_utils.py
@@ -1,6 +1,7 @@
 import json
 import uuid
 
+from django.contrib.auth.models import User
 from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import FieldDoesNotExist
 from django.db import models
@@ -59,6 +60,7 @@ class NimbusExperimentChangeLogSerializer(serializers.ModelSerializer):
         many=True, read_only=True, slug_field="email"
     )
     tags = serializers.SlugRelatedField(many=True, read_only=True, slug_field="name")
+    message_reviewer = serializers.SlugRelatedField(read_only=True, slug_field="email")
 
     class Meta:
         model = NimbusExperiment
@@ -147,6 +149,16 @@ def get_formatted_change_object(field_name, field_diff, changelog, timestamp):
 
         old_value = json.dumps(old_value, indent=2)
         new_value = json.dumps(new_value, indent=2)
+
+    # elif (
+    #     isinstance(field_instance, models.ForeignKey)
+    #     and field_instance.related_model is User
+    # ):
+    #     values = {
+    #         User.objects.
+    #     }
+    #     old_value = "dingus"
+    #     new_value = "dongus"
 
     elif isinstance(field_instance, (models.JSONField, ArrayField)):
         event_name = ChangeEventType.DETAILED.name

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -203,6 +203,8 @@ class ApplicationConfig:
     #: If None, this application will not support Firefox Labs.
     firefox_labs: FirefoxLabs | None = field(default=None)
 
+    messaging_features: list[str] = field(default=None)
+
     def get_kinto_collection_for_experiment(self, experiment: NimbusExperiment) -> str:
         if self.kinto_collections_by_feature_id is not None:
             return self.get_kinto_collection_for_feature_ids(
@@ -295,6 +297,42 @@ APPLICATION_CONFIG_DESKTOP = ApplicationConfig(
             FirefoxLabs.Groups.NEWTAB_WIDGETS: Version.FIREFOX_151,
         },
     ),
+    # https://searchfox.org/firefox-main/source/browser/components/asrouter/modules/MessagingExperimentConstants.sys.mjs
+    messaging_features=[
+        "cfr",
+        "infobar",
+        "moments-page",
+        "pbNewtab",
+        "spotlight",
+        "featureCallout",
+        "fxms_bmb_button",
+        "fxms-message",
+        "fxms-message-1",
+        "fxms-message-2",
+        "fxms-message-3",
+        "fxms-message-4",
+        "fxms-message-5",
+        "fxms-message-6",
+        "fxms-message-7",
+        "fxms-message-8",
+        "fxms-message-9",
+        "fxms-message-10",
+        "fxms-message-11",
+        "fxms-message-12",
+        "fxms-message-13",
+        "fxms-message-14",
+        "fxms-message-15",
+        "fxms-message-16",
+        "fxms-message-17",
+        "fxms-message-18",
+        "fxms-message-19",
+        "fxms-message-20",
+        "fxms-message-21",
+        "fxms-message-22",
+        "fxms-message-23",
+        "fxms-message-24",
+        "fxms-message-25",
+    ]
 )
 
 APPLICATION_CONFIG_FENIX = ApplicationConfig(

--- a/experimenter/experimenter/experiments/migrations/0338_nimbusexperiment_message_reviewer.py
+++ b/experimenter/experimenter/experiments/migrations/0338_nimbusexperiment_message_reviewer.py
@@ -1,0 +1,57 @@
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+def create_permissions(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    content_type = ContentType.objects.get_for_model(NimbusExperiment)
+
+    omc = Group.objects.create(name="OMC")
+    can_perform_message_review = Permission.objects.create(
+        codename="can_perform_message_review",
+        name="Can perform message review",
+        content_type=content_type,
+    )
+    omc.permissions.add(can_perform_message_review)
+
+
+def delete_permissions(apps, schema_editor):
+    ContentType = apps.get_model("contenttypes", "ContentType")
+    NimbusExperiment = apps.get_model("experiments", "NimbusExperiment")
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    content_type = ContentType.objects.get_for_model(NimbusExperiment)
+
+    Group.objects.filter(name="OMC").delete()
+    Permission.objects.filter(
+        content_type=content_type, codename="can_perform_message_review"
+    ).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("experiments", "0337_nimbusexperiment_sizing_data"),
+        ("contenttypes", "0002_remove_content_type_name"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="nimbusexperiment",
+            name="message_reviewer",
+            field=models.ForeignKey(
+                blank=True,
+                default=None,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                to=settings.AUTH_USER_MODEL,
+            ),
+        ),
+        migrations.RunPython(create_permissions, delete_permissions),
+    ]

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -423,6 +423,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     risk_message = models.BooleanField(
         "Is a Message Risk Flag", default=None, blank=True, null=True
     )
+    message_reviewer = models.ForeignKey(User, default=None, blank=True, null=True, on_delete=models.SET_NULL)
     risk_ai = models.BooleanField(
         "Is an AI Risk Flag", default=None, blank=True, null=True
     )
@@ -2921,6 +2922,16 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             self.feature_configs.values_list("subscribers__email", flat=True),
         )
         return list({email for email in emails if email})
+
+    @property
+    def is_messaging_experiment(self):
+        application_config = self.application_config
+        return (
+            application_config.messaging_features
+            and self.feature_configs.filter(
+                slug__in=application_config.messaging_features
+            ).exists()
+        )
 
 
 class NimbusBranch(models.Model):

--- a/experimenter/experimenter/features/__init__.py
+++ b/experimenter/experimenter/features/__init__.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import re
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -30,6 +31,7 @@ FEATURE_PYTHON_TYPES = {
     FeatureVariableType.BOOLEAN: bool,
 }
 
+logger = logging.getLogger()
 
 @dataclass
 class Feature:
@@ -122,6 +124,7 @@ class Features:
     def _load_features(cls):
         features = []
         version_re = re.compile(r"^v(?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)")
+        i = 0
 
         for application in NimbusConstants.APPLICATION_CONFIGS.values():
             application_dir: Path = settings.FEATURE_MANIFESTS_PATH / application.slug
@@ -139,11 +142,15 @@ class Features:
 
                         application_yaml_path = child / "experimenter.yaml"
                         if application_yaml_path.exists():
+                            i+=1
+                            logging.info(f"Loading manifest {i} {application_yaml_path}")
                             features.extend(
                                 cls._read_manifest(
                                     application, application_yaml_path, version
                                 )
                             )
+                            logging.info(f"Loaded manifest {i} {application_yaml_path}")
+
 
         return features
 

--- a/experimenter/experimenter/features/management/commands/load_feature_configs.py
+++ b/experimenter/experimenter/features/management/commands/load_feature_configs.py
@@ -48,10 +48,14 @@ class Command(BaseCommand):
         # When we are ingesting versioned Features, we want to update the
         # NimbusFeatureConfig objects with the most up-to-date description.
         updated: set[tuple[str, str]] = set()
-        for feature in itertools.chain(
+        ALL_FEATURES = list(itertools.chain(
             Features.unversioned(),
             sorted(Features.versioned(), key=lambda f: f.version, reverse=True),
-        ):
+        ))
+        N = len(ALL_FEATURES)
+        for (i, feature) in enumerate(ALL_FEATURES):
+            logger.info(f"processing feature {i}/{N}")
+
             key = (feature.application_slug, feature.slug)
             if key in updated:
                 # We have already processes the unversioned feature OR a
@@ -210,10 +214,11 @@ class Command(BaseCommand):
                 schema.save(update_fields=dirty_fields)
 
             logger.info(
-                f"Feature Loaded: {feature.application_slug}/{feature.slug} "
+                f"Feature {i}/{N} Loaded: {feature.application_slug}/{feature.slug} "
                 f"(version {feature.version})"
             )
 
+        logger.info("attempting bulk create of {len(schemas_to_create)} schemas")
         NimbusVersionedSchema.objects.bulk_create(schemas_to_create)
 
         logger.info("Features Updated")

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -35,8 +35,8 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE = (
         "Cannot duplicate the final phase because this rollout has no current phase."
     )
+    MESSAGE_CONSULT_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/2542436381/OMC+Team+2026+-+Onboarding+Messaging+Communication#OMC-Intake---Requesting-work%2FCode-Reviews%2FConsultation"
 
-    RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
     REVIEW_URL = "https://experimenter.info/getting-started/for-reviewers"
     VALIDATING_EXPERIMENTS_URL = (
         "https://experimenter.info/data-analysis/validating-experiments/"
@@ -193,7 +193,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     }
     OVERVIEW_PAGE_LINKS = {
         "risk_link": "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthishavehighrisktothebrand?",
-        "message_consult_link": "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation",
+        "message_consult_link": "https://mozilla-hub.atlassian.net/wiki/spaces/FPS/pages/2542436381/OMC+Team+2026+-+Onboarding+Messaging+Communication#OMC-Intake---Requesting-work%2FCode-Reviews%2FConsultation",
         "revenue_risk_link": "https://experimenter.info/workflow/risk-mitigation#vp-sign-off",
         "partner_related_risk_link": "https://experimenter.info/workflow/risk-mitigation#legal-sign-off",
     }

--- a/experimenter/experimenter/nimbus_ui/forms.py
+++ b/experimenter/experimenter/nimbus_ui/forms.py
@@ -392,13 +392,6 @@ class OverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
         widget=InlineRadioSelect,
         coerce=lambda x: x == "True",
     )
-    risk_message = forms.TypedChoiceField(
-        required=False,
-        choices=YES_NO_CHOICES,
-        widget=InlineRadioSelect,
-        coerce=lambda x: x == "True",
-    )
-
     public_description = forms.CharField(
         required=False, widget=forms.Textarea(attrs={"class": "form-control", "rows": 3})
     )
@@ -430,7 +423,6 @@ class OverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "risk_partner_related",
             "risk_revenue",
             "risk_brand",
-            "risk_message",
             "risk_ai",
         ]
 
@@ -446,7 +438,6 @@ class OverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
             data=self.data or None,
             instance=self.instance,
         )
-
     def is_valid(self):
         return super().is_valid() and self.documentation_links.is_valid()
 
@@ -722,6 +713,10 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
     )
     is_first_run = forms.BooleanField(required=False, widget=forms.HiddenInput())
+    message_review = forms.BooleanField(
+        required=False,
+        widget=forms.CheckboxInput(attrs={"class": "form-check-input"}),
+    )
 
     update_on_change_fields = (
         "equal_branch_ratio",
@@ -729,6 +724,7 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         "is_firefox_labs_opt_in",
         "is_localized",
         "is_rollout",
+        "message_review",
     )
 
     class Meta:
@@ -817,6 +813,14 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
         self.was_labs_opt_in = self.instance.is_firefox_labs_opt_in
 
+        if not self.instance.is_messaging_experiment:
+            self.fields.pop("message_review")
+        else:
+            if not self.request.user.has_perm("experiments.can_perform_message_review"):
+                self.fields["message_review"].disabled = True
+
+            self.fields["message_review"].initial = self.instance.message_reviewer_id is not None
+
     @property
     def errors(self):
         errors = super().errors
@@ -845,6 +849,24 @@ class NimbusBranchesForm(NimbusChangeLogFormMixin, forms.ModelForm):
     @transaction.atomic
     def save(self, *args, **kwargs):
         self.branches.save()
+
+        if (
+            self.instance.is_messaging_experiment
+            and self.request.user.has_perm("experiments.can_perform_message_review")
+        ):
+            message_review = self.cleaned_data.pop("message_review", None)
+
+            if (
+                self.instance.message_reviewer_id is None
+                and message_review is True
+            ):
+                self.instance.message_reviewer_id = self.request.user.id
+            elif (
+                self.instance.message_reviewer_id is not None
+                and message_review is False
+            ):
+                self.instance.message_reviewer_id = None
+
         experiment = super().save(*args, **kwargs)
 
         if experiment.is_rollout:

--- a/experimenter/experimenter/nimbus_ui/static/js/review_controls.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/review_controls.js
@@ -7,10 +7,12 @@ window.showRecommendation = function () {
   recommendationMessage.classList.remove("d-none");
 };
 window.toggleSubmitButton = function () {
-  const checkbox1 = document.getElementById("checkbox-1");
-  const checkbox2 = document.getElementById("checkbox-2");
-  const submitButton = document.getElementById("request-launch-button");
-  submitButton.disabled = !(checkbox1.checked && checkbox2.checked);
+  const required = Array.from(
+    document.getElementById("recommendation-message")
+    .querySelectorAll('input[type="checkbox"][data-required-for-launch]')
+  );
+
+  document.getElementById("request-launch-button").disabled = required.some(el => !el.checked);
 };
 
 window.updatePreviewURL = function () {

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail.html
@@ -10,6 +10,7 @@
   <div id="PageSummary" class="mt-3">
     {% include "nimbus_experiments/invalid_pages_warning.html" %}
     {% include "nimbus_experiments/audience_overlap_warnings.html" %}
+    {% include "nimbus_experiments/message_review_warning.html" %}
 
     {% if not invalid_pages or not experiment.is_draft %}
       {% include "nimbus_experiments/launch_controls.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -59,8 +59,8 @@
               <div class="form-check">
                 {{ form.is_holdback }}
                 <label class="form-check-label" for="id_is_holdback">{{ NimbusUIConstants.HOLDBACK_LABEL }}</label>
+                <div class="form-text">{{ NimbusUIConstants.HOLDBACK_HELP_TEXT }}</div>
               </div>
-              <p class="form-text">{{ NimbusUIConstants.HOLDBACK_HELP_TEXT }}</p>
               {% for error in form.is_holdback.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
               {% for error in validation_errors.is_holdback %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
@@ -100,6 +100,34 @@
               {% endfor %}
             </div>
           </div>
+          {% if experiment.is_messaging_experiment %}
+            <div class="row mb-3">
+              <div class="col">
+                <div class="form-check">
+                  {{ form.message_review }}
+                  <label for="id_message_consult" class="form-label">
+                    This messaging {% if experiment.is_rollout %}rollout{% else %}experiment{% endif %} went through the
+                    <a target="_blank"
+                       href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Review</a>
+                    process.
+                  </label>
+                  {% if experiment.message_reviewer is None and not perms.experiments.can_perform_message_review %}
+                    <div class="form-text text-warning">
+                      You lack the necessary permissions to perform the message review. Please ask a member of OMC to perform the review.
+                    </div>
+                  {% endif %}
+                  <div class="form-text">
+                    This process is optional, but is considered best practice in
+                    order to ensure that end users do not have degraded experiences
+                    due to multiple conflicting messages.
+                  </div>
+                  {% if experiment.message_reviewer_id is not None %}
+                    <div class="form-text">The message review was completed by {{ experiment.message_reviewer }}.</div>
+                  {% endif %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
           <div id="branches">
             {{ form.branches.management_form }}
             {% for branch_form in form.branches %}
@@ -220,7 +248,7 @@
                             {% endwith %}
                           </div>
                           <div class="col-8">
-                            <div class=" d-flex align-items-end">
+                            <div class="d-flex align-items-end">
                               {{ screenshot_form.description|add_error_class:"is-invalid" }}
                               <button type="button"
                                       id="delete-screenshot-{{ screenshot_form.instance.id }}"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_overview.html
@@ -125,20 +125,6 @@
               {% endfor %}
             </div>
           </div>
-          <div class="row mb-3">
-            <div class="col-10">
-              <label for="id_risk_message" class="form-label">
-                Does your experiment include ANY messages? If yes, this requires the
-                <a target="_blank"
-                   href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Consult</a>
-              </label>
-            </div>
-            <div class="col-2 text-end">
-              {{ form.risk_message|add_error_class:"is-invalid" }}
-              {% for error in form.risk_message.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
-              {% for error in validation_errors.risk_message %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            </div>
-          </div>
           <div class="row mb-2">
             <div class="col-12">
               <div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/launch_controls.html
@@ -113,35 +113,54 @@
           <div class="form-check">
             <input type="checkbox"
                    class="form-check-input"
-                   id="checkbox-1"
+                   id="id-launch-risk"
+                   data-required-for-launch
                    onchange="toggleSubmitButton()">
-            <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+            <label class="form-check-label" for="id-launch-risk">I understand the risks associated with launching an experiment</label>
           </div>
           <div class="form-check">
             <input type="checkbox"
                    class="form-check-input"
-                   id="checkbox-2"
+                   id="id-launch-onboarding"
+                   data-required-for-launch
                    onchange="toggleSubmitButton()">
-            <label class="form-check-label" for="checkbox-2">
+            <label class="form-check-label" for="id-launch-onboarding">
               I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
             </label>
           </div>
-          <button type="button"
-                  class="btn btn-primary"
-                  id="request-launch-button"
-                  hx-post="{% url 'nimbus-ui-draft-to-review' slug=experiment.slug %}"
-                  hx-select="#content"
-                  hx-target="#content"
-                  hx-swap="outerHTML"
-                  disabled>Request Launch</button>
-          {% if experiment.can_publish_to_preview %}
+          {% if experiment.is_messaging_experiment and not experiment.message_reviewer_id %}
+            <div class="form-check">
+              <input type="checkbox"
+                     class="form-check-input"
+                     id="id-launch-override-message-review"
+                     data-required-for-launch
+                     onchange="toggleSubmitButton()">
+              <label class="form-check-label" for="id-launch-override-message-review">
+                  I acknowledge that I have <em>not</em> gone through the
+                  <a target="_blank"
+                     href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Review</a>
+                  for this {% if experiment.is_rollout %}rollout{% else %}experiment{% endif %}.
+              </label>
+            </div>
+          {% endif %}
+          <div class="mt-2">
             <button type="button"
-                    class="btn btn-secondary"
-                    hx-post="{% url 'nimbus-ui-review-to-draft' slug=experiment.slug %}"
+                    class="btn btn-primary"
+                    id="request-launch-button"
+                    hx-post="{% url 'nimbus-ui-draft-to-review' slug=experiment.slug %}"
                     hx-select="#content"
                     hx-target="#content"
-                    hx-swap="outerHTML">Cancel</button>
-          {% endif %}
+                    hx-swap="outerHTML"
+                    disabled>Request Launch</button>
+            {% if experiment.can_publish_to_preview %}
+              <button type="button"
+                      class="btn btn-secondary"
+                      hx-post="{% url 'nimbus-ui-review-to-draft' slug=experiment.slug %}"
+                      hx-select="#content"
+                      hx-target="#content"
+                      hx-swap="outerHTML">Cancel</button>
+            {% endif %}
+          </div>
         </div>
       </div>
       <!-- Preview Mode Controls -->
@@ -158,19 +177,36 @@
         <div class="form-check">
           <input type="checkbox"
                  class="form-check-input"
-                 id="checkbox-1"
+                 id="id-launch-risk"
+                 data-required-for-launch
                  onchange="toggleSubmitButton()">
-          <label class="form-check-label" for="checkbox-1">I understand the risks associated with launching an experiment</label>
+          <label class="form-check-label" for="id-launch-risk">I understand the risks associated with launching an experiment</label>
         </div>
         <div class="form-check">
           <input type="checkbox"
                  class="form-check-input"
-                 id="checkbox-2"
+                 id="id-launch-onboarding"
+                 data-required-for-launch
                  onchange="toggleSubmitButton()">
-          <label class="form-check-label" for="checkbox-2">
+          <label class="form-check-label" for="id-launch-onboarding">
             I have gone through the <a href="{{ EXTERNAL_URLS.TRAINING_AND_PLANNING_DOC }}" target="_blank">experiment onboarding program</a>
           </label>
         </div>
+        {% if experiment.is_messaging_experiment and not experiment.message_reviewer_id %}
+          <div class="form-check">
+            <input type="checkbox"
+                   class="form-check-input"
+                   id="id-launch-override-message-review"
+                   data-required-for-launch
+                   onchange="toggleSubmitButton()">
+            <label class="form-check-label" for="id-launch-override-message-review">
+                I acknowledge that I have <em>not</em> gone through the
+                <a target="_blank"
+                    href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Review</a>
+                for this {% if experiment.is_rollout %}rollout{% else %}experiment{% endif %}.
+            </label>
+          </div>
+        {% endif %}
         {% if experiment.can_preview_to_review %}
           <button type="button"
                   class="btn btn-primary"
@@ -241,7 +277,6 @@
 
       {% else %}
         {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="Launch Experiment" approval_url="nimbus-ui-review-to-approve" cancel_reject_url="nimbus-ui-review-to-draft" experiment=experiment %}
-
       {% endif %}
     {% elif experiment.is_enrolling or experiment.is_observation %}
       {% if experiment.is_rollout_update_requested %}
@@ -256,7 +291,6 @@
 
         {% else %}
           {% include "nimbus_experiments/approval_rejection_controls.html" with action_label="End Experiment" approval_url="nimbus-ui-approve-end-experiment" cancel_reject_url="nimbus-ui-cancel-end-experiment" experiment=experiment %}
-
         {% endif %}
       {% elif experiment.should_show_end_enrollment or experiment.should_show_end_experiment or experiment.should_show_end_rollout or experiment.should_show_rollout_request_update %}
         <div id="default-controls" class="alert alert-primary mt-3">
@@ -301,7 +335,6 @@
         </div>
         {% if experiment.should_show_end_experiment %}
           {% include "nimbus_experiments/end_experiment_modal.html" with experiment=experiment %}
-
         {% endif %}
       {% endif %}
     {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/message_review_warning.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/message_review_warning.html
@@ -1,0 +1,13 @@
+{% if experiment.is_draft and experiment.is_messaging_experiment and experiment.message_reviewer_id is None %}
+  <div class="alert alert-warning" role="alert">
+    <p>
+    This is a messaging {% if experiment.is_rollout %}rollout{% else %}experiment{% endif %} that has <em>not</em> gone through the
+    <a target="_blank"
+       href="{{ NimbusUIConstants.OVERVIEW_PAGE_LINKS.message_consult_link }}">Message Review</a>
+    process.
+    </p>
+    <p class="mb-0">
+    This process is optional, but is considered best practice in order to ensure that end users do not have degraded experiences due to multiple conflicting messages.
+    </p>
+  </div>
+{% endif %}

--- a/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
+++ b/experimenter/tests/integration/nimbus/pages/experimenter/summary.py
@@ -222,13 +222,13 @@ class SummaryPage(ExperimenterBase):
     class RequestReview(Region, Base):
         PAGE_TITLE = "Review Region"
         _root_locator = (By.CSS_SELECTOR, "#launch-controls")
-        _checkbox1_locator = (By.CSS_SELECTOR, "#checkbox-1")
-        _checkbox2_locator = (By.CSS_SELECTOR, "#checkbox-2")
+        _checkbox_launch_risk_locator = (By.CSS_SELECTOR, "#id-launch-risk")
+        _checkbox_launch_onboarding_locator = (By.CSS_SELECTOR, "#id-launch-onboarding")
         _request_launch_locator = (By.CSS_SELECTOR, "#request-launch-button")
 
         def click_launch_checkboxes(self):
-            checkbox1 = self.wait_for_and_find_element(*self._checkbox1_locator)
-            checkbox2 = self.wait_for_and_find_element(*self._checkbox2_locator)
+            checkbox1 = self.wait_for_and_find_element(*self._checkbox_launch_risk_locator)
+            checkbox2 = self.wait_for_and_find_element(*self._checkbox_launch_onboarding_locator)
             self.js_click(checkbox1)
             self.js_click(checkbox2)
 


### PR DESCRIPTION
Because:

- the existing message risk workflow was not meeting our needs:
  - it appeared on every experiment/rollout, regardless of whether or not it contained a message; and
  - it only asked "is this a message?" and did not actually record whether or not the process was followed.
- we do not want to hard gate launching experiments/rollouts with required sign-offs (besides the pre-existing reviewer & Remote Settings checks).

this commit:

- removing the existing messaging risk section;
- adds a new "OMC" user group;
- adds a new "can perform message review" permission flag that is granted to all members of the "OMC" group;
- adds a new "message review" flag on the branches page which requires the "can perform message review" permission to toggle;
- will display a banner warning on messaging experiments/rollouts that have do not have the message review flag set;
- will display a new signoff checkbox in the launch controls when the message review flag is not set; and
- makes some minor cleanups to the launch control JavaScript.

Fixes #16641
