### PR TITLE
feat(nimbus): add pop sizing card to rollouts page

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -79,6 +79,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     behaviour.  Running an experiment on multiple channels can create misleading or
     inaccurate results.  It is recommended to run experiments only on a single channel."""
 
+    POPULATION_SIZING_CARD_TITLE = "Audience Size Estimate"
     AUDIENCE_OVERLAP_WARNING = (
         "https://experimenter.info/advanced/warnings#audience-overlap"
     )
@@ -513,6 +514,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     ROLLOUT_CARD_ICONS = {
         "monitoring": "fa-regular fa-chart-bar",
+        "population_sizing": "fa-solid fa-user-group",
         "schedule": "fa-regular fa-calendar-days",
         "preview": "fa-regular fa-eye",
         "overview": "fa-regular fa-file-lines",

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -199,7 +199,7 @@ def get_rollout_phase_population_estimates(experiment):
             "phase": phase,
             "estimated_count": int(eligible_count * phase.population_percent / 100),
         }
-        for phase in experiment.rollout_phases.all()
+        for phase in experiment.annotated_rollout_phases()
     ]
 
 

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -189,6 +189,20 @@ def build_experiment_context(experiment):
     return context
 
 
+def get_rollout_phase_population_estimates(experiment):
+    eligible_count = experiment.sizing_eligible_count
+    if eligible_count is None:
+        return []
+
+    return [
+        {
+            "phase": phase,
+            "estimated_count": int(eligible_count * phase.population_percent / 100),
+        }
+        for phase in experiment.rollout_phases.all()
+    ]
+
+
 class NimbusExperimentDetailView(
     NimbusExperimentViewMixin,
     CloneExperimentFormMixin,
@@ -323,6 +337,9 @@ class NimbusRolloutDetailView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context.update(build_experiment_context(self.object))
+        context["rollout_phase_population_estimates"] = (
+            get_rollout_phase_population_estimates(self.object)
+        )
         return context
 
     def get_queryset(self):
@@ -717,6 +734,9 @@ class NewRolloutScheduleUpdateView(NewCardUpdateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["rollout_phase_population_estimates"] = (
+            get_rollout_phase_population_estimates(self.object)
+        )
         selected_plan = self.request.POST.get("template_name") or self.request.POST.get(
             "rollout_plan"
         )

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
@@ -11,30 +11,59 @@
     {% endif %}
     {% if experiment.sizing_eligible_count is not None %}
       <section data-testid="sizing-callout">
-        <div class="row row-cols-1 row-cols-md-2 g-3">
-          <div class="col">
-            <div class="h-100 rounded-3 bg-body-tertiary p-3">
-              <div class="small text-secondary mb-1">Estimated eligible clients</div>
-              <div class="fs-4 fw-semibold text-body">~{{ experiment.sizing_eligible_count|short_number }}</div>
-            </div>
-          </div>
-          {% for estimate in rollout_phase_population_estimates %}
-            <div class="col" data-testid="sizing-phase-estimate">
-              <div class="h-100 rounded-3 bg-body-tertiary p-3">
-                <div class="small text-secondary mb-1">
-                  Phase {{ forloop.counter }} projected enrollment at
-                  {{ estimate.phase.population_percent|floatformat:"-2" }}%
-                </div>
-                <div class="fs-4 fw-semibold text-body">~{{ estimate.estimated_count|short_number }}</div>
-              </div>
-            </div>
-          {% endfor %}
+        <div class="d-flex align-items-baseline gap-2 mb-3">
+          <span class="fs-4 fw-semibold text-body">~{{ experiment.sizing_eligible_count|short_number }}</span>
+          <span class="small text-body">estimated eligible clients</span>
         </div>
+        {% if rollout_phase_population_estimates %}
+          <table class="table table-borderless table-sm align-middle mb-0 w-auto">
+            <thead>
+              <tr style="font-size: 11px">
+                <th class="border-0 text-secondary fw-normal py-1"
+                    style="padding-right: 10rem">Phase</th>
+                <th class="border-0 text-secondary fw-normal py-1"
+                    style="padding-right: 10rem">Population ratio</th>
+                <th class="border-0 text-secondary fw-normal py-1 text-end"
+                    style="padding-right: 1.5rem">Projected enrollment</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for estimate in rollout_phase_population_estimates %}
+                {% with phase=estimate.phase %}
+                  <tr data-testid="sizing-phase-estimate">
+                    <td class="small text-body py-2 text-nowrap fw-normal"
+                        style="padding-right: 6rem">Phase {{ phase.number }}</td>
+                    <td class="py-2" style="padding-right: 6rem">
+                      <div class="d-flex align-items-center gap-2">
+                        <div class="progress rounded-pill"
+                             style="height: 8px;
+                                    width: 18rem"
+                             role="progressbar"
+                             aria-label="Phase {{ phase.number }} population ratio">
+                          <div class="progress-bar bg-primary rounded-pill"
+                               style="width: {{ phase.population_percent }}%"></div>
+                        </div>
+                        <span class="text-secondary text-nowrap"
+                              style="font-size: 11px;
+                                     font-variant-numeric: tabular-nums">
+                          {{ phase.population_percent|floatformat:"-2" }}%
+                        </span>
+                      </div>
+                    </td>
+                    <td class="small text-body py-2 text-end text-nowrap"
+                        style="padding-right: 1.5rem;
+                               font-variant-numeric: tabular-nums">~{{ estimate.estimated_count|short_number }}</td>
+                  </tr>
+                {% endwith %}
+              {% endfor %}
+            </tbody>
+          </table>
+        {% endif %}
         {% if experiment.sizing_warnings %}
           <div class="alert alert-warning small border-0 border-start border-warning border-4 rounded-0 mt-3 mb-0"
                role="alert">
-            <div>
-              <i class="fa-solid fa-triangle-exclamation me-1"></i>
+            <div class="text-body">
+              <i class="fa-solid fa-triangle-exclamation me-1 text-warning"></i>
               <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
             </div>
             <div class="text-secondary mt-1">These attributes couldn't be translated to SQL</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
@@ -1,0 +1,104 @@
+{% extends "new/common/card_base.html" %}
+
+{% load nimbus_extras %}
+
+{% block card %}
+  <div id="rollout-population-sizing-body"
+       class="d-flex flex-column gap-4"
+       {% if population_sizing_oob %}hx-swap-oob="true"{% endif %}>
+    {% if experiment.sizing_data_updated_at %}
+      <div class="small text-secondary">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</div>
+    {% endif %}
+    {% if experiment.sizing_eligible_count is not None %}
+      <section data-testid="sizing-callout">
+        <div class="row row-cols-1 row-cols-md-2 g-3">
+          <div class="col">
+            <div class="h-100 rounded-3 bg-body-tertiary p-3">
+              <div class="small text-secondary mb-1">Estimated eligible clients</div>
+              <div class="fs-4 fw-semibold text-body">~{{ experiment.sizing_eligible_count|short_number }}</div>
+            </div>
+          </div>
+          {% for estimate in rollout_phase_population_estimates %}
+            <div class="col" data-testid="sizing-phase-estimate">
+              <div class="h-100 rounded-3 bg-body-tertiary p-3">
+                <div class="small text-secondary mb-1">
+                  Phase {{ forloop.counter }} projected enrollment at
+                  {{ estimate.phase.population_percent|floatformat:"-2" }}%
+                </div>
+                <div class="fs-4 fw-semibold text-body">~{{ estimate.estimated_count|short_number }}</div>
+              </div>
+            </div>
+          {% endfor %}
+        </div>
+        {% if experiment.sizing_warnings %}
+          <div class="alert alert-warning small border-0 border-start border-warning border-4 rounded-0 mt-3 mb-0"
+               role="alert">
+            <div>
+              <i class="fa-solid fa-triangle-exclamation me-1"></i>
+              <strong>Estimate excludes:</strong> {{ experiment.sizing_warnings|join:", " }}
+            </div>
+            <div class="text-secondary mt-1">These attributes couldn't be translated to SQL</div>
+          </div>
+        {% endif %}
+      </section>
+    {% elif experiment.is_draft %}
+      <p class="small text-secondary mb-0">
+        No sizing data available yet. Estimates are computed daily for Draft experiments.
+      </p>
+    {% endif %}
+    {% if experiment.sizing_full_sql %}
+      <div class="d-flex align-items-center justify-content-between border-top pt-3">
+        <button class="btn btn-sm btn-outline-secondary"
+                type="button"
+                data-bs-toggle="modal"
+                data-bs-target="#sizing-sql-modal">
+          <i class="fa-solid fa-code me-1"></i>Generate SQL
+        </button>
+      </div>
+      <div class="modal fade"
+           id="sizing-sql-modal"
+           tabindex="-1"
+           aria-labelledby="sizing-sql-modal-label"
+           aria-hidden="true">
+        <div class="modal-dialog modal-lg modal-dialog-scrollable">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title" id="sizing-sql-modal-label">Explore this audience in BigQuery</h5>
+              <button type="button"
+                      class="btn-close"
+                      data-bs-dismiss="modal"
+                      aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+              <p class="small text-secondary">
+                Full BigQuery query generated from this experiment's targeting.
+                Copy and paste into BigQuery to explore the eligible population.
+              </p>
+              <div>
+                <div class="d-flex justify-content-end mb-1">
+                  <button type="button"
+                          class="btn btn-sm btn-outline-secondary codemirror-copy-btn"
+                          aria-label="Copy SQL">
+                    <i class="fa-solid fa-copy me-1"></i>Copy
+                  </button>
+                </div>
+                <textarea class="readonly-sql" data-testid="sizing-sql-query">{{ experiment.sizing_full_sql }}</textarea>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <a href="https://sql.telemetry.mozilla.org/queries/124957/source?p_targeting_predicate={{ experiment.sizing_sql_predicate|urlencode }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="btn btn-sm btn-outline-secondary">
+                <i class="fa-solid fa-arrow-up-right-from-square me-1"></i>Open in STMO
+              </a>
+              <button type="button"
+                      class="btn btn-secondary btn-sm"
+                      data-bs-dismiss="modal">Close</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    {% endif %}
+  </div>
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -13,6 +13,10 @@
       {% include "new/rollouts/detail_card.html" with card_id="monitoring" title=NimbusUIConstants.MONITORING_CARD_TITLE subtitle="Enrollment funnel and branch health" show_edit_btn=False body_template="new/rollouts/monitoring/card.html" %}
 
     {% endif %}
+    {% if experiment.is_draft or experiment.sizing_eligible_count is not None %}
+      {% include "new/rollouts/detail_card.html" with card_id="population_sizing" title=NimbusUIConstants.POPULATION_SIZING_CARD_TITLE subtitle="Estimated eligible and enrolled clients" show_edit_btn=False body_template="new/rollouts/population_sizing/card.html" %}
+
+    {% endif %}
     {% if experiment.is_preview %}
       <div class="d-flex flex-column gap-2" id="rollout-preview-section">
         {% include "new/rollouts/detail_card.html" with card_id="preview" title="Preview links & testing details" subtitle="Rollout experience" show_edit_btn=False body_template="new/rollouts/preview/card.html" %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -167,4 +167,10 @@
     {% include "new/common/sidebar_rollout_actions.html" with oob=True %}
 
   {% endif %}
+  {% if hx_swap_oob %}
+    {% if experiment.is_draft or experiment.sizing_eligible_count is not None %}
+      {% include "new/rollouts/population_sizing/card.html" with population_sizing_oob=True hx_swap_oob=False %}
+
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -3,6 +3,12 @@
 {# ── Edit form ── #}
 <div id="rollout-schedule-body">
   {% include "new/common/sidebar_setup_refresh.html" %}
+  {% if hx_swap_oob %}
+    {% if experiment.is_draft or experiment.sizing_eligible_count is not None %}
+      {% include "new/rollouts/population_sizing/card.html" with population_sizing_oob=True hx_swap_oob=False %}
+
+    {% endif %}
+  {% endif %}
 
   <form hx-post="{% url 'nimbus-ui-new-update-schedule' experiment.slug %}"
         hx-target="#rollout-schedule-body"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -3,13 +3,13 @@
 {# ── Edit form ── #}
 <div id="rollout-schedule-body">
   {% include "new/common/sidebar_setup_refresh.html" %}
+
   {% if hx_swap_oob %}
     {% if experiment.is_draft or experiment.sizing_eligible_count is not None %}
       {% include "new/rollouts/population_sizing/card.html" with population_sizing_oob=True hx_swap_oob=False %}
 
     {% endif %}
   {% endif %}
-
   <form hx-post="{% url 'nimbus-ui-new-update-schedule' experiment.slug %}"
         hx-target="#rollout-schedule-body"
         hx-swap="outerHTML"

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -7,7 +7,7 @@
 {% block card_header %}
   <div class="d-flex align-items-center justify-content-between">
     <h4 class="mb-0">
-      <a href="#sizing" class="text-decoration-none text-body">Audience Size Estimate</a>
+      <a href="#sizing" class="text-decoration-none text-body">{{ NimbusUIConstants.POPULATION_SIZING_CARD_TITLE }}</a>
     </h4>
     {% if experiment.sizing_data_updated_at %}
       <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1068,12 +1068,31 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         )
 
         self.assertContains(response, 'data-testid="sizing-phase-estimate"', count=3)
-        self.assertContains(response, "Phase 1 projected enrollment at")
-        self.assertContains(response, "Phase 2 projected enrollment at")
-        self.assertContains(response, "Phase 3 projected enrollment at")
+        self.assertContains(response, "estimated eligible clients")
+        self.assertContains(response, "~100.0K")
+        self.assertContains(response, "Projected enrollment")
         self.assertContains(response, "~10.0K")
         self.assertContains(response, "~25.0K")
         self.assertContains(response, "~100.0K")
+        self.assertContains(response, "width: 10.0000%")
+        self.assertContains(response, "width: 25.0000%")
+        self.assertContains(response, "width: 100.0000%")
+
+    def test_population_sizing_card_without_phases_shows_eligible_count_only(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            sizing_data={"eligible_count": 100_000, "warnings": []},
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertContains(response, "estimated eligible clients")
+        self.assertContains(response, "~100.0K")
+        self.assertNotContains(response, "Projected enrollment")
+        self.assertNotContains(response, 'data-testid="sizing-phase-estimate"')
 
 
 class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
@@ -2002,7 +2021,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         )
         self.assertTrue(response.context["hx_swap_oob"])
         self.assertContains(response, 'id="rollout-population-sizing-body"')
-        self.assertContains(response, "Phase 1 projected enrollment at")
+        self.assertContains(response, "Projected enrollment")
         self.assertContains(response, "~25.0K")
 
     def test_post_in_progress_phase_shows_progress(self):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -998,6 +998,83 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
         self.assertEqual(response.status_code, 404)
 
+    @parameterized.expand(
+        [
+            # Draft with data
+            (
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                {"eligible_count": 12345, "warnings": []},
+                True,
+                False,
+            ),
+            # Draft no data
+            (
+                NimbusExperimentFactory.Lifecycles.CREATED,
+                None,
+                True,
+                True,
+            ),
+            # Live with data
+            (
+                NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+                {"eligible_count": 98765, "warnings": []},
+                True,
+                False,
+            ),
+            # Live no data
+            (
+                NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+                None,
+                False,
+                False,
+            ),
+        ]
+    )
+    def test_population_sizing_card_display(
+        self, lifecycle, sizing_data, shows_card, shows_no_data_message
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            lifecycle,
+            is_rollout=True,
+            sizing_data=sizing_data,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        if shows_card:
+            self.assertContains(response, 'id="rollout-card-population_sizing"')
+        else:
+            self.assertNotContains(response, 'id="rollout-card-population_sizing"')
+        if shows_no_data_message:
+            self.assertContains(response, "No sizing data available yet")
+        else:
+            self.assertNotContains(response, "No sizing data available yet")
+
+    def test_population_sizing_card_shows_estimate_for_each_rollout_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            is_rollout=True,
+            sizing_data={"eligible_count": 100_000, "warnings": []},
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=10)
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=25)
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=100)
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertContains(response, 'data-testid="sizing-phase-estimate"', count=3)
+        self.assertContains(response, "Phase 1 projected enrollment at")
+        self.assertContains(response, "Phase 2 projected enrollment at")
+        self.assertContains(response, "Phase 3 projected enrollment at")
+        self.assertContains(response, "~10.0K")
+        self.assertContains(response, "~25.0K")
+        self.assertContains(response, "~100.0K")
+
 
 class TestNewOverviewUpdateView(NewViewTestMixin, AuthTestCase):
     url_name = "nimbus-ui-new-update-overview"
@@ -1894,6 +1971,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             is_rollout=True,
+            sizing_data={"eligible_count": 100_000, "warnings": []},
         )
         phase = NimbusRolloutPhaseFactory.create(experiment=experiment)
         response = self.client.post(
@@ -1923,6 +2001,9 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
             experiment.rollout_pause_observations, "Test rollout pause observations"
         )
         self.assertTrue(response.context["hx_swap_oob"])
+        self.assertContains(response, 'id="rollout-population-sizing-body"')
+        self.assertContains(response, "Phase 1 projected enrollment at")
+        self.assertContains(response, "~25.0K")
 
     def test_post_in_progress_phase_shows_progress(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

- Rollout users need to see the new population size estimates

This commit

- Adds the "Audience Size Estimate" card to the rollouts page with a consistent design

Fixes #16864