### PR TITLE
fix(nimbus): Improve HTMX error handling

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/new/htmx_failure.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/htmx_failure.js
@@ -1,0 +1,13 @@
+let reloadingAfterHtmxFailure = false;
+
+const reloadOnHtmxFailure = () => {
+  if (reloadingAfterHtmxFailure) {
+    return;
+  }
+  reloadingAfterHtmxFailure = true;
+  window.location.reload();
+};
+
+document.addEventListener("htmx:responseError", reloadOnHtmxFailure);
+document.addEventListener("htmx:sendError", reloadOnHtmxFailure);
+document.addEventListener("htmx:timeout", reloadOnHtmxFailure);

--- a/experimenter/experimenter/nimbus_ui/static/webpack.config.js
+++ b/experimenter/experimenter/nimbus_ui/static/webpack.config.js
@@ -12,6 +12,7 @@ module.exports = {
     edit_branches: "./js/edit_branches.js",
     new_edit_branches: "./js/new/edit_branches.js",
     new_tooltips: "./js/new/tooltips.js",
+    new_htmx_failure: "./js/new/htmx_failure.js",
     experiment_detail: "./js/experiment_detail.js",
     branch_detail: "./js/branch_detail.js",
     features_page: "./js/features_page.js",

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -13,6 +13,7 @@
     | Experimenter</title>
     <script src="{% static 'nimbus_ui/app.bundle.js' %}"></script>
     <script src="{% static 'nimbus_ui/new_tooltips.bundle.js' %}"></script>
+    <script src="{% static 'nimbus_ui/new_htmx_failure.bundle.js' %}"></script>
     {% block extra_head %}{% endblock %}
   </head>
   <body class="m-0 p-0 rollout-page bg-body-tertiary"


### PR DESCRIPTION
Because

* We need to ensure that if a request fails so the UI does not remain in an inconsistent state

This commit

* Add an HTMX failure handler that reloads the page if a request fails

Fixes #16736