### PR TITLE
fix(nimbus): Improve rollout status card and rollout controls

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1382,11 +1382,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return phases[next_index] if next_index < len(phases) else None
 
     @property
-    def has_advanceable_rollout_phase(self):
-        next_phase = self.next_rollout_phase
-        return bool(next_phase and next_phase.population_percent)
-
-    @property
     def has_rollout_review_errors(self):
         from experimenter.experiments.api.v5.serializers import (
             NimbusRolloutReviewSerializer,
@@ -1463,7 +1458,9 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         current_phase = self.rollout_phase
         next_phase = self.next_rollout_phase
 
-        if not next_phase or not next_phase.population_percent:
+        if next_phase is None or (
+            current_phase is None and not next_phase.population_percent
+        ):
             return
 
         resuming = self.status == NimbusExperiment.Status.DISABLED
@@ -1486,7 +1483,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
         next_phase = self.next_rollout_phase
 
-        if next_phase is None or not next_phase.population_percent:
+        if next_phase is None:
+            return None
+
+        if self.rollout_phase_id is None and not next_phase.population_percent:
             return None
 
         self.rollout_phase_next = next_phase
@@ -1701,6 +1701,28 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         for item in timeline:
             if item["is_active"]:
                 return item["step"]
+
+    @property
+    def active_rollout_stage(self):
+        if self.is_rolling_out:
+            return "rollout"
+        if self.is_preview:
+            return "preview"
+        if self.is_review_timeline:
+            review_request = (
+                self.changes.filter(
+                    new_status=self.Status.DRAFT,
+                    new_publish_status=self.PublishStatus.REVIEW,
+                )
+                .order_by("changed_on")
+                .last()
+            )
+            if review_request and review_request.old_status == self.Status.PREVIEW:
+                return "preview"
+            return "setup"
+        if self.is_draft:
+            return "setup"
+        return None
 
     @property
     def should_end(self):

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1175,7 +1175,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def is_preview_complete(self):
-        return self.preview_date is not None and self.status not in (
+        return self.status not in (
             self.Status.DRAFT,
             self.Status.PREVIEW,
         )

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7344,7 +7344,8 @@ class TestAdvanceRolloutPhase(TestCase):
             self.experiment.population_percent, self.phases[1].population_percent
         )
 
-    def test_advance_does_not_start_phase_with_zero_population(self):
+    def test_advance_starts_subsequent_phase_with_zero_population(self):
+        today = timezone.now().date()
         self.phases[1].population_percent = 0
         self.phases[1].save()
         self.experiment.rollout_phase = self.phases[0]
@@ -7356,9 +7357,12 @@ class TestAdvanceRolloutPhase(TestCase):
         self.phases[0].refresh_from_db()
         self.phases[1].refresh_from_db()
 
-        self.assertEqual(self.experiment.rollout_phase, self.phases[0])
-        self.assertIsNone(self.phases[0].end_date)
-        self.assertIsNone(self.phases[1].actual_start_date)
+        self.assertEqual(self.experiment.rollout_phase, self.phases[1])
+        self.assertEqual(self.phases[0].end_date, today)
+        self.assertEqual(self.phases[1].actual_start_date, today)
+        self.assertEqual(
+            self.experiment.population_percent, self.phases[1].population_percent
+        )
 
     def test_advance_does_not_start_first_phase_with_zero_population(self):
         self.phases[0].population_percent = 0
@@ -7455,13 +7459,27 @@ class TestAdvanceRolloutPhase(TestCase):
         self.assertIsNone(self.experiment.rollout_phase_next)
         self.assertEqual(self.experiment.rollout_phases.count(), 3)
 
-    def test_stage_advance_does_not_stage_zero_population_phase(self):
+    def test_stage_advance_stages_subsequent_zero_population_phase(self):
         self.phases[1].population_percent = 0
         self.phases[1].save()
         self.experiment.rollout_phase = self.phases[0]
         self.experiment.save()
 
         next_phase = self.experiment.stage_rollout_phase_advance()
+        self.experiment.refresh_from_db()
+
+        self.assertEqual(next_phase, self.phases[1])
+        self.assertEqual(self.experiment.rollout_phase_next, self.phases[1])
+        self.assertEqual(
+            self.experiment.population_percent, self.phases[1].population_percent
+        )
+
+    def test_stage_advance_does_not_stage_first_phase_with_zero_population(self):
+        self.phases[0].population_percent = 0
+        self.phases[0].save()
+
+        next_phase = self.experiment.stage_rollout_phase_advance()
+        self.experiment.refresh_from_db()
 
         self.assertIsNone(next_phase)
         self.assertIsNone(self.experiment.rollout_phase_next)
@@ -7710,10 +7728,10 @@ class TestRolloutSidebarStateHelpers(TestCase):
         NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=10)
         self.assertIsNone(experiment.current_rollout_phase_display)
 
-    def test_has_advanceable_rollout_phase_false_when_no_phases(self):
-        self.assertFalse(self.live_rollout().has_advanceable_rollout_phase)
+    def test_next_rollout_phase_none_when_no_phases(self):
+        self.assertIsNone(self.live_rollout().next_rollout_phase)
 
