### PR TITLE
feat(nimbus): add loading spinners when transitioning rollout states

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -375,6 +375,23 @@
   }
 }
 
+.sidebar-transition-button .sidebar-transition-spinner {
+  display: none;
+}
+
+.sidebar-transition-button.htmx-request {
+  opacity: 0.55;
+  pointer-events: none;
+
+  > i {
+    display: none;
+  }
+
+  .sidebar-transition-spinner {
+    display: inline-block;
+  }
+}
+
 .rollout-page {
   .cm-editor .cm-scroller {
     font-family: var(--bs-font-monospace);

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -102,16 +102,20 @@
                 {# Preview to Draft #}
                 <button type="button"
                         id="rollout-back-to-setup-btn"
-                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if not experiment.is_preview %} opacity-50{% endif %}"
-                        {% if not experiment.is_preview %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-to-draft-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if not experiment.is_preview %} opacity-50{% endif %}"
+                        {% if not experiment.is_preview %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-to-draft-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                  {% include "new/common/sidebar_transition_spinner.html" %}
+
                   <i class="fa-solid fa-arrow-left-long"></i>
                   Back to Set Up
                 </button>
                 {# Preview to Review #}
                 <button type="button"
                         id="rollout-request-enrollment-btn"
-                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if not experiment.is_preview or setup_issues_count %} opacity-50{% endif %}"
-                        {% if not experiment.is_preview or setup_issues_count %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if not experiment.is_preview or setup_issues_count %} opacity-50{% endif %}"
+                        {% if not experiment.is_preview or setup_issues_count %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-preview-review-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                  {% include "new/common/sidebar_transition_spinner.html" %}
+
                   <i class="fa-regular fa-paper-plane"></i>
                   Request Enrollment
                 </button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -3,17 +3,23 @@
     <div class="d-flex flex-column gap-2 mt-2">
       <button type="button"
               id="rollout-preview-btn"
-              class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+              class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
               hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-disabled-elt="this">
+        {% include "new/common/sidebar_transition_spinner.html" %}
+
         <i class="fa-regular fa-eye"></i>
         Preview
       </button>
       <button type="button"
               id="rollout-launch-btn"
-              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+              class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
               hx-post="{% url 'nimbus-ui-new-draft-to-review-rollout' experiment.slug %}"
-              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
+              hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+              hx-disabled-elt="this">
+        {% include "new/common/sidebar_transition_spinner.html" %}
+
         <i class="fa-regular fa-paper-plane"></i>
         Request Enrollment
       </button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -56,10 +56,13 @@
             {% if experiment.latest_review_requested_by == user.email %}
               <button type="button"
                       id="rollout-review-cancel-btn"
-                      class="btn btn-secondary btn-sm w-100 mb-2 d-flex align-items-center justify-content-center gap-2"
+                      class="btn btn-secondary btn-sm w-100 mb-2 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
                       hx-post="{% url controls.reject_url experiment.slug %}"
                       hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                      hx-disabled-elt="this"
                       hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'>
+                {% include "new/common/sidebar_transition_spinner.html" %}
+
                 <i class="fa-solid fa-rotate-left"></i>
                 Cancel Request
               </button>
@@ -84,11 +87,14 @@
                 </button>
                 <button type="button"
                         id="rollout-review-approve-btn"
-                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
                         hx-post="{% url controls.approve_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                        hx-disabled-elt="this"
                         {% if setup_issues_count %}{% if experiment.is_draft or controls.action_label == "Advance to Next Phase" %}disabled{% endif %}
                         {% endif %}>
+                  {% include "new/common/sidebar_transition_spinner.html" %}
+
                   <i class="fa-regular fa-circle-check"></i>
                   Approve
                 </button>
@@ -104,11 +110,14 @@
                           rows="3"></textarea>
                 <button type="button"
                         id="rollout-review-submit-reject-btn"
-                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2"
+                        class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
                         hx-post="{% url controls.reject_url experiment.slug %}"
                         hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                        hx-disabled-elt="this"
                         hx-vals='{"cancel_message": "cancelled the review request to {{ experiment.review_messages }}"}'
                         hx-include="#rollout-reject-message">
+                  {% include "new/common/sidebar_transition_spinner.html" %}
+
                   <i class="fa-regular fa-circle-xmark"></i>
                   Submit Rejection
                 </button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -10,8 +10,10 @@
                   {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
               <button type="button"
                       id="rollout-resume-btn"
-                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
-                      {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                      {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                {% include "new/common/sidebar_transition_spinner.html" %}
+
                 <i class="fa-regular fa-circle-play"></i>
                 Start next phase
               </button>
@@ -46,8 +48,10 @@
                 </button>
                 <button type="button"
                         id="rollout-duplicate-phase-accept-btn"
-                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
-                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' {% endif %}>
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                  {% include "new/common/sidebar_transition_spinner.html" %}
+
                   <i class="fa-regular fa-circle-check"></i>
                   Accept
                 </button>
@@ -60,8 +64,10 @@
                 {% if transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
             <button type="button"
                     id="rollout-disable-btn"
-                    class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending %} opacity-50{% endif %}"
+                    class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending %} opacity-50{% endif %}"
                     {% if transition_pending %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-live-to-disabled-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+              {% include "new/common/sidebar_transition_spinner.html" %}
+
               <i class="fa-regular fa-circle-stop"></i>
               Disable rollout
             </button>
@@ -71,8 +77,10 @@
                 {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% elif not experiment.next_rollout_phase %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_NO_NEXT_PHASE_TOOLTIP }}"{% endif %}>
             <button type="button"
                     id="rollout-next-phase-btn"
-                    class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or not experiment.next_rollout_phase or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
+                    class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or not experiment.next_rollout_phase or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
                     {% if transition_pending or not experiment.next_rollout_phase or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-advance-phase-review-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+              {% include "new/common/sidebar_transition_spinner.html" %}
+
               <i class="fa-regular fa-circle-play"></i>
               Start next phase
             </button>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_transition_spinner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_transition_spinner.html
@@ -1,0 +1,3 @@
+<span class="spinner-border spinner-border-sm sidebar-transition-spinner"
+      role="status"
+      aria-hidden="true"></span>


### PR DESCRIPTION
Because

- It was unclear when rollout phase transitions were being processed

This commit

- Adds loading spinners to rollout sidebar transition buttons and prevents duplicate submissions while requests are processing

Fixes #16877