### PR TITLE
chore(project): gate desktop targeting integration tests per firefox channel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,6 +176,13 @@ jobs:
       matrix:
         channel: [release, beta, nightly]
         split: [0, 1]
+        include:
+          - channel: release
+            extra_paths: "experimenter/tests/firefox_desktop_release_build.env"
+          - channel: beta
+            extra_paths: "experimenter/tests/firefox_desktop_beta_build.env"
+          - channel: nightly
+            extra_paths: ""
     name: "Desktop Targeting (${{ matrix.channel }} ${{ matrix.split }})"
     runs-on: ubuntu-24.04
     permissions:
@@ -192,7 +199,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/ application-services/"
+          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/tests/integration/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock ${{ matrix.extra_paths }}"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'


### PR DESCRIPTION
Because

* The targeting job was gated on all of `experimenter/`, so nearly every PR ran six Selenium jobs that cannot affect targeting evaluation.
* A bad targeting expression can only enter through the targeting config fragments, the experiment model that composes the expression, or a pinned Firefox build bump.
* A build env bump for one channel should not exercise the other two channels.

This commit

* Narrows the `integration-desktop-targeting` path gate to the experiments app, the targeting package, and the integration test suite and its harness.
* Adds a matrix `include:` supplying a per-channel `extra_paths` so each channel also runs on its own pinned build env file.
* Leaves nightly with no extra path, since it fetches the latest build at runtime and has no pinned env file.

Fixes #16907