### PR TITLE
fix(nimbus): Require name when saving a new rollout plan and add cancel

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -366,6 +366,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     checklist."""
     QA_TICKET_URL = "https://mozilla-hub.atlassian.net/secure/CreateIssueDetails!init.jspa?pid=10212&issuetype=11290"
 
+    ERROR_ROLLOUT_PLAN_NAME_REQUIRED = "Please name this rollout plan before saving it."
     ERROR_ROLLOUT_PLAN_NAME_DUPLICATE = "A rollout plan with this name already exists."
     ERROR_ROLLOUT_PLAN_FIX_ERRORS = (
         "Resolve the highlighted errors above before saving this plan."

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1933,7 +1933,11 @@ class RolloutPlanApplyForm(RolloutScheduleForm):
 class RolloutPlanCreateForm(RolloutScheduleForm):
     def clean_template_name(self):
         name = (self.cleaned_data.get("template_name") or "").strip()
-        if name and name in self.plans:
+        if not name:
+            raise forms.ValidationError(
+                NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_REQUIRED
+            )
+        if name in self.plans:
             raise forms.ValidationError(
                 NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_DUPLICATE
             )
@@ -1950,13 +1954,12 @@ class RolloutPlanCreateForm(RolloutScheduleForm):
     @transaction.atomic
     def save(self):
         experiment = super().save()
-        name = self.cleaned_data.get("template_name")
-        if name:
-            phases = [
-                float(phase.population_percent)
-                for phase in experiment.rollout_phases.all()
-            ]
-            NimbusRolloutPlanTemplate.objects.create(name=name, phases=phases)
+        phases = [
+            float(phase.population_percent) for phase in experiment.rollout_phases.all()
+        ]
+        NimbusRolloutPlanTemplate.objects.create(
+            name=self.cleaned_data["template_name"], phases=phases
+        )
         return experiment
 
     def get_changelog_message(self):

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -117,13 +117,20 @@
         </button>
         <div class="collapse mt-2{% if form.template_name.errors %} show{% endif %}"
              id="new-rollout-plan-field">
-          <div class="input-group">
+          <div class="d-flex gap-2">
             {{ form.template_name|add_error_class:"is-invalid" }}
             <button type="button"
-                    class="btn btn-primary"
+                    id="rollout-schedule-save-plan"
+                    class="btn btn-primary btn-sm flex-shrink-0"
                     hx-post="{% url 'nimbus-ui-new-create-rollout-plan' experiment.slug %}"
                     hx-target="#rollout-schedule-body"
                     hx-swap="outerHTML">Save plan</button>
+            <button type="button"
+                    id="rollout-schedule-cancel-plan"
+                    class="btn btn-outline-secondary btn-sm flex-shrink-0"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#new-rollout-plan-field"
+                    aria-controls="new-rollout-plan-field">Cancel</button>
           </div>
           {% if form.template_name.errors %}
             <div class="text-danger small mt-1">{{ form.template_name.errors|join:", " }}</div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1889,6 +1889,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'id="new-rollout-plan-field"')
+        self.assertContains(response, 'id="rollout-schedule-cancel-plan"')
 
     def test_post_valid_saves_and_returns_display_card(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -2303,21 +2304,30 @@ class TestNewRolloutPlanCreateView(AuthTestCase):
             NimbusRolloutPlanTemplate.objects.filter(name="My plan").exists()
         )
 
-    def test_post_blank_name_creates_nothing(self):
+    def test_post_blank_name_shows_validation_error(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             is_rollout=True,
         )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=10
+        )
         response = self.client.post(
             reverse(self.url_name, kwargs={"slug": experiment.slug}),
             {
-                "rollout_phases-TOTAL_FORMS": "0",
-                "rollout_phases-INITIAL_FORMS": "0",
-                "template_name": "",
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-population_percent": "10",
+                "template_name": "   ",
             },
         )
         self.assertEqual(response.status_code, 200)
-        self.assertFalse(NimbusRolloutPlanTemplate.objects.filter(name="").exists())
+        self.assertTemplateUsed(response, "new/rollouts/schedule/edit_form.html")
+        self.assertContains(response, NimbusUIConstants.ERROR_ROLLOUT_PLAN_NAME_REQUIRED)
+        self.assertContains(response, 'id="new-rollout-plan-field"')
+        self.assertContains(response, "collapse mt-2 show")
+        self.assertFalse(NimbusRolloutPlanTemplate.objects.exists())
 
     def test_post_duplicate_name_is_rejected(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(


### PR DESCRIPTION
Because

* Clicking Save plan with an empty name silently collapsed the field and saved nothing

This commit

* Requires a plan name and renders the validation error on the field
* Adds a Cancel action next to Save plan

Fixes #16940