### PR TITLE
fix(nimbus): Improve Rollout Schedule card behavior and plan editing

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -364,10 +364,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     QA_TICKET_URL = "https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=11290"
 
     ERROR_ROLLOUT_PLAN_NAME_DUPLICATE = "A rollout plan with this name already exists."
-    ERROR_ROLLOUT_PHASE_DATE_ORDER = "The end date must be on or after the start date."
-    ERROR_ROLLOUT_PHASE_DATE_INCOMPLETE = (
-        "Set both a start and an end date or leave both blank."
+    ERROR_ROLLOUT_PLAN_FIX_ERRORS = (
+        "Resolve the highlighted errors above before saving this plan."
     )
+    ERROR_ROLLOUT_PHASE_DATE_ORDER = "The end date must be on or after the start date."
     ERROR_ROLLOUT_PHASE_LOCKED = "This rollout phase is locked and cannot be changed."
     ROLLOUT_TEMPLATE_PLANS = {
         "Low risk": [100],

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1733,12 +1733,7 @@ class RolloutPhaseForm(forms.ModelForm):
         cleaned_data = super().clean()
         start_date = cleaned_data.get("start_date")
         end_date = cleaned_data.get("end_date")
-        if not self.fields["start_date"].disabled and bool(start_date) != bool(end_date):
-            self.add_error(
-                "end_date" if start_date else "start_date",
-                NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_INCOMPLETE,
-            )
-        elif start_date and end_date and end_date < start_date:
+        if start_date and end_date and end_date < start_date:
             self.add_error("end_date", NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER)
         return cleaned_data
 
@@ -1893,15 +1888,19 @@ class RolloutPhaseDeleteForm(RolloutScheduleForm):
 
 class RolloutPlanApplyForm(RolloutScheduleForm):
     @transaction.atomic
-    def save(self, *args, **kwargs):
-        experiment = super().save(*args, **kwargs)
-        plan_name = self.cleaned_data.get("rollout_plan")
+    def apply_plan(self):
+        plan_name = self.data.get("rollout_plan")
         if plan_name and plan_name in self.plans:
-            experiment.rollout_phases.exclude(id__in=self.locked_phase_ids).delete()
+            self.instance.rollout_phases.exclude(id__in=self.locked_phase_ids).delete()
             for population_percent in self.plans[plan_name]:
-                experiment.rollout_phases.create(
+                self.instance.rollout_phases.create(
                     population_percent=Decimal(str(population_percent))
                 )
+
+    @transaction.atomic
+    def save(self, *args, **kwargs):
+        experiment = super().save(*args, **kwargs)
+        self.apply_plan()
         return experiment
 
     def get_changelog_message(self):
@@ -1916,6 +1915,14 @@ class RolloutPlanCreateForm(RolloutScheduleForm):
                 NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_DUPLICATE
             )
         return name
+
+    def clean(self):
+        cleaned_data = super().clean()
+        if cleaned_data.get("template_name") and not self.rollout_phases.is_valid():
+            self.add_error(
+                "template_name", NimbusUIConstants.ERROR_ROLLOUT_PLAN_FIX_ERRORS
+            )
+        return cleaned_data
 
     @transaction.atomic
     def save(self):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -428,13 +428,12 @@ class CardMutationMixin:
         if form.is_valid():
             form.save()
         else:
-            self.mutate()
+            self.mutate(form)
 
-        return self.render_to_response(
-            self.get_context_data(form=self.form_class(instance=self.object))
-        )
+        form = super().form_class(instance=self.object)
+        return self.render_to_response(self.get_context_data(form=form))
 
-    def mutate(self):
+    def mutate(self, form):
         raise NotImplementedError
 
 
@@ -445,7 +444,7 @@ class NewDocumentationLinkCreateView(RenderParentDBResponseMixin, NewOverviewUpd
 class NewDocumentationLinkDeleteView(CardMutationMixin, NewOverviewUpdateView):
     form_class = DocumentationLinkDeleteForm
 
-    def mutate(self):
+    def mutate(self, form):
         link_id = self.request.POST.get("link_id")
         self.object.documentation_links.filter(id=link_id).delete()
 
@@ -688,18 +687,26 @@ class NewRolloutPhaseCreateView(
     form_class = RolloutPhaseCreateForm
 
 
-class NewRolloutPhaseDeleteView(
-    RenderParentDBResponseMixin, NewRolloutScheduleUpdateView
-):
+class NewRolloutPhaseDeleteView(CardMutationMixin, NewRolloutScheduleUpdateView):
     form_class = RolloutPhaseDeleteForm
+
+    def mutate(self, form):
+        phase_id = self.request.POST.get("phase_id")
+        if not phase_id:
+            return
+        if int(phase_id) not in form.locked_phase_ids:
+            self.object.rollout_phases.filter(id=phase_id).delete()
 
 
 class NewRolloutPlanCreateView(RenderParentDBResponseMixin, NewRolloutScheduleUpdateView):
     form_class = RolloutPlanCreateForm
 
 
-class NewRolloutPlanApplyView(RenderParentDBResponseMixin, NewRolloutScheduleUpdateView):
+class NewRolloutPlanApplyView(CardMutationMixin, NewRolloutScheduleUpdateView):
     form_class = RolloutPlanApplyForm
+
+    def mutate(self, form):
+        form.apply_plan()
 
 
 class NewSubscribeView(NimbusExperimentViewMixin, RequestFormMixin, UpdateView):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -80,7 +80,6 @@
       {% endif %}
     </div>
   </div>
-  {# ── Out-of-band: keep the page header name in sync after a save ── #}
   {% if hx_swap_oob %}
     <h1 id="experiment-header-name"
         class="mb-0 fw-semibold fs-4 text-body"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -51,7 +51,7 @@
                       <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
                         <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
                       </div>
-                    {% elif phase.end_date %}
+                    {% elif phase.start_date and phase.end_date %}
                       <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                         <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
                         <span class="mx-1" style="color: var(--bs-border-color);">•</span>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -10,34 +10,12 @@
     {# Choose rollout plan #}
     <div>
       <label for="id_rollout_plan" class="small text-body mb-1">Choose rollout plan</label>
-      <div class="d-flex align-items-stretch gap-2">
-        <div class="flex-grow-1">{{ form.rollout_plan|add_class:"form-select"|add_error_class:"is-invalid" }}</div>
-        <button type="button"
-                class="btn btn-outline-secondary px-3 flex-shrink-0 d-flex align-items-center"
-                data-bs-toggle="collapse"
-                data-bs-target="#new-rollout-plan-field">
-          <i class="fa-solid fa-plus"></i>
-        </button>
-      </div>
-      <div class="collapse mt-2{% if form.template_name.errors %} show{% endif %}"
-           id="new-rollout-plan-field">
-        <div class="input-group has-validation">
-          {{ form.template_name|add_class:"form-control"|add_error_class:"is-invalid" }}
-          <button type="button"
-                  class="btn btn-outline-primary"
-                  hx-post="{% url 'nimbus-ui-new-create-rollout-plan' experiment.slug %}"
-                  hx-target="#rollout-schedule-body"
-                  hx-swap="outerHTML">Save plan</button>
-          {% if form.template_name.errors %}
-            <div class="text-danger small mt-1">{{ form.template_name.errors|join:", " }}</div>
-          {% endif %}
-        </div>
-      </div>
+      {{ form.rollout_plan|add_error_class:"is-invalid" }}
     </div>
     {{ form.rollout_phases.management_form }}
-    <div class="d-flex flex-column gap-3">
+    <div class="d-flex flex-column">
       {% for phase_form in form.rollout_phases %}
-        <div {% if phase_form.errors %}class="pb-3"{% endif %}>
+        <div class="pb-3">
           {{ phase_form.id }}
           <div class="d-flex gap-4 align-items-end">
             {# Phase Number #}
@@ -48,7 +26,7 @@
                      class="text-secondary mb-1"
                      style="font-size: 12px">Population</label>
               <div class="input-group">
-                {{ phase_form.population_percent|add_class:"form-control"|add_error_class:"is-invalid" }}
+                {{ phase_form.population_percent|add_error_class:"is-invalid" }}
                 <span class="input-group-text">%</span>
               </div>
               {% if phase_form.population_percent.errors %}
@@ -58,25 +36,30 @@
               {% endif %}
             </div>
             {# Duration #}
-            <div class="flex-grow-1 position-relative" style="min-width: 0">
+            <div class="flex-grow-1" style="min-width: 0">
               <label class="text-secondary mb-1" style="font-size: 12px">Duration</label>
               <div class="d-flex gap-2 align-items-center">
-                <div class="flex-grow-1" style="min-width: 0">
-                  {{ phase_form.start_date|add_class:"form-control"|add_error_class:"is-invalid" }}
+                <div class="flex-grow-1 position-relative"
+                     style="min-width: 0;
+                            flex-basis: 0">
+                  {{ phase_form.start_date|add_error_class:"is-invalid" }}
+                  {% if phase_form.start_date.errors %}
+                    <div class="text-danger small position-absolute mt-1" style="top: 100%">
+                      {{ phase_form.start_date.errors|join:", " }}
+                    </div>
+                  {% endif %}
                 </div>
-                <div class="flex-grow-1" style="min-width: 0">
-                  {{ phase_form.end_date|add_class:"form-control"|add_error_class:"is-invalid" }}
+                <div class="flex-grow-1 position-relative"
+                     style="min-width: 0;
+                            flex-basis: 0">
+                  {{ phase_form.end_date|add_error_class:"is-invalid" }}
+                  {% if phase_form.end_date.errors %}
+                    <div class="text-danger small position-absolute mt-1" style="top: 100%">
+                      {{ phase_form.end_date.errors|join:", " }}
+                    </div>
+                  {% endif %}
                 </div>
               </div>
-              {% if phase_form.start_date.errors %}
-                <div class="text-danger small position-absolute mt-1" style="top: 100%">
-                  {{ phase_form.start_date.errors|join:", " }}
-                </div>
-              {% elif phase_form.end_date.errors %}
-                <div class="text-danger small position-absolute mt-1" style="top: 100%">
-                  {{ phase_form.end_date.errors|join:", " }}
-                </div>
-              {% endif %}
             </div>
             {% if not phase_form.is_locked %}
               <button type="button"
@@ -95,7 +78,7 @@
       <div>
         <button type="button"
                 id="rollout-schedule-add-phase"
-                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small mt-2"
+                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small mt-1"
                 hx-post="{% url 'nimbus-ui-new-create-rollout-phase' experiment.slug %}"
                 hx-include="closest form"
                 hx-target="#rollout-schedule-body"
@@ -105,12 +88,38 @@
         </button>
       </div>
     </div>
+    {% if form.rollout_phases|length %}
+      <div class="border-top pt-3">
+        <div class="text-secondary mb-2" style="font-size: 12px">Reuse this schedule on other rollouts</div>
+        <button type="button"
+                class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2"
+                data-bs-toggle="collapse"
+                data-bs-target="#new-rollout-plan-field">
+          <i class="fa-regular fa-bookmark"></i>
+          Save as new plan
+        </button>
+        <div class="collapse mt-2{% if form.template_name.errors %} show{% endif %}"
+             id="new-rollout-plan-field">
+          <div class="input-group">
+            {{ form.template_name|add_error_class:"is-invalid" }}
+            <button type="button"
+                    class="btn btn-primary"
+                    hx-post="{% url 'nimbus-ui-new-create-rollout-plan' experiment.slug %}"
+                    hx-target="#rollout-schedule-body"
+                    hx-swap="outerHTML">Save plan</button>
+          </div>
+          {% if form.template_name.errors %}
+            <div class="text-danger small mt-1">{{ form.template_name.errors|join:", " }}</div>
+          {% endif %}
+        </div>
+      </div>
+    {% endif %}
     {# Move to next phase observations #}
     <div>
       <label for="id_rollout_advance_observations" class="small text-body mb-1">
         {{ NimbusUIConstants.ROLLOUT_ADVANCE_OBSERVATIONS_LABEL }}
       </label>
-      {{ form.rollout_advance_observations|add_class:"form-control"|add_error_class:"is-invalid" }}
+      {{ form.rollout_advance_observations|add_error_class:"is-invalid" }}
       {% if form.rollout_advance_observations.errors %}
         <div class="text-danger small mt-1">{{ form.rollout_advance_observations.errors|join:", " }}</div>
       {% endif %}
@@ -120,7 +129,7 @@
       <label for="id_rollout_pause_observations" class="small text-body mb-1">
         {{ NimbusUIConstants.ROLLOUT_PAUSE_OBSERVATIONS_LABEL }}
       </label>
-      {{ form.rollout_pause_observations|add_class:"form-control"|add_error_class:"is-invalid" }}
+      {{ form.rollout_pause_observations|add_error_class:"is-invalid" }}
       {% if form.rollout_pause_observations.errors %}
         <div class="text-danger small mt-1">{{ form.rollout_pause_observations.errors|join:", " }}</div>
       {% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -2290,22 +2290,6 @@ class TestRolloutPhaseForm(TestCase):
         form = RolloutPhaseForm(data={"population_percent": "10"})
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_start_date_without_end_date_is_invalid(self):
-        form = RolloutPhaseForm(data={"start_date": "2026-01-15"})
-        self.assertFalse(form.is_valid())
-        self.assertIn(
-            NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_INCOMPLETE,
-            form.errors["end_date"],
-        )
-
-    def test_end_date_without_start_date_is_invalid(self):
-        form = RolloutPhaseForm(data={"end_date": "2026-01-15"})
-        self.assertFalse(form.is_valid())
-        self.assertIn(
-            NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_INCOMPLETE,
-            form.errors["start_date"],
-        )
-
     def test_population_over_100_is_invalid(self):
         form = RolloutPhaseForm(data={"population_percent": "150"})
         self.assertFalse(form.is_valid())

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1491,6 +1491,30 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
             self.assertContains(response, name)
             self.assertContains(response, NimbusRolloutPlanTemplate.summary(phases))
 
+    def test_get_hides_save_plan_action_when_no_phases(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        self.assertFalse(experiment.rollout_phases.exists())
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="new-rollout-plan-field"')
+
+    def test_get_shows_save_plan_action_after_phase_added(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment)
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="new-rollout-plan-field"')
+
     def test_post_valid_saves_and_returns_display_card(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
@@ -1660,6 +1684,57 @@ class TestNewRolloutPhaseDeleteView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTrue(experiment.rollout_phases.filter(id=done.id).exists())
 
+    def test_post_deletes_phase_when_another_phase_has_invalid_dates(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        invalid = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        target = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=50
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "2",
+                "rollout_phases-INITIAL_FORMS": "2",
+                "rollout_phases-0-id": invalid.id,
+                "rollout_phases-0-start_date": "2026-01-15",
+                "rollout_phases-0-end_date": "2026-01-01",
+                "rollout_phases-0-population_percent": "10",
+                "rollout_phases-1-id": target.id,
+                "rollout_phases-1-population_percent": "50",
+                "phase_id": str(target.id),
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
+        self.assertFalse(experiment.rollout_phases.filter(id=target.id).exists())
+        self.assertTrue(experiment.rollout_phases.filter(id=invalid.id).exists())
+
+    def test_post_without_phase_id_deletes_nothing(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-population_percent": "10",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
+        self.assertTrue(experiment.rollout_phases.filter(id=phase.id).exists())
+
 
 class TestNewRolloutPlanApplyView(AuthTestCase):
     url_name = "nimbus-ui-new-apply-rollout-plan"
@@ -1714,12 +1789,14 @@ class TestNewRolloutPlanApplyView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(experiment.rollout_phases.count(), 1)
 
-    def test_post_applies_plan_with_completed_phase_with_inconsistent_dates(self):
+    def test_post_applies_plan_preserving_locked_phase_with_inconsistent_dates(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
         )
-        plan_name = next(iter(NimbusUIConstants.ROLLOUT_TEMPLATE_PLANS))
+        plan_name, plan_percentages = next(
+            iter(NimbusUIConstants.ROLLOUT_TEMPLATE_PLANS.items())
+        )
         done = NimbusRolloutPhaseFactory.create(
             experiment=experiment,
             population_percent=1,
@@ -1745,11 +1822,16 @@ class TestNewRolloutPlanApplyView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
-        self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER)
         percents = sorted(
             experiment.rollout_phases.values_list("population_percent", flat=True)
         )
-        self.assertEqual(percents, [Decimal("1.0000"), Decimal("10.0000")])
+        self.assertEqual(
+            percents,
+            sorted(
+                [Decimal("1.0000"), Decimal("10.0000")]
+                + [Decimal(pct) for pct in plan_percentages]
+            ),
+        )
 
 
 class TestNewRolloutPlanCreateView(AuthTestCase):
@@ -1811,11 +1893,16 @@ class TestNewRolloutPlanCreateView(AuthTestCase):
             is_rollout=True,
         )
         plan_name = next(iter(NimbusUIConstants.ROLLOUT_TEMPLATE_PLANS))
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
         response = self.client.post(
             reverse(self.url_name, kwargs={"slug": experiment.slug}),
             {
-                "rollout_phases-TOTAL_FORMS": "0",
-                "rollout_phases-INITIAL_FORMS": "0",
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-population_percent": "10",
                 "template_name": plan_name,
             },
         )
@@ -1823,6 +1910,33 @@ class TestNewRolloutPlanCreateView(AuthTestCase):
         self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_DUPLICATE)
         self.assertFalse(
             NimbusRolloutPlanTemplate.objects.filter(name=plan_name).exists()
+        )
+
+    def test_post_blocked_by_phase_error_shows_message_and_keeps_name(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-start_date": "2026-01-15",
+                "rollout_phases-0-end_date": "2026-01-01",
+                "rollout_phases-0-population_percent": "10",
+                "template_name": "My plan",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_FIX_ERRORS)
+        self.assertContains(response, "My plan")
+        self.assertFalse(
+            NimbusRolloutPlanTemplate.objects.filter(name="My plan").exists()
         )
 
 


### PR DESCRIPTION
Because

* Editing dates should not shift the UI
* Deleting a phase should not be blocked because another phase has an invalid date
* We should not allow an empty rollout plan to be saved
* We need to remove the save-plan + action from the initial empty state

This commit

* Fixes all of the above
* Removes requirement of both start and end date to allow for planning and not block adding phases and creating plans on that requirement

Fixes #16704