### PR TITLE
feat(nimbus): Show actual phase progress in the rollout schedule

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -3208,9 +3208,13 @@ class NimbusRolloutPhase(models.Model):
         return f"Rollout phase ({self.population_percent}%)"
 
     @property
+    def effective_start_date(self):
+        return self.actual_start_date or self.start_date
+
+    @property
     def duration_days(self):
-        if self.start_date and self.end_date:
-            return max(0, (self.end_date - self.start_date).days)
+        if self.effective_start_date and self.end_date:
+            return max(0, (self.end_date - self.effective_start_date).days)
         return None
 
     @property
@@ -3222,9 +3226,9 @@ class NimbusRolloutPhase(models.Model):
 
     @property
     def days_elapsed(self):
-        if not self.start_date:
+        if not self.effective_start_date:
             return 0
-        return max(0, (timezone.now().date() - self.start_date).days)
+        return max(0, (timezone.now().date() - self.effective_start_date).days)
 
     @property
     def days_elapsed_capped(self):

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -7097,6 +7097,28 @@ class TestNimbusRolloutPhase(TestCase):
         phase = NimbusRolloutPhaseFactory.build(start_date=today - 2 * day, end_date=None)
         self.assertEqual(phase.days_elapsed_capped, 2)
 
+    def test_effective_start_date_prefers_actual_start_date(self):
+        phase = NimbusRolloutPhaseFactory.build(
+            start_date=datetime.date(2026, 1, 1),
+            actual_start_date=datetime.date(2026, 1, 5),
+        )
+        self.assertEqual(phase.effective_start_date, datetime.date(2026, 1, 5))
+
+        phase.actual_start_date = None
+        self.assertEqual(phase.effective_start_date, datetime.date(2026, 1, 1))
+
+    def test_duration_and_days_elapsed_use_actual_start_date(self):
+        today = timezone.now().date()
+        day = datetime.timedelta(days=1)
+
+        phase = NimbusRolloutPhaseFactory.build(
+            start_date=today - 10 * day,
+            actual_start_date=today - 4 * day,
+            end_date=today + 3 * day,
+        )
+        self.assertEqual(phase.duration_days, 7)
+        self.assertEqual(phase.days_elapsed, 4)
+
     def test_duration_none_without_dates(self):
         phase = NimbusRolloutPhaseFactory.build(start_date=None, end_date=None)
         self.assertIsNone(phase.duration_days)

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -384,6 +384,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     ROLLOUT_PAUSE_OBSERVATIONS_LABEL = "Pause rollout if these observations occur"
     ROLLOUT_PHASE_FIELDS = ("start_date", "end_date", "population_percent")
