### PR TITLE
fix(nimbus): parse Fenix targeting fields independent of source formatting

### DIFF
--- a/experimenter/experimenter/targeting/targeting_context_parser.py
+++ b/experimenter/experimenter/targeting/targeting_context_parser.py
@@ -40,21 +40,40 @@ class TargetingContextFields:
 
     @staticmethod
     def _parse_fenix_targeting_fields(targeting_context_code):
-        found_block = False
         targeting_fields = []
-        target_line_match = re.compile(r'"([^"]+)"')
+        map_of_match = re.compile(r"JSONObject\s*\(\s*mapOf\s*\(")
+        target_entry_match = re.compile(r'"([^"]*)"\s*to\s')
 
-        for line in targeting_context_code.splitlines():
-            stripped_line = line.strip()
+        map_of = map_of_match.search(targeting_context_code)
+        if map_of is None:
+            return targeting_fields
 
-            if stripped_line == "val obj = JSONObject(":
-                found_block = True
-            elif found_block and stripped_line == "),":
-                break
-            elif found_block:
-                res = target_line_match.search(stripped_line)
-                if res:
-                    targeting_fields.append(res.group(1))
+        depth = 1
+        index = map_of.end()
+
+        while index < len(targeting_context_code) and depth > 0:
+            character = targeting_context_code[index]
+
+            if character == '"':
+                entry = target_entry_match.match(targeting_context_code, index)
+                if depth == 1 and entry:
+                    targeting_fields.append(entry.group(1))
+                    index = entry.end()
+                else:
+                    closing_quote = targeting_context_code.find('"', index + 1)
+                    index = (
+                        len(targeting_context_code)
+                        if closing_quote == -1
+                        else closing_quote + 1
+                    )
+                continue
+
+            if character in "([{":
+                depth += 1
+            elif character in ")]}":
+                depth -= 1
+
+            index += 1
 
         return targeting_fields
 

--- a/experimenter/experimenter/targeting/tests/test_targeting_context_parser.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_context_parser.py
@@ -7,6 +7,49 @@ from experimenter.experiments.constants import NimbusConstants
 from experimenter.targeting.targeting_context_parser import TargetingContextFields
 from experimenter.targeting.tests import mock_targeting_manifests
 
+FENIX_TARGETING_CONTEXT_OLD_FORMAT = """
+class RecordedNimbusContext {
+    private val decoy = mapOf("not_a_targeting_field" to 1)
+
+    override fun toJson(): JsonObject {
+        val obj = JSONObject(
+            mapOf(
+                "is_first_run" to isFirstRun,
+                "events" to JSONObject(eventQueryValues),
+                "app_version" to appVersion,
+                "nested_object" to JSONObject(mapOf("inner_key" to innerValue)),
+                "region" to region,
+            ),
+        )
+        return obj
+    }
+
+    fun other(): Map<String, Any> = mapOf("after_block" to 1)
+}
+"""
+
+FENIX_TARGETING_CONTEXT_NEW_FORMAT = """
+class RecordedNimbusContext {
+    private val decoy = mapOf("not_a_targeting_field" to 1)
+
+    override fun toJson(): JsonObject {
+        val obj =
+            JSONObject(
+                mapOf(
+                    "is_first_run" to isFirstRun,
+                    "events" to JSONObject(eventQueryValues),
+                    "app_version" to appVersion,
+                    "nested_object" to JSONObject(mapOf("inner_key" to innerValue)),
+                    "region" to region,
+                )
+            )
+        return obj
+    }
+
+    fun other(): Map<String, Any> = mapOf("after_block" to 1)
+}
+"""
+
 
 @mock_targeting_manifests
 class TestTargetingContextFields(TestCase):
@@ -139,6 +182,37 @@ class TestTargetingContextFields(TestCase):
 
         for field in expected_fields:
             self.assertIn(field, targeting_fields)
+
+    def test_parse_fenix_targeting_fields_independent_of_source_formatting(self):
+        expected_fields = [
+            "is_first_run",
+            "events",
+            "app_version",
+            "nested_object",
+            "region",
+        ]
+
+        old_format_fields = TargetingContextFields._parse_fenix_targeting_fields(
+            FENIX_TARGETING_CONTEXT_OLD_FORMAT
+        )
+        new_format_fields = TargetingContextFields._parse_fenix_targeting_fields(
+            FENIX_TARGETING_CONTEXT_NEW_FORMAT
+        )
+
+        self.assertEqual(old_format_fields, expected_fields)
+        self.assertEqual(new_format_fields, expected_fields)
+
+        for fields in (old_format_fields, new_format_fields):
+            self.assertNotIn("inner_key", fields)
+            self.assertNotIn("not_a_targeting_field", fields)
+            self.assertNotIn("after_block", fields)
+
+    def test_parse_fenix_targeting_fields_without_recorded_context_map(self):
+        targeting_fields = TargetingContextFields._parse_fenix_targeting_fields(
+            "class RecordedNimbusContext {\n    private val decoy = mapOf()\n}\n"
+        )
+
+        self.assertEqual(targeting_fields, [])
 
     def test_attempt_load_targeting_fields_for_unknown_application(self):
         self.assertRaises(


### PR DESCRIPTION
Because

* The Fenix parser matched two exact source lines (`val obj = JSONObject(` and `),`), so an upstream reformat of `RecordedNimbusContext.kt` silently yields an empty Fenix targeting field set.
* Every Fenix targeting field then reads as unknown, which fails the targeting config tests and would emit spurious review errors on affected versions.

This commit

* Anchors on the `JSONObject(mapOf(` construct and collects the map's own `"key" to` entries by tracking bracket depth, so keys of nested calls and objects are excluded.
* Adds a regression test asserting both the old and reformatted source layouts yield the same field list.

Fixes #16828