-    def test_has_advanceable_rollout_phase_true_when_next_has_population(self):
+    def test_next_rollout_phase_returns_following_phase(self):
         experiment = self.live_rollout()
         phases = [
             NimbusRolloutPhaseFactory.create(
@@ -7723,9 +7741,9 @@ class TestRolloutSidebarStateHelpers(TestCase):
         ]
         experiment.rollout_phase = phases[0]
         experiment.save()
-        self.assertTrue(experiment.has_advanceable_rollout_phase)
+        self.assertEqual(experiment.next_rollout_phase, phases[1])
 
-    def test_has_advanceable_rollout_phase_false_on_last_phase(self):
+    def test_next_rollout_phase_none_on_last_phase(self):
         experiment = self.live_rollout()
         phases = [
             NimbusRolloutPhaseFactory.create(
@@ -7735,9 +7753,9 @@ class TestRolloutSidebarStateHelpers(TestCase):
         ]
         experiment.rollout_phase = phases[1]
         experiment.save()
-        self.assertFalse(experiment.has_advanceable_rollout_phase)
+        self.assertIsNone(experiment.next_rollout_phase)
 
-    def test_has_advanceable_rollout_phase_false_when_next_has_zero_population(self):
+    def test_next_rollout_phase_returns_following_phase_with_zero_population(self):
         experiment = self.live_rollout()
         phases = [
             NimbusRolloutPhaseFactory.create(
@@ -7747,8 +7765,62 @@ class TestRolloutSidebarStateHelpers(TestCase):
         ]
         experiment.rollout_phase = phases[0]
         experiment.save()
-        self.assertFalse(experiment.has_advanceable_rollout_phase)
+        self.assertEqual(experiment.next_rollout_phase, phases[1])
 
     def test_has_rollout_review_errors_false_when_not_rollout(self):
         experiment = NimbusExperimentFactory.create(is_rollout=False)
         self.assertFalse(experiment.has_rollout_review_errors)
+
+    def test_active_rollout_stage_setup_when_draft(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+        )
+        self.assertEqual(experiment.active_rollout_stage, "setup")
+
+    def test_active_rollout_stage_preview_when_previewing(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
+        )
+        self.assertEqual(experiment.active_rollout_stage, "preview")
+
+    def test_active_rollout_stage_setup_when_review_requested_from_draft(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LAUNCH_REVIEW_REQUESTED,
+            is_rollout=True,
+        )
+        self.assertTrue(experiment.is_review_timeline)
+        self.assertEqual(experiment.active_rollout_stage, "setup")
+
+    def test_active_rollout_stage_preview_when_review_requested_from_preview(self):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            old_status=NimbusExperiment.Status.PREVIEW,
+            new_status=NimbusExperiment.Status.DRAFT,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            changed_on=datetime.datetime(2099, 1, 1),
+        )
+        self.assertTrue(experiment.is_review_timeline)
+        self.assertEqual(experiment.active_rollout_stage, "preview")
+
+    def test_active_rollout_stage_rollout_when_live(self):
+        self.assertEqual(self.live_rollout().active_rollout_stage, "rollout")
+
+    def test_active_rollout_stage_rollout_when_disabled(self):
+        self.assertEqual(self.disabled_rollout().active_rollout_stage, "rollout")
+
+    def test_active_rollout_stage_none_when_complete(self):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.COMPLETE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+        self.assertIsNone(experiment.active_rollout_stage)

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7580,7 +7580,7 @@ class TestIsPreviewComplete(TestCase):
             (NimbusExperiment.Status.LIVE, True, True),
             (NimbusExperiment.Status.COMPLETE, True, True),
             (NimbusExperiment.Status.DISABLED, True, True),
-            (NimbusExperiment.Status.LIVE, False, False),
+            (NimbusExperiment.Status.LIVE, False, True),
         ]
     )
     def test_is_preview_complete(self, status, has_preview_change, expected):

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -262,6 +262,9 @@ class RolloutSetupProgressMixin:
         }
         context["setup_issues"] = issues
         context["setup_issues_count"] = sum(len(group["fields"]) for group in issues)
+        context["setup_issue_card_ids"] = [
+            issue["card_id"] for issue in issues if issue["card_id"]
+        ]
         context["setup_completion_percent"] = round(
             100 * (len(tracked) - len(broken)) / len(tracked)
         )

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -139,12 +139,16 @@
             </div>
             {% for toast_id, toast_message in NimbusUIConstants.TOASTS.items %}
               <div id="{{ toast_id }}"
-                   class="toast hide text-bg-primary mb-1"
+                   class="toast hide {% if toast_id == NimbusUIConstants.TOAST_EDIT_CANCELLED %}text-bg-secondary{% else %}text-bg-primary{% endif %} mb-1"
                    role="alert"
                    aria-live="assertive"
                    aria-atomic="true">
                 <div class="toast-body">
-                  <i class="fa-regular fa-circle-check"></i>
+                  {% if toast_id == NimbusUIConstants.TOAST_EDIT_CANCELLED %}
+                    <i class="fa-regular fa-circle-xmark"></i>
+                  {% else %}
+                    <i class="fa-regular fa-circle-check"></i>
+                  {% endif %}
                   {{ toast_message }}
                 </div>
               </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/card_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/card_actions.html
@@ -1,12 +1,26 @@
 {% with 'nimbus-ui-new-update-'|add:card_id as url_name %}
