### PR TITLE
feat(nimbus): show full SQL in Generate SQL modal with CodeMirror and STMO link

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1081,6 +1081,38 @@ ENROLLMENT_FUNNEL_STAGES = {
     ),
 }
 
+NIMBUS_TARGETING_CONTEXT_TABLE = (
+    "moz-fx-data-shared-prod.firefox_desktop.nimbus_targeting_context"
+)
+SIZING_SAMPLE_ID_MAX = 10
+SIZING_WINDOW_DAYS = 7
+SIZING_FULL_SQL_TEMPLATE = """\
+-- Matches the 7-day window and 10% sample used by the population sizing ETL.
+-- Deduplicates on client_id, keeping the most recent ping per client.
+WITH latest_per_client AS (
+  SELECT
+    *,
+    ROW_NUMBER() OVER (
+      PARTITION BY client_info.client_id
+      ORDER BY submission_timestamp DESC
+    ) AS rn
+  FROM `{table}`
+  WHERE DATE(submission_timestamp)
+      BETWEEN DATE_SUB(CURRENT_DATE(), INTERVAL {window_days} DAY)
+      AND DATE_SUB(CURRENT_DATE(), INTERVAL 1 DAY)
+    AND sample_id < {sample_id_max}
+    AND client_info.client_id IS NOT NULL
+),
+clients AS (SELECT * EXCEPT (rn) FROM latest_per_client WHERE rn = 1)
+SELECT
+  client_info.client_id,
+  DATE(submission_timestamp) AS submission_date
+FROM clients
+WHERE (
+    {predicate}
+)
+LIMIT 1000"""
+
 RISK_QUESTIONS = {
     "BRAND": (
         "If the public, users or press, were to discover this experiment and "

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -32,6 +32,10 @@ from prose.fields import RichTextField
 from experimenter.base.models import Country, Language, Locale
 from experimenter.experiments.constants import (
     ENROLLMENT_FUNNEL_STAGES,
+    NIMBUS_TARGETING_CONTEXT_TABLE,
+    SIZING_FULL_SQL_TEMPLATE,
+    SIZING_SAMPLE_ID_MAX,
+    SIZING_WINDOW_DAYS,
     BucketRandomizationUnit,
     ChangeEventType,
     NimbusConstants,
@@ -2413,6 +2417,22 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if sql:
             sql = sql.replace(" AND ", "\nAND ")
         return sql
+
+    @property
+    def sizing_sql_predicate(self):
+        return jexl_to_sql(self.targeting).sql
+
+    @property
+    def sizing_full_sql(self):
+        predicate = self.sizing_sql
+        if not predicate:
+            return None
+        return SIZING_FULL_SQL_TEMPLATE.format(
+            table=NIMBUS_TARGETING_CONTEXT_TABLE,
+            window_days=SIZING_WINDOW_DAYS,
+            sample_id_max=SIZING_SAMPLE_ID_MAX,
+            predicate=predicate.replace("\n", "\n    "),
+        )
 
     @property
     def has_displayable_results(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -651,6 +651,20 @@ class TestNimbusExperiment(TestCase):
             "AND metrics.quantity.nimbus_targeting_context_firefox_version >= 120)",
         )
 
+    def test_sizing_full_sql_returns_none_when_no_predicate(self):
+        experiment = NimbusExperimentFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            targeting_config_slug=NimbusExperiment.TargetingConfig.NO_TARGETING,
+            locales=[],
+            countries=[],
+            languages=[],
+            risk_ai=False,
+        )
+        self.assertIsNone(experiment.sizing_full_sql)
+
     def test_sizing_sql_none_for_match_all_targeting(self):
         experiment = NimbusExperimentFactory.create(
             application=NimbusExperiment.Application.DESKTOP,

--- a/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/codemirror_utils.js
@@ -70,6 +70,40 @@ export const setupCodemirrorCollapsibleDisplay = (textarea) => {
     });
 };
 
+export const createReadonlySqlEditor = (textarea) => {
+  if (!textarea || textarea.dataset.is_rendered) return null;
+
+  textarea.dataset.is_rendered = true;
+
+  const view = new EditorView({
+    doc: textarea.value,
+    extensions: [
+      basicSetup,
+      EditorState.readOnly.of(true),
+      EditorView.editable.of(false),
+      EditorView.lineWrapping,
+      themeCompartment.of(getThemeExtensions()),
+    ],
+    parent: textarea.parentNode,
+  });
+
+  view.dom.style.border = "1px solid #ccc";
+  textarea.parentNode.insertBefore(view.dom, textarea);
+  textarea.style.display = "none";
+
+  registerView(view);
+  return view;
+};
+
+export const setupReadonlySqlEditors = (container = document) => {
+  container.querySelectorAll(".readonly-sql").forEach((textarea) => {
+    const view = createReadonlySqlEditor(textarea);
+    if (view) {
+      setupCopyButton(textarea, view);
+    }
+  });
+};
+
 export const setupReadonlyJsonEditors = () => {
   document.querySelectorAll(".readonly-json").forEach((textarea) => {
     const maxLines = textarea.closest(".collapsed-json")

--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -7,7 +7,10 @@ import * as $ from "jquery";
 import * as bootstrap from "bootstrap";
 import "htmx.org";
 import "bootstrap-select";
-import { setupReadonlyJsonEditors } from "./codemirror_utils.js";
+import {
+  setupReadonlyJsonEditors,
+  setupReadonlySqlEditors,
+} from "./codemirror_utils.js";
 import { setupDevtoolsBanner } from "./nimbus_devtools.js";
 
 window.bootstrap = bootstrap;
@@ -141,6 +144,9 @@ $(() => {
   setupSlugCopyToast();
   setupHTMXLoadingOverlay();
   setupReadonlyJsonEditors();
+  document.addEventListener("shown.bs.modal", (event) => {
+    setupReadonlySqlEditors(event.target);
+  });
 
   document.body.addEventListener("htmx:afterSwap", function () {
     $(".selectpicker").selectpicker();

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -44,25 +44,57 @@
       <p class="text-muted mb-0">No sizing data available yet. Estimates are computed daily for Draft experiments.</p>
     </div>
   {% endif %}
-  {% if experiment.sizing_sql %}
-    <div class="mt-3">
+  {% if experiment.sizing_full_sql %}
+    <div class="border-top px-3 py-2">
       <button class="btn btn-sm btn-outline-secondary"
               type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#sizing-sql"
-              aria-expanded="false"
-              aria-controls="sizing-sql">
-        <i class="fa-solid fa-code me-1"></i>Show SQL snippet
+              data-bs-toggle="modal"
+              data-bs-target="#sizing-sql-modal">
+        <i class="fa-solid fa-code me-1"></i>Generate SQL
       </button>
-      <div class="collapse mt-2 me-1" id="sizing-sql">
-        <label for="sizing-sql-query" class="form-text mt-0">
-          BigQuery predicate generated from this experiment's targeting, for validation or exploring the population.
-        </label>
-        <textarea id="sizing-sql-query"
-                  class="form-control font-monospace small"
-                  rows="8"
-                  readonly
-                  data-testid="sizing-sql-query">{{ experiment.sizing_sql }}</textarea>
+    </div>
+    <div class="modal fade"
+         id="sizing-sql-modal"
+         tabindex="-1"
+         aria-labelledby="sizing-sql-modal-label"
+         aria-hidden="true">
+      <div class="modal-dialog modal-lg modal-dialog-scrollable">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title" id="sizing-sql-modal-label">Explore this audience in BigQuery</h5>
+            <button type="button"
+                    class="btn-close"
+                    data-bs-dismiss="modal"
+                    aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <p class="text-muted small">
+              Full BigQuery query generated from this experiment's targeting.
+              Copy and paste into BigQuery to explore the eligible population.
+            </p>
+            <div>
+              <div class="d-flex justify-content-end mb-1">
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary codemirror-copy-btn"
+                        aria-label="Copy SQL">
+                  <i class="fa-solid fa-copy me-1"></i>Copy
+                </button>
+              </div>
+              <textarea class="readonly-sql" data-testid="sizing-sql-query">{{ experiment.sizing_full_sql }}</textarea>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <a href="https://sql.telemetry.mozilla.org/queries/124957/source?p_targeting_predicate={{ experiment.sizing_sql_predicate|urlencode }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="btn btn-sm btn-outline-secondary">
+              <i class="fa-solid fa-arrow-up-right-from-square me-1"></i>Open in STMO
+            </a>
+            <button type="button"
+                    class="btn btn-secondary btn-sm"
+                    data-bs-dismiss="modal">Close</button>
+          </div>
+        </div>
       </div>
     </div>
   {% endif %}


### PR DESCRIPTION
Because

- Experiment owners need to explore the eligible population in BigQuery but had no way to get a ready-to-run query from Experimenter.

This commit

- Adds a "Generate SQL" button on the audience size estimate card that opens a modal showing the full BigQuery query (7-day window, 10% sample, deduplicated on client_id) rendered in a CodeMirror editor with a copy button and an "Open in STMO" link that pre-fills the targeting predicate in query [#124957](https://sql.telemetry.mozilla.org/queries/124957/source)

Fixes #16767 