### PR TITLE
feat(nimbus): Show sql query for the esitmated pop sizing data

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2409,12 +2409,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def sizing_sql(self):
-        """The BigQuery SQL predicate generated from this experiment's targeting.
-
-        Surfaced on the sizing card so it can be used to validate or explore the
-        eligible population. Returns None when the targeting can't be translated.
-        """
-        return jexl_to_sql(self.targeting).sql
+        sql = jexl_to_sql(self.targeting).sql
+        if sql:
+            sql = sql.replace(" AND ", "\nAND ")
+        return sql
 
     @property
     def has_displayable_results(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -37,6 +37,7 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
+from experimenter.experiments.jexl_to_sql import jexl_to_sql
 from experimenter.experiments.jexl_utils import format_jexl
 from experimenter.experiments.monitoring_utils import (
     check_srm_mismatch,
@@ -2405,6 +2406,15 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.sizing_eligible_count is not None and self.population_percent:
             return int(self.sizing_eligible_count * self.population_percent / 100)
         return None
+
+    @property
+    def sizing_sql(self):
+        """The BigQuery SQL predicate generated from this experiment's targeting.
+
+        Surfaced on the sizing card so it can be used to validate or explore the
+        eligible population. Returns None when the targeting can't be translated.
+        """
+        return jexl_to_sql(self.targeting).sql
 
     @property
     def has_displayable_results(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -644,10 +644,13 @@ class TestNimbusExperiment(TestCase):
             channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
         )
-        raw_sql = jexl_to_sql(experiment.targeting).sql
-        self.assertEqual(experiment.sizing_sql, raw_sql.replace(" AND ", "\nAND "))
-        self.assertIsNotNone(experiment.sizing_sql)
-        self.assertIn("nimbus_targeting_context", experiment.sizing_sql)
+        self.assertEqual(
+            experiment.sizing_sql,
+            "(("
+            "JSON_VALUE(metrics.object.nimbus_targeting_context_browser_settings,"
+            " '$.update.channel') IN ('release'))\n"
+            "AND metrics.quantity.nimbus_targeting_context_firefox_version >= 120)",
+        )
 
     def test_sizing_sql_none_for_match_all_targeting(self):
         experiment = NimbusExperimentFactory.create(

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -33,6 +33,7 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
+from experimenter.experiments.jexl_to_sql import jexl_to_sql
 from experimenter.experiments.models import (
     NimbusAlert,
     NimbusBranch,
@@ -636,6 +637,31 @@ class TestNimbusExperiment(TestCase):
     def test_str(self):
         experiment = NimbusExperimentFactory.create(slug="experiment-slug")
         self.assertEqual(str(experiment), experiment.name)
+
+    def test_sizing_sql_translates_targeting(self):
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+        )
+        self.assertEqual(experiment.sizing_sql, jexl_to_sql(experiment.targeting).sql)
+        self.assertIsNotNone(experiment.sizing_sql)
+        self.assertIn("nimbus_targeting_context", experiment.sizing_sql)
+
+    def test_sizing_sql_none_for_match_all_targeting(self):
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            locales=[],
+            countries=[],
+            languages=[],
+            risk_ai=False,
+        )
+        self.assertEqual(experiment.targeting, "true")
+        self.assertIsNone(experiment.sizing_sql)
 
     def test_get_rollout_url(self):
         experiment = NimbusExperimentFactory.create(slug="my-rollout")

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -644,7 +644,8 @@ class TestNimbusExperiment(TestCase):
             channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
         )
-        self.assertEqual(experiment.sizing_sql, jexl_to_sql(experiment.targeting).sql)
+        raw_sql = jexl_to_sql(experiment.targeting).sql
+        self.assertEqual(experiment.sizing_sql, raw_sql.replace(" AND ", "\nAND "))
         self.assertIsNotNone(experiment.sizing_sql)
         self.assertIn("nimbus_targeting_context", experiment.sizing_sql)
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -33,7 +33,6 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
-from experimenter.experiments.jexl_to_sql import jexl_to_sql
 from experimenter.experiments.models import (
     NimbusAlert,
     NimbusBranch,

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -44,4 +44,26 @@
       <p class="text-muted mb-0">No sizing data available yet. Estimates are computed daily for Draft experiments.</p>
     </div>
   {% endif %}
+  {% if experiment.sizing_sql %}
+    <div class="mt-3">
+      <button class="btn btn-sm btn-outline-secondary"
+              type="button"
+              data-bs-toggle="collapse"
+              data-bs-target="#sizing-sql"
+              aria-expanded="false"
+              aria-controls="sizing-sql">
+        <i class="fa-solid fa-code me-1"></i>Show SQL query
+      </button>
+      <div class="collapse mt-2" id="sizing-sql">
+        <label for="sizing-sql-query" class="form-text mt-0">
+          BigQuery predicate generated from this experiment's targeting, for validation or exploring the population.
+        </label>
+        <textarea id="sizing-sql-query"
+                  class="form-control font-monospace small"
+                  rows="8"
+                  readonly
+                  data-testid="sizing-sql-query">{{ experiment.sizing_sql }}</textarea>
+      </div>
+    </div>
+  {% endif %}
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -52,7 +52,7 @@
               data-bs-target="#sizing-sql"
               aria-expanded="false"
               aria-controls="sizing-sql">
-        <i class="fa-solid fa-code me-1"></i>Show SQL query
+        <i class="fa-solid fa-code me-1"></i>Show SQL snippet
       </button>
       <div class="collapse mt-2 me-1" id="sizing-sql">
         <label for="sizing-sql-query" class="form-text mt-0">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -54,7 +54,7 @@
               aria-controls="sizing-sql">
         <i class="fa-solid fa-code me-1"></i>Show SQL query
       </button>
-      <div class="collapse mt-2" id="sizing-sql">
+      <div class="collapse mt-2 me-1" id="sizing-sql">
         <label for="sizing-sql-query" class="form-text mt-0">
           BigQuery predicate generated from this experiment's targeting, for validation or exploring the population.
         </label>


### PR DESCRIPTION
Because

- We have added the pop sizing numbers, we should show the sql query that we have used to calculate so that users can debug and understand it better

This commit

- Adds the sql query near the estimated numbers

Fixes #16730 