### PR TITLE
Add targeting for Win10+ users and no MSIX with different state of Firefox pinned and Firefox default

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1944,6 +1944,60 @@ WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_ = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WINDOWS_10_PLUS_NOMSIX_NOT_PINNED_NOT_DEFAULT = NimbusTargetingConfig(
+    name="Windows 10+ users, no MSIX, not pinned, not default",
+    slug="win10_plus_nomsix_notpinned_notdefault",
+    description=(
+        "Windows 10+ users who are not running MSIX, "
+        "who have not pinned Firefox to the taskbar, "
+        "and who do not have Firefox set as the default browser"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && !isMSIX "
+        "&& doesAppNeedPin && !isDefaultBrowser"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+WINDOWS_10_PLUS_NOMSIX_PINNED_NOT_DEFAULT = NimbusTargetingConfig(
+    name="Windows 10+ users, no MSIX, pinned, not default",
+    slug="win10_plus_nomsix_pinned_notdefault",
+    description=(
+        "Windows 10+ users who are not running MSIX, "
+        "who have pinned Firefox to the taskbar, "
+        "and who do not have Firefox set as the default browser"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && !isMSIX "
+        "&& !doesAppNeedPin && !isDefaultBrowser"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+WINDOWS_10_PLUS_NOMSIX_NOT_PINNED_DEFAULT = NimbusTargetingConfig(
+    name="Windows 10+ users, no MSIX, not pinned, default",
+    slug="win10_plus_nomsix_notpinned_default",
+    description=(
+        "Windows 10+ users who are not running MSIX, "
+        "who have not pinned Firefox to the taskbar, "
+        "and who have Firefox set as the default browser"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && !isMSIX "
+        "&& doesAppNeedPin && isDefaultBrowser"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 WINDOWS_10_PLUS_BACKGROUND_TASK_NOTIFICATION_AT_RISK_USER = NimbusTargetingConfig(
     name="At risk user background task notification",
     slug="background_task_notification_at_risk_user",


### PR DESCRIPTION
Because 

- [HNT Custom Icon Experiment requires ](https://docs.google.com/document/d/1LfM-GiNY3JA1oNoJfGTQZutZzJr6BE8BMRBx1fZHadI/edit?usp=sharing)

This commit

- Added Advance targeting for Win10+ && No MSIX && Not Pinned && Not set defaulted
- Added Advance targeting for Win10+ && No MSIX && Pinned && Not set defaulted
- Added Advance targeting for Win10+ && No MSIX && Not Pinned && set defaulted

Fixes #16865