### PR TITLE
fix(nimbus): fix rollout approval, rejection, and validation workflow

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -26,6 +26,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Cannot perform this action: experiment must be in state {required_state}, "
         "but is currently in state {current_state}."
     )
+    ERROR_INVALID_ROLLOUT_LAUNCH = (
+        "Resolve all rollout setup issues before requesting or approving this change."
+    )
     ERROR_INVALID_DISABLED_TRANSITION = (
         "Cannot perform this action: only rollouts may be disabled."
     )

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1210,6 +1210,7 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
     required_status_next = None
     required_publish_status = None
     required_is_paused = None
+    requires_valid_rollout_launch = False
 
     class Meta:
         model = NimbusExperiment
@@ -1259,6 +1260,18 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 NimbusUIConstants.ERROR_INVALID_DISABLED_TRANSITION
             )
 
+        if self.requires_valid_rollout_launch:
+            from experimenter.experiments.api.v5.serializers import (
+                NimbusRolloutReviewSerializer,
+            )
+
+            if self.instance.get_invalid_fields_errors(
+                serializer_class=NimbusRolloutReviewSerializer
+            ):
+                raise forms.ValidationError(
+                    NimbusUIConstants.ERROR_INVALID_ROLLOUT_LAUNCH
+                )
+
         return cleaned_data
 
     @transaction.atomic
@@ -1292,6 +1305,7 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
 
 class DraftReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
+    requires_valid_rollout_launch = True
     required_status = NimbusExperiment.Status.DRAFT
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1307,6 +1321,7 @@ class DraftReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
 
 
 class DraftReviewApproveRolloutForm(UpdateStatusForm):
+    requires_valid_rollout_launch = True
     required_status = NimbusExperiment.Status.DRAFT
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW
@@ -1371,6 +1386,7 @@ class DraftReviewRejectForm(CancelRequestMixin, UpdateStatusForm):
 
 
 class PreviewReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
+    requires_valid_rollout_launch = True
     required_status = NimbusExperiment.Status.PREVIEW
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1431,6 +1447,7 @@ class PreviewToDraftRolloutForm(UpdateStatusForm):
 
 
 class AdvancePhaseReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
+    requires_valid_rollout_launch = True
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1445,6 +1462,7 @@ class AdvancePhaseReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
 
 
 class AdvancePhaseReviewApproveRolloutForm(UpdateStatusForm):
+    requires_valid_rollout_launch = True
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -137,7 +137,7 @@
                       class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                       hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}"
                       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                      {% if not experiment.is_preview %}disabled{% endif %}>
+                      {% if not experiment.is_preview or setup_issues_count %}disabled{% endif %}>
                 <i class="fa-solid fa-rocket"></i>Request Enrollment
               </button>
             </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -73,16 +73,18 @@
               <div class="d-flex flex-column gap-2">
                 <button type="button"
                         id="rollout-review-reject-btn"
-                        class="btn btn-danger btn-sm w-100"
+                        class="btn btn-secondary btn-sm w-100"
                         data-bs-toggle="collapse"
                         data-bs-target="#rollout-reject-form"
                         aria-expanded="false"
                         aria-controls="rollout-reject-form">Reject</button>
                 <button type="button"
                         id="rollout-review-approve-btn"
-                        class="btn btn-success btn-sm w-100"
+                        class="btn btn-primary btn-sm w-100"
                         hx-post="{% url controls.approve_url experiment.slug %}"
-                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>Approve</button>
+                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                        {% if setup_issues_count %} {% if experiment.is_draft or controls.action_label == "Advance to Next Phase" %}disabled{% endif %}
+                        {% endif %}>Approve</button>
               </div>
               <div class="collapse mt-2" id="rollout-reject-form">
                 <label for="rollout-reject-message" class="form-label small mb-1">
@@ -95,7 +97,7 @@
                           rows="3"></textarea>
                 <button type="button"
                         id="rollout-review-submit-reject-btn"
-                        class="btn btn-danger btn-sm w-100"
+                        class="btn btn-secondary btn-sm w-100"
                         hx-post="{% url controls.reject_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                         hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -62,7 +62,7 @@
                   hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
                   hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                   hx-disabled-elt="this"
