### PR TITLE
chore(nimbus): Add NOT_DEFAULT_BROWSER_DESKTOP targeting

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -5487,6 +5487,18 @@ EXISTING_USER_NO_ENTERPRISE = NimbusTargetingConfig(
 )
 
 
+NOT_DEFAULT_BROWSER_DESKTOP = NimbusTargetingConfig(
+    name="Firefox is not the default browser",
+    slug="not_default_browser_desktop",
+    description="Users that do not have Firefox as the default browser",
+    targeting=NEED_DEFAULT,
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+
 class TargetingConstants:
     TARGETING_CONFIGS = {
         targeting.slug: targeting for targeting in NimbusTargetingConfig.targeting_configs


### PR DESCRIPTION
Because:

- we want to target users who do not have Firefox set as their default browser

this commit:

- adds targeting to that effect.

Fixes #16321