### PR TITLE
fix(nimbus): Improve Overview card editing experience

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -168,7 +168,13 @@ class NimbusDocumentationLinkForm(forms.ModelForm):
         widget=forms.Select(attrs={"class": "form-select"}),
     )
     link = forms.CharField(
-        required=False, widget=forms.TextInput(attrs={"class": "form-control"})
+        required=False,
+        widget=forms.TextInput(
+            attrs={
+                "class": "form-control",
+                "placeholder": "Paste link here",
+            }
+        ),
     )
 
     class Meta:
@@ -491,6 +497,7 @@ class RolloutOverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
     def save(self):
         experiment = super().save()
         self.documentation_links.save()
+        experiment.documentation_links.filter(link="").delete()
         return experiment
 
     def get_changelog_message(self):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -332,6 +332,12 @@ class NewOverviewUpdateView(CardMixin, NewCardUpdateView):
     template_name = "new/rollouts/overview/edit_form.html"
 
 
+class NewOverviewCancelView(NimbusRolloutDetailView):
+    def post(self, request, *args, **kwargs):
+        self.get_object().documentation_links.filter(link="").delete()
+        return self.get(request, *args, **kwargs)
+
+
 class NewRisksUpdateView(CardMixin, NewCardUpdateView):
     form_class = RolloutRisksForm
     display_template = "new/rollouts/risks/card.html"
@@ -409,12 +415,39 @@ class NewSignoffUpdateView(CardMixin, NewCardUpdateView):
         return True
 
 
+class CardMutationMixin:
+    def post(self, request, *args, **kwargs):
+        self.object = self.get_object()
+        if not self.can_edit():
+            response = HttpResponse()
+            base_url = reverse("nimbus-ui-detail", kwargs={"slug": self.object.slug})
+            response.headers["HX-Redirect"] = f"{base_url}?save_failed=true"
+            return response
+
+        form = self.get_form()
+        if form.is_valid():
+            form.save()
+        else:
+            self.mutate()
+
+        return self.render_to_response(
+            self.get_context_data(form=self.form_class(instance=self.object))
+        )
+
+    def mutate(self):
+        raise NotImplementedError
+
+
 class NewDocumentationLinkCreateView(RenderParentDBResponseMixin, NewOverviewUpdateView):
     form_class = DocumentationLinkCreateForm
 
 
-class NewDocumentationLinkDeleteView(RenderParentDBResponseMixin, NewOverviewUpdateView):
+class NewDocumentationLinkDeleteView(CardMutationMixin, NewOverviewUpdateView):
     form_class = DocumentationLinkDeleteForm
+
+    def mutate(self):
+        link_id = self.request.POST.get("link_id")
+        self.object.documentation_links.filter(id=link_id).delete()
 
 
 class NewM2MSearchView(NimbusExperimentViewMixin, DetailView):
@@ -481,13 +514,25 @@ class NewM2MDeltaMixin:
         return kwargs
 
 
-class NewTagView(NewM2MDeltaMixin, CardMixin, NewCardUpdateView):
+class NewOverviewFieldUpdateView(NewCardUpdateView):
+    field_template = None
+
+    def form_valid(self, form):
+        self.object = form.save()
+        return self.response_class(
+            request=self.request,
+            template=self.field_template,
+            context=self.get_context_data(),
+        )
+
+
+class NewTagView(NewM2MDeltaMixin, CardMixin, NewOverviewFieldUpdateView):
     item_id_key = "tag_id"
     m2m_attr = "tags"
     form_field = "tags"
     form_class = TagAssignForm
-    display_template = "new/rollouts/overview/card.html"
     template_name = "new/rollouts/overview/edit_form.html"
+    field_template = "new/rollouts/overview/tags_field.html"
 
 
 class NewAddTagView(NewTagView):
@@ -507,13 +552,13 @@ class NewSubscriberSearchView(NewM2MSearchView):
     require_query = True
 
 
-class NewSubscriberView(NewM2MDeltaMixin, CardMixin, NewCardUpdateView):
+class NewSubscriberView(NewM2MDeltaMixin, CardMixin, NewOverviewFieldUpdateView):
     item_id_key = "user_id"
     m2m_attr = "subscribers"
     form_field = "collaborators"
     form_class = CollaboratorsForm
-    display_template = "new/rollouts/overview/card.html"
     template_name = "new/rollouts/overview/edit_form.html"