-  <button class="btn p-0 border-0 text-secondary"
-          type="button"
-          data-card-action="edit"
-          aria-label="Edit {{ card_id }}"
-          hx-get="{% url url_name experiment.slug %}"
-          hx-target="#rollout-{{ card_id }}-body"
-          hx-swap="outerHTML">
-    <i class="fa-regular fa-pen-to-square"></i>
-  </button>
+  {% if lock_edit %}
+    <span class="d-inline-flex align-items-center"
+          data-bs-toggle="tooltip"
+          title="{{ lock_tooltip }}">
+      <button class="btn p-0 border-0 text-secondary opacity-50"
+              type="button"
+              disabled
+              aria-disabled="true"
+              aria-label="Edit {{ card_id }}">
+        <i class="fa-regular fa-pen-to-square"></i>
+      </button>
+    </span>
+  {% else %}
+    <button class="btn p-0 border-0 text-secondary"
+            type="button"
+            data-card-action="edit"
+            aria-label="Edit {{ card_id }}"
+            hx-get="{% url url_name experiment.slug %}"
+            hx-target="#rollout-{{ card_id }}-body"
+            hx-swap="outerHTML">
+      <i class="fa-regular fa-pen-to-square"></i>
+    </button>
+  {% endif %}
 {% endwith %}
 {% include "new/common/card_cancel_button.html" with icon_only=True %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -2,231 +2,202 @@
 
 {% include "new/common/sidebar_review_controls.html" %}
 
-{# Set up card #}
-<div class="accordion accordion-flush rounded-3 bg-body-secondary"
-     style="--bs-accordion-btn-active-color: var(--bs-body-color);
-            --bs-accordion-btn-active-bg: transparent;
-            --bs-accordion-active-color: var(--bs-body-color)"
-     id="accordion-setup">
-  <div class="accordion-item border-0 bg-transparent rounded-3">
-    <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_draft %} collapsed{% endif %}"
-              type="button"
-              data-bs-toggle="collapse"
-              data-bs-target="#sidebar-setup"
-              aria-expanded="{% if experiment.is_draft %}true{% else %}false{% endif %}"
-              aria-controls="sidebar-setup">
-        {% if experiment.is_setup_complete %}
-          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
-            <i class="fa-solid fa-check" style="font-size: 10px"></i>
-          </span>
-        {% else %}
-          <i class="fa-regular fa-pen-to-square text-secondary me-2 align-self-start mt-1"></i>
-        {% endif %}
-        <span class="d-flex flex-column">
-          <span>Set up</span>
-          {% if experiment.draft_date %}
-            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
-              {{ experiment.draft_date|date:"M j, Y" }}
-              <span class="text-body-tertiary">|</span>
-              {% with days=experiment.draft_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+{% with stage=experiment.active_rollout_stage %}
+  {# Set up card #}
+  <div class="accordion accordion-flush rounded-3 {% if stage == 'setup' %}bg-primary-subtle{% else %}bg-body-secondary{% endif %}"
+       style="--bs-accordion-btn-active-color: var(--bs-body-color);
+              --bs-accordion-btn-active-bg: transparent;
+              --bs-accordion-active-color: var(--bs-body-color)"
+       id="accordion-setup">
+    <div class="accordion-item border-0 bg-transparent rounded-3">
+      <h2 class="accordion-header">
+        <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_draft %} collapsed{% endif %}"
+                type="button"
+                data-bs-toggle="collapse"
+                data-bs-target="#sidebar-setup"
+                aria-expanded="{% if experiment.is_draft %}true{% else %}false{% endif %}"
+                aria-controls="sidebar-setup">
+          {% if experiment.is_setup_complete %}
+            <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
+              <i class="fa-solid fa-check" style="font-size: 10px"></i>
             </span>
+          {% else %}
+            <i class="fa-regular fa-pen-to-square text-secondary me-2 align-self-start mt-1"></i>
           {% endif %}
-        </span>
-      </button>
-    </h2>
-    <div class="accordion-collapse collapse{% if experiment.is_draft %} show{% endif %}"
-         id="sidebar-setup"
-         data-bs-parent="#accordion-setup">
-      <div class="accordion-body pt-0 px-3 pb-3">
-        {% include "new/common/setup_progress.html" %}
+          <span class="d-flex flex-column">
+            <span>Set up</span>
+            {% if experiment.draft_date %}
+              <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
+                {{ experiment.draft_date|date:"M j, Y" }}
+                <span class="text-body-tertiary">|</span>
+                {% with days=experiment.draft_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+              </span>
+            {% endif %}
+          </span>
+        </button>
+      </h2>
+      <div class="accordion-collapse collapse{% if experiment.is_draft %} show{% endif %}"
+           id="sidebar-setup"
+           data-bs-parent="#accordion-setup">
+        <div class="accordion-body pt-0 px-3 pb-3">
+          {% include "new/common/setup_progress.html" %}
 
-        <div class="d-flex flex-column gap-1">
-          {% for item in sidebar_setup_items %}
-            <a href="#rollout-card-{{ item.id }}"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
-              <span class="text-body" style="min-width: 16px; font-size: 12px;">{{ forloop.counter }}</span>
-              {{ item.label }}
-            </a>
-          {% empty %}
-            <a href="#rollout-card-overview"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">1</span>Overview</a>
-            <a href="#rollout-card-risks"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">2</span>Risks</a>
-            <a href="#rollout-card-signoff"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">3</span>Sign-Offs</a>
-            <a href="#rollout-card-configuration"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">4</span>Configuration &amp; Localization</a>
-            <a href="#rollout-card-audience"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">5</span>Audience</a>
-            <a href="#rollout-card-features"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">6</span>Rollout experience</a>
-            <a href="#rollout-card-schedule"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">7</span>Rollout schedule</a>
-            <a href="#rollout-card-qa"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body"><span class="text-body" style="min-width:16px;font-size:12px;">8</span>QA</a>
-          {% endfor %}
-          {% include "new/common/sidebar_preview_button.html" %}
+          <div class="d-flex flex-column gap-1">
+            {% include "new/common/sidebar_setup_nav.html" %}
+            {% include "new/common/sidebar_preview_button.html" %}
 
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="accordion accordion-flush rounded-3 bg-body-secondary"
-     style="--bs-accordion-btn-active-color: var(--bs-body-color);
-            --bs-accordion-btn-active-bg: transparent;
-            --bs-accordion-active-color: var(--bs-body-color)"
-     id="accordion-preview">
-  <div class="accordion-item border-0 bg-transparent rounded-3">
-    <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_preview %} collapsed{% endif %}"
-              type="button"
-              {% if experiment.preview_date and not experiment.is_draft %}data-bs-toggle="collapse" data-bs-target="#sidebar-preview" aria-controls="sidebar-preview" aria-expanded="{% if experiment.is_preview %}true{% else %}false{% endif %}
-              "
-              {% else %}
-              aria-expanded="false"
-              aria-disabled="true"
-              {% endif %}>
-        {% if experiment.is_preview_complete %}
-          <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
-            <i class="fa-solid fa-check" style="font-size: 10px"></i>
-          </span>
-        {% else %}
-          <i class="fa-regular fa-eye text-secondary me-2 align-self-start mt-1"></i>
-        {% endif %}
-        <span class="d-flex flex-column">
-          <span>Preview</span>
-          {% if experiment.preview_date and not experiment.is_draft %}
-            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
-              {{ experiment.preview_date|date:"M j, Y" }}
-              <span class="text-body-tertiary">|</span>
-              {% with days=experiment.preview_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+  <div class="accordion accordion-flush rounded-3 {% if stage == 'preview' %}bg-primary-subtle{% else %}bg-body-secondary{% endif %}"
+       style="--bs-accordion-btn-active-color: var(--bs-body-color);
+              --bs-accordion-btn-active-bg: transparent;
+              --bs-accordion-active-color: var(--bs-body-color)"
+       id="accordion-preview">
+    <div class="accordion-item border-0 bg-transparent rounded-3">
+      <h2 class="accordion-header">
+        <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_preview %} collapsed{% endif %}"
+                type="button"
+                {% if experiment.preview_date and not experiment.is_draft %}data-bs-toggle="collapse" data-bs-target="#sidebar-preview" aria-controls="sidebar-preview" aria-expanded="{% if experiment.is_preview %}true{% else %}false{% endif %}
+                "
+                {% else %}
+                aria-expanded="false"
+                aria-disabled="true"
+                {% endif %}>
+          {% if experiment.is_preview_complete %}
+            <span class="d-inline-flex align-items-center justify-content-center rounded-circle bg-primary-subtle text-primary me-2 align-self-start mt-1 p-1">
+              <i class="fa-solid fa-check" style="font-size: 10px"></i>
             </span>
+          {% else %}
+            <i class="fa-regular fa-eye text-secondary me-2 align-self-start mt-1"></i>
           {% endif %}
-        </span>
-      </button>
-    </h2>
-    <div class="accordion-collapse collapse{% if experiment.is_preview %} show{% endif %}"
-         id="sidebar-preview"
-         data-bs-parent="#accordion-preview">
-      <div class="accordion-body pt-0 px-3 pb-3">
-        {% if experiment.preview_date and not experiment.is_draft %}
-          <div class="d-flex flex-column gap-3">
-            <p class="mb-0 text-secondary" style="font-size: 12px;">
-              {{ NimbusUIConstants.ROLLOUT_PREVIEW_MESSAGE }}
-              <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
-                 target="_blank"
-                 rel="noopener noreferrer"
-                 class="text-decoration-none">Learn more</a>
-            </p>
-            <a href="#rollout-card-preview"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
-              <i class="fa-regular fa-eye text-secondary"></i>
-              Preview and testing details
-            </a>
-            <div class="d-flex flex-column gap-2">
-              {# Preview to Draft #}
-              <button type="button"
-                      id="rollout-back-to-setup-btn"
-                      class="btn btn-secondary btn-sm w-100"
-                      hx-post="{% url 'nimbus-ui-new-preview-to-draft-rollout' experiment.slug %}"
-                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                      {% if not experiment.is_preview %}disabled{% endif %}>Back to Set Up</button>
-              {# Preview to Review #}
-              <button type="button"
-                      id="rollout-request-enrollment-btn"
-                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
-                      hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}"
-                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                      {% if not experiment.is_preview or setup_issues_count %}disabled{% endif %}>
-                <i class="fa-solid fa-rocket"></i>Request Enrollment
-              </button>
+          <span class="d-flex flex-column">
+            <span>Preview</span>
+            {% if experiment.preview_date and not experiment.is_draft %}
+              <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
+                {{ experiment.preview_date|date:"M j, Y" }}
+                <span class="text-body-tertiary">|</span>
+                {% with days=experiment.preview_date|days_since %}{{ days }} day{{ days|pluralize }}{% endwith %}
+              </span>
+            {% endif %}
+          </span>
+        </button>
+      </h2>
+      <div class="accordion-collapse collapse{% if experiment.is_preview %} show{% endif %}"
+           id="sidebar-preview"
+           data-bs-parent="#accordion-preview">
+        <div class="accordion-body pt-0 px-3 pb-3">
+          {% if experiment.preview_date and not experiment.is_draft %}
+            <div class="d-flex flex-column gap-3">
+              <p class="mb-0 text-secondary" style="font-size: 12px;">
+                {{ NimbusUIConstants.ROLLOUT_PREVIEW_MESSAGE }}
+                <a href="{{ EXTERNAL_URLS.PREVIEW_LAUNCH_DOC }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   class="text-decoration-none">Learn more</a>
+              </p>
+              <div class="d-flex flex-column gap-2">
+                {# Preview to Draft #}
+                <button type="button"
+                        id="rollout-back-to-setup-btn"
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if not experiment.is_preview %} opacity-50{% endif %}"
+                        {% if not experiment.is_preview %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-to-draft-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                  <i class="fa-solid fa-arrow-left-long"></i>
+                  Back to Set Up
+                </button>
+                {# Preview to Review #}
+                <button type="button"
+                        id="rollout-request-enrollment-btn"
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if not experiment.is_preview or setup_issues_count %} opacity-50{% endif %}"
+                        {% if not experiment.is_preview or setup_issues_count %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                  <i class="fa-regular fa-paper-plane"></i>
+                  Request Enrollment
+                </button>
+              </div>
             </div>
-          </div>
-        {% endif %}
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
-</div>
-<div class="accordion accordion-flush rounded-3 bg-body-secondary"
-     style="--bs-accordion-btn-active-color: var(--bs-body-color);
-            --bs-accordion-btn-active-bg: transparent;
-            --bs-accordion-active-color: var(--bs-body-color)"
-     id="accordion-rollout">
-  <div class="accordion-item border-0 bg-transparent rounded-3">
-    <h2 class="accordion-header">
-      <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_rolling_out %} collapsed{% endif %}"
-              type="button"
-              {% if experiment.is_rolling_out %}data-bs-toggle="collapse" data-bs-target="#sidebar-rollout" aria-expanded="true" aria-controls="sidebar-rollout"{% else %}aria-expanded="false" aria-disabled="true"{% endif %}>
-        <i class="fa-solid fa-rocket text-secondary me-2 align-self-start mt-1"></i>
-        <span class="d-flex flex-column">
-          <span>Rollout</span>
-          {% if experiment.start_date %}
-            <span class="text-secondary fw-normal mt-1" style="font-size: 11px">
-              {{ experiment.start_date|date:"M j, Y" }}
-              <span class="text-body-tertiary">|</span>
-              {% if experiment.is_disabled %}
-                Disabled
+  <div class="accordion accordion-flush rounded-3 {% if stage == 'rollout' %}bg-primary-subtle{% else %}bg-body-secondary{% endif %}"
+       style="--bs-accordion-btn-active-color: var(--bs-body-color);
+              --bs-accordion-btn-active-bg: transparent;
+              --bs-accordion-active-color: var(--bs-body-color)"
+       id="accordion-rollout">
+    <div class="accordion-item border-0 bg-transparent rounded-3">
+      <h2 class="accordion-header">
+        <button class="accordion-button bg-transparent shadow-none fw-semibold text-body small{% if not experiment.is_rolling_out %} collapsed{% endif %}"
+                type="button"
+                {% if experiment.is_rolling_out %}data-bs-toggle="collapse" data-bs-target="#sidebar-rollout" aria-expanded="true" aria-controls="sidebar-rollout"{% else %}aria-expanded="false" aria-disabled="true"{% endif %}>
+          {% if experiment.is_live_rollout %}
+            <i class="fa-regular fa-circle-play text-primary me-2 align-self-start mt-1"></i>
+          {% else %}
+            <i class="fa-regular fa-circle-stop text-secondary me-2 align-self-start mt-1"></i>
+          {% endif %}
+          <span class="d-flex flex-column">
+            <span>
+              {% if experiment.is_live_rollout %}
+                Enabled
               {% else %}
-                In Progress
+                Disabled
               {% endif %}
             </span>
-          {% endif %}
-        </span>
-      </button>
-    </h2>
-    <div class="accordion-collapse collapse{% if experiment.is_rolling_out %} show{% endif %}"
-         id="sidebar-rollout"
-         data-bs-parent="#accordion-rollout">
-      <div class="accordion-body pt-0 px-3 pb-3">
-        {% if experiment.is_rolling_out %}
-          <div class="d-flex flex-column gap-3">
-            {% with phase=experiment.current_rollout_phase_display %}
-              {% if phase %}
-                <div>
-                  <div class="small fw-semibold text-body mb-0">Phase {{ phase.number }}</div>
-                  <div class="text-secondary d-flex flex-wrap align-items-center gap-1"
-                       style="font-size: 12px">
-                    {% if phase.duration_days %}
-                      <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
-                    {% else %}
-                      <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
-                    {% endif %}
-                    <span class="text-body-tertiary">|</span>
-                    <span>{{ phase.population_percent|floatformat:"-2" }}% population</span>
-                  </div>
-                  <div class="progress mt-1 bg-body"
-                       style="height: 6px"
-                       role="progressbar"
-                       aria-label="Phase {{ phase.number }} progress">
-                    <div class="progress-bar {% if experiment.is_disabled %}bg-secondary{% else %}bg-primary{% endif %}"
-                         style="width: {% if phase.duration_days %}{% widthratio phase.days_elapsed_capped phase.duration_days 100 %}{% else %}0{% endif %}%">
+            {% if experiment.start_date %}
+              <span class="text-secondary fw-normal mt-1" style="font-size: 11px">{{ experiment.start_date|date:"M j, Y" }}</span>
+            {% endif %}
+          </span>
+        </button>
+      </h2>
+      <div class="accordion-collapse collapse{% if experiment.is_rolling_out %} show{% endif %}"
+           id="sidebar-rollout"
+           data-bs-parent="#accordion-rollout">
+        <div class="accordion-body pt-0 px-3 pb-3">
+          {% if experiment.is_rolling_out %}
+            <div class="d-flex flex-column gap-3">
+              {% with phase=experiment.current_rollout_phase_display %}
+                {% if phase %}
+                  <div>
+                    <div class="small fw-semibold text-body mb-0">Phase {{ phase.number }}</div>
+                    <div class="text-secondary d-flex flex-wrap align-items-center gap-1"
+                         style="font-size: 12px">
+                      {% if phase.duration_days %}
+                        <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
+                      {% else %}
+                        <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
+                      {% endif %}
+                      <span class="text-body-tertiary">|</span>
+                      <span>{{ phase.population_percent|floatformat:"-2" }}% population</span>
+                    </div>
+                    <div class="progress mt-1 bg-body"
+                         style="height: 6px"
+                         role="progressbar"
+                         aria-label="Phase {{ phase.number }} progress">
+                      <div class="progress-bar {% if experiment.is_disabled %}bg-secondary{% else %}bg-primary{% endif %}"
+                           style="width: {% if phase.duration_days %}{% widthratio phase.days_elapsed_capped phase.duration_days 100 %}{% else %}0{% endif %}%">
+                      </div>
                     </div>
                   </div>
-                </div>
-              {% endif %}
-            {% endwith %}
-            <p class="text-secondary mb-0" style="font-size: 12px;">
-              {% if experiment.is_disabled %}
-                {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
-              {% else %}
-                {{ NimbusUIConstants.ROLLOUT_LIVE_MESSAGE }}
-              {% endif %}
-            </p>
-            <a href="#rollout-card-schedule"
-               class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
-              <i class="fa-regular fa-clock text-secondary"></i>
-              Rollout Schedule
-            </a>
-            {% include "new/common/sidebar_rollout_actions.html" %}
+                {% endif %}
+              {% endwith %}
+              <p class="text-secondary mb-0" style="font-size: 12px;">
+                {% if experiment.is_disabled %}
+                  {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
+                {% else %}
+                  {{ NimbusUIConstants.ROLLOUT_LIVE_MESSAGE }}
+                {% endif %}
+              </p>
+              {% include "new/common/sidebar_rollout_actions.html" %}
 
-          </div>
-        {% endif %}
+            </div>
+          {% endif %}
+        </div>
       </div>
     </div>
   </div>
-</div>
+{% endwith %}
 {# Links, History & Help #}
 <div class="d-flex flex-column gap-1">
   {% include "new/common/sidebar_links.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_links.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_links.html
@@ -39,7 +39,7 @@
            target="_blank"
            rel="noopener noreferrer">
           <span class="d-flex align-items-center gap-2">
-            <i class="fa-solid fa-chart-simple text-secondary"
+            <i class="fa-regular fa-chart-bar text-secondary"
                style="min-width: 16px"></i>
             Live Monitoring Dashboard
           </span>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -3,7 +3,7 @@
     <div class="d-flex flex-column gap-2 mt-2">
       <button type="button"
               id="rollout-preview-btn"
-              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+              class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
               hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
         <i class="fa-regular fa-eye"></i>
@@ -14,7 +14,7 @@
               class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
               hx-post="{% url 'nimbus-ui-new-draft-to-review-rollout' experiment.slug %}"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
-        <i class="fa-solid fa-rocket"></i>
+        <i class="fa-regular fa-paper-plane"></i>
         Request Enrollment
       </button>
     </div>
@@ -23,7 +23,7 @@
           {% if experiment.is_draft and setup_issues_count %} data-bs-toggle="tooltip" data-bs-title="{{ NimbusUIConstants.ROLLOUT_PREVIEW_BLOCKED_TOOLTIP }}"{% endif %}>
       <div class="d-flex flex-column gap-2">
         <button type="button"
-                class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
+                class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
                 disabled>
           <i class="fa-regular fa-eye"></i>
           Preview
@@ -31,7 +31,7 @@
         <button type="button"
                 class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
                 disabled>
-          <i class="fa-solid fa-rocket"></i>
+          <i class="fa-regular fa-paper-plane"></i>
           Request Enrollment
         </button>
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -74,7 +74,7 @@
               <div class="d-flex flex-column gap-2">
                 <button type="button"
                         id="rollout-review-reject-btn"
-                        class="btn btn-danger btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         data-bs-toggle="collapse"
                         data-bs-target="#rollout-reject-form"
                         aria-expanded="false"
@@ -84,7 +84,7 @@
                 </button>
                 <button type="button"
                         id="rollout-review-approve-btn"
-                        class="btn btn-success btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         hx-post="{% url controls.approve_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                         {% if setup_issues_count %}{% if experiment.is_draft or controls.action_label == "Advance to Next Phase" %}disabled{% endif %}
@@ -104,7 +104,7 @@
                           rows="3"></textarea>
                 <button type="button"
                         id="rollout-review-submit-reject-btn"
-                        class="btn btn-danger btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         hx-post="{% url controls.reject_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                         hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -16,10 +16,10 @@
               <i class="fa-regular fa-hourglass-half text-secondary me-2"></i>
               Review requested
             {% elif rejection %}
-              <i class="fa-solid fa-circle-xmark text-secondary me-2"></i>
+              <i class="fa-regular fa-circle-xmark text-secondary me-2"></i>
               Review rejected
             {% else %}
-              <i class="fa-solid fa-cloud-arrow-up text-secondary me-2"></i>
+              <i class="fa-regular fa-bell text-secondary me-2"></i>
               Action required
             {% endif %}
           </div>
@@ -56,10 +56,11 @@
             {% if experiment.latest_review_requested_by == user.email %}
               <button type="button"
                       id="rollout-review-cancel-btn"
-                      class="btn btn-secondary btn-sm w-100 mb-2"
+                      class="btn btn-secondary btn-sm w-100 mb-2 d-flex align-items-center justify-content-center gap-2"
                       hx-post="{% url controls.reject_url experiment.slug %}"
                       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                       hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
+                <i class="fa-solid fa-rotate-left"></i>
                 Cancel Request
               </button>
             {% endif %}
@@ -73,18 +74,24 @@
               <div class="d-flex flex-column gap-2">
                 <button type="button"
                         id="rollout-review-reject-btn"
-                        class="btn btn-secondary btn-sm w-100"
+                        class="btn btn-danger btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         data-bs-toggle="collapse"
                         data-bs-target="#rollout-reject-form"
                         aria-expanded="false"
-                        aria-controls="rollout-reject-form">Reject</button>
+                        aria-controls="rollout-reject-form">
+                  <i class="fa-regular fa-circle-xmark"></i>
+                  Reject
+                </button>
                 <button type="button"
                         id="rollout-review-approve-btn"
-                        class="btn btn-primary btn-sm w-100"
+                        class="btn btn-success btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         hx-post="{% url controls.approve_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                        {% if setup_issues_count %} {% if experiment.is_draft or controls.action_label == "Advance to Next Phase" %}disabled{% endif %}
-                        {% endif %}>Approve</button>
+                        {% if setup_issues_count %}{% if experiment.is_draft or controls.action_label == "Advance to Next Phase" %}disabled{% endif %}
+                        {% endif %}>
+                  <i class="fa-regular fa-circle-check"></i>
+                  Approve
+                </button>
               </div>
               <div class="collapse mt-2" id="rollout-reject-form">
                 <label for="rollout-reject-message" class="form-label small mb-1">
@@ -97,11 +104,14 @@
                           rows="3"></textarea>
                 <button type="button"
                         id="rollout-review-submit-reject-btn"
-                        class="btn btn-secondary btn-sm w-100"
+                        class="btn btn-danger btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         hx-post="{% url controls.reject_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                         hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'
-                        hx-include="#rollout-reject-message">Submit Rejection</button>
+                        hx-include="#rollout-reject-message">
+                  <i class="fa-regular fa-circle-xmark"></i>
+                  Submit Rejection
+                </button>
               </div>
             {% else %}
               <p class="small text-body mb-2">
@@ -131,7 +141,10 @@
                href="{{ experiment.review_url }}"
                target="_blank"
                rel="noopener noreferrer"
-               class="btn btn-primary btn-sm w-100">Open Remote Settings</a>
+               class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2">
+              <i class="fa-regular fa-circle-right"></i>
+              Open Remote Settings
+            </a>
           {% endif %}
         </div>
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -4,26 +4,31 @@
     {% with transition_pending=experiment.has_pending_rollout_transition %}
       <div class="d-flex flex-column gap-2">
         {% if experiment.is_disabled %}
-          {% if experiment.has_advanceable_rollout_phase %}
+          {% if experiment.next_rollout_phase %}
             {# Disabled to Live #}
-            <button type="button"
-                    id="rollout-resume-btn"
-                    class="btn btn-primary btn-sm w-100"
-                    hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}"
-                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-disabled-elt="this"
-                    {% if transition_pending %}disabled{% endif %}>Start next phase</button>
+            <span class="d-inline-block w-100"
+                  {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+              <button type="button"
+                      id="rollout-resume-btn"
+                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                      {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                <i class="fa-regular fa-circle-play"></i>
+                Start next phase
+              </button>
+            </span>
           {% else %}
             {# Disabled to Live #}
             <div class="collapse show rollout-resume-swap" id="rollout-resume-trigger">
-              <button type="button"
-                      id="rollout-resume-btn"
-                      class="btn btn-primary btn-sm w-100"
-                      data-bs-toggle="collapse"
-                      data-bs-target=".rollout-resume-swap"
-                      aria-expanded="false"
-                      aria-controls="rollout-duplicate-phase-confirm"
-                      {% if transition_pending %}disabled{% endif %}>Start next phase</button>
+              <span class="d-inline-block w-100"
+                    {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+                <button type="button"
+                        id="rollout-resume-btn"
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} data-bs-toggle="collapse" data-bs-target=".rollout-resume-swap" aria-expanded="false" aria-controls="rollout-duplicate-phase-confirm" {% endif %}>
+                  <i class="fa-regular fa-circle-play"></i>
+                  Start next phase
+                </button>
+              </span>
             </div>
             <div class="collapse rollout-resume-swap"
                  id="rollout-duplicate-phase-confirm">
@@ -31,18 +36,21 @@
               <div class="d-flex flex-column gap-2">
                 <button type="button"
                         id="rollout-duplicate-phase-cancel-btn"
-                        class="btn btn-secondary btn-sm w-100"
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
                         data-bs-toggle="collapse"
                         data-bs-target=".rollout-resume-swap"
                         aria-expanded="false"
-                        aria-controls="rollout-resume-trigger">Cancel</button>
+                        aria-controls="rollout-resume-trigger">
+                  <i class="fa-regular fa-circle-xmark"></i>
+                  Cancel
+                </button>
                 <button type="button"
                         id="rollout-duplicate-phase-accept-btn"
-                        class="btn btn-success btn-sm w-100"
-                        hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}"
-                        hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                        hx-disabled-elt="this"
-                        {% if transition_pending %}disabled{% endif %}>Accept</button>
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                  <i class="fa-regular fa-circle-check"></i>
+                  Accept
+                </button>
               </div>
             </div>
           {% endif %}
@@ -52,22 +60,20 @@
                 {% if transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
             <button type="button"
                     id="rollout-disable-btn"
-                    class="btn btn-secondary btn-sm w-100"
-                    hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}"
-                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-disabled-elt="this"
-                    {% if transition_pending %}disabled{% endif %}>Disable rollout</button>
+                    class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending %} opacity-50{% endif %}"
+                    {% if transition_pending %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+              <i class="fa-regular fa-circle-stop"></i>
+              Disable rollout
+            </button>
           </span>
           {# Live to Live phase advance #}
           <span class="d-inline-block w-100"
-                {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif not experiment.has_advanceable_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
+                {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif not experiment.next_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
             <button type="button"
                     id="rollout-next-phase-btn"
-                    class="btn btn-primary btn-sm w-100"
-                    hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
-                    hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                    hx-disabled-elt="this"
-                    {% if transition_pending or not experiment.has_advanceable_rollout_phase or experiment.has_rollout_review_errors %}disabled{% endif %}>
+                    class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or not experiment.next_rollout_phase or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                    {% if transition_pending or not experiment.next_rollout_phase or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+              <i class="fa-regular fa-circle-play"></i>
               Start next phase
             </button>
           </span>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_item_health.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_item_health.html
@@ -1,0 +1,11 @@
+{% if card_id in setup_issue_card_ids %}
+  <i class="fa-solid fa-triangle-exclamation text-primary"
+     style="min-width: 16px;
+            font-size: 12px"
+     title="Warning: issues detected"></i>
+{% else %}
+  <i class="fa-regular fa-circle-check text-primary"
+     style="min-width: 16px;
+            font-size: 12px"
+     title="Healthy"></i>
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_nav.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_nav.html
@@ -1,0 +1,46 @@
+<div id="sidebar-setup-nav"
+     {% if oob %}hx-swap-oob="true"{% endif %}
+     class="d-flex flex-column gap-1">
+  <a href="#rollout-card-overview"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="overview" %}
+
+    Overview
+  </a>
+  <a href="#rollout-card-schedule"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="schedule" %}
+
+    Rollout schedule
+  </a>
+  <a href="#rollout-card-audience"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="audience" %}
+
+    Audience
+  </a>
+  <a href="#rollout-card-rollout-features"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="rollout-features" %}
+
+    Rollout Features
+  </a>
+  <a href="#rollout-card-signoff"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="signoff" %}
+
+    Sign-Offs
+  </a>
+  <a href="#rollout-card-risks"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="risks" %}
+
+    Risks
+  </a>
+  <a href="#rollout-card-qa"
+     class="text-decoration-none d-flex align-items-center gap-2 rounded-2 py-1 px-2 small text-body">
+    {% include "new/common/sidebar_setup_item_health.html" with card_id="qa" %}
+
+    QA
+  </a>
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
@@ -1,5 +1,6 @@
 {% if hx_swap_oob %}
   {% include "new/common/setup_progress.html" with oob=True %}
+  {% include "new/common/sidebar_setup_nav.html" with oob=True %}
   {% include "new/common/setup_issues_modal.html" with oob=True %}
   {% include "new/common/sidebar_preview_button.html" with oob=True %}
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -20,14 +20,7 @@
       </div>
     {% endif %}
     {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" show_edit_btn=experiment.is_draft body_template="new/rollouts/overview/card.html" %}
-
-    {% if experiment.is_rolling_out %}
-      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=True body_template="new/rollouts/schedule/card.html" %}
-
-    {% else %}
-      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=experiment.is_draft body_template="new/rollouts/schedule/card.html" %}
-
-    {% endif %}
+    {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=experiment.is_rolling_out|default:experiment.is_draft lock_edit=experiment.has_pending_rollout_transition lock_tooltip=NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP body_template="new/rollouts/schedule/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="audience" title="Audience" show_edit_btn=experiment.is_draft body_template="new/rollouts/audience/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="rollout-features" title="Rollout Features" show_edit_btn=experiment.is_draft body_template="new/rollouts/rollout_features/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="signoff" title="Sign-Offs" show_edit_btn=True body_template="new/rollouts/signoff/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -88,7 +88,7 @@
       <div>
         <button type="button"
                 id="rollout-schedule-add-phase"
-                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small mt-2"
+                class="btn p-0 border-0 text-primary d-inline-flex align-items-center gap-2 small{% if form.rollout_phases|length %} mt-3{% else %} mt-1{% endif %}"
                 hx-post="{% url 'nimbus-ui-new-create-rollout-phase' experiment.slug %}"
                 hx-include="closest form"
                 hx-target="#rollout-schedule-body"
@@ -97,11 +97,13 @@
           Add phase
         </button>
       </div>
-      {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_phases %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.population_percent %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_enrollment %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_duration %}
+      <div class="mt-2">
+        {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_phases %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.population_percent %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_enrollment %}
+        {% include "new/common/validation_errors.html" with errors=validation_errors.proposed_duration %}
 
+      </div>
     </div>
     {% if form.rollout_phases|length %}
       <div class="border-top pt-3">

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -495,6 +495,36 @@ class TestNimbusRolloutDetailView(AuthTestCase):
             ),
         )
 
+    @parameterized.expand(
+        [
+            (NimbusExperiment.PublishStatus.REVIEW,),
+            (NimbusExperiment.PublishStatus.APPROVED,),
+            (NimbusExperiment.PublishStatus.WAITING,),
+        ]
+    )
+    def test_disable_button_disabled_while_disable_transition_pending(
+        self, publish_status
+    ):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.DISABLED,
+            publish_status=publish_status,
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment)
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        start = content.index('id="rollout-disable-btn"')
+        button_tag = content[start : content.index(">", start)]
+        self.assertNotIn("hx-post", button_tag)
+        button_tag = button_tag.replace('hx-disabled-elt="this"', "")
+        self.assertIn("disabled", button_tag)
+
     def test_get_returns_new_rollout_detail_context(self):
         tag = TagFactory.create()
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* We need to make improvements to make the sidebar controls more intuitive
* We need to allow users to create a phase with 0% population percent

This commit

* Removes some unnecessary links from the sidebar and replaces the number with icons
* Highlights the current active sidebar card and improves wording and icons
* Fixes issue with disabled button being clickable when it shouldn’t be
* Allows next phase with 0% population

Fixes #16740
