### PR TITLE
fix(nimbus): Prevent re-enabling rollouts below supported minimum version

### DIFF
--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -651,6 +651,10 @@ class NimbusConstants:
         Application.IOS: Version.FIREFOX_116,
     }
 
+    ROLLOUT_REENABLE_MIN_SUPPORTED_VERSION = {
+        Application.DESKTOP: Version.FIREFOX_156,
+    }
+
     LOCALIZATION_SUPPORTED_VERSION = {
         Application.DESKTOP: Version.FIREFOX_113,
     }

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2673,6 +2673,32 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             }
 
     @property
+    def supports_rollout_reenable(self):
+        if not self.is_rollout:
+            return True
+
+        min_required_version = NimbusConstants.ROLLOUT_REENABLE_MIN_SUPPORTED_VERSION.get(
+            self.application
+        )
+        if min_required_version is None:
+            return True
+
+        if not self.firefox_min_version:
+            return False
+
+        return NimbusExperiment.Version.parse(
+            self.firefox_min_version
+        ) >= NimbusExperiment.Version.parse(min_required_version)
+
+    @property
+    def show_rollout_reenable_warning(self):
+        return not self.supports_rollout_reenable and self.status in (
+            NimbusConstants.Status.DRAFT,
+            NimbusConstants.Status.PREVIEW,
+            NimbusConstants.Status.LIVE,
+        )
+
+    @property
     def audience_overlap_warnings(self):
         if self.status not in [
             NimbusConstants.Status.DRAFT,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3433,6 +3433,92 @@ class TestNimbusExperiment(TestCase):
         ]
         self.assertEqual(len(version_issues), 1)
 
+    # Firefox Desktop 156 is the first version that supports re-enabling a rollout
+    # under the same slug, so anything below it cannot be re-enabled once disabled.
+    @parameterized.expand(
+        [
+            (
+                False,
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Version.FIREFOX_100,
+                True,
+            ),
+            (
+                True,
+                NimbusExperiment.Application.FENIX,
+                NimbusExperiment.Version.FIREFOX_100,
+                True,
+            ),
+            (
+                True,
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Version.NO_VERSION,
+                False,
+            ),
+            (
+                True,
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Version.FIREFOX_100,
+                False,
+            ),
+            (
+                True,
+                NimbusExperiment.Application.DESKTOP,
+                NimbusExperiment.Version.FIREFOX_156,
+                True,
+            ),
+        ]
+    )
+    def test_supports_rollout_reenable(
+        self, is_rollout, application, firefox_min_version, expected
+    ):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=is_rollout,
+            application=application,
+            firefox_min_version=firefox_min_version,
+        )
+
+        self.assertEqual(experiment.supports_rollout_reenable, expected)
+
+    @parameterized.expand(
+        [
+            (
+                NimbusExperiment.Version.FIREFOX_100,
+                NimbusExperiment.Status.DRAFT,
+                True,
+            ),
+            (
+                NimbusExperiment.Version.FIREFOX_100,
+                NimbusExperiment.Status.LIVE,
+                True,
+            ),
+            (
+                NimbusExperiment.Version.FIREFOX_156,
+                NimbusExperiment.Status.DRAFT,
+                False,
+            ),
+            (
+                NimbusExperiment.Version.NO_VERSION,
+                NimbusExperiment.Status.DRAFT,
+                True,
+            ),
+            (
+                NimbusExperiment.Version.FIREFOX_100,
+                NimbusExperiment.Status.DISABLED,
+                False,
+            ),
+        ]
+    )
+    def test_show_rollout_reenable_warning(self, firefox_min_version, status, expected):
+        experiment = NimbusExperimentFactory.create(
+            status=status,
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=firefox_min_version,
+        )
+
+        self.assertEqual(experiment.show_rollout_reenable_warning, expected)
+
     def test_allocate_buckets_generates_bucket_range(self):
         feature = NimbusFeatureConfigFactory(slug="feature")
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -38,6 +38,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_ROLLOUT_REENABLE_REQUIRES_CURRENT_PHASE = (
         "Cannot duplicate the final phase because this rollout has no current phase."
     )
+    ERROR_ROLLOUT_REENABLE_UNSUPPORTED_VERSION = (
+        "Cannot perform this action: this rollout targets Firefox versions that do "
+        "not support re-enabling a rollout that has been disabled."
+    )
 
     RISK_MESSAGE_URL = "https://mozilla-hub.atlassian.net/wiki/spaces/FIREFOX/pages/208308555/Message+Consult+Creation"
     REVIEW_URL = "https://experimenter.info/getting-started/for-reviewers"
