### PR TITLE
test(cirrus): add integration test for experimenter's own cirrus integration

### DIFF
--- a/.env.integration-tests
+++ b/.env.integration-tests
@@ -56,4 +56,5 @@ CIRRUS_FML_PATH=./feature_manifest/sample.yml
 CIRRUS_SENTRY_DSN=
 CIRRUS_ENV_NAME=test_instance_stage
 CIRRUS_GLEAN_MAX_EVENTS_BUFFER=1
+CIRRUS_URL=http://cirrus-experimenter:8001/v2/features/
 EXPERIMENTER_CI_TEST_RUN=True

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,3 +300,30 @@ jobs:
         if: steps.check-paths.outputs.should-run == 'true'
         with:
           artifact-name: remote-settings-launch-test-report
+
+  integration-experimenter-cirrus:
+    name: "Experimenter Cirrus Integration"
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    env:
+      FIREFOX_CHANNEL: release
+      PYTEST_ARGS: -m experimenter_cirrus --reruns 1 --base-url https://nginx/nimbus/
+      PYTEST_BASE_URL: https://nginx/nimbus/
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/experimenter/ experimenter/tests/integration/ cirrus/ application-services/"
+
+      - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
+
+      - uses: ./.github/actions/run-integration-test
+        if: steps.check-paths.outputs.should-run == 'true'
+        with:
+          artifact-name: experimenter-cirrus-test-report

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -13,6 +13,7 @@ services:
       - db
       - redis
       - kinto
+      - cirrus-experimenter
     ports:
       - "7001:7001"
     volumes:
@@ -72,6 +73,17 @@ services:
     image: mozilla/autograph:4.1.1
     ports:
       - "8000:8000"
+
+  cirrus-experimenter:
+    image: cirrus:deploy
+    env_file: .env
+    environment:
+      CIRRUS_APP_ID: experimenter.cirrus
+      CIRRUS_APP_NAME: experimenter
+      CIRRUS_CHANNEL: developer
+      CIRRUS_FML_PATH: /fml/experimenter/developer.fml.yaml
+    depends_on:
+      - kinto
 
 volumes:
   db_volume:

--- a/experimenter/tests/integration/nimbus/test_experimenter_cirrus.py
+++ b/experimenter/tests/integration/nimbus/test_experimenter_cirrus.py
@@ -1,0 +1,84 @@
+import contextlib
+import json
+import os
+import time
+
+import pytest
+
+from nimbus.kinto.client import KINTO_COLLECTION_WEB, KintoClient
+from nimbus.utils import helpers
+
+APPLICATION = "experimenter"
+FEATURE_SLUG = "example-feature"
+FEATURE_EMOJI = "\N{SNOWMAN}"
+LIST_PAGE_PATH = "/nimbus/"
+CIRRUS_RETRIES = 60
+CIRRUS_RETRY_DELAY = 2.0
+
+
+def read_title():
+    html = helpers.get_page_text(LIST_PAGE_PATH)
+    if "<title>" not in html:
+        raise AssertionError("Experiment list page did not render a title")
+    return html.split("<title>", 1)[1].split("</title>", 1)[0]
+
+
+def wait_for_title_emoji():
+    title = read_title()
+    for _ in range(CIRRUS_RETRIES):
+        if FEATURE_EMOJI in title:
+            return title
+        time.sleep(CIRRUS_RETRY_DELAY)
+        title = read_title()
+    return title
+
+
+@pytest.mark.experimenter_cirrus
+def test_experimenter_cirrus_serves_launched_recipe(experiment_slug):
+    feature_config_id = helpers.get_feature_id_as_string(FEATURE_SLUG, APPLICATION)
+    assert feature_config_id is not None, (
+        f"No {FEATURE_SLUG} feature config for the {APPLICATION} application"
+    )
+
+    kinto_client = KintoClient(
+        collection=KINTO_COLLECTION_WEB,
+        server_url=os.getenv("INTEGRATION_TEST_KINTO_URL", "http://kinto:8888/v1"),
+    )
+
+    # CirrusMiddleware only calls Cirrus once the request user has glean prefs,
+    # which GleanMiddleware creates on the first authenticated request. Reading the
+    # page here both bootstraps those prefs and proves the emoji is absent before
+    # the recipe is launched, so the assertion below cannot pass vacuously.
+    assert FEATURE_EMOJI not in read_title()
+
+    helpers.create_experiment(
+        experiment_slug,
+        APPLICATION,
+        targeting="",
+        is_rollout=True,
+        data={
+            "channel": "developer",
+            "firefox_min_version": "",
+            "feature_config_ids": [int(feature_config_id)],
+            "reference_branch": {
+                "feature_value": json.dumps(
+                    {"enabled": True, "emoji": FEATURE_EMOJI}, ensure_ascii=False
+                ),
+            },
+        },
+    )
+
+    try:
+        helpers.launch_experiment(experiment_slug)
+        kinto_client.approve()
+        helpers.wait_for_published_recipe(experiment_slug)
+
+        title = wait_for_title_emoji()
+        assert FEATURE_EMOJI in title, (
+            f"Cirrus did not apply {FEATURE_SLUG} from {experiment_slug},"
+            f" list page title was {title!r}"
+        )
+    finally:
+        with contextlib.suppress(Exception):
+            helpers.end_experiment(experiment_slug)
+            kinto_client.approve()

