### PR TITLE
fix(nimbus): Show issue status directly on rollout cards

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2034,6 +2034,15 @@ class NimbusRolloutReviewSerializer(NimbusReviewSerializer):
             raise serializers.ValidationError(
                 NimbusConstants.ERROR_ROLLOUT_FIRST_PHASE_ZERO
             )
+        for phase in phases:
+            if not (0 <= phase.population_percent <= 100):
+                raise serializers.ValidationError(
+                    NimbusConstants.ERROR_ROLLOUT_PHASE_POPULATION_RANGE
+                )
+            if phase.start_date and phase.end_date and phase.end_date < phase.start_date:
+                raise serializers.ValidationError(
+                    NimbusConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER
+                )
         return value
 
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -729,6 +729,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_ROLLOUT_FIRST_PHASE_ZERO = (
         "The first rollout phase must have a population percent greater than 0."
     )
+    ERROR_ROLLOUT_PHASE_DATE_ORDER = "The end date must be on or after the start date."
+    ERROR_ROLLOUT_PHASE_POPULATION_RANGE = (
+        "Each rollout phase population percent must be between 0 and 100."
+    )
     ERROR_FIREFOX_VERSION_MIN = (
         "Ensure this value is less than or equal to the maximum version"
     )

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1387,6 +1387,18 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return bool(next_phase and next_phase.population_percent)
 
     @property
+    def has_rollout_review_errors(self):
+        from experimenter.experiments.api.v5.serializers import (
+            NimbusRolloutReviewSerializer,
+        )
+
+        if not self.is_rollout:
+            return False
+        return bool(
+            self.get_invalid_fields_errors(serializer_class=NimbusRolloutReviewSerializer)
+        )
+
+    @property
     def rollout_review_controls(self):
         if self.publish_status != self.PublishStatus.REVIEW:
             return None

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -579,6 +579,31 @@ class TestNimbusReviewSerializerSingleFeature(
             [NimbusConstants.ERROR_ROLLOUT_FIRST_PHASE_ZERO],
         )
 
+    def test_rollout_serializer_rejects_phase_end_before_start(self):
+        experiment = self.create_rollout()
+        NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=10,
+            start_date=datetime.date(2026, 2, 1),
+            end_date=datetime.date(2026, 1, 1),
+        )
+        serializer = self.get_rollout_review_serializer(experiment)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["rollout_phases"],
+            [NimbusConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER],
+        )
+
+    def test_rollout_serializer_rejects_phase_population_out_of_range(self):
+        experiment = self.create_rollout()
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=150)
+        serializer = self.get_rollout_review_serializer(experiment)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["rollout_phases"],
+            [NimbusConstants.ERROR_ROLLOUT_PHASE_POPULATION_RANGE],
+        )
+
     def test_invalid_experiment_treatment_branch_requires_description(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7748,3 +7748,7 @@ class TestRolloutSidebarStateHelpers(TestCase):
         experiment.rollout_phase = phases[0]
         experiment.save()
         self.assertFalse(experiment.has_advanceable_rollout_phase)
+
+    def test_has_rollout_review_errors_false_when_not_rollout(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=False)
+        self.assertFalse(experiment.has_rollout_review_errors)

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -370,8 +370,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_ROLLOUT_PLAN_FIX_ERRORS = (
         "Resolve the highlighted errors above before saving this plan."
     )
-    ERROR_ROLLOUT_PHASE_DATE_ORDER = "The end date must be on or after the start date."
     ERROR_ROLLOUT_PHASE_LOCKED = "This rollout phase is locked and cannot be changed."
+    ROLLOUT_REVIEW_PENDING_TOOLTIP = "A review is currently pending."
+    ROLLOUT_NO_NEXT_PHASE_TOOLTIP = "There is no further phase to start."
+    ROLLOUT_HAS_ISSUES_TOOLTIP = "All rollout issues must be resolved first."
     ROLLOUT_TEMPLATE_PLANS = {
         "Low risk": [100],
         "Medium risk": [1, 10, 50, 100],
@@ -417,6 +419,108 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         TOAST_SLACK_ENABLED: "Review Slack notifications enabled",
         TOAST_SLACK_DISABLED: "Review Slack notifications disabled",
         TOAST_EDIT_CANCELLED: "Edit cancelled",
+    }
+
+    ROLLOUT_CARD_FIELDS = {
+        "overview": {
+            "section": "Overview",
+            "rows": (
+                ("Name", ("name",)),
+                ("Observations & Problem Space", ("hypothesis",)),
+                ("Public Description", ("public_description",)),
+                ("Application", ("application",)),
+                ("Important Links", ("documentation_links",)),
+                ("Project Tags", ()),
+                ("Subscribers", ()),
+            ),
+        },
+        "risks": {
+            "section": "Risks",
+            "rows": (
+                ("AI Risk", ("risk_ai",)),
+                ("Brand Perception", ("risk_brand",)),
+                ("Revenue", ("risk_revenue",)),
+                ("External Vendor", ("risk_partner_related",)),
+                ("Messaging", ("risk_message",)),
+            ),
+        },
+        "rollout-features": {
+            "section": "Features",
+            "rows": (
+                ("Rollout Experience", ("takeaways_summary",)),
+                ("Feature Configuration", ("feature_configs", "reference_branch")),
+                ("Warn On Schema Failure", ("warn_feature_schema",)),
+                ("Prevent Pref Conflicts", ("prevent_pref_conflicts",)),
+                ("Screenshots", ()),
+                (
+                    "Firefox Labs",
+                    (
+                        "is_firefox_labs_opt_in",
+                        "firefox_labs_title",
+                        "firefox_labs_description",
+                        "firefox_labs_description_links",
+                        "firefox_labs_group",
+                        "requires_restart",
+                    ),
+                ),
+            ),
+        },
+        "audience": {
+            "section": "Audience",
+            "rows": (
+                ("Channel", ("channel", "channels")),
+                ("Min Version", ("firefox_min_version",)),
+                ("Max Version", ("firefox_max_version",)),
+                (
+                    "Locales & Languages",
+                    ("locales", "exclude_locales", "languages", "exclude_languages"),
+                ),
+                ("Countries", ("countries", "exclude_countries")),
+                ("Advanced Targeting", ("targeting_config_slug",)),
+                ("Targeting Expression", ("targeting",)),
+                ("Required Experiments", ("required_experiments_branches",)),
+                ("Excluded Experiments", ("excluded_experiments_branches",)),
+                ("Sticky Enrollment", ("is_sticky",)),
+                ("Localized Rollout", ("is_localized", "localizations")),
+            ),
+        },
+        "schedule": {
+            "section": "Rollout schedule",
+            "rows": (
+                ("Rollout Schedule", ("rollout_phases",)),
+                ("Advance Observations", ("rollout_advance_observations",)),
+                ("Pause Observations", ("rollout_pause_observations",)),
+            ),
+        },
+        "signoff": {
+            "section": "Sign-Offs",
+            "tracked": False,
+            "rows": (
+                ("QA Sign-off", ("qa_signoff",)),
+                ("VP Sign-off", ("vp_signoff",)),
+                ("Legal Sign-off", ("legal_signoff",)),
+            ),
+        },
+        "qa": {
+            "section": "Quality Assurance",
+            "tracked": False,
+            "rows": (
+                ("QA Status", ("qa_status",)),
+                ("QA Notes", ("qa_comment",)),
+            ),
+        },
+    }
+
+    ROLLOUT_CARD_ICONS = {
+        "monitoring": "fa-regular fa-chart-bar",
+        "schedule": "fa-regular fa-calendar-days",
+        "preview": "fa-regular fa-eye",
+        "overview": "fa-regular fa-file-lines",
+        "risks": "fa-regular fa-flag",
+        "signoff": "fa-regular fa-square-check",
+        "audience": "fa-regular fa-circle-user",
+        "rollout-features": "fa-regular fa-lightbulb",
+        "qa": "fa-regular fa-clipboard",
     }
 
     class RolloutPhaseStatus:

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -181,6 +181,9 @@ class NimbusDocumentationLinkForm(forms.ModelForm):
         model = NimbusDocumentationLink
         fields = ("title", "link")
 
+    def _get_validation_exclusions(self):
+        return super()._get_validation_exclusions() | {"title", "link"}
+
 
 class SingleSelectWidget(SelectedFirstMixin, forms.Select):
     class_attrs = "selectpicker form-control"
@@ -497,7 +500,6 @@ class RolloutOverviewForm(NimbusChangeLogFormMixin, forms.ModelForm):
     def save(self):
         experiment = super().save()
         self.documentation_links.save()
-        experiment.documentation_links.filter(link="").delete()
         return experiment
 
     def get_changelog_message(self):
@@ -1738,22 +1740,12 @@ class RolloutPhaseForm(forms.ModelForm):
     )
     population_percent = forms.DecimalField(
         required=False,
-        min_value=0,
-        max_value=100,
-        widget=forms.NumberInput(attrs={"class": "form-control", "min": 0, "max": 100}),
+        widget=forms.NumberInput(attrs={"class": "form-control"}),
     )
 
     class Meta:
         model = NimbusRolloutPhase
         fields = ("start_date", "end_date", "population_percent")
