### PR TITLE
feat(nimbus): add advanced targeting for win10 + hnt stories disabled

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2669,6 +2669,24 @@ EXISTING_USER_ONLY_WIN10 = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WIN10_EXISTING_USER_STORIES_DISABLED = NimbusTargetingConfig(
+    name="Windows 10 existing users with HNT stories disabled.",
+    slug="win10_existing_user_stories_disabled",
+    description=(
+        "Windows 10 users with profiles older than 28 days, with HNT stories "
+        "disabled, with CFRs enabled, and without enterprise policies"
+    ),
+    targeting=(
+        f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && ",
+        f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && ",
+        "userPrefs.cfrFeatures && !hasActiveEnterprisePolicies"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 NEW_USER_FIVE_BOOKMARKS = NimbusTargetingConfig(
     name="New user (5 bookmarks)",
     slug="new_user_5_bookmarks",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2679,7 +2679,8 @@ WIN10_EXISTING_USER_STORIES_DISABLED = NimbusTargetingConfig(
     targeting=(
         f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && "
         f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && "
-        "defaultProfile.userPrefs.cfrFeatures && !hasActiveEnterprisePolicies"
+        "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue "
+        "&& !hasActiveEnterprisePolicies"
     ),
     desktop_telemetry="",
     sticky_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2679,7 +2679,7 @@ WIN10_EXISTING_USER_STORIES_DISABLED = NimbusTargetingConfig(
     targeting=(
         f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && ",
         f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && ",
-        "userPrefs.cfrFeatures && !hasActiveEnterprisePolicies"
+        "defaultProfile.userPrefs.cfrFeatures && !hasActiveEnterprisePolicies"
     ),
     desktop_telemetry="",
     sticky_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2679,8 +2679,8 @@ WIN10_EXISTING_USER_STORIES_DISABLED = NimbusTargetingConfig(
     targeting=(
         f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && "
         f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && "
-        "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue "
-        "&& !hasActiveEnterprisePolicies"
+        "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'"
+        "|preferenceValue && !hasActiveEnterprisePolicies"
     ),
     desktop_telemetry="",
     sticky_required=False,

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -2677,8 +2677,8 @@ WIN10_EXISTING_USER_STORIES_DISABLED = NimbusTargetingConfig(
         "disabled, with CFRs enabled, and without enterprise policies"
     ),
     targeting=(
-        f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && ",
-        f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && ",
+        f"{PROFILE28DAYS} && {WIN10_NOT_WIN11.targeting} && "
+        f"{RECOMMENDED_OR_SPONSORED_STORIES_DISABLED} && "
         "defaultProfile.userPrefs.cfrFeatures && !hasActiveEnterprisePolicies"
     ),
     desktop_telemetry="",


### PR DESCRIPTION
To support the [Win10 EoS HNT Improve Fx Backup discovery (without stories) re-run](https://docs.google.com/document/d/1J4qDh3CYz157OTcGW7LRDo-L1h4td2WRD-YncLu58Gg/edit?tab=t.0) experiment, this commit adds advanced targeting that cover:
- Win10 users
- Profiles older than 28 days
- HNT recommended or sponsored stories disabled
- CFRs enabled
- Non-enterprise users