--- a/experimenter/tests/integration/nimbus/utils/helpers.py
+++ b/experimenter/tests/integration/nimbus/utils/helpers.py
@@ -363,3 +363,24 @@ def end_experiment(slug):
 
 def launch_to_preview(slug):
     _post_form(f"/nimbus/{slug}/draft-to-preview/")
+
+
+def launch_experiment(slug):
+    _post_form(f"/nimbus/{slug}/draft-to-review/")
+    _post_form(f"/nimbus/{slug}/review-to-approve/")
+
+
+def get_page_text(path):
+    resp = _get_page(path)
+    if resp.status_code != 200:
+        raise RuntimeError(f"GET {path} failed ({resp.status_code})")
+    return resp.text
+
+
+def wait_for_published_recipe(slug):
+    for _ in range(LOAD_DATA_RETRIES):
+        experiment = _get_api(f"/api/v6/experiments/{slug}/")
+        if experiment and "detail" not in experiment:
+            return experiment
+        time.sleep(LOAD_DATA_RETRY_DELAY)
+    raise RuntimeError(f"Recipe {slug} was never published to the v6 API")

--- a/experimenter/tests/pytest.ini
+++ b/experimenter/tests/pytest.ini
@@ -13,6 +13,7 @@ markers =
     nimbus_ui: tests that only involve the UI, nothing else
     desktop_enrollment: tests that integrate with nimbus and external services
     cirrus_enrollment: tests that integrate with demo app and cirrus
+    experimenter_cirrus: tests that integrate experimenter itself with cirrus
     fenix_enrollment: fenix end-to-end enrollment test on an android emulator
     ios_enrollment: firefox-ios end-to-end enrollment test on an iOS simulator
     ios_create_recipe: creates the recipe consumed by the iOS enrollment test


### PR DESCRIPTION
Because

* No test exercises Cirrus end to end. The demo-app suite has not run since its
  CI job was deleted, and the middleware unit tests mock the Cirrus call.
* CirrusMiddleware swallows every failure to Sentry, so a broken Cirrus renders
  as absent features rather than an error.

This commit

* Adds a cirrus-experimenter service to the compose stack the integration tests
  bring up, configured for the experimenter application and its developer FML.
* Sets CIRRUS_URL in .env.integration-tests, leaving the demo-app Cirrus config
  untouched.
* Adds a test that launches an EXPERIMENTER rollout carrying a known
  example-feature emoji and asserts it reaches the experiment list page title.
* Adds a path-gated gating job for it in ci.yml.

Fixes #16992