-
-    def clean(self):
-        cleaned_data = super().clean()
-        start_date = cleaned_data.get("start_date")
-        end_date = cleaned_data.get("end_date")
-        if start_date and end_date and end_date < start_date:
-            self.add_error("end_date", NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER)
-        return cleaned_data
 
 
 class RolloutScheduleForm(NimbusChangeLogFormMixin, forms.ModelForm):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -202,30 +202,6 @@ class UpdateRedirectViewMixin:
 
 
 class RolloutSetupProgressMixin:
-    SETUP_SECTIONS = {
-        "Overview": {
-            "card_id": "overview",
-            "fields": {*RolloutOverviewForm.Meta.fields},
-        },
-        "Risks": {
-            "card_id": "risks",
-            "fields": {*RolloutRisksForm.Meta.fields},
-        },
-        "Features": {
-            "card_id": "rollout-features",
-            "fields": {*RolloutFeaturesForm.Meta.fields},
-        },
-        "Audience": {
-            "card_id": "audience",
-            "fields": {*RolloutAudienceForm.Meta.fields},
-        },
-        "Rollout schedule": {
-            "card_id": "schedule",
-            "fields": {"rollout_phases"},
-            "labels": {"rollout_phases": "Rollout Schedule"},
-        },
-    }
-
     def flatten_errors(self, messages):
         if isinstance(messages, dict):
             return [m for value in messages.values() for m in self.flatten_errors(value)]
@@ -233,52 +209,69 @@ class RolloutSetupProgressMixin:
             return [m for value in messages for m in self.flatten_errors(value)]
         return [str(messages)]
 
+    def unique_messages(self, messages):
+        seen = set()
+        unique = []
+        for message in self.flatten_errors(messages):
+            if message not in seen:
+                seen.add(message)
+                unique.append(message)
+        return unique
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         field_errors = self.object.get_invalid_fields_errors(
             serializer_class=NimbusRolloutReviewSerializer
         )
