### PR TITLE
fix(nimbus): Fix parsing of Fenix targeting fields

### DIFF
--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/RecordedNimbusContext.kt
@@ -1,6 +1,8 @@
-val obj = JSONObject(
-    mapOf(
-        "knownField" to knownField,
-    ),
-)
-return obj
+override fun toJson(): JsonObject {
+    val obj = JSONObject(
+        mapOf(
+            "knownField" to knownField,
+        ),
+    )
+    return obj
+}

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v120.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v120.0.0/RecordedNimbusContext.kt
@@ -1,6 +1,8 @@
-val obj = JSONObject(
-    mapOf(
-        "knownField" to knownField,
-    ),
-)
-return obj
+override fun toJson(): JsonObject {
+    val obj = JSONObject(
+        mapOf(
+            "knownField" to knownField,
+        ),
+    )
+    return obj
+}

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v121.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v121.0.0/RecordedNimbusContext.kt
@@ -1,6 +1,8 @@
-val obj = JSONObject(
-    mapOf(
-        "knownField" to knownField,
-    ),
-)
-return obj
+override fun toJson(): JsonObject {
+    val obj = JSONObject(
+        mapOf(
+            "knownField" to knownField,
+        ),
+    )
+    return obj
+}

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v122.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v122.0.0/RecordedNimbusContext.kt
@@ -1,6 +1,8 @@
-val obj = JSONObject(
-    mapOf(
-        "knownField" to knownField,
-    ),
-)
-return obj
+override fun toJson(): JsonObject {
+    val obj = JSONObject(
+        mapOf(
+            "knownField" to knownField,
+        ),
+    )
+    return obj
+}

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v123.0.0/RecordedNimbusContext.kt
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/fixtures/fenix/v123.0.0/RecordedNimbusContext.kt
@@ -1,6 +1,8 @@
-val obj = JSONObject(
-    mapOf(
-        "knownField" to knownField,
-    ),
-)
-return obj
+override fun toJson(): JsonObject {
+    val obj = JSONObject(
+        mapOf(
+            "knownField" to knownField,
+        ),
+    )
+    return obj
+}

--- a/experimenter/experimenter/targeting/targeting_context_parser.py
+++ b/experimenter/experimenter/targeting/targeting_context_parser.py
@@ -47,7 +47,7 @@ class TargetingContextFields:
         for line in targeting_context_code.splitlines():
             stripped_line = line.strip()
 
-            if stripped_line == "val obj = JSONObject(":
+            if stripped_line == "override fun toJson(): JsonObject {":
                 found_block = True
             elif found_block and stripped_line == "),":
                 break


### PR DESCRIPTION
Because:

- Fenix recently starting ktlint-ing the entire project; and
- we were using certain lines as markers in RecordedNimbusContext.kt to parse targeting attributes

this commit:

- updates the parser to use the entire function name as the starting marker, fixing parsing.

Fixes #16820
