### PR TITLE
style(nimbus): Improve rollout phase progress visualization

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1416,11 +1416,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return transitions.get((self.status, self.status_next))
 
     def rollout_phase_status_display(self, status):
-        if status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
-            if self.is_disabled:
-                return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED
-            if self.is_paused:
-                return NimbusUIConstants.ROLLOUT_PHASE_STATUS_PAUSED
+        if (
+            status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
+            and self.is_disabled
+        ):
+            return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED
         return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[status]
 
     def annotated_rollout_phases(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1360,7 +1360,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
     @property
     def current_rollout_phase_display(self):
         for phase in self.annotated_rollout_phases():
-            if phase.card_status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
+            if phase.is_current:
                 return phase
         return None
 
@@ -1415,14 +1415,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         }
         return transitions.get((self.status, self.status_next))
 
-    def rollout_phase_status_display(self, status):
-        if (
-            status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-            and self.is_disabled
-        ):
-            return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED
-        return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[status]
-
     def annotated_rollout_phases(self):
         phases = list(self.rollout_phases.all())
         current_index = None
@@ -1435,11 +1427,18 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             if current_index is None or i > current_index:
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED
             elif i == current_index:
-                phase.card_status = NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
+                phase.card_status = (
+                    NimbusUIConstants.RolloutPhaseStatus.DISABLED
+                    if self.is_disabled
+                    else NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
+                )
             else:
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.COMPLETE
-            phase.card_status_display = self.rollout_phase_status_display(
+            phase.card_status_display = NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[
                 phase.card_status
+            ]
+            phase.is_current = (
+                phase.card_status in NimbusUIConstants.RolloutPhaseStatus.CURRENT
             )
             phase.number = i + 1
         return phases

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1359,9 +1359,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def current_rollout_phase_display(self):
-        for number, phase in enumerate(self.annotated_rollout_phases(), start=1):
+        for phase in self.annotated_rollout_phases():
             if phase.card_status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
-                phase.number = number
                 return phase
         return None
 
@@ -1416,6 +1415,14 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         }
         return transitions.get((self.status, self.status_next))
 
+    def rollout_phase_status_display(self, status):
+        if status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
+            if self.is_disabled:
+                return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED
+            if self.is_paused:
+                return NimbusUIConstants.ROLLOUT_PHASE_STATUS_PAUSED
+        return NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[status]
+
     def annotated_rollout_phases(self):
         phases = list(self.rollout_phases.all())
         current_index = None
@@ -1431,6 +1438,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
             else:
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.COMPLETE
+            phase.card_status_display = self.rollout_phase_status_display(
+                phase.card_status
+            )
+            phase.number = i + 1
         return phases
 
     def advance_rollout_phase(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7195,32 +7195,64 @@ class TestRolloutPhaseProgress(TestCase):
             ],
         )
 
-    def test_rollout_phase_status_display_when_disabled(self):
+    def test_annotated_rollout_phases_marks_current_phase_disabled(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
         )
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (10, 50, 100)
+        ]
+        experiment.rollout_phase = phases[1]
         experiment.status = NimbusExperiment.Status.DISABLED
         experiment.save()
-        self.assertEqual(
-            experiment.rollout_phase_status_display(
-                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-            ),
-            NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED,
-        )
 
-    def test_rollout_phase_status_display_when_not_disabled(self):
+        annotated = experiment.annotated_rollout_phases()
+        self.assertEqual(
+            [p.card_status for p in annotated],
+            ["complete", "disabled", "not_started"],
+        )
+        self.assertEqual(
+            [p.card_status_display["label"] for p in annotated],
+            ["Complete", "Disabled", "Not started"],
+        )
+        self.assertEqual([p.is_current for p in annotated], [False, True, False])
+
+    def test_annotated_rollout_phases_marks_current_phase_in_progress_when_live(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
         )
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (10, 50)
+        ]
+        experiment.rollout_phase = phases[1]
+        experiment.save()
+
+        annotated = experiment.annotated_rollout_phases()
+        self.assertEqual([p.card_status for p in annotated], ["complete", "in_progress"])
+        self.assertEqual([p.is_current for p in annotated], [False, True])
+
+    def test_current_rollout_phase_display_returns_disabled_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(experiment=experiment)
+        experiment.rollout_phase = phase
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.save()
+
+        current = experiment.current_rollout_phase_display
+        self.assertEqual(current, phase)
         self.assertEqual(
-            experiment.rollout_phase_status_display(
-                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-            ),
-            NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[
-                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-            ],
+            current.card_status, NimbusUIConstants.RolloutPhaseStatus.DISABLED
         )
 
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7195,19 +7195,6 @@ class TestRolloutPhaseProgress(TestCase):
             ],
         )
 