+    ROLLOUT_SCHEDULE_DATES_NOTE = (
+        "Phase dates are used for planning and reminders only. Phases do not start or "
+        "end automatically, so these dates are optional."
+    )
     ROLLOUT_PREVIEW_MESSAGE = (
         "This rollout is in Preview mode and is live for testing now. It can take up "
         "to an hour before clients receive the preview. When you're ready, request "

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -1849,9 +1849,11 @@ class RolloutScheduleForm(NimbusChangeLogFormMixin, forms.ModelForm):
             if status == NimbusUIConstants.RolloutPhaseStatus.COMPLETE:
                 disabled_fields = NimbusUIConstants.ROLLOUT_PHASE_FIELDS
             elif status in NimbusUIConstants.RolloutPhaseStatus.CURRENT:
-                disabled_fields = ("population_percent",)
+                disabled_fields = ("population_percent", "start_date")
             else:
                 disabled_fields = ()
+            if phase and phase.effective_start_date:
+                phase_form.initial["start_date"] = phase.effective_start_date
             for field_name in disabled_fields:
                 phase_form.fields[field_name].disabled = True
 

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/monitoring/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/monitoring/card.html
@@ -4,7 +4,7 @@
   <div class="d-flex flex-column gap-4">
     {% if experiment.monitoring_data_updated_at %}
       <div class="text-secondary" style="font-size: 12px;">
-        Last updated: {{ experiment.monitoring_data_updated_at|date:"N j, Y" }}
+        Last updated: {{ experiment.monitoring_data_updated_at|date:"M j, Y" }}
       </div>
     {% endif %}
     {% if experiment.is_complete %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -20,7 +20,7 @@
                 <tr id="rollout-schedule-phase-{{ forloop.counter0 }}"
                     {% if phase.is_current %}style="--bs-table-bg: rgba(var(--bs-{{ display.color }}-rgb), 0.07)"{% endif %}>
                   {# Rollout Phase #}
-                  <td class="small text-body py-3 ps-3 {% if phase.is_current %}fw-bold{% else %}fw-semibold{% endif %}">
+                  <td class="small text-body py-3 ps-3 {% if phase.is_current %}fw-bold rounded-start{% else %}fw-semibold{% endif %}">
                     Phase {{ forloop.counter }}
                   </td>
                   {# Status #}
@@ -43,14 +43,18 @@
                     </div>
                   </td>
                   {# Estimated Duration #}
-                  <td class="small py-3 pe-3">
+                  <td class="small py-3 pe-3{% if phase.is_current %} rounded-end{% endif %}">
                     {% if phase.is_current %}
                       {% if phase.card_status == "disabled" %}
                         <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                          <span>Disabled</span>
-                          {% if phase.actual_start_date %}
+                          {% if phase.end_date %}
+                            <span>Disabled on {{ phase.end_date|date:"M j, Y" }}</span>
+                          {% else %}
+                            <span>Disabled</span>
+                          {% endif %}
+                          {% if phase.effective_start_date %}
                             <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                            <span>Started {{ phase.actual_start_date|date:"M j, Y" }}</span>
+                            <span>Started on {{ phase.effective_start_date|date:"M j, Y" }}</span>
                           {% endif %}
                         </div>
                         <div class="progress"
@@ -60,7 +64,7 @@
                              aria-label="Phase {{ forloop.counter }} duration progress">
                           <div class="progress-bar bg-secondary opacity-25" style="width: 100%"></div>
                         </div>
-                      {% elif phase.start_date and phase.end_date %}
+                      {% elif phase.effective_start_date and phase.end_date %}
                         <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                           <span>{{ phase.days_elapsed }}/{{ phase.duration_days }} days complete</span>
                           <span class="mx-1" style="color: var(--bs-border-color);">•</span>
@@ -77,9 +81,13 @@
                         </div>
                       {% else %}
                         <div class="d-flex align-items-center gap-1 text-secondary mb-1">
-                          <span>In progress</span>
-                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                          <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} running</span>
+                          {% if phase.effective_start_date %}
+                            <span>{{ phase.days_elapsed }} day{{ phase.days_elapsed|pluralize }} complete</span>
+                            <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                            <span>Started on {{ phase.effective_start_date|date:"M j, Y" }}</span>
+                          {% else %}
+                            <span>In progress</span>
+                          {% endif %}
                         </div>
                         <div class="progress"
                              style="height: 6px;
@@ -92,9 +100,11 @@
                     {% elif phase.card_status == "complete" %}
                       <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                         <span>Completed</span>
-                        {% if phase.actual_start_date and phase.end_date %}
+                        {% if phase.effective_start_date and phase.end_date %}
                           <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                          <span>{{ phase.actual_start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
+                          <span>{{ phase.effective_start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.duration_display }}</span>
                         {% endif %}
                       </div>
                       <div class="progress"
@@ -107,13 +117,11 @@
                     {% else %}
                       <div class="d-flex align-items-center gap-1 text-secondary mb-1">
                         <span>Not started</span>
-                        {% if phase.duration_display %}
-                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
-                          <span>{{ phase.duration_display }}</span>
-                        {% endif %}
                         {% if phase.start_date and phase.end_date %}
                           <span class="mx-1" style="color: var(--bs-border-color);">•</span>
                           <span>{{ phase.start_date|date:"M j" }} - {{ phase.end_date|date:"M j, Y" }}</span>
+                          <span class="mx-1" style="color: var(--bs-border-color);">•</span>
+                          <span>{{ phase.duration_display }}</span>
                         {% endif %}
                       </div>
                       <div class="progress"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/edit_form.html
@@ -17,6 +17,9 @@
     </div>
     {{ form.rollout_phases.management_form }}
     <div class="d-flex flex-column">
+      {% if form.rollout_phases|length %}
+        <div class="text-secondary mb-2" style="font-size: 12px">{{ NimbusUIConstants.ROLLOUT_SCHEDULE_DATES_NOTE }}</div>
+      {% endif %}
       {% for phase_form in form.rollout_phases %}
         {% with display=phase_form.card_status_display %}
           <div class="p-3 rounded"

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -9,6 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 from django.urls import resolve, reverse
 from django.utils import timezone
+from django.utils.dateformat import format as date_format
 from parameterized import parameterized
 
 from experimenter.base.models import SiteFlag, SiteFlagNameChoices
@@ -1953,7 +1954,149 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         self.assertTemplateUsed(response, "new/rollouts/schedule/card.html")
         self.assertContains(response, "3/7 days complete")
 
-    def test_post_can_change_in_progress_phase_dates(self):
+    def test_post_disabled_phase_shows_disabled_on_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=50,
+            start_date=datetime.date(2026, 1, 3),
+            actual_start_date=datetime.date(2026, 1, 3),
+            end_date=datetime.date(2026, 1, 20),
+        )
+        experiment.rollout_phase = phase
+        experiment.status = NimbusExperiment.Status.DISABLED
+        experiment.save()
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-end_date": "2026-01-20",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/schedule/card.html")
+        self.assertContains(response, "Disabled on Jan 20, 2026")
+        self.assertContains(response, "Started on Jan 3, 2026")
+
+    def test_post_completed_phase_shows_dates_and_days(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        completed = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=25,
+            start_date=datetime.date(2026, 1, 1),
+            actual_start_date=datetime.date(2026, 1, 3),
+            end_date=datetime.date(2026, 1, 15),
+        )
+        current = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=50,
+            actual_start_date=datetime.date(2026, 1, 15),
+        )
+        experiment.rollout_phase = current
+        experiment.save()
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "2",
+                "rollout_phases-INITIAL_FORMS": "2",
+                "rollout_phases-0-id": completed.id,
+                "rollout_phases-1-id": current.id,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/schedule/card.html")
+        self.assertContains(response, "Jan 3 - Jan 15, 2026")
+        self.assertContains(response, "12 days")
+
+    def test_post_in_progress_phase_uses_actual_start_date_for_progress(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+
+        today = timezone.now().date()
+        start = today - datetime.timedelta(days=6)
+        actual_start = today - datetime.timedelta(days=2)
+        end = today + datetime.timedelta(days=3)
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            start_date=start,
+            actual_start_date=actual_start,
+            end_date=end,
+        )
+        experiment.rollout_phase = phase
+        experiment.save()
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-end_date": end.isoformat(),
+                "rollout_phases-0-population_percent": "50",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "2/5 days complete")
+
+    def test_post_in_progress_phase_without_end_date_shows_start_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+
+        actual_start = timezone.now().date() - datetime.timedelta(days=3)
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            start_date=None,
+            actual_start_date=actual_start,
+            end_date=None,
+        )
+        experiment.rollout_phase = phase
+        experiment.save()
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            {
+                "rollout_phases-TOTAL_FORMS": "1",
+                "rollout_phases-INITIAL_FORMS": "1",
+                "rollout_phases-0-id": phase.id,
+                "rollout_phases-0-population_percent": "50",
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"Started on {date_format(actual_start, 'M j, Y')}")
+        self.assertContains(response, "3 days complete")
+
+    def test_get_locks_start_date_for_in_progress_phase(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
+            is_rollout=True,
+        )
+        phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            start_date=datetime.date(2026, 1, 1),
+            actual_start_date=datetime.date(2026, 1, 3),
+            end_date=datetime.date(2026, 1, 15),
+        )
+        experiment.rollout_phase = phase
+        experiment.save()
+        response = self.client.get(
+            reverse(self.url_name, kwargs={"slug": experiment.slug})
+        )
+        self.assertEqual(response.status_code, 200)
+        phase_form = response.context["form"].rollout_phases.forms[0]
+        self.assertTrue(phase_form.fields["start_date"].disabled)
+        self.assertEqual(phase_form["start_date"].value(), datetime.date(2026, 1, 3))
+
+    def test_post_can_change_in_progress_phase_end_date_only(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_ENROLLING,
             is_rollout=True,
@@ -1962,6 +2105,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
             experiment=experiment,
             population_percent=50,
             start_date=datetime.date(2026, 1, 1),
+            actual_start_date=datetime.date(2026, 1, 3),
             end_date=datetime.date(2026, 1, 15),
         )
         experiment.rollout_phase = phase