-                  {% if transition_pending or not experiment.has_advanceable_rollout_phase %}disabled{% endif %}>
+                  {% if transition_pending or setup_issues_count or not experiment.has_advanceable_rollout_phase %}disabled{% endif %}>
             Start next phase
           </button>
         {% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -1480,9 +1480,14 @@ class TestRolloutStatusForms(
             "experimenter.nimbus_ui.new.forms."
             "nimbus_check_kinto_push_queue_by_collection.apply_async"
         ).start()
+        self.invalid_fields_patcher = patch.object(
+            NimbusExperiment, "get_invalid_fields_errors", return_value={}
+        )
+        self.mock_invalid_fields = self.invalid_fields_patcher.start()
         self.addCleanup(self.mock_preview_task.stop)
         self.addCleanup(self.mock_allocate_bucket_range.stop)
         self.addCleanup(self.mock_kinto_push_queue.stop)
+        self.addCleanup(self.invalid_fields_patcher.stop)
 
     @parameterized.expand(
         [
@@ -1912,6 +1917,60 @@ class TestRolloutStatusForms(
             experiment.id,
             NimbusConstants.AlertType.LAUNCH_REQUEST,
             SlackConstants.EmojiReaction.APPROVE,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                DraftReviewRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.PublishStatus.IDLE,
+                None,
+            ),
+            (
+                DraftReviewApproveRolloutForm,
+                NimbusExperiment.Status.DRAFT,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+            ),
+            (
+                PreviewReviewRolloutForm,
+                NimbusExperiment.Status.PREVIEW,
+                NimbusExperiment.PublishStatus.IDLE,
+                None,
+            ),
+            (
+                AdvancePhaseReviewRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.IDLE,
+                None,
+            ),
+            (
+                AdvancePhaseReviewApproveRolloutForm,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.Status.LIVE,
+            ),
+        ]
+    )
+    def test_review_transition_rejects_setup_errors(
+        self, form_class, status, publish_status, status_next
+    ):
+        self.mock_invalid_fields.return_value = {
+            "risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]
+        }
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            status_next=status_next,
+            publish_status=publish_status,
+            is_rollout=True,
+        )
+        form = form_class(data={}, instance=experiment, request=self.request)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            NimbusUIConstants.ERROR_INVALID_ROLLOUT_LAUNCH,
+            form.errors["__all__"],
         )
 
     def test_approve_phase_advance_stages_population_and_queues_kinto(self):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -77,11 +77,16 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
         self.mock_remove_emoji_task = patch(
             "experimenter.slack.tasks.remove_emoji_from_message_async.delay"
         ).start()
+        self.invalid_fields_patcher = patch.object(
+            NimbusExperiment, "get_invalid_fields_errors", return_value={}
+        )
+        self.mock_invalid_fields = self.invalid_fields_patcher.start()
         self.addCleanup(self.mock_preview_task.stop)
         self.addCleanup(self.mock_allocate_bucket_range.stop)
         self.addCleanup(self.mock_kinto_push_queue.stop)
         self.addCleanup(self.mock_emoji_task.stop)
         self.addCleanup(self.mock_remove_emoji_task.stop)
+        self.addCleanup(self.invalid_fields_patcher.stop)
 
     @parameterized.expand(
         [
@@ -241,6 +246,31 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
         self.assertEqual(experiment.status, expected_status)
         self.assertEqual(experiment.status_next, expected_status_next)
         self.assertEqual(experiment.publish_status, expected_publish_status)
+
+    def test_invalid_rollout_cannot_request_launch(self):
+        self.mock_invalid_fields.return_value = {
+            "risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]
+        }
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+        )
+
+        response = self.client.post(
+            reverse(
+                "nimbus-ui-new-draft-to-review-rollout",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertIn(
+            NimbusUIConstants.ERROR_INVALID_ROLLOUT_LAUNCH,
+            response.context["update_status_form_errors"],
+        )
 
     def test_htmx_progress_card_renders_fragment(self):
         experiment = NimbusExperimentFactory.create(
@@ -691,6 +721,62 @@ class TestNimbusRolloutDetailView(AuthTestCase):
                 kwargs={"slug": experiment.slug},
             ),
         )
+
+    def test_setup_issues_disable_phase_advance_but_not_disable_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=20)
+        experiment.rollout_phase = current_phase
+        experiment.save()
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={"risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]},
+        ):
+            response = self.client.get(
+                reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+            )
+
+        content = response.content.decode()
+        next_phase_button = content.split('id="rollout-next-phase-btn"', 1)[1].split(
+            "</button>", 1
+        )[0]
+        disable_button = content.split('id="rollout-disable-btn"', 1)[1].split(
+            "</button>", 1
+        )[0]
+        self.assertRegex(next_phase_button, r"\sdisabled(?:\s|>)")
+        self.assertNotRegex(disable_button, r"\sdisabled(?:\s|>)")
+
+    @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
+    def test_setup_issues_disable_phase_advance_approval(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+        )
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={"risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]},
+        ):
+            response = self.client.get(
+                reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
+                **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
+            )
+
+        content = response.content.decode()
+        approve_button = content.split('id="rollout-review-approve-btn"', 1)[1].split(
+            "</button>", 1
+        )[0]
+        self.assertRegex(approve_button, r"\sdisabled(?:\s|>)")
 
     @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
     def test_sidebar_shows_remote_settings_link_when_approved(self):


### PR DESCRIPTION
Because

- Rollouts could request or approve enrollment with unresolved setup errors
- Approval and rejection buttons used inconsistent styling

This commit

- Blocks enrollment requests and approvals when setup issues exist
- Disables affected enrollment and approval controls
- Changes Approve to blue and Reject to grey
- Adds regression coverage for rollout validation

Fixes #16738 