### PR TITLE
fix(nimbus): Show rollout card errors and pending review state

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -1,5 +1,7 @@
 from enum import Enum, IntEnum
 
+from django.conf import settings
+
 from experimenter.experiments.constants import NimbusConstants
 
 
@@ -46,6 +48,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     )
     UNENROLLMENT_SPIKE_THRESHOLD_DISPLAY = "10%"
     SRM_P_VALUE_THRESHOLD_DISPLAY = "0.001"
+
+    SLACK_NIMBUS_CHANNEL = settings.SLACK_NIMBUS_CHANNEL
+    ASK_EXPERIMENTER_SLACK_CHANNEL = "ask-experimenter"
 
     ARCHIVE_DISABLED_TOOLTIP = (
         "Experiments can only be archived when in Draft or Complete."

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -451,7 +451,7 @@ Optional - We believe this outcome will <describe impact> on <core metric>
                 ("Feature Configuration", ("feature_configs", "reference_branch")),
                 ("Warn On Schema Failure", ("warn_feature_schema",)),
                 ("Prevent Pref Conflicts", ("prevent_pref_conflicts",)),
-                ("Screenshots", ()),
+                ("Screenshots", ("reference_branch_screenshots",)),
                 (
                     "Firefox Labs",
                     (

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -983,35 +983,35 @@ class RolloutFeaturesForm(NimbusChangeLogFormMixin, forms.ModelForm):
         prefix = "branch-feature-value"
         total_forms_key = f"{prefix}-TOTAL_FORMS"
         total_forms = int(data[total_forms_key])
+        selected = self._get_selected_feature_config_ids(data)
 
-        for feature_config_id in self._get_new_feature_config_ids(
-            data, prefix, total_forms
-        ):
-            data[f"{prefix}-{total_forms}-feature_config"] = feature_config_id
-            data[f"{prefix}-{total_forms}-value"] = "{}"
-            total_forms += 1
+        for index in range(total_forms):
+            feature_config_id = data.get(f"{prefix}-{index}-feature_config")
+            if feature_config_id and int(feature_config_id) not in selected:
+                data[f"{prefix}-{index}-DELETE"] = "on"
 
-        data[total_forms_key] = str(total_forms)
-        return data
-
-    def _get_new_feature_config_ids(self, data, prefix, total_forms):
-        selected_values = self.fields["feature_configs"].widget.value_from_datadict(
-            data, self.files, "feature_configs"
-        )
-        selected = [
-            int(feature_config_id)
-            for feature_config_id in selected_values or []
-            if feature_config_id
-        ]
         submitted = {
             int(data[f"{prefix}-{index}-feature_config"])
             for index in range(total_forms)
             if data.get(f"{prefix}-{index}-feature_config")
         }
+        for feature_config_id in selected:
+            if feature_config_id not in submitted:
+                data[f"{prefix}-{total_forms}-feature_config"] = feature_config_id
+                data[f"{prefix}-{total_forms}-value"] = "{}"
+                total_forms += 1
+
+        data[total_forms_key] = str(total_forms)
+        return data
+
+    def _get_selected_feature_config_ids(self, data):
+        selected_values = self.fields["feature_configs"].widget.value_from_datadict(
+            data, self.files, "feature_configs"
+        )
         return [
-            feature_config_id
-            for feature_config_id in selected
-            if feature_config_id not in submitted
+            int(feature_config_id)
+            for feature_config_id in selected_values or []
+            if feature_config_id
         ]
 
     @property

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -242,19 +242,48 @@ class RolloutSetupProgressMixin:
             return [m for value in messages for m in self.flatten_errors(value)]
         return [str(messages)]
 
-    def unique_messages(self, messages):
-        seen = set()
-        unique = []
-        for message in self.flatten_errors(messages):
-            if message not in seen:
-                seen.add(message)
-                unique.append(message)
-        return unique
+    def drop_documentation_link_title_errors(self, field_errors):
+        # The title select has no blank option so a just-added link always errors
+        # until the next save picks up its default
+        errors = field_errors.get("documentation_links")
+        if not isinstance(errors, (list, tuple)):
+            return field_errors
+
+        remaining = [
+            {key: value for key, value in link.items() if key != "title"}
+            if isinstance(link, dict)
+            else link
+            for link in errors
+        ]
+        if any(remaining):
+            field_errors["documentation_links"] = remaining
+        else:
+            field_errors.pop("documentation_links")
+        return field_errors
+
+    def split_branch_screenshot_errors(self, field_errors):
+        branch_errors = field_errors.get("reference_branch")
+        if not isinstance(branch_errors, dict) or "screenshots" not in branch_errors:
+            return field_errors
+
+        branch_errors = dict(branch_errors)
+        screenshots = branch_errors.pop("screenshots")
+        if any(screenshots):
+            field_errors["reference_branch_screenshots"] = screenshots
+        if branch_errors:
+            field_errors["reference_branch"] = branch_errors
+        else:
+            field_errors.pop("reference_branch")
+        return field_errors
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        field_errors = self.object.get_invalid_fields_errors(
-            serializer_class=NimbusRolloutReviewSerializer
+        field_errors = self.split_branch_screenshot_errors(
+            self.drop_documentation_link_title_errors(
+                self.object.get_invalid_fields_errors(
+                    serializer_class=NimbusRolloutReviewSerializer
+                )
+            )
         )
         cards = NimbusUIConstants.ROLLOUT_CARD_FIELDS
 
@@ -274,19 +303,23 @@ class RolloutSetupProgressMixin:
                 field, (None, "Other", field.replace("_", " ").title())
             )
             group = groups.setdefault(
-                card_id, {"card_id": card_id, "section": section, "fields": []}
+                card_id, {"card_id": card_id, "section": section, "fields": {}}
             )
-            group["fields"].append(
-                {
-                    "label": label,
-                    "messages": self.unique_messages(messages),
-                }
-            )
+            group["fields"].setdefault(label, []).extend(self.flatten_errors(messages))
+        for group in groups.values():
+            group["fields"] = [
+                {"label": label, "messages": messages}
+                for label, messages in group["fields"].items()
+            ]
         issues = [groups[card_id] for card_id in cards if card_id in groups]
         if None in groups:
             issues.append(groups[None])
 
-        raw_error_fields = ("reference_branch", "documentation_links")
+        raw_error_fields = (
+            "reference_branch",
+            "reference_branch_screenshots",
+            "documentation_links",
+        )
         context["validation_errors"] = {
             field: (
                 messages if field in raw_error_fields else self.flatten_errors(messages)
@@ -294,7 +327,9 @@ class RolloutSetupProgressMixin:
             for field, messages in field_errors.items()
         }
         context["setup_issues"] = issues
-        context["setup_issues_count"] = sum(len(group["fields"]) for group in issues)
+        context["setup_issues_count"] = sum(
+            len(field["messages"]) for group in issues for field in group["fields"]
+        )
         context["setup_issue_card_ids"] = [
             issue["card_id"] for issue in issues if issue["card_id"]
         ]
@@ -308,7 +343,21 @@ class RolloutSetupProgressMixin:
             ]
             for card_id, card in cards.items()
         }
+        context.update(self.readonly_card_errors(field_errors))
         return context
+
+    def readonly_card_errors(self, field_errors):
+        return {
+            "feature_value_errors": self.flatten_errors(
+                field_errors.get("reference_branch") or []
+            ),
+            "screenshot_errors": self.flatten_errors(
+                field_errors.get("reference_branch_screenshots") or []
+            ),
+            "documentation_link_errors": self.flatten_errors(
+                field_errors.get("documentation_links") or []
+            ),
+        }
 
 
 class NimbusRolloutDetailView(

--- a/experimenter/experimenter/nimbus_ui/static/js/new/edit_branches.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/edit_branches.js
@@ -67,7 +67,9 @@ const setupCodemirror = (selector, textarea, extraExtensions) => {
 
 const setupCodemirrorFeatures = () => {
   const selector = ".value-editor";
-  const textareas = document.querySelectorAll(selector);
+  const textareas = document.querySelectorAll(
+    `.feature-value-editor ${selector}`,
+  );
 
   textareas.forEach((textarea) => {
     const extensions = [];
@@ -156,7 +158,7 @@ $(() => {
     initializeAllEditors();
     observeThemeChanges(updateAllViewThemes);
 
-    document.body.addEventListener("htmx:afterSwap", function (event) {
+    document.body.addEventListener("htmx:afterSettle", function (event) {
       if (
         event.detail.target.id === BRANCHES_FORM_ID ||
         event.detail.target.id === ROLLOUT_FEATURES_BODY_ID ||

--- a/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
@@ -28,6 +28,23 @@ document.addEventListener("click", (event) => {
   }
 });
 
+const expandCard = (card) => {
+  const collapse = card.querySelector(".accordion-collapse");
+  if (collapse && !collapse.classList.contains("show")) {
+    window.bootstrap?.Collapse.getOrCreateInstance(collapse, {
+      toggle: false,
+    }).show();
+  }
+};
+
+document.addEventListener("click", (event) => {
+  const editButton = event.target.closest?.("[data-card-action='edit']");
+  const card = editButton?.closest(".rollout-card");
+  if (card) {
+    expandCard(card);
+  }
+});
+
 let pendingCardId = null;
 
 document.addEventListener("htmx:beforeRequest", (event) => {

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -1,7 +1,7 @@
 {% load nimbus_extras %}
 
-{% with controls=experiment.rollout_review_controls timed_out=experiment.should_show_timeout_message rejection=experiment.rejection_block %}
-  {% if controls or experiment|should_show_remote_settings_pending:user or timed_out or rejection %}
+{% with controls=experiment.rollout_review_controls timed_out=experiment.should_show_timeout_message rejection=experiment.rejection_block rs_pending=experiment.remote_settings_pending_message %}
+  {% if controls or rs_pending or timed_out or rejection %}
     <div class="accordion accordion-flush rounded-3 bg-body-secondary"
          style="--bs-accordion-btn-active-color: var(--bs-body-color);
                 --bs-accordion-btn-active-bg: transparent;
@@ -15,6 +15,11 @@
             {% if controls %}
               <i class="fa-regular fa-hourglass-half text-secondary me-2"></i>
               Review requested
+            {% elif rs_pending and not experiment|should_show_remote_settings_pending:user %}
+              <span class="spinner-border spinner-border-sm text-secondary me-2"
+                    role="status"
+                    aria-hidden="true"></span>
+              Waiting for Remote Settings
             {% elif rejection %}
               <i class="fa-regular fa-circle-xmark text-secondary me-2"></i>
               Review rejected
@@ -123,37 +128,24 @@
                 </button>
               </div>
             {% else %}
-              <p class="small text-body mb-2">
-                Ask someone on your team with
-                <a href="{{ NimbusUIConstants.REVIEW_URL }}"
-                   target="_blank"
-                   rel="noopener noreferrer"
-                   class="text-decoration-none">review privileges</a>
-                or a qualified reviewer to {{ controls.action_label|lower }}.
-              </p>
-              <p class="small text-body mb-2">
-                If you don't have a team reviewer, paste the experiment URL in
-                <strong>#ask-experimenter</strong> and ask for a review.
-              </p>
-              <a href="#"
-                 class="small text-decoration-none"
-                 onclick="navigator.clipboard.writeText(window.location.href).then(() => alert('URL copied to clipboard!')); return false;">
-                Click here to copy the URL to send them.
-              </a>
+              {% include "new/common/sidebar_review_help.html" with action=controls.action_label|lower %}
+
             {% endif %}
-          {% elif experiment|should_show_remote_settings_pending:user %}
-            <p class="small text-secondary mb-2">
-              Review this change in Remote Settings to
-              {{ experiment.remote_settings_pending_message }}.
-            </p>
-            <a id="rollout-remote-settings-link"
-               href="{{ experiment.review_url }}"
-               target="_blank"
-               rel="noopener noreferrer"
-               class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2">
-              <i class="fa-regular fa-circle-right"></i>
-              Open Remote Settings
-            </a>
+          {% elif rs_pending %}
+            {% if experiment|should_show_remote_settings_pending:user %}
+              <p class="small text-secondary mb-2">Review this change in Remote Settings to {{ rs_pending }}.</p>
+              <a id="rollout-remote-settings-link"
+                 href="{{ experiment.review_url }}"
+                 target="_blank"
+                 rel="noopener noreferrer"
+                 class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2">
+                <i class="fa-regular fa-circle-right"></i>
+                Open Remote Settings
+              </a>
+            {% else %}
+              {% include "new/common/sidebar_review_help.html" with action=rs_pending %}
+
+            {% endif %}
           {% endif %}
         </div>
       </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_help.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_help.html
@@ -1,0 +1,17 @@
+<p class="small text-body mb-2">
+  Ask someone on your team with
+  <a href="{{ NimbusUIConstants.REVIEW_URL }}"
+     target="_blank"
+     rel="noopener noreferrer"
+     class="text-decoration-none">review privileges</a>
+  or a qualified reviewer to {{ action }}.
+</p>
+<p class="small text-body mb-2">
+  If you don't have a team reviewer, paste the experiment URL in
+  <strong>#ask-experimenter</strong> and ask for a review.
+</p>
+<a href="#"
+   class="small text-decoration-none"
+   onclick="navigator.clipboard.writeText(window.location.href).then(() => alert('URL copied to clipboard!')); return false;">
+  Click here to copy the URL to send them.
+</a>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_help.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_help.html
@@ -7,8 +7,10 @@
   or a qualified reviewer to {{ action }}.
 </p>
 <p class="small text-body mb-2">
-  If you don't have a team reviewer, paste the experiment URL in
-  <strong>#ask-experimenter</strong> and ask for a review.
+  If review Slack notifications are on, this was already posted to
+  <strong>#{{ NimbusUIConstants.SLACK_NIMBUS_CHANNEL }}</strong>. Otherwise, paste the
+  experiment URL in <strong>#{{ NimbusUIConstants.ASK_EXPERIMENTER_SLACK_CHANNEL }}</strong>
+  and ask for a review.
 </p>
 <a href="#"
    class="small text-decoration-none"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -1,7 +1,5 @@
 {% extends "new/common/card_base.html" %}
 
-{% load error_helpers %}
-
 {% block card %}
   <div class="d-flex flex-column gap-3" id="rollout-overview-body">
     {# Name #}
@@ -53,14 +51,13 @@
                 </a>
               </div>
             {% endif %}
-            {% with dl_errors=validation_errors.documentation_links|get_item:forloop.counter0 %}
-              {% for error in dl_errors.link %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-            {% endwith %}
           {% endfor %}
         </div>
       {% else %}
         <div class="small text-body">—</div>
       {% endif %}
+      {% include "new/common/validation_errors.html" with errors=documentation_link_errors %}
+
     </div>
     {# Project Tags #}
     <div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -98,7 +98,7 @@
                 hx-swap="outerHTML">
           <i class="fa-solid fa-plus me-1"></i>Add link
         </button>
-        {% include "new/common/validation_errors.html" with errors=validation_errors.documentation_links %}
+        {% include "new/common/validation_errors.html" with errors=documentation_link_errors %}
 
       </div>
       {# Project Tags — search input + pills #}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -25,11 +25,8 @@
         <div class="small text-body">—</div>
       {% endfor %}
       {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
+      {% include "new/common/validation_errors.html" with errors=feature_value_errors %}
 
-      {% for feature_value_errors in validation_errors.reference_branch.feature_values %}
-        {% include "new/common/validation_errors.html" with errors=feature_value_errors.value %}
-
-      {% endfor %}
     </div>
     {# Warn only on feature schema validation failure #}
     <div>
@@ -85,13 +82,8 @@
           <div class="small text-body">—</div>
         {% endif %}
       {% endwith %}
-      {% for screenshot_errors in validation_errors.reference_branch.screenshots %}
-        {% if screenshot_errors.image %}
-          <div class="small text-danger mt-1">{{ screenshot_errors.image.0 }}</div>
-        {% elif screenshot_errors.description %}
-          <div class="small text-danger mt-1">{{ screenshot_errors.description.0 }}</div>
-        {% endif %}
-      {% endfor %}
+      {% include "new/common/validation_errors.html" with errors=screenshot_errors %}
+
     </div>
     {# Firefox Labs #}
     {% if experiment.application_config.firefox_labs %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -43,40 +43,44 @@
         {% for branch_feature_values_form in branch_feature_values %}
           {{ branch_feature_values_form.id }}
           {{ branch_feature_values_form.feature_config }}
-          <div class="row mt-2">
-            <div class="col">
-              <label class="small mb-2 text-secondary">
-                {{ branch_feature_values_form.instance.feature_config.name }}
-                {% if branch_feature_values_form.instance.allow_coenrollment %}
-                  <div class="form-text">{{ NimbusUIConstants.COENROLLMENT_NOTE }}</div>
-                {% endif %}
-              </label>
-              <div class="feature-value-editor position-relative"
-                   data-nimbus-devtools-feature-editor
-                   data-feature-id="{{ branch_feature_values_form.instance.feature_config.slug }}">
-                {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
-                <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
-                  <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
-                    <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
-                            type="button"
-                            title="Preview with about:messagepreview"
-                            data-bs-toggle="dropdown"
-                            aria-expanded="false">
-                      <span class="fa fa-eye"></span>
-                    </button>
-                    <ul class="dropdown-menu dropdown-menu-end text-nowrap">
-                    </ul>
+          {% if branch_feature_values_form.DELETE.value %}
+            {{ branch_feature_values_form.value.as_hidden }}
+          {% else %}
+            <div class="row mt-2">
+              <div class="col">
+                <label class="small mb-2 text-secondary">
+                  {{ branch_feature_values_form.instance.feature_config.name }}
+                  {% if branch_feature_values_form.instance.allow_coenrollment %}
+                    <div class="form-text">{{ NimbusUIConstants.COENROLLMENT_NOTE }}</div>
+                  {% endif %}
+                </label>
+                <div class="feature-value-editor position-relative"
+                     data-nimbus-devtools-feature-editor
+                     data-feature-id="{{ branch_feature_values_form.instance.feature_config.slug }}">
+                  {{ branch_feature_values_form.value|add_error_class:"is-invalid" }}
+                  <div class="position-absolute top-0 end-0 m-1 py-1 px-1">
+                    <div class="dropdown d-none" data-nimbus-devtools-try-preview-dropdown>
+                      <button class="dropdown-toggle btn btn-sm btn-outline-secondary ms-1"
+                              type="button"
+                              title="Preview with about:messagepreview"
+                              data-bs-toggle="dropdown"
+                              aria-expanded="false">
+                        <span class="fa fa-eye"></span>
+                      </button>
+                      <ul class="dropdown-menu dropdown-menu-end text-nowrap">
+                      </ul>
+                    </div>
                   </div>
                 </div>
+                {% for error in branch_feature_values_form.value.errors %}
+                  <div class="form-text text-danger">{{ error }}</div>
+                {% endfor %}
+                {% with fv_errors=validation_errors.reference_branch.feature_values|get_item:forloop.counter0 %}
+                  {% for error in fv_errors.value %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
+                {% endwith %}
               </div>
-              {% for error in branch_feature_values_form.value.errors %}
-                <div class="form-text text-danger">{{ error }}</div>
-              {% endfor %}
-              {% with fv_errors=validation_errors.reference_branch.feature_values|get_item:forloop.counter0 %}
-                {% for error in fv_errors.value %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
-              {% endwith %}
             </div>
-          </div>
+          {% endif %}
         {% endfor %}
       </div>
     {% endwith %}
@@ -107,7 +111,7 @@
         {{ rollout_screenshots.management_form }}
         <div class="d-flex flex-column gap-2 mt-4">
           {% for screenshot_form in rollout_screenshots %}
-            {% with ss_errors=validation_errors.reference_branch.screenshots|get_item:forloop.counter0 %}
+            {% with ss_errors=validation_errors.reference_branch_screenshots|get_item:forloop.counter0 %}
               <div>
                 {{ screenshot_form.id }}
                 <div class="d-flex gap-3">

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -29,6 +29,7 @@ from experimenter.experiments.models import (
 from experimenter.experiments.tests.factories import (
     TINY_PNG,
     NimbusBranchScreenshotFactory,
+    NimbusChangeLogFactory,
     NimbusDocumentationLinkFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
@@ -700,7 +701,11 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         setup_issues = response.context["setup_issues"]
         self.assertEqual(
             response.context["setup_issues_count"],
-            sum(len(group["fields"]) for group in setup_issues),
+            sum(
+                len(field["messages"])
+                for group in setup_issues
+                for field in group["fields"]
+            ),
         )
         for group in setup_issues:
             self.assertIn("section", group)
@@ -802,7 +807,269 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertContains(response, 'id="rollout-card-overview-summary"')
         self.assertContains(response, "Observations &amp; Problem Space")
 
-    def test_reference_branch_errors_deduped_into_one_field(self):
+    @parameterized.expand(
+        [
+            (NimbusExperiment.PublishStatus.APPROVED,),
+            (NimbusExperiment.PublishStatus.WAITING,),
+        ]
+    )
+    def test_sidebar_shows_waiting_state_for_review_requester(self, publish_status):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=publish_status,
+            is_rollout=True,
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            changed_by=self.user,
+            old_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            new_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(experiment.should_show_remote_settings_pending(self.user))
+        self.assertContains(response, "Waiting for Remote Settings")
+        self.assertContains(response, "review privileges")
+        self.assertContains(response, "#ask-experimenter")
+        self.assertContains(response, experiment.review_messages())
+        self.assertNotContains(response, "Open Remote Settings")
+        self.assertNotContains(response, 'id="rollout-remote-settings-link"')
+
+    @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
+    def test_sidebar_keeps_action_required_panel_for_reviewer(self):
+        experiment = NimbusExperimentFactory.create(
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=NimbusExperiment.Status.LIVE,
+            publish_status=NimbusExperiment.PublishStatus.APPROVED,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug}),
+            **{settings.OPENIDC_EMAIL_HEADER: settings.DEV_USER_EMAIL},
+        )
+
+        self.assertContains(response, "Action required")
+        self.assertContains(response, "Review this change in Remote Settings to")
+        self.assertContains(response, "Open Remote Settings")
+        self.assertNotContains(response, "Waiting for Remote Settings")
+
+    def test_sidebar_hides_waiting_state_when_publish_status_idle(self):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertNotContains(response, "Waiting for Remote Settings")
+        self.assertNotContains(response, 'id="rollout-remote-settings-link"')
+
+    @parameterized.expand(
+        [
+            ({"feature_values": [{"value": ["boom"]}]}, ["boom"], []),
+            ({"feature_values": [{"feature_config": ["boom"]}]}, ["boom"], []),
+            (["boom"], ["boom"], []),
+            ({"name": ["boom"]}, ["boom"], []),
+            ({"screenshots": [{"image": ["boom"]}]}, [], ["boom"]),
+            (
+                {"screenshots": [{"image": ["one"], "description": ["two"]}]},
+                [],
+                ["one", "two"],
+            ),
+        ]
+    )
+    def test_branch_errors_reach_the_readonly_card(
+        self, branch_errors, expected_features, expected_screenshots
+    ):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={"reference_branch": branch_errors},
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.context["feature_value_errors"], expected_features)
+        self.assertEqual(response.context["screenshot_errors"], expected_screenshots)
+        for message in expected_features + expected_screenshots:
+            self.assertContains(response, message)
+
+    def test_screenshot_errors_reach_the_edit_form_per_screenshot(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            is_rollout=True,
+        )
+        experiment.reference_branch.screenshots.all().delete()
+        clean_screenshot = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+        broken_screenshot = NimbusBranchScreenshotFactory.create(
+            branch=experiment.reference_branch
+        )
+        broken_screenshot.image = None
+        broken_screenshot.description = ""
+        broken_screenshot.save()
+
+        response = self.client.get(
+            reverse(
+                "nimbus-ui-new-update-rollout-features",
+                kwargs={"slug": experiment.slug},
+            )
+        )
+
+        screenshot_errors = response.context["validation_errors"][
+            "reference_branch_screenshots"
+        ]
+        self.assertEqual(screenshot_errors[0], {})
+        self.assertIn("image", screenshot_errors[1])
+        self.assertIn("description", screenshot_errors[1])
+        self.assertContains(response, "This field may not be blank.", count=2)
+        self.assertContains(response, clean_screenshot.description)
+
+    def test_documentation_link_errors_shown_when_there_are_no_links(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        experiment.documentation_links.all().delete()
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={"documentation_links": [{"link": ["Enter a valid URL."]}]},
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(
+            response.context["documentation_link_errors"], ["Enter a valid URL."]
+        )
+        self.assertContains(response, "Enter a valid URL.")
+
+    @parameterized.expand(
+        [
+            ("new-nimbus-ui-rollout-detail",),
+            ("nimbus-ui-new-update-overview",),
+        ]
+    )
+    def test_documentation_link_errors_render_as_messages_not_raw_dicts(self, url_name):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, is_rollout=True
+        )
+        experiment.documentation_links.all().delete()
+        link = NimbusDocumentationLinkFactory.create(experiment=experiment)
+        link.title = ""
+        link.link = ""
+        link.save()
+
+        response = self.client.get(reverse(url_name, kwargs={"slug": experiment.slug}))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "ErrorDetail")
+        self.assertNotContains(response, "is not a valid choice")
+        self.assertContains(response, "This field may not be blank.")
+
+    def test_documentation_link_title_only_error_is_not_reported(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED, is_rollout=True
+        )
+        experiment.documentation_links.all().delete()
+        link = NimbusDocumentationLinkFactory.create(experiment=experiment)
+        link.title = ""
+        link.save()
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertNotIn("documentation_links", response.context["validation_errors"])
+        self.assertEqual(response.context["documentation_link_errors"], [])
+        self.assertNotContains(response, "is not a valid choice")
+
+    def test_readonly_card_error_lists_empty_without_errors(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+
+        with mock.patch.object(
+            NimbusExperiment, "get_invalid_fields_errors", return_value={}
+        ):
+            context = self.client.get(
+                reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+            ).context
+
+        self.assertEqual(context["feature_value_errors"], [])
+        self.assertEqual(context["screenshot_errors"], [])
+        self.assertEqual(context["documentation_link_errors"], [])
+
+    def test_fields_sharing_a_row_are_merged_into_one_label(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={
+                "reference_branch": {
+                    "feature_values": [
+                        {"value": ["This field may not be blank."]},
+                        {"value": ["This field may not be blank."]},
+                    ]
+                },
+                "feature_configs": ["You must select a feature configuration."],
+            },
+        ):
+            context = self.client.get(url).context
+
+        (features_group,) = [
+            group
+            for group in context["setup_issues"]
+            if group["card_id"] == "rollout-features"
+        ]
+        self.assertEqual(
+            features_group["fields"],
+            [
+                {
+                    "label": "Feature Configuration",
+                    "messages": [
+                        "This field may not be blank.",
+                        "This field may not be blank.",
+                        "You must select a feature configuration.",
+                    ],
+                },
+            ],
+        )
+        self.assertEqual(context["setup_issues_count"], 3)
+
+    def test_setup_issues_count_counts_every_message_not_every_field(self):
+        experiment = NimbusExperimentFactory.create(is_rollout=True)
+        url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+
+        with mock.patch.object(
+            NimbusExperiment,
+            "get_invalid_fields_errors",
+            return_value={
+                "reference_branch": {
+                    "feature_values": [
+                        {"value": ["This field may not be blank."]},
+                        {"value": ["This field may not be blank."]},
+                    ]
+                },
+                "name": ["This field may not be blank."],
+            },
+        ):
+            response = self.client.get(url)
+
+        self.assertEqual(response.context["setup_issues_count"], 3)
+        self.assertContains(response, "3 issues detected")
+
+    def test_reference_branch_errors_grouped_into_one_field(self):
         experiment = NimbusExperimentFactory.create(is_rollout=True)
         url = reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
 
@@ -822,7 +1089,7 @@ class TestNimbusRolloutDetailView(AuthTestCase):
 
         self.assertEqual(
             context["validation_errors"]["reference_branch"],
-            reference_branch_errors,
+            {"feature_values": reference_branch_errors["feature_values"]},
         )
         (features_group,) = [
             group
@@ -836,11 +1103,16 @@ class TestNimbusRolloutDetailView(AuthTestCase):
                     "label": "Feature Configuration",
                     "messages": [
                         "This field may not be blank.",
-                        "This field is required.",
+                        "This field may not be blank.",
                     ],
+                },
+                {
+                    "label": "Screenshots",
+                    "messages": ["This field is required."],
                 },
             ],
         )
+        self.assertEqual(context["screenshot_errors"], ["This field is required."])
 
     def test_preview_card_hidden_when_not_in_preview(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -1269,6 +1541,18 @@ class TestNewAudienceUpdateView(NewViewTestMixin, AuthTestCase):
 class TestNewRolloutFeaturesUpdateView(AuthTestCase):
     url_name = "nimbus-ui-new-update-rollout-features"
 
+    def features_data(self, feature_value, **kwargs):
+        return {
+            "rollout_experience": "Original rollout experience",
+            "branch-feature-value-TOTAL_FORMS": "1",
+            "branch-feature-value-INITIAL_FORMS": "1",
+            "branch-feature-value-0-id": feature_value.id,
+            "branch-feature-value-0-feature_config": feature_value.feature_config_id,
+            "branch-feature-value-0-value": feature_value.value,
+            "rollout-screenshots-TOTAL_FORMS": "0",
+            "rollout-screenshots-INITIAL_FORMS": "0",
+        } | kwargs
+
     def test_post_valid_saves_and_returns_display_card(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
@@ -1325,6 +1609,114 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
         experiment.refresh_from_db()
         self.assertEqual(experiment.takeaways_summary, "Original rollout experience")
         self.assertEqual(experiment.feature_configs.count(), 0)
+
+    def test_post_deselecting_feature_hides_editor_without_saving(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-deselected",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.features_data(feature_value, feature_configs=[]),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
+        self.assertNotContains(response, 'data-feature-id="rollout-feature-deselected"')
+        experiment.refresh_from_db()
+        self.assertEqual(list(experiment.feature_configs.all()), [feature_config])
+        self.assertTrue(
+            experiment.reference_branch.feature_values.filter(
+                id=feature_value.id
+            ).exists()
+        )
+
+    def test_post_deselecting_feature_leaves_no_editor_to_attach_to(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-orphan",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.features_data(feature_value, feature_configs=[]),
+        )
+
+        content = response.content.decode()
+        self.assertNotContains(response, "feature-value-editor")
+        self.assertIn('name="branch-feature-value-0-value"', content)
+        self.assertNotIn("value-editor", content.split("branch-feature-value-0-value")[1])
+
+    def test_post_deselecting_feature_drops_its_validation_errors(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-invalid",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+        data = self.features_data(feature_value, feature_configs=[feature_config.id])
+        del data["branch-feature-value-0-id"]
+
+        selected = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}), data
+        )
+        self.assertIn("branch_feature_values", selected.context["form"].errors)
+
+        deselected = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            data | {"feature_configs": []},
+        )
+
+        self.assertNotIn("branch_feature_values", deselected.context["form"].errors)
+        self.assertNotContains(deselected, 'data-feature-id="rollout-feature-invalid"')
+
+    def test_post_deselecting_feature_and_saving_deletes_the_stored_json(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-saved-delete",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.features_data(feature_value, feature_configs=[], save="True"),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/rollout_features/card.html")
+        experiment.refresh_from_db()
+        self.assertEqual(experiment.feature_configs.count(), 0)
+        self.assertEqual(experiment.reference_branch.feature_values.count(), 0)
 
 
 class TestNewRolloutScreenshotCreateView(AuthTestCase):

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -835,6 +835,10 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertFalse(experiment.should_show_remote_settings_pending(self.user))
         self.assertContains(response, "Waiting for Remote Settings")
         self.assertContains(response, "review privileges")
+        self.assertContains(response, "If review Slack notifications are on")
+        self.assertContains(
+            response, f"#{NimbusUIConstants.SLACK_NIMBUS_CHANNEL}", html=False
+        )
         self.assertContains(response, "#ask-experimenter")
         self.assertContains(response, experiment.review_messages())
         self.assertNotContains(response, "Open Remote Settings")


### PR DESCRIPTION
Because

* Clicking Edit on a collapsed card did not open the card
* Deselecting a feature left its JSON editor and errors on the card
* The review panel disappeared entirely for the requester once a reviewer approved on experimenter and not on RS

This commit

* Expands a collapsed card when its Edit button is clicked
* Flags deselected features for deletion so their editor and errors get dropped
* Shows a waiting for RS panel to non-reviewers, reusing the existing review guidance block

Fixes #16883