-    def test_rollout_phase_status_display_when_paused(self):
-        experiment = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
-            is_rollout=True,
-            is_paused=True,
-        )
-        self.assertEqual(
-            experiment.rollout_phase_status_display(
-                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-            ),
-            NimbusUIConstants.ROLLOUT_PHASE_STATUS_PAUSED,
-        )
-
     def test_rollout_phase_status_display_when_disabled(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
@@ -7222,18 +7209,17 @@ class TestRolloutPhaseProgress(TestCase):
             NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED,
         )
 
-    def test_rollout_phase_status_display_ignores_paused_for_other_statuses(self):
+    def test_rollout_phase_status_display_when_not_disabled(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
-            is_paused=True,
         )
         self.assertEqual(
             experiment.rollout_phase_status_display(
-                NimbusUIConstants.RolloutPhaseStatus.COMPLETE
+                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
             ),
             NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[
-                NimbusUIConstants.RolloutPhaseStatus.COMPLETE
+                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
             ],
         )
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7167,6 +7167,76 @@ class TestRolloutPhaseProgress(TestCase):
         statuses = [p.card_status for p in experiment.annotated_rollout_phases()]
         self.assertEqual(statuses, ["not_started", "not_started"])
 
+    def test_annotated_rollout_phases_annotates_status_display_and_number(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        phases = [
+            NimbusRolloutPhaseFactory.create(
+                experiment=experiment, population_percent=percent
+            )
+            for percent in (10, 50, 100)
+        ]
+        experiment.rollout_phase = phases[1]
+        experiment.save()
+
+        annotated = experiment.annotated_rollout_phases()
+        self.assertEqual([p.number for p in annotated], [1, 2, 3])
+        self.assertEqual(
+            [p.card_status_display for p in annotated],
+            [
+                NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[status]
+                for status in (
+                    NimbusUIConstants.RolloutPhaseStatus.COMPLETE,
+                    NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS,
+                    NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED,
+                )
+            ],
+        )
+
+    def test_rollout_phase_status_display_when_paused(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+            is_paused=True,
+        )
+        self.assertEqual(
+            experiment.rollout_phase_status_display(
+                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
+            ),
+            NimbusUIConstants.ROLLOUT_PHASE_STATUS_PAUSED,
+        )
+
+    def test_rollout_phase_status_display_when_disabled(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.save()
+        self.assertEqual(
+            experiment.rollout_phase_status_display(
+                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
+            ),
+            NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISABLED,
+        )
+
+    def test_rollout_phase_status_display_ignores_paused_for_other_statuses(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+            is_paused=True,
+        )
+        self.assertEqual(
+            experiment.rollout_phase_status_display(
+                NimbusUIConstants.RolloutPhaseStatus.COMPLETE
+            ),
+            NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[
+                NimbusUIConstants.RolloutPhaseStatus.COMPLETE
+            ],
+        )
+
 
 class TestAdvanceRolloutPhase(TestCase):
     def setUp(self):

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -419,8 +419,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             "color": "success",
         },
     }