+    field_template = "new/rollouts/overview/subscribers_field.html"
 
 
 class NewAddSubscriberView(NewSubscriberView):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -32,15 +32,17 @@
       {% if experiment.documentation_links.exists %}
         <div class="d-flex flex-column gap-1">
           {% for link in experiment.documentation_links.all %}
-            <div class="small">
-              <a href="{{ link.link }}"
-                 target="_blank"
-                 rel="noopener noreferrer"
-                 class="text-primary text-decoration-none">
-                {{ link.get_title_display|default:link.link }}
-                <i class="fa-solid fa-arrow-up-right-from-square fa-2xs ms-1"></i>
-              </a>
-            </div>
+            {% if link.link %}
+              <div class="small">
+                <a href="{{ link.link }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="text-primary text-decoration-none">
+                  {{ link.get_title_display|default:link.link }}
+                  <i class="fa-solid fa-arrow-up-right-from-square fa-2xs ms-1"></i>
+                </a>
+              </div>
+            {% endif %}
           {% endfor %}
         </div>
       {% else %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -60,17 +60,16 @@
                   {{ link_form.link }}
                 </div>
                 <div style="width: 40%; min-width: 0" class="flex-shrink-0">{{ link_form.title }}</div>
-                {% if link_form.instance.pk %}
-                  <button type="button"
-                          class="btn p-0 border-0 text-secondary flex-shrink-0"
-                          hx-post="{% url 'nimbus-ui-new-delete-documentation-link' experiment.slug %}"
-                          hx-vals='{"link_id": "{{ link_form.instance.pk }}"}'
-                          hx-target="#rollout-overview-body"
-                          hx-swap="outerHTML"
-                          aria-label="Remove link">
-                    <i class="fa-solid fa-xmark"></i>
-                  </button>
-                {% endif %}
+                <button type="button"
+                        class="btn p-0 border-0 text-secondary flex-shrink-0"
+                        style="width: 1rem"
+                        hx-post="{% url 'nimbus-ui-new-delete-documentation-link' experiment.slug %}"
+                        hx-vals='{"link_id": "{{ link_form.instance.pk }}"}'
+                        hx-target="#rollout-overview-body"
+                        hx-swap="outerHTML"
+                        aria-label="Remove link">
+                  <i class="fa-solid fa-xmark"></i>
+                </button>
               </div>
               {% if link_form.link.errors %}
                 <div class="text-danger small mt-1">{{ link_form.link.errors|join:", " }}</div>
@@ -80,118 +79,28 @@
               {% endif %}
             </div>
           {% endfor %}
-          {# Add link row — always visible #}
-          <div class="d-flex gap-2 align-items-center">
-            <div class="input-group flex-grow-1">
-              <span class="input-group-text bg-body border-end-0 text-secondary">
-                <i class="fa-solid fa-link fa-sm"></i>
-              </span>
-              <input type="text"
-                     class="form-control border-start-0 small"
-                     placeholder="Paste link here"
-                     disabled>
-            </div>
-            <input type="text"
-                   class="form-control flex-grow-1 small"
-                   placeholder="Link name"
-                   disabled>
-            <button type="button"
-                    class="btn p-0 border-0 text-primary flex-shrink-0"
-                    hx-post="{% url 'nimbus-ui-new-create-documentation-link' experiment.slug %}"
-                    hx-target="#rollout-overview-body"
-                    hx-swap="outerHTML"
-                    aria-label="Add link">
-              <i class="fa-solid fa-plus"></i>
-            </button>
-          </div>
         </div>
+        <button type="button"
+                class="btn p-0 border-0 text-primary small mt-2"
+                hx-post="{% url 'nimbus-ui-new-create-documentation-link' experiment.slug %}"
+                hx-target="#rollout-overview-body"
+                hx-swap="outerHTML">
+          <i class="fa-solid fa-plus me-1"></i>Add link
+        </button>
       </div>
       {# Project Tags — search input + pills #}
-      <div>
-        <label class="small text-body mb-1">Project Tags</label>
-        <div class="input-group">
-          <span class="input-group-text bg-body border-end-0 text-secondary">
-            <i class="fa-solid fa-magnifying-glass fa-sm"></i>
-          </span>
-          <input type="text"
-                 class="form-control border-start-0 ps-1 small"
-                 placeholder="Search existing tags or features"
-                 autocomplete="off"
-                 name="q"
-                 hx-get="{% url 'nimbus-ui-new-search-tags' experiment.slug %}"
-                 hx-trigger="input changed delay:300ms, focus"
-                 hx-target="#tag-search-results"
-                 hx-swap="innerHTML">
-        </div>
-        <div id="tag-search-results"></div>
-        {% if experiment.tags.exists %}
-          <div class="d-flex align-items-center flex-wrap gap-1 mt-2">
-            <span class="text-secondary small">Added tags:</span>
-            {% for tag in experiment.tags.all %}
-              <span class="badge rounded-pill fw-normal d-inline-flex align-items-center gap-1"
-                    style="background-color: {{ tag.color }};
-                           color: white">
-                {{ tag.name }}
-                <button type="button"
-                        class="btn p-0 border-0 bg-transparent text-white lh-1"
-                        aria-label="Remove {{ tag.name }}"
-                        hx-post="{% url 'nimbus-ui-new-remove-tag' experiment.slug %}"
-                        hx-vals='{"tag_id": "{{ tag.id }}"}'
-                        hx-target="#rollout-overview-body"
-                        hx-swap="outerHTML">
-                  <i class="fa-solid fa-xmark fa-xs"></i>
-                </button>
-              </span>
-            {% endfor %}
-          </div>
-        {% endif %}
-      </div>
+      {% include "new/rollouts/overview/tags_field.html" %}
+
       {# Subscribers — search input + list of added #}
-      <div>
-        <label class="small text-body mb-1">Subscribers</label>
-        <div class="input-group">
-          <span class="input-group-text bg-body border-end-0 text-secondary">
-            <i class="fa-solid fa-magnifying-glass fa-sm"></i>
-          </span>
-          <input type="text"
-                 class="form-control border-start-0 ps-1 small"
-                 placeholder="Search by first and last name"
-                 autocomplete="off"
-                 name="q"
-                 hx-get="{% url 'nimbus-ui-new-search-subscribers' experiment.slug %}"
-                 hx-trigger="input changed delay:300ms"
-                 hx-target="#subscriber-search-results"
-                 hx-swap="innerHTML">
-        </div>
-        <div id="subscriber-search-results"></div>
-        {% if experiment.subscribers.exists %}
-          <div class="d-flex flex-wrap gap-1 mt-2">
-            {% for subscriber in experiment.subscribers.all %}
-              <span class="badge rounded-pill fw-normal d-inline-flex align-items-center gap-1 small text-body"
-                    style="background-color: var(--bs-secondary-bg);
-                           border: 1px solid var(--bs-border-color)">
-                {{ subscriber.email }}
-                <button type="button"
-                        class="btn p-0 border-0 bg-transparent text-secondary lh-1"
-                        aria-label="Remove {{ subscriber.email }}"
-                        hx-post="{% url 'nimbus-ui-new-remove-subscriber' experiment.slug %}"
-                        hx-vals='{"user_id": "{{ subscriber.id }}"}'
-                        hx-target="#rollout-overview-body"
-                        hx-swap="outerHTML">
-                  <i class="fa-solid fa-xmark fa-xs"></i>
-                </button>
-              </span>
-            {% endfor %}
-          </div>
-        {% endif %}
-      </div>
+      {% include "new/rollouts/overview/subscribers_field.html" %}
+
     </div>
     {# Action buttons #}
     <div class="d-flex align-items-center gap-2">
       <button type="submit" class="btn btn-primary btn-sm">Save</button>
       <button type="button"
               class="btn btn-outline-secondary btn-sm"
-              hx-get="{{ cancel_url }}"
+              hx-post="{% url 'nimbus-ui-new-cancel-overview' experiment.slug %}"
               hx-select="#rollout-card-overview"
               hx-target="#rollout-card-overview"
               hx-swap="outerHTML">Cancel</button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscriber_search_results.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscriber_search_results.html
@@ -1,14 +1,14 @@
 {% if users %}
-  <div class="border rounded-2 bg-body shadow-sm mt-1">
+  <div class="border rounded-2 bg-body shadow-sm overflow-auto"
+       style="max-height: 15rem">
     {% for user in users %}
       <div class="px-3 py-2 small d-flex align-items-center gap-2 {% if not forloop.last %}border-bottom{% endif %}"
            role="button"
            style="cursor: pointer"
            hx-post="{% url 'nimbus-ui-new-add-subscriber' experiment.slug %}"
            hx-vals='{"user_id": "{{ user.id }}"}'
-           hx-target="#rollout-overview-body"
+           hx-target="#overview-subscribers-field"
            hx-swap="outerHTML">
-        {% csrf_token %}
         <i class="fa-solid fa-user fa-sm text-secondary"></i>
         {{ user.email }}
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscribers_field.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscribers_field.html
@@ -1,0 +1,44 @@
+<div id="overview-subscribers-field">
+  <label class="small text-body mb-1">Subscribers</label>
+  <div class="dropdown">
+    <div class="input-group"
+         data-bs-toggle="dropdown"
+         data-bs-auto-close="outside"
+         aria-expanded="false">
+      <span class="input-group-text bg-body border-end-0 text-secondary">
+        <i class="fa-solid fa-magnifying-glass fa-sm"></i>
+      </span>
+      <input type="text"
+             class="form-control border-start-0 ps-1 small"
+             placeholder="Search by first and last name"
+             autocomplete="off"
+             name="q"
+             hx-get="{% url 'nimbus-ui-new-search-subscribers' experiment.slug %}"
+             hx-trigger="input changed delay:300ms"
+             hx-target="#subscriber-search-results"
+             hx-swap="innerHTML">
+    </div>
+    <div class="dropdown-menu w-100 border-0 bg-transparent p-0"
+         id="subscriber-search-results"></div>
+  </div>
+  {% if experiment.subscribers.exists %}
+    <div class="d-flex flex-wrap gap-1 mt-2">
+      {% for subscriber in experiment.subscribers.all %}
+        <span class="badge rounded-pill fw-normal d-inline-flex align-items-center gap-1 small text-body"
+              style="background-color: var(--bs-secondary-bg);
+                     border: 1px solid var(--bs-border-color)">
+          {{ subscriber.email }}
+          <button type="button"
+                  class="btn p-0 border-0 bg-transparent text-secondary lh-1"
+                  aria-label="Remove {{ subscriber.email }}"
+                  hx-post="{% url 'nimbus-ui-new-remove-subscriber' experiment.slug %}"
+                  hx-vals='{"user_id": "{{ subscriber.id }}"}'
+                  hx-target="#overview-subscribers-field"
+                  hx-swap="outerHTML">
+            <i class="fa-solid fa-xmark fa-xs"></i>
+          </button>
+        </span>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tag_search_results.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tag_search_results.html
@@ -1,14 +1,14 @@
 {% if tags %}
-  <div class="border rounded-2 bg-body shadow-sm mt-1">
+  <div class="border rounded-2 bg-body shadow-sm overflow-auto"
+       style="max-height: 15rem">
     {% for tag in tags %}
       <div class="px-3 py-2 small d-flex align-items-center gap-2 {% if not forloop.last %}border-bottom{% endif %}"
            role="button"
            style="cursor: pointer"
            hx-post="{% url 'nimbus-ui-new-add-tag' experiment.slug %}"
            hx-vals='{"tag_id": "{{ tag.id }}"}'
-           hx-target="#rollout-overview-body"
+           hx-target="#overview-tags-field"
            hx-swap="outerHTML">
-        {% csrf_token %}
         <span style="color: {{ tag.color }}">
           <i class="fa-solid fa-circle" style="font-size: 8px;"></i>
         </span>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tags_field.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tags_field.html
@@ -1,0 +1,45 @@
+<div id="overview-tags-field">
+  <label class="small text-body mb-1">Project Tags</label>
+  <div class="dropdown">
+    <div class="input-group"
+         data-bs-toggle="dropdown"
+         data-bs-auto-close="outside"
+         aria-expanded="false">
+      <span class="input-group-text bg-body border-end-0 text-secondary">
+        <i class="fa-solid fa-magnifying-glass fa-sm"></i>
+      </span>
+      <input type="text"
+             class="form-control border-start-0 ps-1 small"
+             placeholder="Search existing tags or features"
+             autocomplete="off"
+             name="q"
+             hx-get="{% url 'nimbus-ui-new-search-tags' experiment.slug %}"
+             hx-trigger="input changed delay:300ms, focus"
+             hx-target="#tag-search-results"
+             hx-swap="innerHTML">
+    </div>
+    <div class="dropdown-menu w-100 border-0 bg-transparent p-0"
+         id="tag-search-results"></div>
+  </div>
+  {% if experiment.tags.exists %}
+    <div class="d-flex align-items-center flex-wrap gap-1 mt-2">
+      <span class="text-secondary small">Added tags:</span>
+      {% for tag in experiment.tags.all %}
+        <span class="badge rounded-pill fw-normal d-inline-flex align-items-center gap-1"
+              style="background-color: {{ tag.color }};
+                     color: white">
+          {{ tag.name }}
+          <button type="button"
+                  class="btn p-0 border-0 bg-transparent text-white lh-1"
+                  aria-label="Remove {{ tag.name }}"
+                  hx-post="{% url 'nimbus-ui-new-remove-tag' experiment.slug %}"
+                  hx-vals='{"tag_id": "{{ tag.id }}"}'
+                  hx-target="#overview-tags-field"
+                  hx-swap="outerHTML">
+            <i class="fa-solid fa-xmark fa-xs"></i>
+          </button>
+        </span>
+      {% endfor %}
+    </div>
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1192,6 +1192,23 @@ class TestNewDocumentationLinkCreateView(AuthTestCase):
         self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
         self.assertEqual(experiment.documentation_links.count(), 1)
 
+    def test_post_invalid_does_not_create_link(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            documentation_links=[],
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "documentation_links-TOTAL_FORMS": "0",
+                "documentation_links-INITIAL_FORMS": "0",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
+        self.assertTrue(response.context["form"].errors)
+        self.assertEqual(experiment.documentation_links.count(), 0)
+
 
 class TestNewDocumentationLinkDeleteView(AuthTestCase):
     url_name = "nimbus-ui-new-delete-documentation-link"
@@ -1226,6 +1243,66 @@ class TestNewDocumentationLinkDeleteView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
         self.assertEqual(experiment.documentation_links.count(), 0)
+
+    def test_post_deletes_link_even_when_form_invalid(self):
+        documentation_link = NimbusDocumentationLinkFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            documentation_links=[documentation_link],
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "documentation_links-TOTAL_FORMS": "0",
+                "documentation_links-INITIAL_FORMS": "0",
+                "link_id": documentation_link.id,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
+        self.assertEqual(experiment.documentation_links.count(), 0)
+
+    def test_post_locked_experiment_redirects(self):
+        documentation_link = NimbusDocumentationLinkFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            documentation_links=[documentation_link],
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {"link_id": documentation_link.id},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers.get("HX-Redirect"),
+            (
+                f"{reverse('nimbus-ui-detail', kwargs={'slug': experiment.slug})}"
+                "?save_failed=true"
+            ),
+        )
+        self.assertEqual(experiment.documentation_links.count(), 1)
+
+
+class TestNewOverviewCancelView(AuthTestCase):
+    url_name = "nimbus-ui-new-cancel-overview"
+
+    def test_post_discards_blank_links_and_returns_card(self):
+        blank_link = NimbusDocumentationLinkFactory.create(link="")
+        filled_link = NimbusDocumentationLinkFactory.create(
+            link="https://www.example.com"
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            documentation_links=[blank_link, filled_link],
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/overview/card.html")
+        links = list(experiment.documentation_links.all())
+        self.assertNotIn(blank_link, links)
+        self.assertIn(filled_link, links)
 
 
 class TestNewTagSearchView(AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -22,6 +22,7 @@ from experimenter.nimbus_ui.new.views import (
     NewCloneView,
     NewDocumentationLinkCreateView,
     NewDocumentationLinkDeleteView,
+    NewOverviewCancelView,
     NewOverviewUpdateView,
     NewQAUpdateView,
     NewRemoveSubscriberView,
@@ -446,6 +447,11 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/update_overview/$",
         NewOverviewUpdateView.as_view(),
         name="nimbus-ui-new-update-overview",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/cancel_overview/$",
+        NewOverviewCancelView.as_view(),
+        name="nimbus-ui-new-cancel-overview",
     ),
     re_path(
         r"^new/(?P<slug>[\w-]+)/update_risks/$",


### PR DESCRIPTION
Because

* The first link is currently locked which is confusing
* Alignment of link fields is off
* Tags/subscribers dropdowns aren’t dismissible by clicking away
* Changing tags/subscribers should not close the Overview card

This commit

* Removes the first locked link and fixes alignment
* Makes the tags/subscribers dropdowns dismissible
* Prevents the overview card from closing when making changes

Fixes #16701
