### PR TITLE
feat(nimbus): add user set to default targeting config

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -51,6 +51,7 @@ PRESERVED_TARGETING_KEYS_BY_APPLICATION = {
 
 HAS_PIN = "!doesAppNeedPin"
 NEED_DEFAULT = "!isDefaultBrowser"
+IS_DEFAULT = "isDefaultBrowser"
 PROFILE28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"
 PROFILELESSTHAN28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 < 28"
 PROFILELESSTHAN1HOUR = "(currentDate|date - profileAgeCreated|date) / 3600000 < 1"
@@ -2645,6 +2646,17 @@ USER_NOT_SET_TO_DEFAULT = NimbusTargetingConfig(
     slug="user_not_set_to_default",
     description="Users who have not set to default",
     targeting=f"{NEED_DEFAULT}",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+USER_SET_TO_DEFAULT = NimbusTargetingConfig(
+    name="User set to default",
+    slug="user_set_to_default",
+    description="Users who have set to default",
+    targeting=f"{IS_DEFAULT}",
     desktop_telemetry="",
     sticky_required=True,
     is_first_run_required=False,


### PR DESCRIPTION
Because

* There is a targeting config for users who have not set Firefox as default, but none for the inverse case.
* Experiment owners targeting clients that already have Firefox as default have to hand-write the expression.

This commit

* Adds an IS_DEFAULT constant beside the existing NEED_DEFAULT.
* Adds a desktop-only USER_SET_TO_DEFAULT config mirroring USER_NOT_SET_TO_DEFAULT.

Fixes #16842