### PR TITLE
bug(ci): Fix preview workflow for experimenter

### DIFF
--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -15,13 +15,13 @@ env:
 jobs:
   build_and_push:
     if: >
-      github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
+        github.event_name == 'push' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -48,40 +48,77 @@ jobs:
             ./scripts/store_git_info.sh
             make build_prod
 
-      - name: Generate MozCloud Tag
+      - name: Generate MozCloud Tags
         if: steps.check-paths.outputs.should-run == 'true'
         id: mozcloud-tag
         shell: bash
         env:
           REF_TYPE: ${{ github.ref_type }}
           REF_NAME: ${{ github.ref_name }}
+          IS_DEPLOY: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
+          IS_PREVIEW_PR: >-
+            ${{
+              github.event_name == 'pull_request' &&
+              contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
+              github.event.pull_request.head.repo.full_name == github.repository
+            }}
         run: |
           if [[ "${REF_TYPE}" == "tag" ]]; then
-            tag="${REF_NAME}"
+            deploy_tag="${REF_NAME}"
           else
-            tag="sha-$(git rev-parse --short=9 HEAD)"
+            deploy_tag="sha-$(git rev-parse --short=9 HEAD)"
           fi
 
-          echo "Setting IMAGE_TAG=${tag} as output"
-          echo "image_tag=${tag}" >> "$GITHUB_OUTPUT"
+          if [[ "${IS_DEPLOY}" == "true" ]]; then
+            echo "Adding DEPLOY_TAG=${deploy_tag} as output"
+            echo -n "deploy_tag=${deploy_tag}" >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Tag image(s) for GAR
+          if [[ "${IS_PREVIEW_PR}" == "true" ]]; then
+            preview_tag="$(git rev-parse --short=10 HEAD)"
+
+            echo "Adding PREVIEW_TAG=${preview_tag} as output"
+            echo -n "preview_tag=${preview_tag}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Tag image(s) for Google Artifact Registry
         if: steps.check-paths.outputs.should-run == 'true'
-        id: meta
         shell: bash
         env:
-          IMAGE_TAG: ${{ steps.mozcloud-tag.outputs.image_tag }}
+          DEPLOY_TAG: ${{ steps.mozcloud-tag.outputs.deploy_tag }}
+          PREVIEW_TAG: ${{ steps.mozcloud-tag.outputs.preview_tag }}
         run: |
-          docker tag experimenter:deploy "${IMAGE_BASE}:latest"
-          docker tag experimenter:deploy "${IMAGE_BASE}:${IMAGE_TAG}"
-          echo "image_tag=${IMAGE_TAG}" >> "$GITHUB_OUTPUT"
+          if [[ ! -z "${DEPLOY_TAG}" ]]; then
+            docker tag experimenter:deploy "${IMAGE_BASE}:latest"
+            docker tag experimenter:deploy "${IMAGE_BASE}:${DEPLOY_TAG}"
+          fi
 
-      - name: Push to Google Artifact Registry
-        if: steps.check-paths.outputs.should-run == 'true'
+          if [[ ! -z "${PREVIEW_TAG}" ]]; then
+            docker tag experimenter:deploy "${IMAGE_BASE}:${PREVIEW_TAG}"
+          fi
+      - name: Push Deploy Image to Google Artifact Registry
+        if: >
+          steps.check-paths.outputs.should-run == 'true' &&
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+        id: push-deploy
         uses: mozilla-it/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
         with:
           image_tags: |-
             ${{ env.IMAGE_BASE }}:latest
-            ${{ env.IMAGE_BASE }}:${{ steps.meta.outputs.image_tag }}
+            ${{ env.IMAGE_BASE }}:${{ steps.mozcloud-tag.outputs.image_tag }}
+          workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
+          project_id: ${{ env.PROJECT_ID }}
+
+      - name: Push Preview Image to Google Artifact Registry
+        if: >
+          steps.check-paths.outputs.should-run == 'true' &&
+          github.event_name == 'pull_request' &&
+          contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        id: push-preview
+        uses: mozilla-it/deploy-actions/docker-push@ef0f037316873ff408a598f1cd98876dd7851e53 # v6.7.0
+        with:
+          image_tags: |-
+            ${{ env.IMAGE_BASE }}:${{ steps.mozcloud-tag.outputs.preview_tag }}
           workload_identity_pool_project_number: ${{ vars.GCPV2_WORKLOAD_IDENTITY_POOL_PROJECT_NUMBER }}
           project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
Because:

- the preview tag is expected to be `experimenter:{SHA[..10]}`;
- the deploy tag is expected to be `experimenter:sha-{SHA[..9]}`;
- we were only tagging images with the SHA9 version in either case; and
- we were unconditionally pushing the `experimenter:latest`

this commit:

- conditionally tags images for deploys in the deploy scenario;
- conditionally tags images for preview in the preview scenario;
- only pushes one set of tags, depending on the scenario; and
- will no longer push `experimenter:latest` for previews.

Fixes #16729