### PR TITLE
style(nimbus): Improve Risks/Sign-offs/QA card UI 

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -53,16 +53,18 @@
                class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">1</span>Overview</a>
             <a href="#rollout-card-risks"
                class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">2</span>Risks</a>
+            <a href="#rollout-card-signoff"
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">3</span>Sign-Offs</a>
             <a href="#rollout-card-configuration"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">3</span>Configuration &amp; Localization</a>
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">4</span>Configuration &amp; Localization</a>
             <a href="#rollout-card-audience"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">4</span>Audience</a>
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">5</span>Audience</a>
             <a href="#rollout-card-features"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">5</span>Rollout experience</a>
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">6</span>Rollout experience</a>
             <a href="#rollout-card-schedule"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">6</span>Rollout schedule</a>
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">7</span>Rollout schedule</a>
             <a href="#rollout-card-qa"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">7</span>QA</a>
+               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">8</span>QA</a>
           {% endfor %}
           {% include "new/common/sidebar_preview_button.html" %}
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/qa/edit_form.html
@@ -7,53 +7,42 @@
         hx-swap="outerHTML"
         class="d-flex flex-column gap-4">
     {% csrf_token %}
-    {% with qa_status=form.qa_status.value %}
-      <div class="d-flex flex-column gap-4">
-        {# QA method #}
-        <div>
-          <div class="text-secondary small">{{ NimbusUIConstants.QA_CARD_DESCRIPTION }}</div>
+    <div class="d-flex flex-column gap-4">
+      {# QA method #}
+      <div class="text-secondary small">{{ NimbusUIConstants.QA_CARD_DESCRIPTION }}</div>
+      {# Request QA review #}
+      <div>
+        <div class="d-flex justify-content-between">
+          <label class="small text-body mb-1">Request QA review</label>
+          <a target="_blank"
+             rel="noopener noreferrer"
+             href="{{ NimbusUIConstants.QA_TICKET_URL }}"
+             class="ms-2"
+             style="font-size: 0.9em">Submit Jira ticket <i class="fs-6 fa-solid fa-arrow-up-right-from-square ms-1"></i></a>
         </div>
-        {# QA review option #}
-        <div class="bg-body-tertiary rounded-3 p-4">
-          <div class="flex-grow-1">
-            <div class="mb-4">
-              <div class="fw-semibold text-body mb-0">QA review</div>
-              <div class="small text-secondary">{{ NimbusUIConstants.QA_METHOD_DESCRIPTION }}</div>
-            </div>
-            <div class="row g-4 align-items-end">
-              <div class="col-md-6">
-                <label class="small text-body mb-1">Request QA review</label>
-                <a href="{{ NimbusUIConstants.QA_TICKET_URL }}"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="btn btn-primary w-100 d-flex align-items-center justify-content-center gap-1">
-                  <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                  Submit Jira ticket
-                </a>
-              </div>
-              <div class="col-md-6">
-                <label for="id_qa_status" class="small text-body mb-1">QA status</label>
-                {{ form.qa_status|add_class:"form-select"|add_error_class:"is-invalid" }}
-                {% if form.qa_status.errors %}
-                  <div class="text-danger small mt-1">{{ form.qa_status.errors|join:", " }}</div>
-                {% endif %}
-                {% include "new/common/validation_errors.html" with errors=validation_errors.qa_status %}
-
-              </div>
-            </div>
-            <div class="mt-4">
-              <label for="id_qa_comment" class="small text-body mb-1">QA notes</label>
-              {{ form.qa_comment|add_class:"form-control"|add_error_class:"is-invalid" }}
-              {% if form.qa_comment.errors %}
-                <div class="text-danger small mt-1">{{ form.qa_comment.errors|join:", " }}</div>
-              {% endif %}
-              {% include "new/common/validation_errors.html" with errors=validation_errors.qa_comment %}
-
-            </div>
-          </div>
-        </div>
+        <div class="small text-secondary">{{ NimbusUIConstants.QA_METHOD_DESCRIPTION }}</div>
       </div>
-    {% endwith %}
+      {# QA status #}
+      <div>
+        <label for="id_qa_status" class="small text-body mb-1">QA status</label>
+        {{ form.qa_status|add_class:"form-select"|add_error_class:"is-invalid" }}
+        {% if form.qa_status.errors %}
+          <div class="text-danger small mt-1">{{ form.qa_status.errors|join:", " }}</div>
+        {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.qa_status %}
+
+      </div>
+      {# QA notes #}
+      <div>
+        <label for="id_qa_comment" class="small text-body mb-1">QA notes</label>
+        {{ form.qa_comment|add_class:"form-control"|add_error_class:"is-invalid" }}
+        {% if form.qa_comment.errors %}
+          <div class="text-danger small mt-1">{{ form.qa_comment.errors|join:", " }}</div>
+        {% endif %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.qa_comment %}
+
+      </div>
+    </div>
     {# Action buttons #}
     <div class="d-flex align-items-center gap-2">
       <button type="submit" class="btn btn-primary btn-sm">Save</button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/card.html
@@ -4,75 +4,105 @@
   <div class="d-flex flex-column gap-3" id="rollout-risks-body">
     {# AI risk #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">AI risk</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.risk_ai is None %}
-          <span id="rollout-risks-ai" class="small text-body">—</span>
+          <span id="rollout-risks-ai"
+                class="small text-body text-center"
+                style="min-width: 16px">—</span>
         {% elif experiment.risk_ai %}
-          <i id="rollout-risks-ai" class="fas fa-check text-success"></i>
+          <i id="rollout-risks-ai"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-risks-ai" class="fas fa-times text-danger"></i>
+          <i id="rollout-risks-ai"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">AI risk</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.risk_ai %}
 
     </div>
     {# Brand perception impact #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">Brand perception impact</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.risk_brand is None %}
-          <span id="rollout-risks-brand" class="small text-body">—</span>
+          <span id="rollout-risks-brand"
+                class="small text-body text-center"
+                style="min-width: 16px">—</span>
         {% elif experiment.risk_brand %}
-          <i id="rollout-risks-brand" class="fas fa-check text-success"></i>
+          <i id="rollout-risks-brand"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-risks-brand" class="fas fa-times text-danger"></i>
+          <i id="rollout-risks-brand"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">Brand perception impact</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.risk_brand %}
 
     </div>
     {# Revenue impact #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary" style="font-size: 12px;">Revenue impact</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.risk_revenue is None %}
-          <span id="rollout-risks-revenue" class="small text-body">—</span>
+          <span id="rollout-risks-revenue"
+                class="small text-body text-center"
+                style="min-width: 16px">—</span>
         {% elif experiment.risk_revenue %}
-          <i id="rollout-risks-revenue" class="fas fa-check text-success"></i>
+          <i id="rollout-risks-revenue"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-risks-revenue" class="fas fa-times text-danger"></i>
+          <i id="rollout-risks-revenue"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">Revenue impact</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.risk_revenue %}
 
     </div>
     {# External vendor impact #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">External vendor impact</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.risk_partner_related is None %}
-          <span id="rollout-risks-partner-related" class="small text-body">—</span>
+          <span id="rollout-risks-partner-related"
+                class="small text-body text-center"
+                style="min-width: 16px">—</span>
         {% elif experiment.risk_partner_related %}
-          <i id="rollout-risks-partner-related" class="fas fa-check text-success"></i>
+          <i id="rollout-risks-partner-related"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-risks-partner-related" class="fas fa-times text-danger"></i>
+          <i id="rollout-risks-partner-related"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">External vendor impact</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.risk_partner_related %}
 
     </div>
     {# Messaging impact #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">Messaging impact</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.risk_message is None %}
-          <span id="rollout-risks-message" class="small text-body">—</span>
+          <span id="rollout-risks-message"
+                class="small text-body text-center"
+                style="min-width: 16px">—</span>
         {% elif experiment.risk_message %}
-          <i id="rollout-risks-message" class="fas fa-check text-success"></i>
+          <i id="rollout-risks-message"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-risks-message" class="fas fa-times text-danger"></i>
+          <i id="rollout-risks-message"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">Messaging impact</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.risk_message %}
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/risks/edit_form.html
@@ -17,10 +17,7 @@
       {# AI risk #}
       <div>
         <label for="id_risk_ai" class="small text-body mb-2">
-          <div class="d-block fw-normal">
-            <div class="fw-bold">{{ RISK_QUESTIONS.AI }}</div>
-            <div class="text-secondary">{{ NimbusUIConstants.RISK_AI_TEXT }}</div>
-          </div>
+          {{ RISK_QUESTIONS.AI }} <span class="d-block text-secondary fw-normal">{{ NimbusUIConstants.RISK_AI_TEXT }}</span>
         </label>
         {{ form.risk_ai }}
         {% if form.risk_ai.errors %}<div class="text-danger small mt-1">{{ form.risk_ai.errors|join:", " }}</div>{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/signoff/card.html
@@ -4,39 +4,51 @@
   <div class="d-flex flex-column gap-3" id="rollout-signoff-body">
     {# QA sign-off #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">QA sign-off</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.qa_signoff %}
-          <i id="rollout-signoff-qa" class="fas fa-check text-success"></i>
+          <i id="rollout-signoff-qa"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-signoff-qa" class="fas fa-times text-danger"></i>
+          <i id="rollout-signoff-qa"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">QA sign-off</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.qa_signoff %}
 
     </div>
     {# VP sign-off #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">VP sign-off</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.vp_signoff %}
-          <i id="rollout-signoff-vp" class="fas fa-check text-success"></i>
+          <i id="rollout-signoff-vp"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-signoff-vp" class="fas fa-times text-danger"></i>
+          <i id="rollout-signoff-vp"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">VP sign-off</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.vp_signoff %}
 
     </div>
     {# Legal sign-off #}
     <div>
-      <div class="d-flex flex-row gap-3">
-        <div class="text-secondary mb-1" style="font-size: 12px;">Legal sign-off</div>
+      <div class="d-flex flex-row align-items-baseline gap-2">
         {% if experiment.legal_signoff %}
-          <i id="rollout-signoff-legal" class="fas fa-check text-success"></i>
+          <i id="rollout-signoff-legal"
+             class="fas fa-check text-success text-center"
+             style="min-width: 16px"></i>
         {% else %}
-          <i id="rollout-signoff-legal" class="fas fa-times text-danger"></i>
+          <i id="rollout-signoff-legal"
+             class="fas fa-times text-danger text-center"
+             style="min-width: 16px"></i>
         {% endif %}
+        <div class="text-secondary" style="font-size: 12px;">Legal sign-off</div>
       </div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.legal_signoff %}
 


### PR DESCRIPTION
Because

* We need to fix the alignment of risk fields and signoffs and make the text style consistent
* We also need to add signoffs to the sidebar because it is currently missing
* We need to make the QA card style match the rest of the cards

This commit

* Makes the style changes mentioned

Fixes #16706