### PR TITLE
style(nimbus): rollout page general visual improvements

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -283,6 +283,9 @@ class NimbusRolloutDetailView(
         context.update(build_experiment_context(self.object))
         return context
 
+    def get_queryset(self):
+        return super().get_queryset().filter(is_rollout=True)
+
 
 class CardMixin:
     form_class: type[forms.ModelForm]

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -14,39 +14,27 @@
     <script src="{% static 'nimbus_ui/app.bundle.js' %}"></script>
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="m-0 p-0 rollout-page"
+  <body class="m-0 p-0 rollout-page bg-body-tertiary"
         style="font-family: -apple-system, 'SF Pro', BlinkMacSystemFont, sans-serif">
-    <div class="d-flex overflow-hidden" style="height: 100vh;">
+    <div class="container-fluid bg-body border-bottom border-1 py-1">
+      {% block header %}
+        {% include "common/header.html" %}
+
+      {% endblock header %}
+    </div>
+    <div class="d-flex">
       {# ── Sidebar ── #}
-      <div class="d-flex flex-column overflow-y-auto flex-shrink-0 bg-body-tertiary"
-           style="width: 340px">
-        {# Sidebar top bar: Nimbus logo | Back #}
-        <div class="d-flex align-items-center justify-content-between px-3 pt-3"
-             style="min-height: 56px">
-          <div class="d-flex align-items-center gap-2">
-            <img src="{% static 'assets/logo.svg' %}"
-                 alt="Nimbus"
-                 width="24"
-                 height="24">
-            <span class="fw-semibold text-body fs-4" style="letter-spacing: -0.01em;">Nimbus</span>
-          </div>
-          <input id="theme-selector" type="checkbox" class="d-none">
-          <a href="{% url 'nimbus-list' %}"
-             class="text-decoration-none d-flex align-items-center gap-1 small fw-normal text-primary">
-            <i class="fa-solid fa-chevron-left" style="font-size: 11px;"></i>
-            Back
-          </a>
-        </div>
+      <div class="d-flex flex-column overflow-y-auto flex-shrink-0 bg-body-tertiary sticky-top align-self-start"
+           style="width: 340px;
+                  max-height: 100vh">
         {# Sidebar navigation #}
-        <div class="d-flex flex-column gap-2 p-3 pb-5 flex-grow-1">
+        <div class="d-flex flex-column gap-2 p-3 py-4 flex-grow-1">
           {% include "new/common/sidebar.html" with experiment=experiment %}
 
         </div>
       </div>
       {# ── Main content ── #}
-      <div class="flex-grow-1 overflow-y-auto bg-body-tertiary"
-           style="padding: 32px 97px;
-                  min-width: 0">
+      <div class="flex-grow-1 overflow-y-auto bg-body-tertiary p-4">
         {# Experiment header #}
         <div class="d-flex align-items-start justify-content-between mb-4">
           <div>
@@ -93,25 +81,24 @@
                 </ul>
               </div>
             </div>
-            <div class="d-flex align-items-center gap-2 mt-1">
-              {% if experiment.is_rollout %}
-                <span class="badge rounded-pill fw-medium small"
-                      style="background-color: #2AC3A2">Rollout</span>
-              {% endif %}
-              {% if experiment.is_live_rollout %}
-                <span id="rollout-live-badge"
-                      class="badge rounded-pill text-bg-success fw-medium small">Live</span>
-              {% endif %}
-              {% if experiment.is_archived %}
-                <span id="rollout-archived-badge"
-                      class="badge rounded-pill bg-danger fw-medium small">Archived</span>
-              {% endif %}
+            <div class="d-flex flex-column align-items-start gap-2 mt-1">
               <button id="experiment-slug"
                       class="btn p-0 border-0 text-secondary d-flex align-items-center gap-1 small"
                       aria-label="Copy slug">
                 <span>{{ experiment.slug }}</span>
                 <i class="fa-regular fa-copy"></i>
               </button>
+              {% if experiment.parent %}
+                <p class="text-secondary small mb-0">
+                  Cloned from
+                  <a href="{% url 'nimbus-ui-detail' experiment.parent.slug %}"
+                     target="_blank"
+                     data-testid="experiment-parent"
+                     rel="noopener noreferrer">{{ experiment.parent.name }}</a>
+                </p>
+              {% endif %}
+              {% include "nimbus_experiments/experiment_tags.html" with show_status_badges=True hide_project_tags=True %}
+
             </div>
             {% if experiment.latest_change %}
               <div class="small text-secondary mt-1">Updated {{ experiment.latest_change.changed_on|timesince }} ago</div>
@@ -159,6 +146,9 @@
         {% block main_content %}{% endblock %}
       </div>
     </div>
+    {# Keep modals outside the sticky sidebar's stacking context. #}
+    {% include "new/common/setup_issues_modal.html" %}
+
     {# Clone modal #}
     <div class="modal fade"
          id="cloneModal"

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -240,4 +240,3 @@
     Help
   </a>
 </div>
-{% include "new/common/setup_issues_modal.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/experiment_tags.html
@@ -18,8 +18,12 @@
     {% if experiment.is_rollout_dirty %}
       <span class="badge rounded-pill bg-danger" id="unpublished-rollout-badge">Unpublished changes</span>
     {% endif %}
+    {% if experiment.is_live_rollout %}
+      <span id="rollout-live-badge"
+            class="badge rounded-pill text-bg-success fw-medium small">Live</span>
+    {% endif %}
   {% endif %}
-  {% if experiment.tags.all %}
+  {% if experiment.tags.all and not hide_project_tags %}
     {% for tag in experiment.tags.all %}
       <span class="badge rounded-pill"
             style="background-color: {{ tag.color }};

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -415,7 +415,8 @@ class TestNimbusRolloutDetailView(AuthTestCase):
     def test_get_returns_new_rollout_detail_context(self):
         tag = TagFactory.create()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
         )
 
         response = self.client.get(
@@ -502,6 +503,7 @@ class TestNimbusRolloutDetailView(AuthTestCase):
             public_description="",
             hypothesis=NimbusExperiment.HYPOTHESIS_DEFAULT,
             feature_configs=[],
+            is_rollout=True,
         )
 
         response = self.client.get(
@@ -570,7 +572,8 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
     def test_preview_card_hidden_when_not_in_preview(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
         )
 
         response = self.client.get(
@@ -583,7 +586,8 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
     def test_preview_card_shown_when_in_preview(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.PREVIEW
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
         )
 
         response = self.client.get(
@@ -598,7 +602,8 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
     def test_preview_card_lists_all_screenshots(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.PREVIEW
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
         )
         screenshot_1 = NimbusBranchScreenshotFactory.create(
             branch=experiment.reference_branch
@@ -655,6 +660,15 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Open Remote Settings")
+
+    def test_get_returns_404_for_experiment(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=False)
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 404)
 
 
 class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
@@ -1294,6 +1308,7 @@ class TestNewOverviewCancelView(AuthTestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             documentation_links=[blank_link, filled_link],
+            is_rollout=True,
         )
         response = self.client.post(
             reverse(self.url_name, kwargs={"slug": experiment.slug}),
@@ -1948,6 +1963,7 @@ class TestNewToggleArchiveView(AuthTestCase):
     def test_detail_page_renders_archive_button(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
         )
 
         response = self.client.get(
@@ -1967,6 +1983,7 @@ class TestNewToggleReviewSlackNotificationsView(AuthTestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             enable_review_slack_notifications=True,
+            is_rollout=True,
         )
 
         response = self.client.get(

--- a/experimenter/tests/integration/nimbus/pages/rollouts/base.py
+++ b/experimenter/tests/integration/nimbus/pages/rollouts/base.py
@@ -17,7 +17,7 @@ class RolloutBase(Base):
     _clone_name_locator = (By.ID, "clone-name")
     _clone_submit_locator = (By.CSS_SELECTOR, "#cloneForm button[type='submit']")
     _header_name_locator = (By.ID, "experiment-header-name")
-    _archived_badge_locator = (By.ID, "rollout-archived-badge")
+    _archived_badge_locator = (By.ID, "archive-badge")
     _live_badge_locator = (By.ID, "rollout-live-badge")
     _preview_button_locator = (By.ID, "rollout-preview-btn")
     _preview_section_locator = (By.ID, "rollout-preview-section")

--- a/experimenter/tests/integration/nimbus/pages/rollouts/overview.py
+++ b/experimenter/tests/integration/nimbus/pages/rollouts/overview.py
@@ -9,10 +9,19 @@ class OverviewSection(FormBase):
     PAGE_TITLE = "Rollout Overview"
     CARD_ID = "overview"
 
-    _name_locator = (By.ID, "id_name")
-    _hypothesis_locator = (By.ID, "id_hypothesis")
-    _public_description_locator = (By.ID, "id_public_description")
-    _application_locator = (By.ID, "id_application")
+    _name_locator = (By.CSS_SELECTOR, "#rollout-overview-body #id_name")
+    _hypothesis_locator = (
+        By.CSS_SELECTOR,
+        "#rollout-overview-body #id_hypothesis",
+    )
+    _public_description_locator = (
+        By.CSS_SELECTOR,
+        "#rollout-overview-body #id_public_description",
+    )
+    _application_locator = (
+        By.CSS_SELECTOR,
+        "#rollout-overview-body #id_application",
+    )
     _displayed_name_locator = (By.ID, "rollout-overview-name")
     _displayed_hypothesis_locator = (By.ID, "rollout-overview-hypothesis")
     _displayed_public_description_locator = (


### PR DESCRIPTION
Because

- The rollout page needed several small visual tweaks

This commit

- Make the Nimbus logo clickable and link back to the home/list page.
- Throws 404 if an experiment tries to access the rollout page
- Adds the missing full header
- Adds a parent link when a rollout was cloned.
- Moves the slug onto its own line
- Adds the missing QA status tag at the top.
- Reduces side margins.

Fixes #16698 