@@ -399,6 +403,15 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ROLLOUT_DISABLED_MESSAGE = (
         "This rollout is currently disabled. You can re-enable it by starting the "
         "next phase."
+    )
+    ROLLOUT_REENABLE_UNSUPPORTED_MESSAGE = (
+        "This rollout cannot be re-enabled because Firefox Desktop versions under "
+        "156 do not support re-enabling a rollout that has been disabled."
+    )
+    ROLLOUT_REENABLE_VERSION_WARNING = (
+        "Firefox Desktop versions under 156 do not support re-enabling a rollout "
+        "once it has been disabled. If this rollout is disabled, it cannot be "
+        "started again."
     )
     ROLLOUT_DUPLICATE_PHASE_MESSAGE = (
         "There is no next phase to start. Accept to copy and launch the current "

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1222,6 +1222,7 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
     required_publish_status = None
     required_is_paused = None
     requires_valid_rollout_launch = False
+    requires_rollout_reenable_support = False
 
     class Meta:
         model = NimbusExperiment
@@ -1282,6 +1283,14 @@ class UpdateStatusForm(NimbusChangeLogFormMixin, forms.ModelForm):
                 raise forms.ValidationError(
                     NimbusUIConstants.ERROR_INVALID_ROLLOUT_LAUNCH
                 )
+
+        if (
+            self.requires_rollout_reenable_support
+            and not self.instance.supports_rollout_reenable
+        ):
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_ROLLOUT_REENABLE_UNSUPPORTED_VERSION
+            )
 
         return cleaned_data
 
