### PR TITLE
feat(nimbus): Add Labs to the new delivery menu

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -675,7 +675,11 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         ).exists()
 
     def get_detail_url(self):
-        if self.is_rollout and self.is_new_rollout_ui_enabled:
+        if (
+            self.is_rollout
+            and not self.is_firefox_labs_opt_in
+            and self.is_new_rollout_ui_enabled
+        ):
             return reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": self.slug})
 
         return reverse("nimbus-ui-detail", kwargs={"slug": self.slug})

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -709,6 +709,25 @@ class TestNimbusExperiment(TestCase):
             reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
         )
 
+    def test_get_detail_url_uses_legacy_url_for_labs_when_flag_is_enabled(self):
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+        experiment = NimbusExperimentFactory.create(
+            slug="my-labs",
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="test-fx-labs-title",
+            firefox_labs_description="test-fx-labs-description",
+            firefox_labs_group="group",
+        )
+
+        self.assertEqual(
+            experiment.get_detail_url(),
+            reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+        )
+
     def test_get_detail_url_caches_site_flag_query(self):
         experiment = NimbusExperimentFactory.create(slug="my-rollout", is_rollout=True)
 

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -288,6 +288,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "for the selected versions."
     )
 
+    NEW_DELIVERY_LABS_DESCRIPTION = (
+        "Give users early access to your experimental feature. Start a foxfooding "
+        "campaign to get qualitative external feedback sooner."
+    )
+
     KEY_TAKEAWAYS_EMPTY_TEXT = """Was your hypothesis right, wrong, or somewhere in
     between? Call out what changed in a meaningful way (ideally things that were
     statistically significant)."""

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -306,6 +306,20 @@ class NimbusRolloutCreateForm(NimbusExperimentCreateForm):
         return super().save(*args, **kwargs)
 
 
