### PR TITLE
fix(project): only select an application services build with all megazords published

### DIFF
--- a/application-services/fetch-application-services.sh
+++ b/application-services/fetch-application-services.sh
@@ -17,7 +17,7 @@ function download_megazord {
 
     curl --proto '=https' \
          --tlsv1.2 \
-         -sSL \
+         -fsSL \
          --output "${PROJECT}.zip" \
          "${URL}"
 
@@ -46,10 +46,12 @@ function prepare_megazord {
 }
 
 source application-services.env
+source megazords.env
 echo APPLICATION SERVICES VERSION "${APPLICATION_SERVICES_BUILD_ID}"
 
-download_megazord cirrus
-download_megazord nimbus-experimenter
+for MEGAZORD in ${MEGAZORDS}; do
+    download_megazord "${MEGAZORD}"
+done
 
 TARGET=$(/tmp/cirrus/scripts/detect-target.sh)
 
@@ -60,5 +62,6 @@ fi
 
 echo TARGET "${TARGET}"
 
-prepare_megazord cirrus "${TARGET}"
-prepare_megazord nimbus-experimenter "${TARGET}"
+for MEGAZORD in ${MEGAZORDS}; do
+    prepare_megazord "${MEGAZORD}" "${TARGET}"
+done

--- a/application-services/megazords.env
+++ b/application-services/megazords.env
@@ -1,0 +1,1 @@
+MEGAZORDS="cirrus nimbus-experimenter"

--- a/application-services/update-application-services.sh
+++ b/application-services/update-application-services.sh
@@ -4,19 +4,47 @@ set -euo pipefail
 set +x
 
 TASKCLUSTER_API="https://firefox-ci-tc.services.mozilla.com/api/index/v1"
-INDEX_BASE="project.application-services.v2.cirrus"
+INDEX_PREFIX="project.application-services.v2"
+INDEX_BASE="${INDEX_PREFIX}.cirrus"
 CURLFLAGS=("--proto" "=https" "--tlsv1.2" "-sS")
 
-LATEST_VERSION=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/namespaces/${INDEX_BASE}" | jq -r '[ .namespaces[].name | tonumber ] | max')
+source megazords.env
+
+function megazord_published {
+    local MEGAZORD="${1}"
+    local BUILD_ID="${2}"
+    local URL="${TASKCLUSTER_API}/task/${INDEX_PREFIX}.${MEGAZORD}.${BUILD_ID}/artifacts/public%2Fbuild%2F${MEGAZORD}.zip"
+
+    curl "${CURLFLAGS[@]}" -fL -r 0-0 -o /dev/null "${URL}"
+}
+
+LATEST_VERSION=$(curl "${CURLFLAGS[@]}" "${TASKCLUSTER_API}/namespaces/${INDEX_BASE}" | jq -r '[ .namespaces[].name | tonumber ] | max')
 
 echo LATEST VERSION "${LATEST_VERSION}"
 
-INDEX=$(curl ${CURLFLAGS[@]} "${TASKCLUSTER_API}/tasks/${INDEX_BASE}.${LATEST_VERSION}" | jq -r '[.tasks[].namespace] | max')
+BUILD_IDS=$(curl "${CURLFLAGS[@]}" "${TASKCLUSTER_API}/tasks/${INDEX_BASE}.${LATEST_VERSION}" \
+    | jq -r --arg prefix "${INDEX_BASE}." '[.tasks[].namespace | ltrimstr($prefix)] | sort | reverse | .[]')
 
-echo INDEX "${INDEX}"
+for BUILD_ID in ${BUILD_IDS}; do
+    UNPUBLISHED=""
 
-BUILD_ID="${INDEX#"${INDEX_BASE}."}"
+    for MEGAZORD in ${MEGAZORDS}; do
+        if ! megazord_published "${MEGAZORD}" "${BUILD_ID}"; then
+            UNPUBLISHED="${MEGAZORD}"
+            break
+        fi
+    done
 
-echo BUILD ID "${BUILD_ID}"
+    if [[ -n "${UNPUBLISHED}" ]]; then
+        echo SKIPPING BUILD ID "${BUILD_ID}" - "${UNPUBLISHED}" megazord not published yet
+        continue
+    fi
 
-echo "APPLICATION_SERVICES_BUILD_ID=${BUILD_ID}" > application-services.env
+    echo BUILD ID "${BUILD_ID}"
+
+    echo "APPLICATION_SERVICES_BUILD_ID=${BUILD_ID}" > application-services.env
+    exit 0
+done
+
+echo >&2 "No build of ${LATEST_VERSION} has all megazords published: ${MEGAZORDS}"
+exit 1


### PR DESCRIPTION
Because

* The update bot picks the build id from the `cirrus` Taskcluster index alone, but the fetch downloads both `cirrus` and `nimbus-experimenter` at that id.
* Those megazords are built by separate tasks that finish minutes apart, so the bot can commit a build id whose `nimbus-experimenter` artifact does not exist yet and CI fails. This happened on #16953.
* The fetch ran `curl` without `--fail`, so a 404 body was written to the zip and `unzip` reported "not a zipfile", hiding the cause.

This commit

* Selects the newest build id whose every megazord artifact is fetchable, exiting non-zero if none qualify.
* Moves the megazord list into a shared `megazords.env` so the bot cannot check a different set than the fetch downloads.
* Adds `--fail` to the megazord download.

Fixes #16966