### PR TITLE
fix(nimbus): pass --legacy-open to nimbus-cli in fenix enrollment test

### DIFF
--- a/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
+++ b/experimenter/tests/integration/nimbus/android/test_fenix_enrollment.py
@@ -52,6 +52,7 @@ def test_fenix_enrollment(
                 "--preserve-bucketing",
                 "--reset-app",
                 "--no-validate",
+                "--legacy-open",
             ]
         )
 


### PR DESCRIPTION
Because

* nimbus-cli now defaults to `am broadcast -a org.mozilla.fenix.NIMBUS_TOOLING` instead of `am start`.
* The receiving `QANimbusToolingReceiver` is only on Fenix nightly, not in the pinned beta or release APKs we test against.
* `am broadcast` reports success without launching the app, so Nimbus never initializes and the enrollment poll times out.

This commit

* Adds `--legacy-open` to the `nimbus-cli enroll` invocation to restore the `am start` launch path.
* Leaves the iOS enrollment test alone, since nimbus-cli rejects the flag for iOS.

Fixes #16938