-        validation_errors = {
-            field: self.flatten_errors(messages)
-            for field, messages in field_errors.items()
+        cards = NimbusUIConstants.ROLLOUT_CARD_FIELDS
+
+        routing = {
+            key: (card_id, card["section"], label)
+            for card_id, card in cards.items()
+            if card.get("tracked", True)
+            for label, keys in card["rows"]
+            for key in keys
         }
-        error_keys = set(field_errors)
+        tracked = set(routing)
+        broken = set(field_errors) & tracked
 
-        field_to_section = {
-            field: name
-            for name, section in self.SETUP_SECTIONS.items()
-            for field in section["fields"]
-        }
-
-        tracked_fields = set(field_to_section)
-        broken = error_keys & tracked_fields
-        context["setup_completion_percent"] = round(
-            100 * (len(tracked_fields) - len(broken)) / len(tracked_fields)
-        )
-
-        issues = []
+        groups = {}
         for field, messages in field_errors.items():
-            section = field_to_section.get(field)
-            if section is not None:
-                meta = self.SETUP_SECTIONS[section]
-                card_id = meta["card_id"]
-                label = meta.get("labels", {}).get(field, field.replace("_", " ").title())
-            else:
-                section = "Other"
-                card_id = None
-                label = field.replace("_", " ").title()
-            issues.append(
+            card_id, section, label = routing.get(
+                field, (None, "Other", field.replace("_", " ").title())
+            )
+            group = groups.setdefault(
+                card_id, {"card_id": card_id, "section": section, "fields": []}
+            )
+            group["fields"].append(
                 {
-                    "section": section,
-                    "card_id": card_id,
                     "label": label,
-                    "messages": self.flatten_errors(messages),
+                    "messages": self.unique_messages(messages),
                 }
             )
+        issues = [groups[card_id] for card_id in cards if card_id in groups]
+        if None in groups:
+            issues.append(groups[None])
 
+        raw_error_fields = ("reference_branch", "documentation_links")
+        context["validation_errors"] = {
+            field: (
+                messages if field in raw_error_fields else self.flatten_errors(messages)
+            )
+            for field, messages in field_errors.items()
+        }
         context["setup_issues"] = issues
-        context["setup_issues_count"] = len(issues)
-        context["validation_errors"] = validation_errors
+        context["setup_issues_count"] = sum(len(group["fields"]) for group in issues)
+        context["setup_completion_percent"] = round(
+            100 * (len(tracked) - len(broken)) / len(tracked)
+        )
+        context["card_summaries"] = {
+            card_id: [
+                {"label": label, "has_error": any(key in field_errors for key in keys)}
+                for label, keys in card["rows"]
+            ]
+            for card_id, card in cards.items()
+        }
         return context
 
 
@@ -354,17 +347,6 @@ class NewOverviewUpdateView(CardMixin, NewCardUpdateView):
     form_class = RolloutOverviewForm
     display_template = "new/rollouts/overview/card.html"
     template_name = "new/rollouts/overview/edit_form.html"
-
-
-class NewOverviewCancelView(NimbusRolloutDetailView):
-    template_name = "new/rollouts/overview/cancel_response.html"
-
-    def post(self, request, *args, **kwargs):
-        self.object = self.get_object()
-        self.object.documentation_links.filter(link="").delete()
-        context = self.get_context_data()
-        context["hx_swap_oob"] = True
-        return self.render_to_response(context)
 
 
 class NewRisksUpdateView(CardMixin, NewCardUpdateView):

--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -354,6 +354,10 @@
   transform: rotate(90deg);
 }
 
+.rollout-card-toggle[aria-expanded="true"] .card-collapsed-subtitle {
+  display: none !important;
+}
+
 .accordion-button[aria-disabled="true"] {
   cursor: not-allowed;
 }

--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -100,11 +100,25 @@ const setupSetupIssueNav = () => {
     if (!card) {
       return;
     }
-    const scrollToCard = () =>
+    const scrollIntoView = () =>
       card.scrollIntoView({ behavior: "smooth", block: "start" });
+    const scrollWhenSettled = () =>
+      requestAnimationFrame(() => requestAnimationFrame(scrollIntoView));
+    const scrollToCard = () => {
+      const collapse = document.getElementById(`collapse-${cardId}`);
+      if (collapse && !collapse.classList.contains("show")) {
+        collapse.addEventListener("shown.bs.collapse", scrollWhenSettled, {
+          once: true,
+        });
+        window.bootstrap.Collapse.getOrCreateInstance(collapse).show();
+      } else {
+        scrollIntoView();
+      }
+    };
 
-    if (trigger.closest(".modal")) {
-      setTimeout(scrollToCard, 300);
+    const modal = trigger.closest(".modal");
+    if (modal) {
+      modal.addEventListener("hidden.bs.modal", scrollToCard, { once: true });
     } else {
       scrollToCard();
     }

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/card_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/card_base.html
@@ -1,2 +1,3 @@
 {% block card %}{% endblock %}
 {% include "new/common/sidebar_setup_refresh.html" %}
+{% include "new/rollouts/card_subtitles_refresh.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/card_cancel_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/card_cancel_button.html
@@ -2,7 +2,7 @@
         class="{% if icon_only %}btn p-0 border-0 text-secondary d-none{% else %}btn btn-outline-secondary btn-sm{% endif %}"
         {% if icon_only %}data-card-action="cancel" aria-label="Cancel editing {{ card_id }}"{% endif %}
         data-toast-id="{{ NimbusUIConstants.TOAST_EDIT_CANCELLED }}"
-        {% if card_id == "overview" %} hx-post="{% url 'nimbus-ui-new-cancel-overview' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% else %} hx-get="{% url 'new-nimbus-ui-rollout-detail' experiment.slug %}" {% endif %}
+        hx-get="{% url 'new-nimbus-ui-rollout-detail' experiment.slug %}"
         hx-select="#rollout-card-{{ card_id }}"
         hx-target="#rollout-card-{{ card_id }}"
         hx-swap="outerHTML">

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/setup_issues_modal.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/setup_issues_modal.html
@@ -8,35 +8,34 @@
             <h1 class="modal-title fs-5 d-flex align-items-center gap-2">Rollout Issues Detected</h1>
             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
-          <div class="modal-body bg-body-tertiary d-flex flex-column gap-2">
-            {% for issue in setup_issues %}
-              <div class="rounded-2 p-3 small"
+          <div class="modal-body bg-body-tertiary d-flex flex-column gap-3 small">
+            {% for group in setup_issues %}
+              <div class="rounded-3 p-3"
                    style="background-color: var(--bs-warning-bg-subtle);
                           border: 1px solid var(--bs-warning-border-subtle)">
-                <button type="button"
-                        class="rollout-card-toggle btn btn-link small p-0 w-100 d-flex align-items-center gap-2 text-black text-decoration-none collapsed"
-                        data-bs-toggle="collapse"
-                        data-bs-target="#setupIssue{{ forloop.counter }}">
-                  <i class="fa-solid fa-triangle-exclamation"
-                     style="color: var(--bs-orange)"></i>
-                  <span class="flex-grow-1 small text-start fw-semibold">{{ issue.label }}</span>
-                  <i class="fa-solid fa-chevron-right chevron-icon"
-                     style="font-size: 11px"></i>
-                </button>
-                <div class="collapse ms-4" id="setupIssue{{ forloop.counter }}">
-                  {% for message in issue.messages %}<div>{{ message }}</div>{% endfor %}
-                  {% if issue.card_id %}
-                    <button type="button"
-                            class="btn btn-sm mt-2"
-                            style="background-color: var(--bs-warning-border-subtle);
-                                   border: 1px solid var(--bs-warning-border-subtle)"
-                            data-bs-dismiss="modal"
-                            data-setup-issue-target="{{ issue.card_id }}">
-                      Go to {{ issue.section }}
-                      <i class="fa-solid fa-arrow-right ms-1" style="font-size: 10px;"></i>
-                    </button>
-                  {% endif %}
+                <div class="d-flex align-items-center gap-2 mb-2">
+                  <i class="fa-solid fa-triangle-exclamation text-warning"></i>
+                  <span class="flex-grow-1 fw-semibold">{{ group.section }}</span>
                 </div>
+                <dl class="row mb-0 g-0 row-gap-2">
+                  {% for field in group.fields %}
+                    <dt class="col-sm-4 fw-semibold">{{ field.label }}</dt>
+                    <dd class="col-sm-8 mb-0 text-body-secondary">
+                      {% for message in field.messages %}<div>{{ message }}</div>{% endfor %}
+                    </dd>
+                  {% endfor %}
+                </dl>
+                {% if group.card_id %}
+                  <button type="button"
+                          class="btn btn-sm mt-3"
+                          style="background-color: var(--bs-warning-border-subtle);
+                                 border: 1px solid var(--bs-warning-border-subtle)"
+                          data-bs-dismiss="modal"
+                          data-setup-issue-target="{{ group.card_id }}">
+                    Go to {{ group.section }}
+                    <i class="fa-solid fa-arrow-right ms-1" style="font-size: 10px;"></i>
+                  </button>
+                {% endif %}
               </div>
             {% endfor %}
           </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/setup_progress.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/setup_progress.html
@@ -12,8 +12,7 @@
          style="background-color: var(--bs-warning-bg-subtle);
                 border: 1px solid var(--bs-warning-border-subtle)">
       <span class="d-flex align-items-center gap-2">
-        <i class="fa-solid fa-triangle-exclamation"
-           style="color: var(--bs-orange)"></i>
+        <i class="fa-solid fa-triangle-exclamation text-warning"></i>
         {{ setup_issues_count }} issue{{ setup_issues_count|pluralize }} detected
       </span>
       <button type="button"

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -48,23 +48,29 @@
           {% endif %}
         {% else %}
           {# Live to Disabled #}
-          <button type="button"
-                  id="rollout-disable-btn"
-                  class="btn btn-secondary btn-sm w-100"
-                  hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}"
-                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                  hx-disabled-elt="this"
-                  {% if transition_pending %}disabled{% endif %}>Disable rollout</button>
+          <span class="d-inline-block w-100"
+                {% if transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+            <button type="button"
+                    id="rollout-disable-btn"
+                    class="btn btn-secondary btn-sm w-100"
+                    hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-disabled-elt="this"
+                    {% if transition_pending %}disabled{% endif %}>Disable rollout</button>
+          </span>
           {# Live to Live phase advance #}
-          <button type="button"
-                  id="rollout-next-phase-btn"
-                  class="btn btn-primary btn-sm w-100"
-                  hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
-                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                  hx-disabled-elt="this"
-                  {% if transition_pending or setup_issues_count or not experiment.has_advanceable_rollout_phase %}disabled{% endif %}>
-            Start next phase
-          </button>
+          <span class="d-inline-block w-100"
+                {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif not experiment.has_advanceable_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
+            <button type="button"
+                    id="rollout-next-phase-btn"
+                    class="btn btn-primary btn-sm w-100"
+                    hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
+                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                    hx-disabled-elt="this"
+                    {% if transition_pending or not experiment.has_advanceable_rollout_phase or experiment.has_rollout_review_errors %}disabled{% endif %}>
+              Start next phase
+            </button>
+          </span>
         {% endif %}
       </div>
     {% endwith %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/validation_errors.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/validation_errors.html
@@ -1,5 +1,1 @@
-{% for error in errors %}
-  <div class="small text-danger mt-1">
-    <i class="fa-solid fa-triangle-exclamation fa-xs me-1"></i>{{ error }}
-  </div>
-{% endfor %}
+{% for error in errors %}<div class="small text-danger mt-1">{{ error }}</div>{% endfor %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/card_subtitle.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/card_subtitle.html
@@ -1,0 +1,13 @@
+{% if card_status %}
+  <div class="card-collapsed-subtitle d-flex flex-wrap align-items-center column-gap-2 row-gap-1 fw-normal mt-2 small"
+       id="rollout-card-{{ card_id }}-summary"
+       {% if oob %}hx-swap-oob="true"{% endif %}>
+    {% for field in card_status %}
+      {% if not forloop.first %}<span class="text-body-tertiary">·</span>{% endif %}
+      <span class="text-secondary">
+        {% if field.has_error %}<i class="fa-solid fa-triangle-exclamation fa-xs me-1 text-warning"></i>{% endif %}
+        {{ field.label }}
+      </span>
+    {% endfor %}
+  </div>
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/card_subtitles_refresh.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/card_subtitles_refresh.html
@@ -1,0 +1,6 @@
+{% if hx_swap_oob %}
+  {% for card_id, card_status in card_summaries.items %}
+    {% include "new/rollouts/card_subtitle.html" with card_status=card_status card_id=card_id oob=True %}
+
+  {% endfor %}
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/cancel_response.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/cancel_response.html
@@ -1,1 +1,0 @@
-{% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" show_edit_btn=experiment.is_draft body_template="new/rollouts/overview/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -1,5 +1,7 @@
 {% extends "new/common/card_base.html" %}
 
+{% load error_helpers %}
+
 {% block card %}
   <div class="d-flex flex-column gap-3" id="rollout-overview-body">
     {# Name #}
@@ -51,13 +53,14 @@
                 </a>
               </div>
             {% endif %}
+            {% with dl_errors=validation_errors.documentation_links|get_item:forloop.counter0 %}
+              {% for error in dl_errors.link %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+            {% endwith %}
           {% endfor %}
         </div>
       {% else %}
         <div class="small text-body">—</div>
       {% endif %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.documentation_links %}
-
     </div>
     {# Project Tags #}
     <div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -26,6 +26,10 @@
       {% endfor %}
       {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
 
+      {% for feature_value_errors in validation_errors.reference_branch.feature_values %}
+        {% include "new/common/validation_errors.html" with errors=feature_value_errors.value %}
+
+      {% endfor %}
     </div>
     {# Warn only on feature schema validation failure #}
     <div>
@@ -81,6 +85,13 @@
           <div class="small text-body">—</div>
         {% endif %}
       {% endwith %}
+      {% for screenshot_errors in validation_errors.reference_branch.screenshots %}
+        {% if screenshot_errors.image %}
+          <div class="small text-danger mt-1">{{ screenshot_errors.image.0 }}</div>
+        {% elif screenshot_errors.description %}
+          <div class="small text-danger mt-1">{{ screenshot_errors.description.0 }}</div>
+        {% endif %}
+      {% endfor %}
     </div>
     {# Firefox Labs #}
     {% if experiment.application_config.firefox_labs %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -1,5 +1,6 @@
 {% load static %}
 {% load nimbus_extras %}
+{% load error_helpers %}
 {% load widget_tweaks %}
 
 {# ── Edit form ── #}
@@ -22,7 +23,7 @@
       </label>
       {{ form.rollout_experience }}
       {% if form.rollout_experience.errors %}
-        <div class="text-danger small mt-1">{{ form.rollout_experience.errors|join:", " }}</div>
+        <div class="form-text text-danger">{{ form.rollout_experience.errors|join:", " }}</div>
       {% endif %}
       {% include "new/common/validation_errors.html" with errors=validation_errors.takeaways_summary %}
 
@@ -69,8 +70,11 @@
                 </div>
               </div>
               {% for error in branch_feature_values_form.value.errors %}
-                <div class="invalid-feedback d-block">{{ error }}</div>
+                <div class="form-text text-danger">{{ error }}</div>
               {% endfor %}
+              {% with fv_errors=validation_errors.reference_branch.feature_values|get_item:forloop.counter0 %}
+                {% for error in fv_errors.value %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+              {% endwith %}
             </div>
           </div>
         {% endfor %}
@@ -103,46 +107,52 @@
         {{ rollout_screenshots.management_form }}
         <div class="d-flex flex-column gap-2 mt-4">
           {% for screenshot_form in rollout_screenshots %}
-            <div>
-              {{ screenshot_form.id }}
-              <div class="d-flex gap-3">
-                <label class="small text-secondary mb-1 flex-shrink-0" style="width: 360px;">Screenshot</label>
-                <label class="small text-secondary mb-1 flex-grow-1">Description</label>
-              </div>
-              <div class="d-flex align-items-center gap-3 mb-2">
-                <div class="flex-shrink-0" style="width: 360px;">
-                  {{ screenshot_form.image }}
-                  {% for error in screenshot_form.image.errors %}<div class="text-danger small mt-1">{{ error }}</div>{% endfor %}
+            {% with ss_errors=validation_errors.reference_branch.screenshots|get_item:forloop.counter0 %}
+              <div>
+                {{ screenshot_form.id }}
+                <div class="d-flex gap-3">
+                  <label class="small text-secondary mb-1 flex-shrink-0" style="width: 360px;">Screenshot</label>
+                  <label class="small text-secondary mb-1 flex-grow-1">Description</label>
                 </div>
-                <div class="flex-grow-1">
-                  {{ screenshot_form.description }}
-                  {% for error in screenshot_form.description.errors %}<div class="text-danger small mt-1">{{ error }}</div>{% endfor %}
+                <div class="d-flex align-items-center gap-3">
+                  <div class="flex-shrink-0" style="width: 360px;">{{ screenshot_form.image }}</div>
+                  <div class="flex-grow-1">{{ screenshot_form.description }}</div>
+                  {% if screenshot_form.instance.pk %}
+                    <button type="button"
+                            class="btn p-0 border-0 text-secondary flex-shrink-0"
+                            title="Delete screenshot"
+                            hx-post="{% url 'nimbus-ui-new-delete-rollout-screenshot' experiment.slug %}"
+                            hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                            hx-vals='{"screenshot_id": "{{ screenshot_form.instance.pk }}"}'
+                            hx-target="#rollout-rollout-features-body"
+                            hx-swap="outerHTML">
+                      <i class="fa-solid fa-trash-can"></i>
+                    </button>
+                  {% endif %}
                 </div>
-                {% if screenshot_form.instance.pk %}
-                  <button type="button"
-                          class="btn p-0 border-0 text-secondary flex-shrink-0"
-                          title="Delete screenshot"
-                          hx-post="{% url 'nimbus-ui-new-delete-rollout-screenshot' experiment.slug %}"
-                          hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                          hx-vals='{"screenshot_id": "{{ screenshot_form.instance.pk }}"}'
-                          hx-target="#rollout-rollout-features-body"
-                          hx-swap="outerHTML">
-                    <i class="fa-solid fa-trash-can"></i>
-                  </button>
+                <div class="d-flex gap-3 mb-2">
+                  <div class="flex-shrink-0" style="width: 360px;">
+                    {% for error in screenshot_form.image.errors %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                    {% for error in ss_errors.image %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                  </div>
+                  <div class="flex-grow-1">
+                    {% for error in screenshot_form.description.errors %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                    {% for error in ss_errors.description %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                  </div>
+                </div>
+                {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
+                  <div class="border border-secondary-subtle rounded overflow-hidden mt-2 d-inline-block">
+                    <img src="{{ screenshot_form.instance.image.url }}"
+                         alt="{{ screenshot_form.instance.description }}"
+                         title="{{ screenshot_form.instance.description }}"
+                         class="rounded"
+                         style="height: 96px;
+                                width: auto;
+                                object-fit: cover">
+                  </div>
                 {% endif %}
               </div>
-              {% if screenshot_form.instance.pk and screenshot_form.instance.image %}
-                <div class="border border-secondary-subtle rounded overflow-hidden mt-2 d-inline-block">
-                  <img src="{{ screenshot_form.instance.image.url }}"
-                       alt="{{ screenshot_form.instance.description }}"
-                       title="{{ screenshot_form.instance.description }}"
-                       class="rounded"
-                       style="height: 96px;
-                              width: auto;
-                              object-fit: cover">
-                </div>
-              {% endif %}
-            </div>
+            {% endwith %}
           {% endfor %}
         </div>
         <div {% if rollout_screenshots|length %}class="mt-2"{% endif %}>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -88,7 +88,7 @@
       <div>
         <button type="button"
                 id="rollout-schedule-add-phase"
-                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small mt-1"
+                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small mt-2"
                 hx-post="{% url 'nimbus-ui-new-create-rollout-phase' experiment.slug %}"
                 hx-include="closest form"
                 hx-target="#rollout-schedule-body"

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -305,6 +305,37 @@ class TestRolloutOverviewForm(RequestFormTestCase):
             f"{self.request.user} updated rollouts overview",
         )
 
+    def test_invalid_documentation_link_url_does_not_block_save(self):
+        documentation_link = NimbusDocumentationLinkFactory.create()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            documentation_links=[documentation_link],
+        )
+
+        form = RolloutOverviewForm(
+            instance=experiment,
+            data={
+                "name": "new rollout name",
+                "hypothesis": "new hypothesis",
+                "public_description": "new description",
+                "documentation_links-TOTAL_FORMS": "1",
+                "documentation_links-INITIAL_FORMS": "1",
+                "documentation_links-0-id": documentation_link.id,
+                "documentation_links-0-title": (
+                    NimbusExperiment.DocumentationLink.DESIGN_DOC.value
+                ),
+                "documentation_links-0-link": "not-a-valid-url",
+            },
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(
+            experiment.documentation_links.all().get().link, "not-a-valid-url"
+        )
+
     def test_name_field_is_required(self):
         form_data = {
             "name": "",
@@ -2321,7 +2352,7 @@ class TestRolloutStatusForms(
 
 
 class TestRolloutPhaseForm(TestCase):
-    def test_end_date_before_start_date_is_invalid(self):
+    def test_end_date_before_start_date_does_not_block_save(self):
         form = RolloutPhaseForm(
             data={
                 "start_date": "2026-02-01",
@@ -2329,11 +2360,7 @@ class TestRolloutPhaseForm(TestCase):
                 "population_percent": "10",
             }
         )
-        self.assertFalse(form.is_valid())
-        self.assertIn(
-            NimbusUIConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER,
-            form.errors["end_date"],
-        )
+        self.assertTrue(form.is_valid(), form.errors)
 
     def test_end_date_equal_to_start_date_is_valid(self):
         form = RolloutPhaseForm(
@@ -2349,21 +2376,11 @@ class TestRolloutPhaseForm(TestCase):
         form = RolloutPhaseForm(data={"population_percent": "10"})
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_population_over_100_is_invalid(self):
-        form = RolloutPhaseForm(data={"population_percent": "150"})
-        self.assertFalse(form.is_valid())
-        self.assertIn("population_percent", form.errors)
-
     def test_population_100_is_valid(self):
         form = RolloutPhaseForm(data={"population_percent": "100"})
         self.assertTrue(form.is_valid(), form.errors)
 
-    def test_negative_population_percent_is_invalid(self):
-        form = RolloutPhaseForm(data={"population_percent": "-1"})
-        self.assertFalse(form.is_valid())
-        self.assertIn("population_percent", form.errors)
-
-    def test_population_percent_over_100_is_invalid(self):
-        form = RolloutPhaseForm(data={"population_percent": "101"})
-        self.assertFalse(form.is_valid())
-        self.assertIn("population_percent", form.errors)
+    def test_population_out_of_range_does_not_block(self):
+        for value in ["150", "101", "-1"]:
+            form = RolloutPhaseForm(data={"population_percent": value})
+            self.assertTrue(form.is_valid(), value)

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -44,7 +44,6 @@ from experimenter.nimbus_ui.new.forms import (
     RolloutRisksForm,
     RolloutSignoffForm,
 )
-from experimenter.nimbus_ui.new.views import RolloutSetupProgressMixin
 from experimenter.openidc.tests.factories import UserFactory
 from experimenter.targeting.constants import NimbusTargetingConfig
 
@@ -161,7 +160,12 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
         if url_name == "nimbus-ui-new-live-to-disabled-rollout":
             NimbusRolloutPhaseFactory.create(experiment=experiment)
 
-        response = self.client.post(reverse(url_name, kwargs={"slug": experiment.slug}))
+        with mock.patch.object(
+            NimbusExperiment, "get_invalid_fields_errors", return_value={}
+        ):
+            response = self.client.post(
+                reverse(url_name, kwargs={"slug": experiment.slug})
+            )
 
         self.assertEqual(response.status_code, 200)
         experiment.refresh_from_db()
@@ -528,54 +532,39 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertEqual(response.context["setup_issues_count"], 0)
         self.assertEqual(response.context["setup_issues"], [])
 
-    def test_setup_progress_reports_issue_when_no_rollout_phases(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
-            is_rollout=True,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
-        )
-        self.assertFalse(experiment.rollout_phases.exists())
+    def test_setup_progress_reports_schedule_phase_issues(self):
+        for populations, expected_message in [
+            ([], NimbusConstants.ERROR_ROLLOUT_NO_PHASES),
+            ([0, 50], NimbusConstants.ERROR_ROLLOUT_FIRST_PHASE_ZERO),
+        ]:
+            experiment = NimbusExperimentFactory.create_with_lifecycle(
+                NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
+                is_rollout=True,
+                firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            )
+            for population_percent in populations:
+                NimbusRolloutPhaseFactory.create(
+                    experiment=experiment, population_percent=population_percent
+                )
 
-        response = self.client.get(
-            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
-        )
+            response = self.client.get(
+                reverse(
+                    "new-nimbus-ui-rollout-detail",
+                    kwargs={"slug": experiment.slug},
+                )
+            )
 
-        schedule_issues = [
-            issue
-            for issue in response.context["setup_issues"]
-            if issue["card_id"] == "schedule"
-        ]
-        self.assertEqual(len(schedule_issues), 1)
-        self.assertEqual(
-            schedule_issues[0]["messages"],
-            [NimbusConstants.ERROR_ROLLOUT_NO_PHASES],
-        )
-        self.assertLess(response.context["setup_completion_percent"], 100)
-
-    def test_setup_progress_reports_issue_when_first_phase_population_zero(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LAUNCH_APPROVE_APPROVE,
-            is_rollout=True,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
-        )
-        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=0)
-        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=50)
-
-        response = self.client.get(
-            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
-        )
-
-        schedule_issues = [
-            issue
-            for issue in response.context["setup_issues"]
-            if issue["card_id"] == "schedule"
-        ]
-        self.assertEqual(len(schedule_issues), 1)
-        self.assertEqual(
-            schedule_issues[0]["messages"],
-            [NimbusConstants.ERROR_ROLLOUT_FIRST_PHASE_ZERO],
-        )
-        self.assertLess(response.context["setup_completion_percent"], 100)
+            schedule_groups = [
+                group
+                for group in response.context["setup_issues"]
+                if group["card_id"] == "schedule"
+            ]
+            self.assertEqual(len(schedule_groups), 1, expected_message)
+            self.assertEqual(
+                schedule_groups[0]["fields"],
+                [{"label": "Rollout Schedule", "messages": [expected_message]}],
+            )
+            self.assertLess(response.context["setup_completion_percent"], 100)
 
     def test_setup_progress_reports_issues_when_review_invalid(self):
         experiment = NimbusExperimentFactory.create(
@@ -591,15 +580,19 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
         self.assertLess(response.context["setup_completion_percent"], 100)
         self.assertGreater(response.context["setup_issues_count"], 0)
+
+        setup_issues = response.context["setup_issues"]
         self.assertEqual(
             response.context["setup_issues_count"],
-            len(response.context["setup_issues"]),
+            sum(len(group["fields"]) for group in setup_issues),
         )
-        for issue in response.context["setup_issues"]:
-            self.assertIn("section", issue)
-            self.assertIn("card_id", issue)
-            self.assertIn("label", issue)
-            self.assertTrue(issue["messages"])
+        for group in setup_issues:
+            self.assertIn("section", group)
+            self.assertIn("card_id", group)
+            self.assertTrue(group["fields"])
+            for field in group["fields"]:
+                self.assertIn("label", field)
+                self.assertTrue(field["messages"])
 
     def test_setup_progress_advances_per_field_within_a_section(self):
         experiment = NimbusExperimentFactory.create(is_rollout=True)
@@ -624,30 +617,114 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
         total_tracked = len(
             {
-                field
-                for section in RolloutSetupProgressMixin.SETUP_SECTIONS.values()
-                for field in section["fields"]
+                key
+                for card in NimbusUIConstants.ROLLOUT_CARD_FIELDS.values()
+                if card.get("tracked", True)
+                for _, keys in card["rows"]
+                for key in keys
             }
         )
         self.assertEqual(two_invalid, round(100 * (total_tracked - 2) / total_tracked))
         self.assertEqual(one_invalid, round(100 * (total_tracked - 1) / total_tracked))
         self.assertGreater(one_invalid, two_invalid)
 
-    def test_setup_progress_untracked_issue_does_not_lower_completion(self):
+    def test_untracked_and_display_only_fields_do_not_lower_completion(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        for field, label in [
+            ("population_percent", "Population Percent"),
+            ("qa_status", "Qa Status"),
+            ("legal_signoff", "Legal Signoff"),
+        ]:
+            with mock.patch.object(
+                NimbusExperiment,
+                "get_invalid_fields_errors",
+                return_value={field: ["This field may not be null."]},
+            ):
+                context = self.client.get(url).context
+
+            self.assertEqual(context["setup_issues_count"], 1, field)
+            self.assertEqual(context["setup_completion_percent"], 100, field)
+            (group,) = context["setup_issues"]
+            self.assertEqual(group["section"], "Other", field)
+            self.assertIsNone(group["card_id"], field)
+            self.assertEqual([f["label"] for f in group["fields"]], [label], field)
+
+    def test_card_summaries_present_for_all_cards(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        card_summaries = response.context["card_summaries"]
+        self.assertEqual(
+            set(card_summaries),
+            set(NimbusUIConstants.ROLLOUT_CARD_FIELDS),
+        )
+        for card_id, summary in card_summaries.items():
+            expected_labels = [
+                label
+                for label, _ in NimbusUIConstants.ROLLOUT_CARD_FIELDS[card_id]["rows"]
+            ]
+            self.assertEqual(
+                [field["label"] for field in summary],
+                expected_labels,
+            )
+
+    def test_card_status_indicators_rendered_in_template(self):
         experiment = NimbusExperimentFactory.create(is_rollout=True)
         url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
 
         with mock.patch.object(
             NimbusExperiment,
             "get_invalid_fields_errors",
-            return_value={
-                "reference_branch": {"feature_values": ["Feature not supported."]}
-            },
+            return_value={"name": ["This field may not be blank."]},
+        ):
+            response = self.client.get(url)
+
+        self.assertContains(response, 'id="rollout-card-overview-summary"')
+        self.assertContains(response, "Observations &amp; Problem Space")
+
+    def test_reference_branch_errors_deduped_into_one_field(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        reference_branch_errors = {
+            "feature_values": [
+                "This field may not be blank.",
+                "This field may not be blank.",
+            ],
+            "screenshots": [{"description": ["This field is required."]}],
+        }
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={"reference_branch": reference_branch_errors},
         ):
             context = self.client.get(url).context
 
-        self.assertEqual(context["setup_issues_count"], 1)
-        self.assertEqual(context["setup_completion_percent"], 100)
+        self.assertEqual(
+            context["validation_errors"]["reference_branch"],
+            reference_branch_errors,
+        )
+        (features_group,) = [
+            group
+            for group in context["setup_issues"]
+            if group["card_id"] == "rollout-features"
+        ]
+        self.assertEqual(
+            features_group["fields"],
+            [
+                {
+                    "label": "Feature Configuration",
+                    "messages": [
+                        "This field may not be blank.",
+                        "This field is required.",
+                    ],
+                },
+            ],
+        )
 
     def test_preview_card_hidden_when_not_in_preview(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -891,6 +968,8 @@ class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(experiment.hypothesis, "updated hypothesis")
         self.assertEqual(experiment.public_description, "updated description")
         self.assertTrue(response.context["hx_swap_oob"])
+        self.assertContains(response, 'id="rollout-card-overview-summary"')
+        self.assertContains(response, 'hx-swap-oob="true"')
 
     def test_post_invalid_returns_edit_form_with_errors(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1485,32 +1564,6 @@ class TestNewDocumentationLinkDeleteView(AuthTestCase):
         self.assertEqual(experiment.documentation_links.count(), 1)
 
 
-class TestNewOverviewCancelView(AuthTestCase):
-    url_name = "nimbus-ui-new-cancel-overview"
-
-    def test_post_discards_blank_links_and_returns_card(self):
-        blank_link = NimbusDocumentationLinkFactory.create(link="")
-        filled_link = NimbusDocumentationLinkFactory.create(
-            link="https://www.example.com"
-        )
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            documentation_links=[blank_link, filled_link],
-            is_rollout=True,
-        )
-        response = self.client.post(
-            reverse(self.url_name, kwargs={"slug": experiment.slug}),
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, "new/rollouts/overview/card.html")
-        self.assertTrue(response.context["hx_swap_oob"])
-        self.assertContains(response, 'id="sidebar-setup-progress"')
-        self.assertContains(response, 'hx-swap-oob="true"')
-        links = list(experiment.documentation_links.all())
-        self.assertNotIn(blank_link, links)
-        self.assertIn(filled_link, links)
-
-
 class TestNewTagSearchView(AuthTestCase):
     def test_get_returns_matching_unassigned_tags(self):
         experiment = NimbusExperimentFactory.create()
@@ -1938,8 +1991,7 @@ class TestNewRolloutPhaseDeleteView(AuthTestCase):
                 "rollout_phases-TOTAL_FORMS": "2",
                 "rollout_phases-INITIAL_FORMS": "2",
                 "rollout_phases-0-id": invalid.id,
-                "rollout_phases-0-start_date": "2026-01-15",
-                "rollout_phases-0-end_date": "2026-01-01",
+                "rollout_phases-0-start_date": "not-a-date",
                 "rollout_phases-0-population_percent": "10",
                 "rollout_phases-1-id": target.id,
                 "rollout_phases-1-population_percent": "50",
@@ -2054,6 +2106,7 @@ class TestNewRolloutPlanApplyView(AuthTestCase):
                 "rollout_phases-INITIAL_FORMS": "2",
                 "rollout_phases-0-id": done.id,
                 "rollout_phases-1-id": current.id,
+                "rollout_phases-1-start_date": "not-a-date",
                 "rollout_plan": plan_name,
             },
         )
@@ -2108,6 +2161,32 @@ class TestNewRolloutPlanCreateView(AuthTestCase):
         self.assertContains(response, '<option value="My custom plan" selected>')
         self.assertNotContains(response, f'<option value="{plan_name}" selected>')
 
+    def test_post_blocked_by_phase_error_keeps_name(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-start_date": "not-a-date",
+                "rollout_phases-0-population_percent": "10",
+                "template_name": "My plan",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_FIX_ERRORS)
+        self.assertContains(response, "My plan")
+        self.assertFalse(
+            NimbusRolloutPlanTemplate.objects.filter(name="My plan").exists()
+        )
+
     def test_post_blank_name_creates_nothing(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
@@ -2147,33 +2226,6 @@ class TestNewRolloutPlanCreateView(AuthTestCase):
         self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_DUPLICATE)
         self.assertFalse(
             NimbusRolloutPlanTemplate.objects.filter(name=plan_name).exists()
-        )
-
-    def test_post_blocked_by_phase_error_shows_message_and_keeps_name(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.CREATED,
-            is_rollout=True,
-        )
-        phase = NimbusRolloutPhaseFactory.create(
-            experiment=experiment, population_percent=10
-        )
-        response = self.client.post(
-            reverse(self.url_name, kwargs={"slug": experiment.slug}),
-            {
-                "rollout_phases-TOTAL_FORMS": "1",
-                "rollout_phases-INITIAL_FORMS": "1",
-                "rollout_phases-0-id": phase.id,
-                "rollout_phases-0-start_date": "2026-01-15",
-                "rollout_phases-0-end_date": "2026-01-01",
-                "rollout_phases-0-population_percent": "10",
-                "template_name": "My plan",
-            },
-        )
-        self.assertEqual(response.status_code, 200)
-        self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_FIX_ERRORS)
-        self.assertContains(response, "My plan")
-        self.assertFalse(
-            NimbusRolloutPlanTemplate.objects.filter(name="My plan").exists()
         )
 
 

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -22,7 +22,6 @@ from experimenter.nimbus_ui.new.views import (
     NewCloneView,
     NewDocumentationLinkCreateView,
     NewDocumentationLinkDeleteView,
-    NewOverviewCancelView,
     NewOverviewUpdateView,
     NewQAUpdateView,
     NewRemoveSubscriberView,
@@ -447,11 +446,6 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/update_overview/$",
         NewOverviewUpdateView.as_view(),
         name="nimbus-ui-new-update-overview",
-    ),
-    re_path(
-        r"^new/(?P<slug>[\w-]+)/cancel_overview/$",
-        NewOverviewCancelView.as_view(),
-        name="nimbus-ui-new-cancel-overview",
     ),
     re_path(
         r"^new/(?P<slug>[\w-]+)/update_risks/$",


### PR DESCRIPTION
Because

* We need to show whether fields contain errors
* We need to group errors by card in the sidebar issues modal

This commit

* Shows what fields have errors in the sidebars
* Groups errors by card in the side bar and gives links to cards which expand them when the button is clicked
* Ensures the sidebar and subtitles update on changes and adds icons to cards

Fixes #16734 