@@ -1622,6 +1631,7 @@ class LiveToDisabledReviewRejectRolloutForm(CancelRequestMixin, UpdateStatusForm
 
 
 class DisabledToLiveReviewRolloutForm(SlackNotificationMixin, UpdateStatusForm):
+    requires_rollout_reenable_support = True
     required_status = NimbusExperiment.Status.DISABLED
     required_status_next = None
     required_publish_status = NimbusExperiment.PublishStatus.IDLE
@@ -1666,6 +1676,7 @@ class DisabledToLiveDuplicatePhaseReviewRolloutForm(DisabledToLiveReviewRolloutF
 
 
 class DisabledToLiveReviewApproveRolloutForm(UpdateStatusForm):
+    requires_rollout_reenable_support = True
     required_status = NimbusExperiment.Status.DISABLED
     required_status_next = NimbusExperiment.Status.LIVE
     required_publish_status = NimbusExperiment.PublishStatus.REVIEW

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/audience_overlap_warnings.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/audience_overlap_warnings.html
@@ -8,8 +8,7 @@
                   border: 1px solid var(--bs-warning-border-subtle)"
            role="alert">
         <p class="mb-1 d-flex align-items-center gap-2 fw-semibold">
-          <i class="fa-solid fa-triangle-exclamation"
-             style="color: var(--bs-orange)"></i>
+          <i class="fa-solid fa-triangle-exclamation text-warning"></i>
           {{ warning.text }}
         </p>
         <ul class="mb-1">

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/rollout_reenable_warning.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/rollout_reenable_warning.html
@@ -1,0 +1,15 @@
+<div id="rollout-reenable-warning"
+     style="display: contents"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  {% if experiment.show_rollout_reenable_warning %}
+    <div class="rounded-2 p-3 small"
+         style="background-color: var(--bs-warning-bg-subtle);
+                border: 1px solid var(--bs-warning-border-subtle)"
+         role="alert">
+      <p class="mb-0 d-flex align-items-center gap-2">
+        <i class="fa-solid fa-triangle-exclamation text-warning"></i>
+        {{ NimbusUIConstants.ROLLOUT_REENABLE_VERSION_WARNING }}
+      </p>
+    </div>
+  {% endif %}
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar.html
@@ -188,7 +188,11 @@
               {% endwith %}
               <p class="text-secondary mb-0" style="font-size: 12px;">
                 {% if experiment.is_disabled %}
-                  {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
+                  {% if not experiment.supports_rollout_reenable %}
+                    {{ NimbusUIConstants.ROLLOUT_REENABLE_UNSUPPORTED_MESSAGE }}
+                  {% else %}
+                    {{ NimbusUIConstants.ROLLOUT_DISABLED_MESSAGE }}
+                  {% endif %}
                 {% else %}
                   {{ NimbusUIConstants.ROLLOUT_LIVE_MESSAGE }}
                 {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_rollout_actions.html
@@ -1,17 +1,17 @@
 <div id="sidebar-rollout-actions"
      {% if oob %}hx-swap-oob="true"{% endif %}>
   {% if experiment.is_rolling_out %}
-    {% with transition_pending=experiment.has_pending_rollout_transition %}
+    {% with transition_pending=experiment.has_pending_rollout_transition reenable_supported=experiment.supports_rollout_reenable %}
       <div class="d-flex flex-column gap-2">
         {% if experiment.is_disabled %}
           {% if experiment.next_rollout_phase %}
             {# Disabled to Live #}
             <span class="d-inline-block w-100"
-                  {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+                  {% if not reenable_supported %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REENABLE_UNSUPPORTED_MESSAGE }}"{% elif experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
               <button type="button"
                       id="rollout-resume-btn"
-                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
-                      {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                      class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} opacity-50{% endif %}"
+                      {% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
                 {% include "new/common/sidebar_transition_spinner.html" %}
 
                 <i class="fa-regular fa-circle-play"></i>
@@ -22,11 +22,11 @@
             {# Disabled to Live #}
             <div class="collapse show rollout-resume-swap" id="rollout-resume-trigger">
               <span class="d-inline-block w-100"
-                    {% if experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
+                    {% if not reenable_supported %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REENABLE_UNSUPPORTED_MESSAGE }}"{% elif experiment.has_rollout_review_errors %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_HAS_ISSUES_TOOLTIP }}"{% elif transition_pending %}data-bs-toggle="tooltip" title="{{ NimbusUIConstants.ROLLOUT_REVIEW_PENDING_TOOLTIP }}"{% endif %}>
                 <button type="button"
                         id="rollout-resume-btn"
-                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
-                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} data-bs-toggle="collapse" data-bs-target=".rollout-resume-swap" aria-expanded="false" aria-controls="rollout-duplicate-phase-confirm" {% endif %}>
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2{% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} opacity-50{% endif %}"
+                        {% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} disabled aria-disabled="true" {% else %} data-bs-toggle="collapse" data-bs-target=".rollout-resume-swap" aria-expanded="false" aria-controls="rollout-duplicate-phase-confirm" {% endif %}>
                   <i class="fa-regular fa-circle-play"></i>
                   Start next phase
                 </button>
@@ -48,8 +48,8 @@
                 </button>
                 <button type="button"
                         id="rollout-duplicate-phase-accept-btn"
-                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors %} opacity-50{% endif %}"
-                        {% if transition_pending or experiment.has_rollout_review_errors %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
+                        class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button{% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} opacity-50{% endif %}"
+                        {% if transition_pending or experiment.has_rollout_review_errors or not reenable_supported %} disabled aria-disabled="true" {% else %} hx-post="{% url 'nimbus-ui-new-disabled-to-live-duplicate-phase-rollout' experiment.slug %}" hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}' hx-disabled-elt="this" {% endif %}>
                   {% include "new/common/sidebar_transition_spinner.html" %}
 
                   <i class="fa-regular fa-circle-check"></i>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -228,6 +228,7 @@
     </div>
   </div>
   {% if hx_swap_oob %}
+    {% include "new/common/rollout_reenable_warning.html" with oob=True %}
     {% include "new/common/audience_overlap_warnings.html" with oob=True %}
 
   {% endif %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -7,6 +7,7 @@
 {% block main_content %}
   {% devtools_integration experiment "rollout" %}
   <div id="RolloutSummary" class="d-flex flex-column gap-4">
+    {% include "new/common/rollout_reenable_warning.html" %}
     {% include "new/common/audience_overlap_warnings.html" %}
 
     {% if experiment.monitoring_data %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -1725,6 +1725,7 @@ class TestRolloutStatusForms(
             publish_status=initial_publish_status,
             is_paused=False,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         if form_class is LiveToDisabledReviewRolloutForm:
             NimbusRolloutPhaseFactory.create(experiment=experiment)
@@ -1798,6 +1799,29 @@ class TestRolloutStatusForms(
         self.assertIn(
             "Cannot perform this action: experiment must be in state",
             form.errors["__all__"][0],
+        )
+
+    @parameterized.expand(
+        [
+            (DisabledToLiveReviewRolloutForm,),
+            (DisabledToLiveReviewApproveRolloutForm,),
+        ]
+    )
+    def test_reenable_below_min_version_rejects_transition(self, form_class):
+        experiment = NimbusExperimentFactory.create(
+            status=form_class.required_status,
+            status_next=form_class.required_status_next,
+            publish_status=form_class.required_publish_status,
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_100,
+        )
+        form = form_class(data={}, instance=experiment, request=self.request)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn(
+            NimbusUIConstants.ERROR_ROLLOUT_REENABLE_UNSUPPORTED_VERSION,
+            form.errors["__all__"],
         )
 
     @parameterized.expand(
@@ -2132,6 +2156,7 @@ class TestRolloutStatusForms(
             publish_status=NimbusExperiment.PublishStatus.REVIEW,
             is_rollout=True,
             population_percent=0,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         current_phase = NimbusRolloutPhaseFactory.create(
             experiment=experiment, population_percent=10
@@ -2172,6 +2197,7 @@ class TestRolloutStatusForms(
             status=NimbusExperiment.Status.DISABLED,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         final_phase = NimbusRolloutPhaseFactory.create(
             experiment=experiment,
@@ -2214,6 +2240,7 @@ class TestRolloutStatusForms(
             status=NimbusExperiment.Status.DISABLED,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         current_phase = NimbusRolloutPhaseFactory.create(
             experiment=experiment, population_percent=25
@@ -2236,6 +2263,7 @@ class TestRolloutStatusForms(
             status=NimbusExperiment.Status.DISABLED,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         form = DisabledToLiveDuplicatePhaseReviewRolloutForm(
             data={}, instance=experiment, request=self.request
@@ -2294,6 +2322,7 @@ class TestRolloutStatusForms(
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
             enable_review_slack_notifications=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         if form_class is LiveToDisabledReviewRolloutForm:
             NimbusRolloutPhaseFactory.create(experiment=experiment)

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -242,6 +242,7 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             status_next=form_class.required_status_next,
             publish_status=form_class.required_publish_status,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         if url_name == "nimbus-ui-new-live-to-disabled-rollout":
             NimbusRolloutPhaseFactory.create(experiment=experiment)
@@ -436,6 +437,7 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             status=NimbusExperiment.Status.DISABLED,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
         final_phase = NimbusRolloutPhaseFactory.create(
             experiment=experiment, population_percent=25
@@ -467,6 +469,7 @@ class TestRolloutStatusUpdateViews(AuthTestCase):
             status=NimbusExperiment.Status.DISABLED,
             publish_status=NimbusExperiment.PublishStatus.IDLE,
             is_rollout=True,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_156,
         )
 
         response = self.client.post(
@@ -598,18 +601,49 @@ class TestNimbusRolloutDetailView(AuthTestCase):
             publish_status=publish_status,
         )
         NimbusRolloutPhaseFactory.create(experiment=experiment)
+        disable_url = reverse(
+            "nimbus-ui-new-live-to-disabled-rollout", kwargs={"slug": experiment.slug}
+        )
 
         response = self.client.get(
             reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
         )
 
         self.assertEqual(response.status_code, 200)
-        content = response.content.decode()
-        start = content.index('id="rollout-disable-btn"')
-        button_tag = content[start : content.index(">", start)]
-        self.assertNotIn("hx-post", button_tag)
-        button_tag = button_tag.replace('hx-disabled-elt="this"', "")
-        self.assertIn("disabled", button_tag)
+        self.assertContains(response, 'id="rollout-disable-btn"')
+        self.assertNotContains(response, disable_url)
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Version.FIREFOX_100, False),
+            (NimbusExperiment.Version.FIREFOX_156, True),
+        ]
+    )
+    def test_resume_button_disabled_below_min_reenable_version(
+        self, firefox_min_version, expected_enabled
+    ):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.DISABLED,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=firefox_min_version,
+        )
+        NimbusRolloutPhaseFactory.create(experiment=experiment)
+        reenable_url = reverse(
+            "nimbus-ui-new-disabled-to-live-rollout", kwargs={"slug": experiment.slug}
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="rollout-resume-btn"')
+        if expected_enabled:
+            self.assertContains(response, reenable_url)
+        else:
+            self.assertNotContains(response, reenable_url)
 
     def test_get_returns_new_rollout_detail_context(self):
         tag = TagFactory.create()

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -434,7 +434,9 @@ def configured_rollout(selenium, create_rollout, default_data):
     audience.edit()
     if default_data.application != "firefox-desktop":
         audience.channel = "Beta"
-    audience.min_version = default_data.audience.min_version
+        audience.min_version = default_data.audience.min_version
+    else:
+        audience.min_version = helpers.ROLLOUT_REENABLE_MIN_VERSION
     audience.countries = ["Canada"]
     audience.is_sticky = True
     audience.save()

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -16,6 +16,10 @@ FIXTURES_DIR = Path(__file__).resolve().parents[1] / "fixtures"
 TARGETING_CONFIGS_PATH = FIXTURES_DIR / "targeting_configs.json"
 FEATURE_CONFIGS_PATH = FIXTURES_DIR / "feature_configs.json"
 
+# Mirrors ROLLOUT_REENABLE_MIN_SUPPORTED_VERSION in experimenter.experiments.constants
+# Rollouts below this version cannot be re-enabled once disabled.
+ROLLOUT_REENABLE_MIN_VERSION = "156.!"
+
 NO_FEATURE_SLUGS = {
     BaseExperimentApplications.FIREFOX_DESKTOP.value: "no-feature-firefox-desktop",
     BaseExperimentApplications.FIREFOX_FENIX.value: "no-feature-fenix",


### PR DESCRIPTION
Because

* When a rollout is launched and later disabled, re-enabling it with a minimum Firefox version lower than 156 is not supported because older versions do not support re-enabling the same rollout slug

This commit

* Prevents user from being able to re-enable the rollout when the configured minimum version is below 156
* Shows user warning at top of page and on the sidebar card

Fixes #16873