-    ROLLOUT_PHASE_STATUS_PAUSED = {"label": "Paused", "color": "warning"}
-    ROLLOUT_PHASE_STATUS_DISABLED = {"label": "Disabled", "color": "secondary"}
+    ROLLOUT_PHASE_STATUS_DISABLED = {"label": "Disabled", "color": "dark"}
 
     class MetricAreaType:
         PRIMARY = {

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -403,7 +403,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     class RolloutPhaseStatus:
         NOT_STARTED = "not_started"
         IN_PROGRESS = "in_progress"
+        DISABLED = "disabled"
         COMPLETE = "complete"
+
+        CURRENT = (IN_PROGRESS, DISABLED)
+        LOCKED = (IN_PROGRESS, DISABLED, COMPLETE)
 
     ROLLOUT_PHASE_STATUS_DISPLAY = {
         RolloutPhaseStatus.NOT_STARTED: {
@@ -414,12 +418,15 @@ Optional - We believe this outcome will <describe impact> on <core metric>
             "label": "In progress",
             "color": "primary",
         },
+        RolloutPhaseStatus.DISABLED: {
+            "label": "Disabled",
+            "color": "dark",
+        },
         RolloutPhaseStatus.COMPLETE: {
             "label": "Complete",
             "color": "success",
         },
     }
-    ROLLOUT_PHASE_STATUS_DISABLED = {"label": "Disabled", "color": "dark"}
 
     class MetricAreaType:
         PRIMARY = {

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -405,6 +405,23 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         IN_PROGRESS = "in_progress"
         COMPLETE = "complete"
 
+    ROLLOUT_PHASE_STATUS_DISPLAY = {
+        RolloutPhaseStatus.NOT_STARTED: {
+            "label": "Not started",
+            "color": "secondary",
+        },
+        RolloutPhaseStatus.IN_PROGRESS: {
+            "label": "In progress",
+            "color": "primary",
+        },
+        RolloutPhaseStatus.COMPLETE: {
+            "label": "Complete",
+            "color": "success",
+        },
+    }
+    ROLLOUT_PHASE_STATUS_PAUSED = {"label": "Paused", "color": "warning"}
+    ROLLOUT_PHASE_STATUS_DISABLED = {"label": "Disabled", "color": "secondary"}
+
     class MetricAreaType:
         PRIMARY = {
             "label": "Primary Metric",

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1807,32 +1807,29 @@ class RolloutScheduleForm(NimbusChangeLogFormMixin, forms.ModelForm):
             }
         )
 
-        phase_statuses = {
-            phase.id: phase.card_status
-            for phase in self.instance.annotated_rollout_phases()
+        annotated_phases = {
+            phase.id: phase for phase in self.instance.annotated_rollout_phases()
         }
         self.locked_phase_ids = {
             phase_id
-            for phase_id, status in phase_statuses.items()
-            if status
-            in (
-                NimbusUIConstants.RolloutPhaseStatus.COMPLETE,
-                NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS,
-            )
+            for phase_id, phase in annotated_phases.items()
+            if phase.card_status in NimbusUIConstants.RolloutPhaseStatus.LOCKED
         }
+        not_started = NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED
         for phase_form in self.rollout_phases.forms:
-            status = phase_statuses.get(
-                phase_form.instance.pk,
-                NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED,
-            )
+            phase = annotated_phases.get(phase_form.instance.pk)
+            status = phase.card_status if phase else not_started
             phase_form.card_status = status
-            phase_form.card_status_display = self.instance.rollout_phase_status_display(
-                status
+            phase_form.card_status_display = (
+                phase.card_status_display
+                if phase
+                else NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[not_started]
             )
+            phase_form.is_current = bool(phase and phase.is_current)
             phase_form.is_locked = phase_form.instance.pk in self.locked_phase_ids
             if status == NimbusUIConstants.RolloutPhaseStatus.COMPLETE:
                 disabled_fields = NimbusUIConstants.ROLLOUT_PHASE_FIELDS
-            elif status == NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS:
+            elif status in NimbusUIConstants.RolloutPhaseStatus.CURRENT:
                 disabled_fields = ("population_percent",)
             else:
                 disabled_fields = ()

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1821,7 +1821,14 @@ class RolloutScheduleForm(NimbusChangeLogFormMixin, forms.ModelForm):
             )
         }
         for phase_form in self.rollout_phases.forms:
-            status = phase_statuses.get(phase_form.instance.pk)
+            status = phase_statuses.get(
+                phase_form.instance.pk,
+                NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED,
+            )
+            phase_form.card_status = status
+            phase_form.card_status_display = self.instance.rollout_phase_status_display(
+                status
+            )
             phase_form.is_locked = phase_form.instance.pk in self.locked_phase_ids
             if status == NimbusUIConstants.RolloutPhaseStatus.COMPLETE:
                 disabled_fields = NimbusUIConstants.ROLLOUT_PHASE_FIELDS

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -8,98 +8,125 @@
                style="table-layout: fixed">
           <thead>
             <tr style="font-size: 12px">
-              <th class="border-0 text-secondary fw-normal" style="width: 20%">Rollout Phase</th>
-              <th class="border-0 text-secondary fw-normal" style="width: 30%">Population Ratio</th>
-              <th class="border-0 text-secondary fw-normal" style="width: 50%">Estimated Duration</th>
+              <th class="border-0 text-secondary fw-normal ps-3" style="width: 14%">Rollout Phase</th>
+              <th class="border-0 text-secondary fw-normal" style="width: 16%">Status</th>
+              <th class="border-0 text-secondary fw-normal" style="width: 26%">Population Ratio</th>
+              <th class="border-0 text-secondary fw-normal" style="width: 44%">Estimated Duration</th>
             </tr>
           </thead>
           <tbody id="rollout-schedule-phases">
             {% for phase in phases %}
-              <tr>
-                {# Rollout Phase #}
-                <td class="small fw-bold text-body">
-                  <span class="d-inline-flex align-items-center gap-1">
+              {% with display=phase.card_status_display %}
+                <tr id="rollout-schedule-phase-{{ forloop.counter0 }}"
+                    {% if phase.card_status == "in_progress" %}style="--bs-table-bg: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
+                  {# Rollout Phase #}
+                  <td class="small text-body py-3 ps-3 {% if phase.card_status == "in_progress" %}fw-bold{% else %}fw-semibold{% endif %}">
                     Phase {{ forloop.counter }}
-                    {% if phase.card_status == "in_progress" and experiment.is_paused %}
-                      <span class="badge rounded-pill fw-normal small text-secondary-emphasis bg-secondary-subtle ms-2">Paused</span>
-                    {% endif %}
-                  </span>
-                </td>
-                {# Population Ratio #}
-                <td>
-                  <div id="rollout-schedule-phase-{{ forloop.counter0 }}-population"
-                       class="small text-body mb-1">{{ phase.population_percent|floatformat:"-2" }}%</div>
-                  <div class="progress"
-                       style="height: 6px;
-                              max-width: 10rem"
-                       role="progressbar">
-                    <div class="progress-bar{% if phase.card_status == 'not_started' %} bg-secondary opacity-25{% endif %}"
-                         style="width: {{ phase.population_percent }}%"></div>
-                  </div>
-                </td>
-                {# Estimated Duration #}
-                <td class="small">
-                  {% if phase.card_status == "in_progress" %}
-                    {% if experiment.is_disabled %}
-                      <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                        <span>Disabled</span>
-                        {% if phase.actual_start_date %}
+                  </td>
+                  {# Status #}
+                  <td class="py-3"
+                      id="rollout-schedule-phase-{{ forloop.counter0 }}-status">
+                    {% include "new/rollouts/schedule/phase_status_badge.html" %}
+
+                  </td>
+                  {# Population Ratio #}
+                  <td class="py-3">
+                    <div id="rollout-schedule-phase-{{ forloop.counter0 }}-population"
+                         class="small text-body mb-1">{{ phase.population_percent|floatformat:"-2" }}%</div>
+                    <div class="progress"
+                         style="height: 6px;
+                                max-width: 10rem"
+                         role="progressbar"
+                         aria-label="Phase {{ forloop.counter }} population ratio">
+                      <div class="progress-bar{% if phase.card_status == "not_started" %} bg-secondary opacity-25{% else %} bg-{{ display.color }}{% endif %}"
+                           style="width: {{ phase.population_percent }}%"></div>
+                    </div>
+                  </td>
+                  {# Estimated Duration #}
+                  <td class="small py-3 pe-3">
+                    {% if phase.card_status == "in_progress" %}
+                      {% if experiment.is_disabled %}
+                        <div class="d-flex align-items-center gap-1 text-secondary mb-1">
+                          <span>Disabled</span>
+                          {% if phase.actual_start_date %}
+                            <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                            <span>Started {{ phase.actual_start_date|date:"M j, Y" }}</span>
+                          {% endif %}
+                        </div>
+                        <div class="progress"
+                             style="height: 6px;
+                                    width: 80%"
+                             role="progressbar"
+                             aria-label="Phase {{ forloop.counter }} duration progress">
+                          <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
+                        </div>
+                      {% elif phase.start_date and phase.end_date %}
+                        <div class="d-flex align-items-center gap-1 text-secondary mb-1">
+                          <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
                           <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                          <span>Started {{ phase.actual_start_date|date:"M j, Y" }}</span>
+                          <span>End on {{ phase.end_date|date:"M j, Y" }}</span>
+                        </div>
+                        <div class="progress"
+                             style="height: 6px;
+                                    width: 80%"
+                             role="progressbar"
+                             aria-label="Phase {{ forloop.counter }} duration progress">
+                          <div class="progress-bar bg-{{ display.color }}"
+                               style="width: {% widthratio phase.days_elapsed_capped phase.duration_days 100 %}%">
+                          </div>
+                        </div>
+                      {% else %}
+                        <div class="d-flex align-items-center gap-1 text-secondary mb-1">
+                          <span>In progress</span>
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
+                        </div>
+                        <div class="progress"
+                             style="height: 6px;
+                                    width: 80%"
+                             role="progressbar"
+                             aria-label="Phase {{ forloop.counter }} duration progress">
+                          <div class="progress-bar bg-{{ display.color }}" style="width: 0%"></div>
+                        </div>
+                      {% endif %}
+                    {% elif phase.card_status == "complete" %}
+                      <div class="d-flex align-items-center gap-1 text-secondary mb-1">
+                        <span>Completed</span>
+                        {% if phase.actual_start_date and phase.end_date %}
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.actual_start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
                         {% endif %}
                       </div>
-                      <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
-                        <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
-                      </div>
-                    {% elif phase.start_date and phase.end_date %}
-                      <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                        <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
-                        <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>End on {{ phase.end_date|date:"M j, Y" }}</span>
-                      </div>
-                      <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
-                        <div class="progress-bar"
-                             style="width: {% widthratio phase.days_elapsed phase.duration_days 100 %}%"></div>
+                      <div class="progress"
+                           style="height: 6px;
+                                  width: 80%"
+                           role="progressbar"
+                           aria-label="Phase {{ forloop.counter }} duration progress">
+                        <div class="progress-bar bg-{{ display.color }}" style="width: 100%"></div>
                       </div>
                     {% else %}
                       <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                        <span>In progress</span>
-                        <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
+                        <span>Not started</span>
+                        {% if phase.duration_display %}
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.duration_display }}</span>
+                        {% endif %}
+                        {% if phase.start_date and phase.end_date %}
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
+                        {% endif %}
                       </div>
-                      <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
-                        <div class="progress-bar" style="width: 0%"></div>
+                      <div class="progress"
+                           style="height: 6px;
+                                  width: 80%"
+                           role="progressbar"
+                           aria-label="Phase {{ forloop.counter }} duration progress">
+                        <div class="progress-bar bg-secondary opacity-25" style="width: 0%"></div>
                       </div>
                     {% endif %}
-                  {% elif phase.card_status == "complete" %}
-                    <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                      <span>Completed</span>
-                      {% if phase.actual_start_date and phase.end_date %}
-                        <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>{{ phase.actual_start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
-                      {% endif %}
-                    </div>
-                    <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
-                      <div class="progress-bar" style="width: 100%"></div>
-                    </div>
-                  {% else %}
-                    <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                      <span>Not started</span>
-                      {% if phase.duration_display %}
-                        <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>{{ phase.duration_display }}</span>
-                      {% endif %}
-                      {% if phase.start_date and phase.end_date %}
-                        <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                        <span>{{ phase.start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
-                      {% endif %}
-                    </div>
-                    <div class="progress" style="height: 6px; width: 80%;" role="progressbar">
-                      <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
-                    </div>
-                  {% endif %}
-                </td>
-              </tr>
+                  </td>
+                </tr>
+              {% endwith %}
             {% endfor %}
           </tbody>
         </table>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -18,9 +18,9 @@
             {% for phase in phases %}
               {% with display=phase.card_status_display %}
                 <tr id="rollout-schedule-phase-{{ forloop.counter0 }}"
-                    {% if phase.card_status == "in_progress" %}style="--bs-table-bg: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
+                    {% if phase.is_current %}style="--bs-table-bg: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
                   {# Rollout Phase #}
-                  <td class="small text-body py-3 ps-3 {% if phase.card_status == "in_progress" %}fw-bold{% else %}fw-semibold{% endif %}">
+                  <td class="small text-body py-3 ps-3 {% if phase.is_current %}fw-bold{% else %}fw-semibold{% endif %}">
                     Phase {{ forloop.counter }}
                   </td>
                   {# Status #}
@@ -44,8 +44,8 @@
                   </td>
                   {# Estimated Duration #}
                   <td class="small py-3 pe-3">
-                    {% if phase.card_status == "in_progress" %}
-                      {% if experiment.is_disabled %}
+                    {% if phase.is_current %}
+                      {% if phase.card_status == "disabled" %}
                         <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                           <span>Disabled</span>
                           {% if phase.actual_start_date %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -19,11 +19,11 @@
       {% for phase_form in form.rollout_phases %}
         {% with display=phase_form.card_status_display %}
           <div class="p-3 rounded"
-               {% if phase_form.card_status == "in_progress" %}style="background-color: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
+               {% if phase_form.is_current %}style="background-color: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
             {{ phase_form.id }}
             {# Phase Number and Status #}
             <div class="d-flex align-items-center gap-2 mb-2">
-              <span class="small text-body {% if phase_form.card_status == "in_progress" %}fw-bold{% else %}fw-semibold{% endif %}">Phase {{ forloop.counter }}</span>
+              <span class="small text-body {% if phase_form.is_current %}fw-bold{% else %}fw-semibold{% endif %}">Phase {{ forloop.counter }}</span>
               {% include "new/rollouts/schedule/phase_status_badge.html" %}
 
             </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -17,65 +17,72 @@
     {{ form.rollout_phases.management_form }}
     <div class="d-flex flex-column">
       {% for phase_form in form.rollout_phases %}
-        <div class="pb-3">
-          {{ phase_form.id }}
-          <div class="d-flex gap-4 align-items-end">
-            {# Phase Number #}
-            <span class="small fw-bold text-body flex-shrink-0 pb-2">Phase {{ forloop.counter }}</span>
-            {# Population in % #}
-            <div class="flex-shrink-0 position-relative">
-              <label for="id_rollout_phases-{{ forloop.counter0 }}-population_percent"
-                     class="text-secondary mb-1"
-                     style="font-size: 12px">Population</label>
-              <div class="input-group">
-                {{ phase_form.population_percent|add_error_class:"is-invalid" }}
-                <span class="input-group-text">%</span>
-              </div>
-              {% if phase_form.population_percent.errors %}
-                <div class="text-danger small position-absolute mt-1" style="top: 100%">
-                  {{ phase_form.population_percent.errors|join:", " }}
+        {% with display=phase_form.card_status_display %}
+          <div class="p-3 rounded"
+               {% if phase_form.card_status == "in_progress" %}style="background-color: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
+            {{ phase_form.id }}
+            {# Phase Number and Status #}
+            <div class="d-flex align-items-center gap-2 mb-2">
+              <span class="small text-body {% if phase_form.card_status == "in_progress" %}fw-bold{% else %}fw-semibold{% endif %}">Phase {{ forloop.counter }}</span>
+              {% include "new/rollouts/schedule/phase_status_badge.html" %}
+
+            </div>
+            <div class="d-flex gap-4 align-items-end">
+              {# Population in % #}
+              <div class="flex-shrink-0 position-relative">
+                <label for="id_rollout_phases-{{ forloop.counter0 }}-population_percent"
+                       class="text-secondary mb-1"
+                       style="font-size: 12px">Population</label>
+                <div class="input-group">
+                  {{ phase_form.population_percent|add_error_class:"is-invalid" }}
+                  <span class="input-group-text">%</span>
                 </div>
+                {% if phase_form.population_percent.errors %}
+                  <div class="text-danger small position-absolute mt-1" style="top: 100%">
+                    {{ phase_form.population_percent.errors|join:", " }}
+                  </div>
+                {% endif %}
+              </div>
+              {# Duration #}
+              <div class="flex-grow-1" style="min-width: 0">
+                <label class="text-secondary mb-1" style="font-size: 12px">Duration</label>
+                <div class="d-flex gap-2 align-items-center">
+                  <div class="flex-grow-1 position-relative"
+                       style="min-width: 0;
+                              flex-basis: 0">
+                    {{ phase_form.start_date|add_error_class:"is-invalid" }}
+                    {% if phase_form.start_date.errors %}
+                      <div class="text-danger small position-absolute mt-1" style="top: 100%">
+                        {{ phase_form.start_date.errors|join:", " }}
+                      </div>
+                    {% endif %}
+                  </div>
+                  <div class="flex-grow-1 position-relative"
+                       style="min-width: 0;
+                              flex-basis: 0">
+                    {{ phase_form.end_date|add_error_class:"is-invalid" }}
+                    {% if phase_form.end_date.errors %}
+                      <div class="text-danger small position-absolute mt-1" style="top: 100%">
+                        {{ phase_form.end_date.errors|join:", " }}
+                      </div>
+                    {% endif %}
+                  </div>
+                </div>
+              </div>
+              {% if not phase_form.is_locked %}
+                <button type="button"
+                        class="btn p-0 border-0 text-secondary flex-shrink-0 pb-2 pe-1"
+                        hx-post="{% url 'nimbus-ui-new-delete-rollout-phase' experiment.slug %}"
+                        hx-vals='{"phase_id": "{{ phase_form.instance.pk }}"}'
+                        hx-include="closest form"
+                        hx-target="#rollout-schedule-body"
+                        hx-swap="outerHTML">
+                  <i class="fa-solid fa-trash-can"></i>
+                </button>
               {% endif %}
             </div>
-            {# Duration #}
-            <div class="flex-grow-1" style="min-width: 0">
-              <label class="text-secondary mb-1" style="font-size: 12px">Duration</label>
-              <div class="d-flex gap-2 align-items-center">
-                <div class="flex-grow-1 position-relative"
-                     style="min-width: 0;
-                            flex-basis: 0">
-                  {{ phase_form.start_date|add_error_class:"is-invalid" }}
-                  {% if phase_form.start_date.errors %}
-                    <div class="text-danger small position-absolute mt-1" style="top: 100%">
-                      {{ phase_form.start_date.errors|join:", " }}
-                    </div>
-                  {% endif %}
-                </div>
-                <div class="flex-grow-1 position-relative"
-                     style="min-width: 0;
-                            flex-basis: 0">
-                  {{ phase_form.end_date|add_error_class:"is-invalid" }}
-                  {% if phase_form.end_date.errors %}
-                    <div class="text-danger small position-absolute mt-1" style="top: 100%">
-                      {{ phase_form.end_date.errors|join:", " }}
-                    </div>
-                  {% endif %}
-                </div>
-              </div>
-            </div>
-            {% if not phase_form.is_locked %}
-              <button type="button"
-                      class="btn p-0 border-0 text-secondary flex-shrink-0 pb-2 pe-1"
-                      hx-post="{% url 'nimbus-ui-new-delete-rollout-phase' experiment.slug %}"
-                      hx-vals='{"phase_id": "{{ phase_form.instance.pk }}"}'
-                      hx-include="closest form"
-                      hx-target="#rollout-schedule-body"
-                      hx-swap="outerHTML">
-                <i class="fa-solid fa-trash-can"></i>
-              </button>
-            {% endif %}
           </div>
-        </div>
+        {% endwith %}
       {% endfor %}
       <div>
         <button type="button"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/phase_status_badge.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/phase_status_badge.html
@@ -1,0 +1,1 @@
+<span class="badge rounded-pill small text-bg-{{ display.color }}">{{ display.label }}</span>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1727,6 +1727,37 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         self.assertEqual(phase.end_date, datetime.date(2026, 2, 20))
         self.assertEqual(phase.population_percent, 50)
 
+    def test_post_keeps_population_locked_for_disabled_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=50,
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 1, 15),
+        )
+        experiment.rollout_phase = phase
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.save()
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-start_date": "2026-02-01",
+                "rollout_phases-0-end_date": "2026-02-20",
+                "rollout_phases-0-population_percent": "90",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        phase.refresh_from_db()
+        self.assertEqual(phase.population_percent, 50)
+
 
 class TestNewRolloutPhaseCreateView(AuthTestCase):
     url_name = "nimbus-ui-new-create-rollout-phase"


### PR DESCRIPTION
Because

* It is hard to clearly identify which phases are complete, enabled or disabled

This commit

* Clearly highlights the currently active phase and adds status pills to each row

Fixes #16705
