### PR TITLE
test(nimbus): validate targeting config jexl transform names

### DIFF
--- a/experimenter/experimenter/experiments/jexl_utils.py
+++ b/experimenter/experimenter/experiments/jexl_utils.py
@@ -95,6 +95,30 @@ def collect_exprs(expr):
     return exprs
 
 
+def extract_transform_names(expression):
+    """
+    Collect the names of every transform applied in a JEXL expression
+    """
+    nodes = [JEXLParser().parse(expression)]
+    names = set()
+
+    while nodes:
+        node = nodes.pop()
+
+        if isinstance(node, Transform):
+            names.add(node.name)
+
+        children = list(node.children)
+        if isinstance(node, ArrayLiteral):
+            children.extend(node.value)
+        elif isinstance(node, ObjectLiteral):
+            children.extend(node.value.values())
+
+        nodes += children
+
+    return names
+
+
 def format_jexl(expression):
     if not expression or expression == "true":
         return expression

--- a/experimenter/experimenter/experiments/tests/test_jexl_utils.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_utils.py
@@ -3,6 +3,7 @@ from parameterized import parameterized
 
 from experimenter.experiments.jexl_utils import (
     JEXLParser,
+    extract_transform_names,
     format_jexl,
     to_str,
 )
@@ -252,3 +253,26 @@ class TestToStr(TestCase):
     def test_invalid_expression_to_str(self):
         with self.assertRaises(Exception):
             to_str("a && || b")
+
+
+class TestExtractTransformNames(TestCase):
+    @parameterized.expand(
+        [
+            ("a == 1", set()),
+            ("a|length", {"length"}),
+            ("a|keys|length", {"keys", "length"}),
+            ("a|mapToProperty(b|keys)", {"mapToProperty", "keys"}),
+            ("a|date > b|date", {"date"}),
+            ("!(a|preferenceValue)", {"preferenceValue"}),
+            ("a ? b|keys : c|values", {"keys", "values"}),
+            ("items[a|length > 1]", {"length"}),
+            ("a in [b|keys, c|values]", {"keys", "values"}),
+            ("{a: b|keys}", {"keys"}),
+            (
+                "'x'|stableSample(0.5) && 'y'|versionCompare('1.0') >= 0",
+                {"stableSample", "versionCompare"},
+            ),
+        ]
+    )
+    def test_extract_transform_names(self, expression, expected_names):
+        self.assertEqual(extract_transform_names(expression), expected_names)

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -49,6 +49,39 @@ PRESERVED_TARGETING_KEYS_BY_APPLICATION = {
     Application.IOS: {"current_date", "nimbus_id"},
 }
 
+DESKTOP_TRANSFORMS = {
+    "date",
+    "stableSample",
+    "bucketSample",
+    "preferenceValue",
+    "preferenceIsUserSet",
+    "preferenceExists",
+    "preferenceIsLocked",
+    "keys",
+    "values",
+    "length",
+    "mapToProperty",
+    "regExpMatch",
+    "versionCompare",
+}
+
+MOBILE_TRANSFORMS = {
+    "versionCompare",
+    "eventSum",
+    "eventCountNonZero",
+    "eventAveragePerInterval",
+    "eventAveragePerNonZeroInterval",
+    "eventLastSeen",
+    "preferenceIsUserSet",
+    "bucketSample",
+}
+
+TRANSFORMS_BY_APPLICATION = {
+    Application.DESKTOP: DESKTOP_TRANSFORMS,
+    Application.FENIX: MOBILE_TRANSFORMS,
+    Application.IOS: MOBILE_TRANSFORMS,
+}
+
 HAS_PIN = "!doesAppNeedPin"
 NEED_DEFAULT = "!isDefaultBrowser"
 PROFILE28DAYS = "(currentDate|date - profileAgeCreated|date) / 86400000 >= 28"

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -7,10 +7,14 @@ from experimenter.experiments.jexl_to_sql import (
     KNOWN_UNTRANSLATABLE,
     jexl_to_sql,
 )
-from experimenter.experiments.jexl_utils import extract_targeting_fields
+from experimenter.experiments.jexl_utils import (
+    extract_targeting_fields,
+    extract_transform_names,
+)
 from experimenter.experiments.tests.jexl_utils import validate_jexl_expr
 from experimenter.targeting.constants import (
     PRESERVED_TARGETING_KEYS_BY_APPLICATION,
+    TRANSFORMS_BY_APPLICATION,
     TargetingConstants,
 )
 from experimenter.targeting.targeting_context_parser import TargetingContextFields
@@ -64,6 +68,28 @@ class TestTargetingConfigs(TestCase):
                 f"{targeting_config.name}. Add it to "
                 f"JEXL_TO_BQ_COLUMN or KNOWN_UNTRANSLATABLE.",
             )
+
+    @parameterized.expand([(t,) for t in TargetingConstants.TARGETING_CONFIGS.values()])
+    def test_targeting_config_transforms_are_known(self, targeting_config):
+        if not targeting_config.targeting:
+            return
+
+        applications = [
+            Application[app]
+            for app in targeting_config.application_choice_names
+            if Application[app] in TRANSFORMS_BY_APPLICATION
+        ]
+
+        for transform in extract_transform_names(targeting_config.targeting):
+            for application in applications:
+                self.assertIn(
+                    transform,
+                    TRANSFORMS_BY_APPLICATION[application],
+                    f"Unknown JEXL transform '{transform}' in "
+                    f"{targeting_config.slug} for {application.name}. "
+                    f"Every transform must be supported by every application "
+                    f"the config targets.",
+                )
 
     def test_desktop_targeting_context_fields_are_mapped(self):
         """Every field in the Desktop targeting context must be in JEXL_TO_BQ_COLUMN


### PR DESCRIPTION
Because

* pyjexl accepts any transform name at any arity, so a misspelled or wrong-platform transform in a targeting config parses cleanly.
* The existing unit tests skip transform warnings and only inspect leaf identifiers, so nothing catches it.
* A bad transform is only reported ~20 minutes into the Selenium run_targeting job as "Invalid Targeting, or bad recipe".

This commit

* Adds `extract_transform_names` to `jexl_utils`, walking the parse tree for every `Transform` node including nested and chained ones.
* Adds per-application transform allowlists to targeting constants, derived from `FilterExpressions.sys.mjs` for Desktop and nimbus `targeting.rs` for mobile.
* Adds `test_targeting_config_transforms_are_known`, requiring every transform to be supported by every application a config targets.

Fixes #16908