### PR TITLE
bug(ci): Disable pr-preview workflow

### DIFF
--- a/.github/workflows/experimenter-mozcloud-publish.yaml
+++ b/.github/workflows/experimenter-mozcloud-publish.yaml
@@ -16,12 +16,7 @@ jobs:
   build_and_push:
     if: >
       github.event_name == 'push' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(github.event.pull_request.labels.*.name, 'pr-preview') &&
-        github.event.pull_request.head.repo.full_name == github.repository
-      )
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Because:

- the PR preview workflow will currently overwrite prod

this commit:

- disables the workflow entirely

Fixes #16786