### PR TITLE
fix(nimbus): return single eligible-client count from sizing SQL preview

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1092,6 +1092,7 @@ SIZING_WINDOW_DAYS = 7
 SIZING_FULL_SQL_TEMPLATE = """\
 -- Matches the 7-day window and 10% sample used by the population sizing ETL.
 -- Deduplicates on client_id, keeping the most recent ping per client.
+-- Returns the eligible client count within the 10% sample.
 WITH latest_per_client AS (
   SELECT
     *,
@@ -1108,13 +1109,11 @@ WITH latest_per_client AS (
 ),
 clients AS (SELECT * EXCEPT (rn) FROM latest_per_client WHERE rn = 1)
 SELECT
-  client_info.client_id,
-  DATE(submission_timestamp) AS submission_date
+  COUNT(*) AS estimated_client_count
 FROM clients
 WHERE (
     {predicate}
-)
-LIMIT 1000"""
+)"""
 
 RISK_QUESTIONS = {
     "BRAND": (


### PR DESCRIPTION
Because

- The Audience Size Estimate "Generate SQL" preview listed individual `client_info.client_id` / `submission_date` rows capped at `LIMIT 1000`, instead of returning the eligible-client count the card is about. Users copying it into BigQuery got up to 1,000 rows rather than a single number.

This commit

- Replaces the generated SQL's final clause with `SELECT COUNT(*) AS estimated_client_count` and removes `LIMIT 1000`, so the query returns a single eligible-client count within the existing 10% sample. The 7-day window, `sample_id < 10` sample, and `ROW_NUMBER()` dedup are unchanged.

Fixes #16889