+class NimbusFirefoxLabsCreateForm(NimbusRolloutCreateForm):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["application"].choices = [
+            (application.value, application.label)
+            for application in NimbusExperiment.Application
+            if NimbusExperiment.APPLICATION_CONFIGS[application].firefox_labs
+        ]
+
+    def save(self, *args, **kwargs):
+        self.instance.is_firefox_labs_opt_in = True
+        return super().save(*args, **kwargs)
+
+
 class NimbusExperimentSidebarCloneForm(NimbusChangeLogFormMixin, forms.ModelForm):
     owner = forms.ModelChoiceField(
         User.objects.all(),

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -36,6 +36,7 @@ from experimenter.nimbus_ui.new.forms import (
     LiveToDisabledReviewRolloutForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
+    NimbusFirefoxLabsCreateForm,
     NimbusRolloutCreateForm,
     PreviewReviewRolloutForm,
     PreviewToDraftRolloutForm,
@@ -106,6 +107,7 @@ class NimbusExperimentViewMixin:
         )
         context["all_tags"] = Tag.objects.all().order_by("name")
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         if experiment and experiment.slug:
             context["slack_notifications_form"] = ToggleReviewSlackNotificationsForm(
@@ -145,6 +147,11 @@ class NimbusRolloutsCreateView(NimbusExperimentsCreateView):
 
     def get_redirect_url(self):
         return reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": self.object.slug})
+
+
+class NimbusFirefoxLabsCreateView(NimbusExperimentsCreateView):
+    form_class = NimbusFirefoxLabsCreateForm
+    template_name = "nimbus_experiments/create.html"
 
 
 def build_experiment_context(experiment):
@@ -326,7 +333,9 @@ class NimbusRolloutDetailView(
         return context
 
     def get_queryset(self):
-        return super().get_queryset().filter(is_rollout=True)
+        return (
+            super().get_queryset().filter(is_rollout=True, is_firefox_labs_opt_in=False)
+        )
 
 
 class CardMixin:

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -84,7 +84,7 @@
               </button>
               <button id="create-new-rollout-button"
                       type="button"
-                      class="dropdown-item d-flex align-items-start gap-3 rounded-2 p-2 text-wrap"
+                      class="dropdown-item d-flex align-items-start gap-3 rounded-2 p-2 mb-2 text-wrap"
                       data-bs-toggle="modal"
                       data-bs-target="#createRolloutModal">
                 <span class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-success-subtle text-success p-2 fs-5">
@@ -95,6 +95,19 @@
                   <span class="d-block small text-secondary">
                     Deliver new features to users early and safely—expand exposure over time and roll back instantly if needed. Ideal for staged launches without change metrics or statistical tracking.
                   </span>
+                </span>
+              </button>
+              <button id="create-new-labs-button"
+                      type="button"
+                      class="dropdown-item d-flex align-items-start gap-3 rounded-2 p-2 text-wrap"
+                      data-bs-toggle="modal"
+                      data-bs-target="#createLabsModal">
+                <span class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-warning-subtle text-warning-emphasis p-2 fs-5">
+                  <i class="fa-solid fa-flask"></i>
+                </span>
+                <span>
+                  <span class="d-block fw-semibold">Lab</span>
+                  <span class="d-block small text-secondary">{{ NimbusUIConstants.NEW_DELIVERY_LABS_DESCRIPTION }}</span>
                 </span>
               </button>
             </div>
@@ -299,6 +312,34 @@
                 hx-post="{% url 'nimbus-ui-new-create-rollout' %}"
                 hx-target="#createRolloutForm">
             {% include "nimbus_experiments/create.html" with form=create_form %}
+
+          </form>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="modal fade"
+       id="createLabsModal"
+       tabindex="-1"
+       aria-labelledby="createLabsModalLabel"
+       aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title" id="createLabsModalLabel">
+            <i class="fa-regular fa-pen-to-square me-1"></i>
+            Create Lab
+          </h5>
+          <button type="button"
+                  class="btn-close"
+                  data-bs-dismiss="modal"
+                  aria-label="Close"></button>
+        </div>
+        <div class="modal-body bg-body-tertiary">
+          <form id="createLabsForm"
+                hx-post="{% url 'nimbus-ui-new-create-labs' %}"
+                hx-target="#createLabsForm">
+            {% include "nimbus_experiments/create.html" with form=create_labs_form %}
 
           </form>
         </div>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_branches.html
@@ -44,7 +44,9 @@
               {% for error in validation_errors.feature_configs %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
             </div>
           </div>
-          {% if not site_flag_enabled.NEW_DELIVERY_MENU %}
+          {% if site_flag_enabled.NEW_DELIVERY_MENU %}
+            <input type="hidden" name="is_rollout" value="{{ experiment.is_rollout }}">
+          {% else %}
             <div class="row mb-3">
               <div class="col">
                 <div class="form-check">
@@ -332,103 +334,109 @@
         </div>
       </div>
       {% if experiment.application_config.firefox_labs %}
-        <div id="labs" class="card mb-3">
-          <div class="card-header">
-            <h4>Firefox Labs</h4>
-          </div>
-          <div class="card-body">
-            <div class="row mb-3">
-              <div class="col">
-                <div class="form-check">
-                  {{ form.is_firefox_labs_opt_in }}
-                  <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
-                </div>
-                {% for error in validation_errors.is_firefox_labs_opt_in %}
-                  <div class="form-text text-danger">{{ error }}</div>
-                {% endfor %}
-              </div>
+        {% if not site_flag_enabled.NEW_DELIVERY_MENU or experiment.is_firefox_labs_opt_in %}
+          <div id="labs" class="card mb-3">
+            <div class="card-header">
+              <h4>Firefox Labs</h4>
             </div>
-            {% if experiment.is_firefox_labs_opt_in %}
-              <div class="row mb-3">
-                <div class="col">
-                  <label class="d-block">
-                    The title to display in Firefox Labs
-                    {% if experiment.is_mobile %}
-                      (Resource ID)
-                    {% else %}
-                      (Fluent ID)
-                    {% endif %}
-                    {{ form.firefox_labs_title }}
-                  </label>
-                  {{ form.firefox_labs_title.errors }}
-                  {% for error in validation_errors.firefox_labs_title %}
-                    <div class="form-text text-danger">{{ error }}</div>
-                  {% endfor %}
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col">
-                  <label class="d-block">
-                    The description to display in Firefox Labs
-                    {% if experiment.is_mobile %}
-                      (Resource ID)
-                    {% else %}
-                      (Fluent ID)
-                    {% endif %}
-                    {{ form.firefox_labs_description }}
-                  </label>
-                  {{ form.firefox_labs_description.errors }}
-                  {% for error in validation_errors.firefox_labs_description %}
-                    <div class="form-text text-danger">{{ error }}</div>
-                  {% endfor %}
-                </div>
-              </div>
-              <div class="row mb-3">
-                <div class="col">
-                  {% if experiment.application_config.firefox_labs.supports_arbitrary_description_links %}
-                    <label class="d-block">
-                      Description Links (JSON)
-                      {{ form.firefox_labs_description_links }}
-                    </label>
-                  {% else %}
-                    <label class="d-block">Feedback Link</label>
-                    {{ form.firefox_labs_description_link }}
-                    <div class="form-text">This link will be the target of the "Share Feedback" button on your Firefox Labs entry.</div>
-                  {% endif %}
-                  {# There are no firefox_labs_description_link errors: the field is always validated as firefox_labs_description_links #}
-                  {{ form.firefox_labs_description_links.errors }}
-                  {% for error in validation_errors.firefox_labs_description_links %}
-                    <div class="form-text text-danger">{{ error }}</div>
-                  {% endfor %}
-                </div>
-              </div>
-              {% if experiment.application_config.firefox_labs.supports_groups %}
+            <div class="card-body">
+              {% if site_flag_enabled.NEW_DELIVERY_MENU %}
+                <input type="hidden" name="is_firefox_labs_opt_in" value="True">
+              {% else %}
                 <div class="row mb-3">
                   <div class="col">
-                    <label class="d-block">
-                      Firefox Labs Group
-                      {{ form.firefox_labs_group }}
-                    </label>
-                    {{ form.firefox_labs_group.errors }}
-                    {% for error in validation_errors.firefox_labs_group %}
+                    <div class="form-check">
+                      {{ form.is_firefox_labs_opt_in }}
+                      <label class="form-check-label" for="id_is_firefox_labs_opt_in">Is this a Firefox Labs rollout?</label>
+                    </div>
+                    {% for error in validation_errors.is_firefox_labs_opt_in %}
                       <div class="form-text text-danger">{{ error }}</div>
                     {% endfor %}
                   </div>
                 </div>
               {% endif %}
-              <div class="row mb-3">
-                <div class="col">
-                  <div class="form-check">
-                    {{ form.requires_restart }}
-                    <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+              {% if experiment.is_firefox_labs_opt_in %}
+                <div class="row mb-3">
+                  <div class="col">
+                    <label class="d-block">
+                      The title to display in Firefox Labs
+                      {% if experiment.is_mobile %}
+                        (Resource ID)
+                      {% else %}
+                        (Fluent ID)
+                      {% endif %}
+                      {{ form.firefox_labs_title }}
+                    </label>
+                    {{ form.firefox_labs_title.errors }}
+                    {% for error in validation_errors.firefox_labs_title %}
+                      <div class="form-text text-danger">{{ error }}</div>
+                    {% endfor %}
                   </div>
-                  {{ form.requires_restart.errors }}
-                  {% for error in validation_errors.requires_restart %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
                 </div>
-              </div>
-            {% endif %}
+                <div class="row mb-3">
+                  <div class="col">
+                    <label class="d-block">
+                      The description to display in Firefox Labs
+                      {% if experiment.is_mobile %}
+                        (Resource ID)
+                      {% else %}
+                        (Fluent ID)
+                      {% endif %}
+                      {{ form.firefox_labs_description }}
+                    </label>
+                    {{ form.firefox_labs_description.errors }}
+                    {% for error in validation_errors.firefox_labs_description %}
+                      <div class="form-text text-danger">{{ error }}</div>
+                    {% endfor %}
+                  </div>
+                </div>
+                <div class="row mb-3">
+                  <div class="col">
+                    {% if experiment.application_config.firefox_labs.supports_arbitrary_description_links %}
+                      <label class="d-block">
+                        Description Links (JSON)
+                        {{ form.firefox_labs_description_links }}
+                      </label>
+                    {% else %}
+                      <label class="d-block">Feedback Link</label>
+                      {{ form.firefox_labs_description_link }}
+                      <div class="form-text">This link will be the target of the "Share Feedback" button on your Firefox Labs entry.</div>
+                    {% endif %}
+                    {# There are no firefox_labs_description_link errors: the field is always validated as firefox_labs_description_links #}
+                    {{ form.firefox_labs_description_links.errors }}
+                    {% for error in validation_errors.firefox_labs_description_links %}
+                      <div class="form-text text-danger">{{ error }}</div>
+                    {% endfor %}
+                  </div>
+                </div>
+                {% if experiment.application_config.firefox_labs.supports_groups %}
+                  <div class="row mb-3">
+                    <div class="col">
+                      <label class="d-block">
+                        Firefox Labs Group
+                        {{ form.firefox_labs_group }}
+                      </label>
+                      {{ form.firefox_labs_group.errors }}
+                      {% for error in validation_errors.firefox_labs_group %}
+                        <div class="form-text text-danger">{{ error }}</div>
+                      {% endfor %}
+                    </div>
+                  </div>
+                {% endif %}
+                <div class="row mb-3">
+                  <div class="col">
+                    <div class="form-check">
+                      {{ form.requires_restart }}
+                      <label class="form-check-label" for="id_requires_restart">Requires restart to take effect?</label>
+                    </div>
+                    {{ form.requires_restart.errors }}
+                    {% for error in validation_errors.requires_restart %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                  </div>
+                </div>
+              {% endif %}
+            </div>
           </div>
-        </div>
+        {% endif %}
       {% endif %}
       <div class="d-flex justify-content-end">
         <button type="submit" id="save-button" class="btn btn-primary">Save</button>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -52,6 +52,7 @@ from experimenter.nimbus_ui.new.forms import (
     NimbusBranchFeatureValueForm,
     NimbusExperimentCreateForm,
     NimbusExperimentSidebarCloneForm,
+    NimbusFirefoxLabsCreateForm,
     NimbusRolloutCreateForm,
     PreviewReviewRolloutForm,
     PreviewToDraftRolloutForm,
@@ -197,6 +198,45 @@ class TestNimbusRolloutCreateForm(RequestFormTestCase):
         self.assertTrue(rollout.is_rollout)
         self.assertEqual(rollout.branches.count(), 1)
         self.assertEqual(rollout.reference_branch.name, "Control")
+
+
+class TestNimbusFirefoxLabsCreateForm(RequestFormTestCase):
+    def test_form_creates_labs_rollout(self):
+        data = {
+            "owner": self.user,
+            "name": "Test Labs",
+            "hypothesis": "test hypothesis",
+            "application": NimbusExperiment.Application.DESKTOP,
+        }
+        form = NimbusFirefoxLabsCreateForm(data, request=self.request)
+        self.assertTrue(form.is_valid(), form.errors)
+
+        labs = form.save()
+
+        self.assertTrue(labs.is_firefox_labs_opt_in)
+        self.assertTrue(labs.is_rollout)
+        self.assertEqual(labs.branches.count(), 1)
+        self.assertEqual(labs.reference_branch.name, "Control")
+
+    def test_form_only_offers_applications_supporting_labs(self):
+        form = NimbusFirefoxLabsCreateForm(request=self.request)
+
+        self.assertEqual(
+            [value for value, _ in form.fields["application"].choices],
+            [NimbusExperiment.Application.DESKTOP, NimbusExperiment.Application.FENIX],
+        )
+
+    def test_form_rejects_application_without_labs_support(self):
+        data = {
+            "owner": self.user,
+            "name": "Test Labs",
+            "hypothesis": "test hypothesis",
+            "application": NimbusExperiment.Application.IOS,
+        }
+        form = NimbusFirefoxLabsCreateForm(data, request=self.request)
+
+        self.assertFalse(form.is_valid())
+        self.assertIn("application", form.errors)
 
 
 class TestNimbusExperimentSidebarCloneForm(RequestFormTestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -107,6 +107,7 @@ class TestNimbusRolloutsCreateView(AuthTestCase):
 
         self.assertNotContains(response, 'id="new-delivery-button"')
         self.assertNotContains(response, 'id="create-new-rollout-button"')
+        self.assertNotContains(response, 'id="create-new-labs-button"')
         self.assertContains(response, 'id="create-new-button"')
 
     def test_new_delivery_menu_shown_when_flag_is_enabled(self):
@@ -117,6 +118,7 @@ class TestNimbusRolloutsCreateView(AuthTestCase):
         self.assertContains(response, 'id="new-delivery-button"')
         self.assertContains(response, 'id="create-new-experiment-button"')
         self.assertContains(response, 'id="create-new-rollout-button"')
+        self.assertContains(response, 'id="create-new-labs-button"')
         self.assertNotContains(response, 'id="create-new-button"')
 
     def test_post_creates_rollout_when_flag_is_enabled(self):
@@ -141,6 +143,68 @@ class TestNimbusRolloutsCreateView(AuthTestCase):
         self.assertEqual(rollout.owner, self.user)
         self.assertEqual(rollout.branches.count(), 1)
         self.assertEqual(rollout.reference_branch.name, "Control")
+
+
+class TestNimbusFirefoxLabsCreateView(AuthTestCase):
+    def setUp(self):
+        super().setUp()
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+
+    def test_post_creates_labs_and_redirects_to_legacy_detail(self):
+        response = self.client.post(
+            reverse("nimbus-ui-new-create-labs"),
+            {
+                "name": "Test Labs",
+                "hypothesis": "test",
+                "application": NimbusExperiment.Application.DESKTOP,
+            },
+        )
+
+        labs = NimbusExperiment.objects.get(slug="test-labs")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.headers["HX-Redirect"],
+            reverse("nimbus-ui-detail", kwargs={"slug": labs.slug}),
+        )
+        self.assertTrue(labs.is_firefox_labs_opt_in)
+        self.assertTrue(labs.is_rollout)
+        self.assertEqual(labs.owner, self.user)
+        self.assertEqual(labs.branches.count(), 1)
+        self.assertEqual(labs.reference_branch.name, "Control")
+
+    def test_post_rejects_application_without_labs_support(self):
+        response = self.client.post(
+            reverse("nimbus-ui-new-create-labs"),
+            {
+                "name": "Test Labs",
+                "hypothesis": "test",
+                "application": NimbusExperiment.Application.IOS,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("application", response.context["form"].errors)
+        self.assertNotIn("HX-Redirect", response.headers)
+        self.assertFalse(NimbusExperiment.objects.filter(slug="test-labs").exists())
+
+    def test_new_rollout_ui_returns_404_for_labs(self):
+        labs = NimbusExperimentFactory.create(
+            slug="test-labs",
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="test-fx-labs-title",
+            firefox_labs_description="test-fx-labs-description",
+            firefox_labs_group="group",
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": labs.slug})
+        )
+
+        self.assertEqual(response.status_code, 404)
 
 
 class TestRolloutStatusUpdateViews(AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -1166,6 +1166,32 @@ class NimbusExperimentsListViewTest(AuthTestCase):
             reverse("nimbus-ui-detail", kwargs={"slug": rollout.slug}),
         )
 
+    def test_labs_links_use_legacy_detail_url_when_flag_is_enabled(self):
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+        labs = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.LIVE,
+            slug="test-labs",
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="test-fx-labs-title",
+            firefox_labs_description="test-fx-labs-description",
+            firefox_labs_group="group",
+        )
+
+        response = self.client.get(reverse("nimbus-list"))
+
+        self.assertContains(
+            response,
+            f'href="{reverse("nimbus-ui-detail", kwargs={"slug": labs.slug})}"',
+        )
+        self.assertNotContains(
+            response,
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": labs.slug}),
+        )
+
 
 class NimbusExperimentsListTableViewTest(AuthTestCase):
     def test_render_to_response(self):
@@ -2072,6 +2098,97 @@ class TestDocumentationLinkDeleteView(AuthTestCase):
 
 
 class TestBranchesUpdateViews(AuthTestCase):
+    def test_get_preserves_is_rollout_for_labs_when_new_delivery_menu_is_enabled(self):
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="test-fx-labs-title",
+            firefox_labs_description="test-fx-labs-description",
+            firefox_labs_group="group",
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-update-branches", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertNotContains(response, 'id="id_is_rollout"')
+        self.assertContains(response, 'name="is_rollout" value="True"')
+        self.assertContains(response, 'id="labs"')
+        self.assertNotContains(response, 'id="id_is_firefox_labs_opt_in"')
+        self.assertContains(response, 'name="is_firefox_labs_opt_in" value="True"')
+
+    def test_get_hides_labs_card_for_non_labs_when_new_delivery_menu_is_enabled(self):
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=False,
+            is_firefox_labs_opt_in=False,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-update-branches", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertNotContains(response, 'id="labs"')
+        self.assertNotContains(response, 'name="is_firefox_labs_opt_in"')
+
+    def test_get_shows_labs_checkbox_when_new_delivery_menu_is_unset(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=False,
+            is_firefox_labs_opt_in=False,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-update-branches", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertContains(response, 'id="labs"')
+        self.assertContains(response, 'id="id_is_firefox_labs_opt_in"')
+        self.assertContains(response, 'id="id_is_rollout"')
+
+    def test_post_keeps_labs_flags_when_new_delivery_menu_is_enabled(self):
+        SiteFlag.objects.create(
+            name=SiteFlagNameChoices.NEW_DELIVERY_MENU.name,
+            value=True,
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+            is_firefox_labs_opt_in=True,
+            firefox_labs_title="test-fx-labs-title",
+            firefox_labs_description="test-fx-labs-description",
+            firefox_labs_group="group",
+        )
+
+        self.client.post(
+            reverse("nimbus-ui-update-branches", kwargs={"slug": experiment.slug}),
+            {
+                "is_rollout": "True",
+                "is_firefox_labs_opt_in": "True",
+                "firefox_labs_title": "test-fx-labs-title",
+                "firefox_labs_description": "test-fx-labs-description",
+                "firefox_labs_group": "group",
+            },
+        )
+
+        experiment.refresh_from_db()
+        self.assertTrue(experiment.is_rollout)
+        self.assertTrue(experiment.is_firefox_labs_opt_in)
+        self.assertEqual(experiment.firefox_labs_title, "test-fx-labs-title")
+
     def test_get_renders_for_draft_experiment(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -44,6 +44,7 @@ from experimenter.nimbus_ui.new.views import (
     NewToggleReviewSlackNotificationsView,
     NewUnsubscribeView,
     NimbusExperimentsCreateView,
+    NimbusFirefoxLabsCreateView,
     NimbusRolloutDetailView,
     NimbusRolloutsCreateView,
     PreviewReviewRolloutView,
@@ -106,6 +107,11 @@ urlpatterns = [
         r"^new/rollouts/create/$",
         NimbusRolloutsCreateView.as_view(),
         name="nimbus-ui-new-create-rollout",
+    ),
+    re_path(
+        r"^new/labs/create/$",
+        NimbusFirefoxLabsCreateView.as_view(),
+        name="nimbus-ui-new-create-labs",
     ),
     re_path(
         r"^table/",

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -80,6 +80,7 @@ from experimenter.nimbus_ui.forms import (
     ToggleReviewSlackNotificationsForm,
     UnsubscribeForm,
 )
+from experimenter.nimbus_ui.new.forms import NimbusFirefoxLabsCreateForm
 
 
 class IntegrationTestBranchDataMixin:
@@ -207,6 +208,7 @@ class NimbusExperimentViewMixin:
             {tag.id for tag in experiment.tags.all()} if experiment else set()
         )
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         return context
 
@@ -292,6 +294,7 @@ class NimbusExperimentsListView(NimbusExperimentViewMixin, FilterView):
             status_counts=status_counts,
             sort_choices=SortChoices,
             create_form=NimbusExperimentCreateForm(),
+            create_labs_form=NimbusFirefoxLabsCreateForm(),
             **kwargs,
         )
 
@@ -1134,6 +1137,7 @@ class NimbusFeaturesView(TemplateView):
         }
 
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         # Add subscribers form if a feature is selected
         if selected_feature_config:
@@ -1249,6 +1253,7 @@ class NimbusExperimentsHomeView(FilterView):
 
         context["sortable_headers"] = HomeSortChoices.sortable_headers()
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
         return context
 
 


### PR DESCRIPTION
Because

* Labs isn't supported in the new rollouts UI so labs users need to stay on the old UI for now

This commit

* Adds a Firefox Labs button to the New delivery menu that creates a labs rollout and opens the old UI
* Limits the labs application choices to the applications that support Firefox Labs
* Returns a 404 when the new rollouts UI is opened for a labs delivery

Fixes #16884
