### PR TITLE
feat(nimbus): Support Firefox Labs rollout end enrollment in the new UI

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -1403,6 +1403,17 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         if self.publish_status != self.PublishStatus.REVIEW:
             return None
 
+        if self.is_enrollment_pause_requested:
+            return {
+                "action_label": "End Enrollment",
+                "approve_url": (
+                    "nimbus-ui-new-live-to-end-enrollment-review-approve-rollout"
+                ),
+                "reject_url": (
+                    "nimbus-ui-new-live-to-end-enrollment-review-reject-rollout"
+                ),
+            }
+
         transitions = {
             (self.Status.DRAFT, self.Status.LIVE): {
                 "action_label": "Launch Rollout",
@@ -1439,11 +1450,12 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             if current_index is None or i > current_index:
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.NOT_STARTED
             elif i == current_index:
-                phase.card_status = (
-                    NimbusUIConstants.RolloutPhaseStatus.DISABLED
-                    if self.is_disabled
-                    else NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
-                )
+                if self.is_disabled:
+                    phase.card_status = NimbusUIConstants.RolloutPhaseStatus.DISABLED
+                elif self.is_paused:
+                    phase.card_status = NimbusUIConstants.RolloutPhaseStatus.PAUSED
+                else:
+                    phase.card_status = NimbusUIConstants.RolloutPhaseStatus.IN_PROGRESS
             else:
                 phase.card_status = NimbusUIConstants.RolloutPhaseStatus.COMPLETE
             phase.card_status_display = NimbusUIConstants.ROLLOUT_PHASE_STATUS_DISPLAY[
@@ -1537,6 +1549,10 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     def can_edit_audience(self):
         return self.is_draft or (self.is_live_rollout and self.is_enrolling)
+
+    @property
+    def can_edit_rollout_schedule(self):
+        return (self.is_draft or self.is_rolling_out) and not self.is_paused
 
     def sidebar_links(self, current_path):
         return [

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7255,6 +7255,21 @@ class TestRolloutPhaseProgress(TestCase):
             current.card_status, NimbusUIConstants.RolloutPhaseStatus.DISABLED
         )
 
+    def test_current_rollout_phase_display_returns_paused_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(experiment=experiment)
+        experiment.rollout_phase = phase
+        experiment.save()
+
+        current = experiment.current_rollout_phase_display
+        self.assertEqual(current, phase)
+        self.assertEqual(current.card_status, NimbusUIConstants.RolloutPhaseStatus.PAUSED)
+        self.assertEqual(current.card_status_display["label"], "Paused")
+        self.assertEqual(current.card_status_display["color"], "warning")
+
 
 class TestAdvanceRolloutPhase(TestCase):
     def setUp(self):
@@ -7638,6 +7653,30 @@ class TestRolloutReviewControls(TestCase):
         controls = experiment.rollout_review_controls
         self.assertEqual(controls["approve_url"], approve_url)
         self.assertEqual(controls["reject_url"], reject_url)
+
+    def test_rollout_review_controls_for_end_enrollment_request(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group="group",
+            is_paused=True,
+            published_dto=None,
+        )
+        controls = experiment.rollout_review_controls
+        self.assertEqual(controls["action_label"], "End Enrollment")
+        self.assertEqual(
+            controls["approve_url"],
+            "nimbus-ui-new-live-to-end-enrollment-review-approve-rollout",
+        )
+        self.assertEqual(
+            controls["reject_url"],
+            "nimbus-ui-new-live-to-end-enrollment-review-reject-rollout",
+        )
 
 
 class TestRolloutSidebarStateHelpers(TestCase):

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -148,6 +148,7 @@ def handle_rejection(applications, kinto_client):
                     in (NimbusExperiment.Status.LIVE, NimbusExperiment.Status.COMPLETE)
                 )
                 and experiment.is_paused is False
+                and experiment.rollout_phase_next_id is None
             ):
                 experiment.is_rollout_dirty = True
 

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1297,6 +1297,8 @@ class TestNimbusCheckKintoPushQueueByCollection(
         experiment.population_percent = current_phase.population_percent
         experiment.save()
         experiment.stage_rollout_phase_advance()
+        experiment.is_rollout_dirty = False
+        experiment.save()
 
         self.mock_kinto_client.collection = experiment.kinto_collection
         self.mock_kinto_client.get_rejected_collection_data.return_value = {
@@ -1309,6 +1311,7 @@ class TestNimbusCheckKintoPushQueueByCollection(
         experiment.refresh_from_db()
         self.assertIsNone(experiment.rollout_phase_next)
         self.assertEqual(experiment.population_percent, current_phase.population_percent)
+        self.assertFalse(experiment.is_rollout_dirty)
 
     @override_settings(KINTO_REVIEW_TIMEOUT=0)
     def test_remote_settings_timeout_reverts_staged_rollout_phase(self):

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -373,6 +373,13 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_ROLLOUT_PHASE_LOCKED = "This rollout phase is locked and cannot be changed."
     ROLLOUT_REVIEW_PENDING_TOOLTIP = "A review is currently pending."
     ROLLOUT_NO_NEXT_PHASE_TOOLTIP = "There is no further phase to start."
+    ROLLOUT_ENROLLMENT_CLOSED_TOOLTIP = (
+        "Enrollment is closed, so no further phase can be started."
+    )
+    ROLLOUT_SCHEDULE_DATES_NOTE = (
+        "Phase dates are used for planning and reminders only. Phases do not start or "
+        "end automatically, so these dates are optional."
+    )
     ROLLOUT_HAS_ISSUES_TOOLTIP = "All rollout issues must be resolved first."
     ROLLOUT_TEMPLATE_PLANS = {
         "Low risk": [100],
@@ -396,9 +403,18 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "This rollout is live. You can advance to the next phase to adjust its "
         "population sizing, or disable it."
     )
+    ROLLOUT_LABS_LIVE_MESSAGE = (
+        "This Firefox Labs rollout is live and eligible clients can opt in from "
+        "Firefox Labs. Close enrollment when you no longer want new clients to "
+        "opt in."
+    )
     ROLLOUT_DISABLED_MESSAGE = (
         "This rollout is currently disabled. You can re-enable it by starting the "
         "next phase."
+    )
+    ROLLOUT_ENROLLMENT_CLOSED_MESSAGE = (
+        "Enrollment is closed for this rollout. Clients who already opted in keep "
+        "the feature, and no new clients will enroll."
     )
     ROLLOUT_DUPLICATE_PHASE_MESSAGE = (
         "There is no next phase to start. Accept to copy and launch the current "
@@ -526,11 +542,12 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     class RolloutPhaseStatus:
         NOT_STARTED = "not_started"
         IN_PROGRESS = "in_progress"
+        PAUSED = "paused"
         DISABLED = "disabled"
         COMPLETE = "complete"
 
-        CURRENT = (IN_PROGRESS, DISABLED)
-        LOCKED = (IN_PROGRESS, DISABLED, COMPLETE)
+        CURRENT = (IN_PROGRESS, PAUSED, DISABLED)
+        LOCKED = (IN_PROGRESS, PAUSED, DISABLED, COMPLETE)
 
     ROLLOUT_PHASE_STATUS_DISPLAY = {
         RolloutPhaseStatus.NOT_STARTED: {
@@ -540,6 +557,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         RolloutPhaseStatus.IN_PROGRESS: {
             "label": "In progress",
             "color": "primary",
+        },
+        RolloutPhaseStatus.PAUSED: {
+            "label": "Paused",
+            "color": "warning",
         },
         RolloutPhaseStatus.DISABLED: {
             "label": "Disabled",

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -695,6 +695,9 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         widget=InlineRadioSelect,
         coerce=lambda x: x == "True",
     )
+    is_first_run = forms.BooleanField(
+        required=False, widget=forms.CheckboxInput(attrs={"class": "form-check-input"})
+    )
 
     class Meta:
         model = NimbusExperiment
@@ -726,10 +729,11 @@ class RolloutAudienceForm(NimbusChangeLogFormMixin, forms.ModelForm):
         self.setup_initial_experiments_branches("excluded_experiments_branches")
         self.setup_channel_choices()
 
+        self.fields["is_first_run"].disabled = self.instance.is_firefox_labs_opt_in
         self.fields["is_first_run"].widget.attrs.update(
             {
                 "hx-post": reverse(
-                    "nimbus-ui-update-audience", kwargs={"slug": self.instance.slug}
+                    "nimbus-ui-new-update-audience", kwargs={"slug": self.instance.slug}
                 ),
                 "hx-trigger": "change",
                 "hx-select": "#first-run-fields",
@@ -1283,6 +1287,9 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
         previous_publish_status = self.instance.publish_status
         self.instance.publish_status = self.publish_status
 
+        if self.is_paused is not None:
+            self.instance.is_paused = self.is_paused
+
         if self.status == NimbusExperiment.Status.DRAFT:
             self.instance.published_dto = None
 
@@ -1453,6 +1460,7 @@ class AdvancePhaseReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
     required_status = NimbusExperiment.Status.LIVE
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
+    required_is_paused = False
 
     status = NimbusExperiment.Status.LIVE
     status_next = NimbusExperiment.Status.LIVE
@@ -1591,6 +1599,95 @@ class LiveToDisabledReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm
     status_next = None
     publish_status = NimbusExperiment.PublishStatus.IDLE
     cancel_request_alert_type = NimbusConstants.AlertType.END_EXPERIMENT_REQUEST
+
+    changelog_message = forms.CharField(
+        required=False, label="Changelog Message", max_length=1000
+    )
+
+    cancel_message = forms.CharField(
+        required=False, label="Cancel Message", max_length=1000
+    )
+
+    def get_changelog_message(self):
+        if self.cleaned_data.get("changelog_message"):
+            return (
+                f"{self.request.user} rejected the review with reason: "
+                f"{self.cleaned_data['changelog_message']}"
+            )
+        return f"{self.request.user} {self.cleaned_data['cancel_message']}"
+
+
+# End enrollment transitions (Firefox Labs rollouts only)
+
+
+class LiveToEndEnrollmentReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = None
+    required_publish_status = NimbusExperiment.PublishStatus.IDLE
+    required_is_paused = False
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.REVIEW
+    is_paused = True
+
+    slack_action = SlackConstants.SLACK_ACTION_END_ENROLLMENT_REQUEST
+
+    def clean(self):
+        cleaned_data = super().clean()
+
+        if self.instance.is_rollout and not self.instance.is_firefox_labs_opt_in:
+            raise forms.ValidationError(NimbusExperiment.ERROR_CANNOT_PAUSE_ROLLOUT)
+
+        return cleaned_data
+
+    def get_changelog_message(self):
+        return f"{self.request.user} requested review to end enrollment"
+
+
+class LiveToEndEnrollmentReviewApproveRolloutForm(UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+    required_is_paused = True
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = NimbusExperiment.Status.LIVE
+    publish_status = NimbusExperiment.PublishStatus.APPROVED
+
+    def get_changelog_message(self):
+        return f"{self.request.user} approved the end enrollment request"
+
+    @transaction.atomic
+    def save(self, commit=True):
+        experiment = super().save(commit=commit)
+        nimbus_check_kinto_push_queue_by_collection.apply_async(
+            countdown=5, args=[experiment.kinto_collection]
+        )
+        remove_emoji_from_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.END_ENROLLMENT_REQUEST,
+            SlackConstants.EmojiReaction.PENDING,
+        )
+        add_emoji_to_message_async.delay(
+            experiment.id,
+            NimbusConstants.AlertType.END_ENROLLMENT_REQUEST,
+            SlackConstants.EmojiReaction.APPROVE,
+        )
+        return experiment
+
+
+class LiveToEndEnrollmentReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm):
+    required_status = NimbusExperiment.Status.LIVE
+    required_status_next = NimbusExperiment.Status.LIVE
+    required_publish_status = NimbusExperiment.PublishStatus.REVIEW
+    required_is_paused = True
+
+    status = NimbusExperiment.Status.LIVE
+    status_next = None
+    publish_status = NimbusExperiment.PublishStatus.IDLE
+    is_paused = False
+    cancel_request_alert_type = NimbusConstants.AlertType.END_ENROLLMENT_REQUEST
 
     changelog_message = forms.CharField(
         required=False, label="Changelog Message", max_length=1000

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -34,6 +34,9 @@ from experimenter.nimbus_ui.new.forms import (
     LiveToDisabledReviewApproveRolloutForm,
     LiveToDisabledReviewRejectRolloutForm,
     LiveToDisabledReviewRolloutForm,
+    LiveToEndEnrollmentReviewApproveRolloutForm,
+    LiveToEndEnrollmentReviewRejectRolloutForm,
+    LiveToEndEnrollmentReviewRolloutForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
     PreviewReviewRolloutForm,
@@ -658,6 +661,18 @@ class LiveToDisabledReviewRejectRolloutView(StatusUpdateView):
     form_class = LiveToDisabledReviewRejectRolloutForm
 
 
+class LiveToEndEnrollmentReviewRolloutView(StatusUpdateView):
+    form_class = LiveToEndEnrollmentReviewRolloutForm
+
+
+class LiveToEndEnrollmentReviewApproveRolloutView(StatusUpdateView):
+    form_class = LiveToEndEnrollmentReviewApproveRolloutForm
+
+
+class LiveToEndEnrollmentReviewRejectRolloutView(StatusUpdateView):
+    form_class = LiveToEndEnrollmentReviewRejectRolloutForm
+
+
 class DisabledToLiveReviewRolloutView(StatusUpdateView):
     form_class = DisabledToLiveReviewRolloutForm
 
@@ -689,7 +704,7 @@ class NewRolloutScheduleUpdateView(NewCardUpdateView):
         return context
 
     def can_edit(self):
-        return self.object.is_draft or self.object.is_rolling_out
+        return self.object.can_edit_rollout_schedule
 
 
 class NewRolloutPhaseCreateView(

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -210,6 +210,10 @@
             <p class="text-secondary mb-0" style="font-size: 12px;">
               {% if experiment.is_disabled %}
                 {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
+              {% elif experiment.is_observation %}
+                {{ NimbusUIConstants.ROLLOUT_ENROLLMENT_CLOSED_MESSAGE }}
+              {% elif experiment.is_firefox_labs_opt_in %}
+                {{ NimbusUIConstants.ROLLOUT_LABS_LIVE_MESSAGE }}
               {% else %}
                 {{ NimbusUIConstants.ROLLOUT_LIVE_MESSAGE }}
               {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -47,6 +47,19 @@
             </div>
           {% endif %}
         {% else %}
+          {% if experiment.should_show_end_enrollment %}
+            {# End enrollment (Firefox Labs only) #}
+            <span class="d-inline-block w-100"
+                  {% if transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+              <button type="button"
+                      id="rollout-end-enrollment-btn"
+                      class="btn btn-secondary btn-sm w-100"
+                      hx-post="{% url 'nimbus-ui-new-live-to-end-enrollment-rollout' experiment.slug %}"
+                      hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-disabled-elt="this"
+                      {% if transition_pending %}disabled{% endif %}>Close enrollment</button>
+            </span>
+          {% endif %}
           {# Live to Disabled #}
           <span class="d-inline-block w-100"
                 {% if transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
@@ -60,14 +73,14 @@
           </span>
           {# Live to Live phase advance #}
           <span class="d-inline-block w-100"
-                {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif not experiment.has_advanceable_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
+                {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif experiment.is_paused %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_ENROLLMENT_CLOSED_TOOLTIP }}"{% elif not experiment.has_advanceable_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
             <button type="button"
                     id="rollout-next-phase-btn"
                     class="btn btn-primary btn-sm w-100"
                     hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}"
                     hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
                     hx-disabled-elt="this"
-                    {% if transition_pending or not experiment.has_advanceable_rollout_phase or experiment.has_rollout_review_errors %}disabled{% endif %}>
+                    {% if transition_pending or not experiment.has_advanceable_rollout_phase or experiment.has_rollout_review_errors or experiment.is_paused %}disabled{% endif %}>
               Start next phase
             </button>
           </span>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -193,6 +193,19 @@
         {% include "new/common/validation_errors.html" with errors=validation_errors.is_sticky %}
 
       </div>
+      {% if experiment.is_mobile %}
+        {# First run #}
+        <div>
+          <div class="text-secondary mb-1" style="font-size: 12px;">First run rollout</div>
+          {% if experiment.is_first_run %}
+            <i id="rollout-audience-first-run" class="fas fa-check text-success"></i>
+          {% else %}
+            <i id="rollout-audience-first-run" class="fas fa-times text-danger"></i>
+          {% endif %}
+          {% include "new/common/validation_errors.html" with errors=validation_errors.is_first_run %}
+
+        </div>
+      {% endif %}
       {# Localization #}
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">Is this a localized rollout?</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -145,6 +145,16 @@
       {% for error in form.is_sticky.errors %}<div class="invalid-feedback">{{ error }}</div>{% endfor %}
       {% for error in validation_errors.is_sticky %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
     </div>
+    {% if experiment.is_mobile %}
+      <div id="first-run-fields">
+        <div class="form-check">
+          {{ form.is_first_run }}
+          <label class="form-check-label small text-body" for="id_is_first_run">First run rollout</label>
+        </div>
+        {% for error in form.is_first_run.errors %}<div class="invalid-feedback d-block">{{ error }}</div>{% endfor %}
+        {% for error in validation_errors.is_first_run %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+      </div>
+    {% endif %}
     <div>
       <div class="form-check">
         {{ form.is_localized }}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -20,14 +20,7 @@
       </div>
     {% endif %}
     {% include "new/rollouts/detail_card.html" with card_id="overview" title="Overview" show_edit_btn=experiment.is_draft body_template="new/rollouts/overview/card.html" %}
-
-    {% if experiment.is_rolling_out %}
-      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=True body_template="new/rollouts/schedule/card.html" %}
-
-    {% else %}
-      {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=experiment.is_draft body_template="new/rollouts/schedule/card.html" %}
-
-    {% endif %}
+    {% include "new/rollouts/detail_card.html" with card_id="schedule" title="Rollout schedule" show_edit_btn=experiment.can_edit_rollout_schedule body_template="new/rollouts/schedule/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="audience" title="Audience" show_edit_btn=experiment.is_draft body_template="new/rollouts/audience/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="rollout-features" title="Rollout Features" show_edit_btn=experiment.is_draft body_template="new/rollouts/rollout_features/card.html" %}
     {% include "new/rollouts/detail_card.html" with card_id="signoff" title="Sign-Offs" show_edit_btn=True body_template="new/rollouts/signoff/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -77,7 +77,7 @@
                         </div>
                       {% else %}
                         <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                          <span>In progress</span>
+                          <span>{{ display.label }}</span>
                           <span class="mx-1" style="color: var(--bs-border-color);">•</span>
                           <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
                         </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -16,6 +16,9 @@
       {{ form.rollout_plan|add_error_class:"is-invalid" }}
     </div>
     {{ form.rollout_phases.management_form }}
+    {% if form.rollout_phases|length %}
+      <p class="text-secondary mb-0" style="font-size: 12px;">{{ NimbusUIConstants.ROLLOUT_SCHEDULE_DATES_NOTE }}</p>
+    {% endif %}
     <div class="d-flex flex-column">
       {% for phase_form in form.rollout_phases %}
         {% with display=phase_form.card_status_display %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -49,6 +49,9 @@ from experimenter.nimbus_ui.new.forms import (
     LiveToDisabledReviewApproveRolloutForm,
     LiveToDisabledReviewRejectRolloutForm,
     LiveToDisabledReviewRolloutForm,
+    LiveToEndEnrollmentReviewApproveRolloutForm,
+    LiveToEndEnrollmentReviewRejectRolloutForm,
+    LiveToEndEnrollmentReviewRolloutForm,
     NimbusBranchFeatureValueForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
@@ -588,6 +591,59 @@ class TestRolloutAudienceForm(RequestFormTestCase):
 
         self.assertTrue(experiment.is_localized)
         self.assertEqual(experiment.localizations, '{"en-US": {}}')
+
+    def test_is_first_run_disabled_for_labs_opt_in(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group="group",
+            application=NimbusExperiment.Application.DESKTOP,
+            is_first_run=False,
+        )
+
+        form = RolloutAudienceForm(
+            instance=experiment,
+            data=self._audience_data(is_first_run=True),
+            request=self.request,
+        )
+
+        self.assertTrue(form.fields["is_first_run"].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        updated_experiment = form.save()
+        updated_experiment.refresh_from_db()
+
+        self.assertFalse(updated_experiment.is_first_run)
+
+    def test_is_first_run_editable_for_non_labs_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            application=NimbusExperiment.Application.FENIX,
+            channel=NimbusExperiment.Channel.BETA,
+            is_first_run=False,
+        )
+
+        form = RolloutAudienceForm(
+            instance=experiment,
+            data=self._audience_data(
+                channel=NimbusExperiment.Channel.BETA,
+                channels=[NimbusExperiment.Channel.BETA],
+                is_first_run=True,
+            ),
+            request=self.request,
+        )
+
+        self.assertFalse(form.fields["is_first_run"].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        updated_experiment = form.save()
+        updated_experiment.refresh_from_db()
+
+        self.assertTrue(updated_experiment.is_first_run)
 
     def test_check_rollout_dirty_does_not_set_flag_for_non_rollout(self):
         experiment = NimbusExperimentFactory.create(
@@ -1873,6 +1929,21 @@ class TestRolloutStatusForms(
             [NimbusUIConstants.ERROR_INVALID_PHASELESS_ROLLOUT_DISABLED_TRANSITION],
         )
 
+    def test_advance_phase_is_rejected_when_enrollment_is_closed(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            is_rollout=True,
+            is_paused=True,
+        )
+        form = AdvancePhaseReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("__all__", form.errors)
+
     def test_draft_to_preview_side_effects(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.DRAFT,
@@ -2348,6 +2419,132 @@ class TestRolloutStatusForms(
         self.assertIn(
             (experiment.id, alert_type, SlackConstants.EmojiReaction.SECURE),
             emoji_calls,
+        )
+
+
+class TestRolloutEndEnrollmentForms(
+    SlackEmojiMockMixin, SlackNotificationMockMixin, RequestFormTestCase
+):
+    def setUp(self):
+        super().setUp()
+        self.mock_kinto_push_queue = patch(
+            "experimenter.nimbus_ui.new.forms."
+            "nimbus_check_kinto_push_queue_by_collection.apply_async"
+        ).start()
+        self.addCleanup(self.mock_kinto_push_queue.stop)
+
+    def create_labs_rollout(self, **kwargs):
+        return NimbusExperimentFactory.create(
+            **{
+                "status": NimbusExperiment.Status.LIVE,
+                "status_next": None,
+                "publish_status": NimbusExperiment.PublishStatus.IDLE,
+                "is_paused": False,
+                "is_rollout": True,
+                "is_firefox_labs_opt_in": True,
+                "firefox_labs_title": "title",
+                "firefox_labs_description": "description",
+                "firefox_labs_group": "group",
+                **kwargs,
+            }
+        )
+
+    def test_request_end_enrollment_for_labs_rollout(self):
+        experiment = self.create_labs_rollout()
+        form = LiveToEndEnrollmentReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.status_next, NimbusExperiment.Status.LIVE)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.REVIEW)
+        self.assertTrue(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(changelog.changed_by, self.user)
+        self.assertIn("requested review to end enrollment", changelog.message)
+
+    def test_request_end_enrollment_invalid_for_non_labs_rollout(self):
+        experiment = self.create_labs_rollout(is_firefox_labs_opt_in=False)
+        form = LiveToEndEnrollmentReviewRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            NimbusExperiment.ERROR_CANNOT_PAUSE_ROLLOUT,
+            form.errors["__all__"],
+        )
+
+    def test_approve_end_enrollment_review(self):
+        experiment = self.create_labs_rollout(
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_paused=True,
+        )
+        form = LiveToEndEnrollmentReviewApproveRolloutForm(
+            data={}, instance=experiment, request=self.request
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(
+            experiment.publish_status, NimbusExperiment.PublishStatus.APPROVED
+        )
+        self.assertTrue(experiment.is_paused)
+        self.mock_kinto_push_queue.assert_called_once()
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertIn("approved the end enrollment request", changelog.message)
+
+    def test_reject_end_enrollment_review_unpauses(self):
+        experiment = self.create_labs_rollout(
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_paused=True,
+        )
+        form = LiveToEndEnrollmentReviewRejectRolloutForm(
+            data={"changelog_message": "rejected the review"},
+            instance=experiment,
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertEqual(experiment.status, NimbusExperiment.Status.LIVE)
+        self.assertIsNone(experiment.status_next)
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertIn("rejected the review", changelog.message)
+
+    def test_reject_end_enrollment_review_with_cancel_message(self):
+        experiment = self.create_labs_rollout(
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            is_paused=True,
+        )
+        form = LiveToEndEnrollmentReviewRejectRolloutForm(
+            data={"cancel_message": "cancelled the end enrollment request"},
+            instance=experiment,
+            request=self.request,
+        )
+
+        self.assertTrue(form.is_valid(), form.errors)
+
+        experiment = form.save()
+        self.assertFalse(experiment.is_paused)
+
+        changelog = experiment.changes.latest("changed_on")
+        self.assertEqual(
+            changelog.message,
+            f"{self.request.user} cancelled the end enrollment request",
         )
 
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -138,6 +138,14 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
                 NimbusExperiment.Status.LIVE,
                 NimbusExperiment.PublishStatus.REVIEW,
             ),
+            # Live -> Live end enrollment
+            (
+                "nimbus-ui-new-live-to-end-enrollment-rollout",
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.Status.LIVE,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
         ]
     )
     def test_valid_submission(
@@ -159,6 +167,9 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
         )
         if url_name == "nimbus-ui-new-live-to-disabled-rollout":
             NimbusRolloutPhaseFactory.create(experiment=experiment)
+        if url_name == "nimbus-ui-new-live-to-end-enrollment-rollout":
+            experiment.is_firefox_labs_opt_in = True
+            experiment.save()
 
         with mock.patch.object(
             NimbusExperiment, "get_invalid_fields_errors", return_value={}
@@ -800,61 +811,75 @@ class TestNimbusRolloutDetailView(AuthTestCase):
             ),
         )
 
-    def test_setup_issues_disable_phase_advance_but_not_disable_rollout(self):
+    def test_sidebar_shows_end_enrollment_for_labs_rollout(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group="group",
         )
-        current_phase = NimbusRolloutPhaseFactory.create(
-            experiment=experiment, population_percent=10
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
         )
-        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=20)
-        experiment.rollout_phase = current_phase
-        experiment.save()
 
-        with mock.patch.object(
-            NimbusExperiment,
-            "get_invalid_fields_errors",
-            return_value={"risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]},
-        ):
-            response = self.client.get(
-                reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
-            )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="rollout-end-enrollment-btn"')
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-live-to-end-enrollment-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+        self.assertContains(response, 'id="rollout-next-phase-btn"')
+        self.assertContains(response, 'id="rollout-disable-btn"')
 
-        content = response.content.decode()
-        next_phase_button = content.split('id="rollout-next-phase-btn"', 1)[1].split(
-            "</button>", 1
-        )[0]
-        disable_button = content.split('id="rollout-disable-btn"', 1)[1].split(
-            "</button>", 1
-        )[0]
-        self.assertRegex(next_phase_button, r"\sdisabled(?:\s|>)")
-        self.assertNotRegex(disable_button, r"\sdisabled(?:\s|>)")
+    def test_sidebar_hides_end_enrollment_for_non_labs_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+            is_firefox_labs_opt_in=False,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="rollout-end-enrollment-btn"')
 
     @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
-    def test_setup_issues_disable_phase_advance_approval(self):
+    def test_sidebar_shows_end_enrollment_review_controls(self):
         experiment = NimbusExperimentFactory.create(
             status=NimbusExperiment.Status.LIVE,
             status_next=NimbusExperiment.Status.LIVE,
             publish_status=NimbusExperiment.PublishStatus.REVIEW,
             is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+            firefox_labs_group="group",
+            is_paused=True,
+            published_dto=None,
         )
 
-        with mock.patch.object(
-            NimbusExperiment,
-            "get_invalid_fields_errors",
-            return_value={"risk_brand": [NimbusConstants.ERROR_REQUIRED_QUESTION]},
-        ):
-            response = self.client.get(
-                reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
-                **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
-            )
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
+            **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
+        )
 
-        content = response.content.decode()
-        approve_button = content.split('id="rollout-review-approve-btn"', 1)[1].split(
-            "</button>", 1
-        )[0]
-        self.assertRegex(approve_button, r"\sdisabled(?:\s|>)")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "end enrollment")
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-live-to-end-enrollment-review-approve-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
 
     @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
     def test_sidebar_shows_remote_settings_link_when_approved(self):
@@ -1056,6 +1081,69 @@ class TestNewAudienceUpdateView(NewViewTestMixin, AuthTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/audience/edit_form.html")
         self.assertResponseUsesForm(response, RolloutAudienceForm)
+
+    def test_get_redirects_for_live_rollout(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+
+        self.assertRedirects(
+            response,
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+            fetch_redirect_response=False,
+        )
+
+    def test_get_renders_first_run_for_mobile(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            application=NimbusExperiment.Application.FENIX,
+        )
+
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="first-run-fields"')
+        self.assertFalse(response.context["form"].fields["is_first_run"].disabled)
+
+    def test_get_renders_first_run_disabled_for_labs_opt_in(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            application=NimbusExperiment.Application.FENIX,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="title",
+            firefox_labs_description="description",
+        )
+
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="first-run-fields"')
+        self.assertTrue(response.context["form"].fields["is_first_run"].disabled)
+
+    def test_get_hides_first_run_for_desktop(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, 'id="first-run-fields"')
 
     def test_post_valid_saves_and_returns_display_card(self):
         country = CountryFactory.create()
@@ -1712,6 +1800,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
+        self.assertNotContains(response, NimbusUIConstants.ROLLOUT_SCHEDULE_DATES_NOTE)
 
     def test_get_editable_when_live_rollout(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1723,6 +1812,20 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
+
+    def test_get_locked_when_enrollment_is_closed(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_PAUSED,
+            is_rollout=True,
+        )
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+        self.assertRedirects(
+            response,
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+            fetch_redirect_response=False,
+        )
 
     def test_get_locked_when_not_draft_or_rolling_out(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -16,6 +16,9 @@ from experimenter.nimbus_ui.new.views import (
     LiveToDisabledReviewApproveRolloutView,
     LiveToDisabledReviewRejectRolloutView,
     LiveToDisabledReviewRolloutView,
+    LiveToEndEnrollmentReviewApproveRolloutView,
+    LiveToEndEnrollmentReviewRejectRolloutView,
+    LiveToEndEnrollmentReviewRolloutView,
     NewAddSubscriberView,
     NewAddTagView,
     NewAudienceUpdateView,
@@ -390,6 +393,21 @@ urlpatterns = [
         r"^new/(?P<slug>[\w-]+)/live-to-disabled-review-reject-rollout/$",
         LiveToDisabledReviewRejectRolloutView.as_view(),
         name="nimbus-ui-new-live-to-disabled-review-reject-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-end-enrollment-rollout/$",
+        LiveToEndEnrollmentReviewRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-end-enrollment-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-end-enrollment-review-approve-rollout/$",
+        LiveToEndEnrollmentReviewApproveRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-end-enrollment-review-approve-rollout",
+    ),
+    re_path(
+        r"^new/(?P<slug>[\w-]+)/live-to-end-enrollment-review-reject-rollout/$",
+        LiveToEndEnrollmentReviewRejectRolloutView.as_view(),
+        name="nimbus-ui-new-live-to-end-enrollment-review-reject-rollout",
     ),
     re_path(
         r"^new/(?P<slug>[\w-]+)/disabled-to-live-rollout/$",


### PR DESCRIPTION
Because:

* Firefox Labs opt-in rollouts close enrollment instead of being disabled and the new UI had no way to do it
* is_first_run was in the audience form not rendered anywhere
* A rejected phase advance marked rollout dirty even though the advance was reverted which blocks Close enrollment

This commit:

* Adds the transitions needed for Labs rollouts
* Adds the Close enrollment sidebar button and end enrollment review controls
* Renders is_first_run on the audience card for mobile but disabled for Labs matching the old UI
* Stops marking a rollout dirty on rejection when the staged phase advance is reverted

Fixes #16861