### PR TITLE
fix(nimbus): Add Options menu and add tooltip to new UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/new/tooltips.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/tooltips.js
@@ -1,0 +1,7 @@
+const disposeAllTooltips = () => {
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+    window.bootstrap?.Tooltip.getInstance(el)?.dispose();
+  });
+};
+
+document.addEventListener("htmx:beforeSwap", disposeAllTooltips);

--- a/experimenter/experimenter/nimbus_ui/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui/static/webpack.config.js
@@ -11,6 +11,7 @@ module.exports = {
     edit_audience: "./js/edit_audience.js",
     edit_branches: "./js/edit_branches.js",
     new_edit_branches: "./js/new/edit_branches.js",
+    new_tooltips: "./js/new/tooltips.js",
     experiment_detail: "./js/experiment_detail.js",
     branch_detail: "./js/branch_detail.js",
     features_page: "./js/features_page.js",

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -80,26 +80,18 @@
               <div class="small text-secondary mt-1">Updated {{ experiment.latest_change.changed_on|timesince }} ago</div>
             {% endif %}
           </div>
-          <div class="align-self-start">
+          <div class="align-self-start d-flex flex-column align-items-end gap-2">
             <div class="dropdown">
               <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
                       id="rollout-actions-dropdown"
                       type="button"
                       data-bs-toggle="dropdown"
-                      data-bs-auto-close="outside"
                       aria-expanded="false"
                       aria-label="Options">
                 <i class="fa-solid fa-bars"></i>
                 Options
               </button>
-              <ul class="dropdown-menu dropdown-menu-end" style="min-width: 14rem;">
-                <li class="px-4 py-2">
-                  {% include "new/common/slack_notifications_toggle.html" %}
-
-                </li>
-                <li>
-                  <hr class="dropdown-divider">
-                </li>
+              <ul class="dropdown-menu dropdown-menu-end">
                 <li>
                   <button class="dropdown-item"
                           id="rollout-clone-button"
@@ -129,6 +121,8 @@
                 </li>
               </ul>
             </div>
+            {% include "new/common/slack_notifications_toggle.html" %}
+
           </div>
         </div>
         {# Toast container #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -12,6 +12,7 @@
       {% block title %}{% endblock %}
     | Experimenter</title>
     <script src="{% static 'nimbus_ui/app.bundle.js' %}"></script>
+    <script src="{% static 'nimbus_ui/new_tooltips.bundle.js' %}"></script>
     {% block extra_head %}{% endblock %}
   </head>
   <body class="m-0 p-0 rollout-page"
@@ -54,44 +55,6 @@
               <h1 id="experiment-header-name" class="mb-0 fw-semibold fs-4 text-body">{{ experiment.name }}</h1>
               {% include "new/common/subscribe_bell.html" %}
 
-              <div class="dropdown">
-                <button class="btn p-0 border-0 text-secondary"
-                        id="rollout-actions-dropdown"
-                        data-bs-toggle="dropdown"
-                        aria-expanded="false"
-                        aria-label="More options">
-                  <i class="fa-solid fa-ellipsis"></i>
-                </button>
-                <ul class="dropdown-menu dropdown-menu-end">
-                  <li>
-                    <button class="dropdown-item"
-                            id="rollout-clone-button"
-                            type="button"
-                            data-bs-toggle="modal"
-                            data-bs-target="#cloneModal">
-                      <i class="fa-regular fa-copy fa-fw me-2"></i>Clone
-                    </button>
-                  </li>
-                  <li>
-                    <form hx-post="{% url 'nimbus-ui-new-toggle-archive' experiment.slug %}"
-                          class="d-flex align-items-center">
-                      {% csrf_token %}
-                      <button class="dropdown-item"
-                              id="rollout-archive-button"
-                              type="submit"
-                              {% if not experiment.can_archive %}disabled{% endif %}>
-                        <i class="fa-regular fa-trash-can fa-fw me-2"></i>{{ experiment.is_archived|yesno:"Unarchive,Archive" }}
-                      </button>
-                      {% if not experiment.can_archive %}
-                        <i class="fa-regular fa-circle-question fa-sm text-secondary pe-3"
-                           data-bs-toggle="tooltip"
-                           data-bs-placement="left"
-                           title="{{ NimbusUIConstants.ARCHIVE_DISABLED_TOOLTIP }}"></i>
-                      {% endif %}
-                    </form>
-                  </li>
-                </ul>
-              </div>
             </div>
             <div class="d-flex align-items-center gap-2 mt-1">
               {% if experiment.is_rollout %}
@@ -117,9 +80,55 @@
               <div class="small text-secondary mt-1">Updated {{ experiment.latest_change.changed_on|timesince }} ago</div>
             {% endif %}
           </div>
-          <div class="align-self-end">
-            {% include "new/common/slack_notifications_toggle.html" %}
+          <div class="align-self-start">
+            <div class="dropdown">
+              <button class="btn btn-sm btn-outline-secondary d-inline-flex align-items-center gap-2"
+                      id="rollout-actions-dropdown"
+                      type="button"
+                      data-bs-toggle="dropdown"
+                      data-bs-auto-close="outside"
+                      aria-expanded="false"
+                      aria-label="Options">
+                <i class="fa-solid fa-bars"></i>
+                Options
+              </button>
+              <ul class="dropdown-menu dropdown-menu-end" style="min-width: 14rem;">
+                <li class="px-4 py-2">
+                  {% include "new/common/slack_notifications_toggle.html" %}
 
+                </li>
+                <li>
+                  <hr class="dropdown-divider">
+                </li>
+                <li>
+                  <button class="dropdown-item"
+                          id="rollout-clone-button"
+                          type="button"
+                          data-bs-toggle="modal"
+                          data-bs-target="#cloneModal">
+                    <i class="fa-regular fa-copy fa-fw me-2"></i>Clone
+                  </button>
+                </li>
+                <li>
+                  <form hx-post="{% url 'nimbus-ui-new-toggle-archive' experiment.slug %}"
+                        class="d-flex align-items-center">
+                    {% csrf_token %}
+                    <button class="dropdown-item"
+                            id="rollout-archive-button"
+                            type="submit"
+                            {% if not experiment.can_archive %}disabled{% endif %}>
+                      <i class="fa-regular fa-trash-can fa-fw me-2"></i>{{ experiment.is_archived|yesno:"Unarchive,Archive" }}
+                    </button>
+                    {% if not experiment.can_archive %}
+                      <i class="fa-regular fa-circle-question fa-sm text-secondary pe-3"
+                         data-bs-toggle="tooltip"
+                         data-bs-placement="left"
+                         title="{{ NimbusUIConstants.ARCHIVE_DISABLED_TOOLTIP }}"></i>
+                    {% endif %}
+                  </form>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
         {# Toast container #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
@@ -5,10 +5,10 @@
       hx-swap="outerHTML"
       class="d-flex align-items-center">
   {% csrf_token %}
-  <div class="form-check form-switch d-flex align-items-center justify-content-between m-0 ps-0 w-100">
+  <div class="form-check form-switch d-flex align-items-center m-0">
     <label for="{{ slack_notifications_form.enable_review_slack_notifications.id_for_label }}"
            class="form-check-label text-secondary small me-2 mb-0">
-      <i class="fa-solid fa-bell me-1"></i>
+      <i class="fa-brands fa-slack me-1"></i>
       <span>Enable review Slack notifications</span>
     </label>
     {{ slack_notifications_form.enable_review_slack_notifications }}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/slack_notifications_toggle.html
@@ -5,7 +5,7 @@
       hx-swap="outerHTML"
       class="d-flex align-items-center">
   {% csrf_token %}
-  <div class="form-check form-switch d-flex align-items-center m-0">
+  <div class="form-check form-switch d-flex align-items-center justify-content-between m-0 ps-0 w-100">
     <label for="{{ slack_notifications_form.enable_review_slack_notifications.id_for_label }}"
            class="form-check-label text-secondary small me-2 mb-0">
       <i class="fa-solid fa-bell me-1"></i>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
@@ -6,7 +6,9 @@
     {% csrf_token %}
     <button type="submit"
             class="btn p-0 border-0 text-secondary"
-            aria-label="Unsubscribe from this experiment">
+            aria-label="Unsubscribe from this experiment"
+            data-bs-toggle="tooltip"
+            title="Unsubscribe from this experiment">
       <i class="fa-solid fa-bell"></i>
     </button>
   </form>
@@ -18,7 +20,9 @@
     {% csrf_token %}
     <button type="submit"
             class="btn p-0 border-0 text-secondary"
-            aria-label="Subscribe to this experiment">
+            aria-label="Subscribe to this experiment"
+            data-bs-toggle="tooltip"
+            title="Subscribe to this experiment">
       <i class="fa-regular fa-bell"></i>
     </button>
   </form>


### PR DESCRIPTION
Because

* We need an Options menu with the Clone, Archive and Slack notification toggle
* We need a tooltip for the subscribe bell

This commit

* Adds the Options menu and moves everything inside
* Adds the tooltips and ensures they disappear once the mouse moves away after a click

Fixes #16699