### PR TITLE
fix(nimbus): fix preview and launch synchronization

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -385,7 +385,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "enrollment to launch."
     )
     ROLLOUT_PREVIEW_BLOCKED_TOOLTIP = (
-        "Resolve the detected setup issues before previewing"
+        "Resolve the detected setup issues before previewing or launching"
     )
     ROLLOUT_LIVE_MESSAGE = (
         "This rollout is live. You can advance to the next phase to adjust its "

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -317,6 +317,11 @@ class NewCardUpdateView(
 ):
     display_template = None
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["hx_swap_oob"] = self.request.method not in ("GET", "HEAD")
+        return context
+
     def can_edit(self):
         return self.object.can_edit_overview()
 
@@ -326,7 +331,6 @@ class NewCardUpdateView(
 
     def render_valid_response(self):
         context = self.get_context_data()
-        context["hx_swap_oob"] = True
         return self.response_class(
             request=self.request,
             template=self.display_template,
@@ -341,9 +345,14 @@ class NewOverviewUpdateView(CardMixin, NewCardUpdateView):
 
 
 class NewOverviewCancelView(NimbusRolloutDetailView):
+    template_name = "new/rollouts/overview/cancel_response.html"
+
     def post(self, request, *args, **kwargs):
-        self.get_object().documentation_links.filter(link="").delete()
-        return self.get(request, *args, **kwargs)
+        self.object = self.get_object()
+        self.object.documentation_links.filter(link="").delete()
+        context = self.get_context_data()
+        context["hx_swap_oob"] = True
+        return self.render_to_response(context)
 
 
 class NewRisksUpdateView(CardMixin, NewCardUpdateView):

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -134,10 +134,12 @@
               {# Preview to Review #}
               <button type="button"
                       id="rollout-request-enrollment-btn"
-                      class="btn btn-primary btn-sm w-100"
+                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                       hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}"
                       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                      {% if not experiment.is_preview %}disabled{% endif %}>Request Enrollment</button>
+                      {% if not experiment.is_preview %}disabled{% endif %}>
+                <i class="fa-solid fa-rocket"></i>Request Enrollment
+              </button>
             </div>
           </div>
         {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -1,22 +1,40 @@
 <div id="sidebar-preview-button" {% if oob %}hx-swap-oob="true"{% endif %}>
   {% if experiment.is_draft and not setup_issues_count %}
-    <button type="button"
-            id="rollout-preview-btn"
-            class="btn btn-primary btn-sm w-100 mt-2 d-flex align-items-center justify-content-center gap-2"
-            hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
-            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-      <i class="fa-regular fa-eye"></i>
-      Preview
-    </button>
-  {% else %}
-    <span class="d-inline-block w-100 mt-2"
-          {% if experiment.is_draft and setup_issues_count %} data-bs-toggle="tooltip" data-bs-title="{{ NimbusUIConstants.ROLLOUT_PREVIEW_BLOCKED_TOOLTIP }}"{% endif %}>
+    <div class="d-flex flex-column gap-2 mt-2">
       <button type="button"
-              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
-              disabled>
+              id="rollout-preview-btn"
+              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+              hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
         <i class="fa-regular fa-eye"></i>
         Preview
       </button>
+      <button type="button"
+              id="rollout-launch-btn"
+              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+              hx-post="{% url 'nimbus-ui-new-draft-to-review-rollout' experiment.slug %}"
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+        <i class="fa-solid fa-rocket"></i>
+        Request Enrollment
+      </button>
+    </div>
+  {% else %}
+    <span class="d-inline-block w-100 mt-2"
+          {% if experiment.is_draft and setup_issues_count %} data-bs-toggle="tooltip" data-bs-title="{{ NimbusUIConstants.ROLLOUT_PREVIEW_BLOCKED_TOOLTIP }}"{% endif %}>
+      <div class="d-flex flex-column gap-2">
+        <button type="button"
+                class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
+                disabled>
+          <i class="fa-regular fa-eye"></i>
+          Preview
+        </button>
+        <button type="button"
+                class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
+                disabled>
+          <i class="fa-solid fa-rocket"></i>
+          Request Enrollment
+        </button>
+      </div>
     </span>
   {% endif %}
 </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -53,6 +53,16 @@
               {{ experiment.latest_review_requested_by }} requested to
               {{ controls.action_label|lower }}.
             </p>
+            {% if experiment.latest_review_requested_by == user.email %}
+              <button type="button"
+                      id="rollout-review-cancel-btn"
+                      class="btn btn-secondary btn-sm w-100 mb-2"
+                      hx-post="{% url controls.reject_url experiment.slug %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
+                Cancel Request
+              </button>
+            {% endif %}
             {% if user_can_review %}
               {% if uses_secure_collection %}
                 <p class="small text-body mb-2">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -2,6 +2,8 @@
 {% load widget_tweaks %}
 
 <div id="rollout-audience-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   {# Explore matching audiences #}
   <div class="mb-2">
     <a href="{{ experiment.audience_url }}"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/cancel_response.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/cancel_response.html
@@ -1,0 +1,1 @@
+{% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" subtitle="Name · Observations & Problem Space · Public Description · Application · Important Links · Project Tags · Subscribers" show_edit_btn=experiment.is_draft body_template="new/rollouts/overview/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -1,5 +1,7 @@
 {# ── Edit form ── #}
 <div id="rollout-overview-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form hx-post="{% url 'nimbus-ui-new-update-overview' experiment.slug %}"
         hx-target="#rollout-overview-body"
         hx-swap="outerHTML"
@@ -99,10 +101,10 @@
 
       </div>
       {# Project Tags — search input + pills #}
-      {% include "new/rollouts/overview/tags_field.html" %}
+      {% include "new/rollouts/overview/tags_field.html" with suppress_sidebar_setup_refresh=True %}
 
       {# Subscribers — search input + list of added #}
-      {% include "new/rollouts/overview/subscribers_field.html" %}
+      {% include "new/rollouts/overview/subscribers_field.html" with suppress_sidebar_setup_refresh=True %}
 
     </div>
     {# Action buttons #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscribers_field.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/subscribers_field.html
@@ -1,4 +1,8 @@
 <div id="overview-subscribers-field">
+  {% if not suppress_sidebar_setup_refresh %}
+    {% include "new/common/sidebar_setup_refresh.html" %}
+
+  {% endif %}
   <label class="small text-body mb-1">Subscribers</label>
   <div class="dropdown">
     <div class="input-group"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tags_field.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/tags_field.html
@@ -1,4 +1,8 @@
 <div id="overview-tags-field">
+  {% if not suppress_sidebar_setup_refresh %}
+    {% include "new/common/sidebar_setup_refresh.html" %}
+
+  {% endif %}
   <label class="small text-body mb-1">Project Tags</label>
   <div class="dropdown">
     <div class="input-group"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
@@ -2,6 +2,8 @@
 
 {# ── Edit form ── #}
 <div id="rollout-qa-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form hx-post="{% url 'nimbus-ui-new-update-qa' experiment.slug %}"
         hx-target="#rollout-qa-body"
         hx-swap="outerHTML"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
@@ -1,5 +1,7 @@
 {# ── Edit form ── #}
 <div id="rollout-risks-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form hx-post="{% url 'nimbus-ui-new-update-risks' experiment.slug %}"
         hx-target="#rollout-risks-body"
         hx-swap="outerHTML"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -25,8 +25,6 @@
         <div class="small text-body">—</div>
       {% endfor %}
       {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.reference_branch %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.treatment_branches %}
 
     </div>
     {# Warn only on feature schema validation failure #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -4,6 +4,8 @@
 
 {# ── Edit form ── #}
 <div id="rollout-rollout-features-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form id="branches-form"
         hx-post="{% url 'nimbus-ui-new-update-rollout-features' experiment.slug %}"
         hx-target="#rollout-rollout-features-body"
@@ -72,9 +74,6 @@
           </div>
         {% endfor %}
       </div>
-      {% include "new/common/validation_errors.html" with errors=validation_errors.reference_branch %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.treatment_branches %}
-
     {% endwith %}
     {#  Feature validation and pref conflict options  #}
     <div class="mt-4">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -2,6 +2,8 @@
 
 {# ── Edit form ── #}
 <div id="rollout-schedule-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form hx-post="{% url 'nimbus-ui-new-update-schedule' experiment.slug %}"
         hx-target="#rollout-schedule-body"
         hx-swap="outerHTML"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/edit_form.html
@@ -1,5 +1,7 @@
 {# ── Edit form ── #}
 <div id="rollout-signoff-body">
+  {% include "new/common/sidebar_setup_refresh.html" %}
+
   <form hx-post="{% url 'nimbus-ui-new-update-signoff' experiment.slug %}"
         hx-target="#rollout-signoff-body"
         hx-swap="outerHTML"

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -285,6 +285,31 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             response.context["update_status_form_errors"][0],
         )
 
+    def test_launch_request_shows_cancel_action_to_requester(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+
+        self.client.post(
+            reverse(
+                "nimbus-ui-new-draft-to-review-rollout",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertContains(response, 'id="rollout-review-cancel-btn"')
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-draft-review-to-reject-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+
     def test_duplicate_phase_resume_submission_creates_phase_and_requests_review(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DISABLED,
@@ -412,6 +437,29 @@ class NewViewTestMixin:
 
 
 class TestNimbusRolloutDetailView(AuthTestCase):
+    @mock.patch.object(NimbusExperiment, "get_invalid_fields_errors", return_value={})
+    def test_ready_rollout_shows_preview_and_launch_actions(self, _mock_errors):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertContains(response, 'id="rollout-preview-btn"')
+        self.assertContains(response, 'id="rollout-launch-btn"')
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-draft-to-review-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+
     def test_get_returns_new_rollout_detail_context(self):
         tag = TagFactory.create()
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -774,6 +822,9 @@ class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/overview/edit_form.html")
         self.assertTrue(response.context["form"].errors)
+        self.assertTrue(response.context["hx_swap_oob"])
+        self.assertContains(response, 'id="sidebar-setup-progress"')
+        self.assertContains(response, 'hx-swap-oob="true"')
 
 
 class TestNewRisksUpdateView(NewViewTestMixin, AuthTestCase):
@@ -1019,6 +1070,56 @@ class TestNewRolloutScreenshotCreateView(AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
         self.assertEqual(experiment.reference_branch.screenshots.count(), 1)
+        self.assertTrue(response.context["hx_swap_oob"])
+        self.assertContains(response, 'id="sidebar-setup-progress"')
+        self.assertContains(response, 'hx-swap-oob="true"')
+
+    @mock.patch.object(NimbusExperiment, "get_invalid_fields_errors", return_value={})
+    def test_post_saves_form_state_and_refreshes_actions_before_preview(
+        self, _mock_errors
+    ):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            feature_configs=[],
+            takeaways_summary="Original rollout experience",
+        )
+        experiment.reference_branch.screenshots.all().delete()
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_experience": "Updated without explicit save",
+                "feature_configs": [],
+                "branch-feature-value-TOTAL_FORMS": "0",
+                "branch-feature-value-INITIAL_FORMS": "0",
+                "rollout-screenshots-TOTAL_FORMS": "0",
+                "rollout-screenshots-INITIAL_FORMS": "0",
+            },
+        )
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.takeaways_summary, "Updated without explicit save")
+        self.assertContains(response, 'id="rollout-preview-btn"')
+        self.assertContains(response, 'id="rollout-launch-btn"')
+
+        with (
+            mock.patch.object(NimbusExperiment, "allocate_bucket_range"),
+            mock.patch(
+                "experimenter.nimbus_ui.new.forms."
+                "nimbus_synchronize_preview_experiments_in_kinto.apply_async"
+            ),
+        ):
+            self.client.post(
+                reverse(
+                    "nimbus-ui-new-draft-to-preview-rollout",
+                    kwargs={"slug": experiment.slug},
+                )
+            )
+        experiment.refresh_from_db()
+        self.assertTrue(experiment.is_preview)
 
 
 class TestNewRolloutScreenshotUploadView(AuthTestCase):
@@ -1315,6 +1416,9 @@ class TestNewOverviewCancelView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/overview/card.html")
+        self.assertTrue(response.context["hx_swap_oob"])
+        self.assertContains(response, 'id="sidebar-setup-progress"')
+        self.assertContains(response, 'hx-swap-oob="true"')
         links = list(experiment.documentation_links.all())
         self.assertNotIn(blank_link, links)
         self.assertIn(filled_link, links)


### PR DESCRIPTION
Because

- Rollout actions and sidebar validation could become stale after server side updates
- Users could not launch a rollout directly without first entering Preview
- Launch requesters had no way to cancel their request

This commit

- Shows both Preview and Launch actions when a rollout is ready
- Saves pending changes, such as newly added screenshots, before sending allowing rollout to Preview
- Refreshes sidebar actions, setup progress, and validation state after every server round trip, including unsuccessful form submissions
- Adds a Cancel Request action for the user who requests a review

Fixes #16737