@@ -1979,7 +2123,7 @@ class TestNewRolloutScheduleUpdateView(AuthTestCase):
         )
         self.assertEqual(response.status_code, 200)
         phase.refresh_from_db()
-        self.assertEqual(phase.start_date, datetime.date(2026, 2, 1))
+        self.assertEqual(phase.start_date, datetime.date(2026, 1, 3))
         self.assertEqual(phase.end_date, datetime.date(2026, 2, 20))
         self.assertEqual(phase.population_percent, 50)
 
@@ -2222,7 +2366,7 @@ class TestNewRolloutPlanApplyView(AuthTestCase):
                 "rollout_phases-INITIAL_FORMS": "2",
                 "rollout_phases-0-id": done.id,
                 "rollout_phases-1-id": current.id,
-                "rollout_phases-1-start_date": "not-a-date",
+                "rollout_phases-1-end_date": "not-a-date",
                 "rollout_plan": plan_name,
             },
         )


### PR DESCRIPTION
Because

* Phase progress was measured from the planned start date so a phase that launched late looked like it had been running longer than it had
* Nothing showed how long a phase with no end date had been running or that phase dates are for planning only

This commit

* Measures phase duration and elapsed days from the actual start date once a phase begins and locks the start date field at that point
* Shows "Started on <date>" for a live phase with no end date, and "Disabled on <date>" for a disabled one
* Rounds the current phase's row highlight and shows a day count after the dates on every row
* Notes in the edit form that phase dates are for planning only

Fixes #16882
