### PR TITLE
feat(nimbus): add Fenix and iOS JEXL-to-SQL column mappings for mobile sizing

### DIFF
--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -5,7 +5,7 @@ import json
 from django.conf import settings
 from rest_framework import serializers
 
-from experimenter.experiments.jexl_to_sql import jexl_to_sql
+from experimenter.experiments.jexl_to_sql import APP_NAME_TO_JEXL_APP, jexl_to_sql
 from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBucketRange,
@@ -168,7 +168,8 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     def get_targetingSql(self, obj):
         if obj.status != NimbusExperiment.Status.DRAFT:
             return None
-        result = jexl_to_sql(obj.targeting)
+        app = APP_NAME_TO_JEXL_APP.get(obj.application_config.app_name)
+        result = jexl_to_sql(obj.targeting, app=app)
         if result.sql is None and not result.warnings:
             return None
 

--- a/experimenter/experimenter/experiments/api/v8/serializers.py
+++ b/experimenter/experimenter/experiments/api/v8/serializers.py
@@ -168,7 +168,8 @@ class NimbusExperimentSerializer(serializers.ModelSerializer):
     def get_targetingSql(self, obj):
         if obj.status != NimbusExperiment.Status.DRAFT:
             return None
-        app = APP_NAME_TO_JEXL_APP.get(obj.application_config.app_name)
+        config = obj.application_config
+        app = APP_NAME_TO_JEXL_APP.get(config.app_name) if config else None
         result = jexl_to_sql(obj.targeting, app=app)
         if result.sql is None and not result.warnings:
             return None

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -114,6 +114,103 @@ _USER_MONTHLY_ACTIVITY_COL = (
     "metrics.object.nimbus_targeting_context_user_monthly_activity"
 )
 
+# App slugs used to select the right mobile column map in jexl_to_sql().
+_FENIX_APP = "fenix"
+_IOS_APP = "ios"
+
+# Mobile BQ tables store all context as a JSON blob column. BOOL columns are wrapped in
+# CAST(col AS BOOL) so that _is_boolean_sql() detects them correctly and _coerce_to_bool()
+# does not try to compare a BOOL column against '' or 'false'.
+# Schema confirmed from live BQ queries against both tables.
+
+# Columns present as typed top-level fields in BOTH Fenix and iOS tables.
+_SHARED_MOBILE_COLUMNS = {
+    "locale": "locale",
+    "region": "region",
+    "language": "language",
+    "appVersion": "appVersion",
+    "app_version": "appVersion",
+    "isFirstRun": "CAST(isFirstRun AS BOOL)",
+    "is_first_run": "CAST(isFirstRun AS BOOL)",
+    "daysSinceInstall": "daysSinceInstall",
+    "days_since_install": "daysSinceInstall",
+    "daysSinceUpdate": "daysSinceUpdate",
+    "days_since_update": "daysSinceUpdate",
+    "eventQueryValues.daysOpenedInLast28": "eventQuery_daysOpenedInLast28",
+    "event_query_values.days_opened_in_last_28": "eventQuery_daysOpenedInLast28",
+    "userDisabledAi": "CAST(userDisabledAi AS BOOL)",
+    "user_disabled_ai": "CAST(userDisabledAi AS BOOL)",
+}
+
+# Fenix (Android) — moz-fx-data-shared-prod.fenix.nimbus_recorded_targeting_context
+JEXL_TO_BQ_COLUMN_FENIX = {
+    **_SHARED_MOBILE_COLUMNS,
+    # Fenix-specific typed columns
+    "androidSdkVersion": "androidSdkVersion",
+    "android_sdk_version": "androidSdkVersion",
+    "deviceManufacturer": "deviceManufacturer",
+    "device_manufacturer": "deviceManufacturer",
+    "deviceModel": "deviceModel",
+    "device_model": "deviceModel",
+    "installReferrerResponseUtmSource": "installReferrerResponseUtmSource",
+    "install_referrer_response_utm_source": "installReferrerResponseUtmSource",
+    "installReferrerResponseUtmCampaign": "installReferrerResponseUtmCampaign",
+    "install_referrer_response_utm_campaign": "installReferrerResponseUtmCampaign",
+    "installReferrerResponseUtmMedium": "installReferrerResponseUtmMedium",
+    "install_referrer_response_utm_medium": "installReferrerResponseUtmMedium",
+    "installReferrerResponseUtmContent": "installReferrerResponseUtmContent",
+    "install_referrer_response_utm_content": "installReferrerResponseUtmContent",
+    "installReferrerResponseUtmTerm": "installReferrerResponseUtmTerm",
+    "install_referrer_response_utm_term": "installReferrerResponseUtmTerm",
+    "addonIds": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
+    "addon_ids": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
+    "userAcceptedTou": "CAST(userAcceptedTou AS BOOL)",
+    "user_accepted_tou": "CAST(userAcceptedTou AS BOOL)",
+    "noShortcutsOrStoriesOptOuts": "CAST(noShortcutsOrStoriesOptOuts AS BOOL)",
+    "no_shortcuts_or_stories_opt_outs": "CAST(noShortcutsOrStoriesOptOuts AS BOOL)",
+    "touPoints": "touPoints",
+    "tou_points": "touPoints",
+    "areNotificationsEnabled": "CAST(areNotificationsEnabled AS BOOL)",
+    "are_notifications_enabled": "CAST(areNotificationsEnabled AS BOOL)",
+    "areMarketingNotificationsEnabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
+    "are_marketing_notifications_enabled": (
+        "CAST(areMarketingNotificationsEnabled AS BOOL)"
+    ),
+    # JSON-only: in context blob but not a typed column on Fenix (iOS has it).
+    # Context keys are camelCase — confirmed from live data.
+    "isReviewCheckerEnabled": (
+        "CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS BOOL)"
+    ),
+    "is_review_checker_enabled": (
+        "CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS BOOL)"
+    ),
+}
+
+# iOS (Firefox for iOS)
+# moz-fx-data-shared-prod.org_mozilla_ios_firefox.nimbus_recorded_targeting_context
+JEXL_TO_BQ_COLUMN_IOS = {
+    **_SHARED_MOBILE_COLUMNS,
+    # iOS-specific typed columns
+    "isDefaultBrowser": "CAST(isDefaultBrowser AS BOOL)",
+    "is_default_browser": "CAST(isDefaultBrowser AS BOOL)",
+    "isPhone": "CAST(isPhone AS BOOL)",
+    "is_phone": "CAST(isPhone AS BOOL)",
+    "isReviewCheckerEnabled": "CAST(isReviewCheckerEnabled AS BOOL)",
+    "is_review_checker_enabled": "CAST(isReviewCheckerEnabled AS BOOL)",
+    "isBottomToolbarUser": "CAST(isBottomToolbarUser AS BOOL)",
+    "is_bottom_toolbar_user": "CAST(isBottomToolbarUser AS BOOL)",
+    "hasEnabledTipsNotifications": "CAST(hasEnabledTipsNotifications AS BOOL)",
+    "has_enabled_tips_notifications": "CAST(hasEnabledTipsNotifications AS BOOL)",
+    "hasAcceptedTermsOfUse": "CAST(hasAcceptedTermsOfUse AS BOOL)",
+    "has_accepted_terms_of_use": "CAST(hasAcceptedTermsOfUse AS BOOL)",
+    "isAppleIntelligenceAvailable": "CAST(isAppleIntelligenceAvailable AS BOOL)",
+    "is_apple_intelligence_available": "CAST(isAppleIntelligenceAvailable AS BOOL)",
+    "cannotUseAppleIntelligence": "CAST(cannotUseAppleIntelligence AS BOOL)",
+    "cannot_use_apple_intelligence": "CAST(cannotUseAppleIntelligence AS BOOL)",
+    "touExperiencePoints": "touExperiencePoints",
+    "tou_experience_points": "touExperiencePoints",
+}
+
 # Attributes with no corresponding column in nimbus_targeting_context.
 KNOWN_UNTRANSLATABLE = {
     "attachedFxAOAuthClients",  # privacy-sensitive, will never be recorded
@@ -134,7 +231,10 @@ KNOWN_UNTRANSLATABLE = {
     "isDefaultHandler",  # file-type handler object, not directly queryable
     "localeLanguageCode",  # derived from locale, not recorded separately
     "homePageSettings",  # parent blocked; simple sub-fields mapped above
-    # Mobile-only attributes
+    # Mobile-only attributes — untranslatable on Desktop.
+    # Those in JEXL_TO_BQ_COLUMN_FENIX / JEXL_TO_BQ_COLUMN_IOS are handled
+    # by the mobile column maps when app="fenix" or app="ios".
+    # Those absent from the mobile maps are not recorded in the BQ context blob.
     "days_since_install",
     "days_since_update",
     "is_default_browser",
@@ -166,39 +266,47 @@ class JEXLToSQLResult:
     warnings: list[str]
 
 
-def jexl_to_sql(jexl_expression: str) -> JEXLToSQLResult:
+def jexl_to_sql(jexl_expression: str, app: Optional[str] = None) -> JEXLToSQLResult:
     """
     Translate a JEXL targeting expression into a BigQuery SQL WHERE clause.
 
+    Pass app="fenix" or app="ios" to use the mobile column mappings.
     Returns sql=None with a warnings list when nothing can be translated.
     Returns partial sql with warnings when only some clauses translate.
     """
+    if app == _FENIX_APP:
+        column_map = JEXL_TO_BQ_COLUMN_FENIX
+    elif app == _IOS_APP:
+        column_map = JEXL_TO_BQ_COLUMN_IOS
+    else:
+        column_map = JEXL_TO_BQ_COLUMN
+
     if not jexl_expression or jexl_expression == "true":
         return JEXLToSQLResult(sql=None, warnings=[])
 
     warnings: list[str] = []
     try:
         ast = JEXLParser().parse(jexl_expression)
-        sql = _node_to_sql(ast, warnings)
+        sql = _node_to_sql(ast, warnings, column_map)
     except Exception:
         return JEXLToSQLResult(sql=None, warnings=["__parse_error__"])
 
     return JEXLToSQLResult(sql=sql or None, warnings=warnings)
 
 
-def _node_to_sql(node, warnings: list[str]) -> Optional[str]:
+def _node_to_sql(node, warnings: list[str], column_map: dict[str, str]) -> Optional[str]:
     if isinstance(node, BinaryExpression):
-        return _binary_to_sql(node, warnings)
+        return _binary_to_sql(node, warnings, column_map)
     if isinstance(node, UnaryExpression):
-        return _unary_to_sql(node, warnings)
+        return _unary_to_sql(node, warnings, column_map)
     if isinstance(node, Identifier):
-        return _identifier_to_sql(node, warnings)
+        return _identifier_to_sql(node, warnings, column_map)
     if isinstance(node, Literal):
         return _literal_to_sql(node)
     if isinstance(node, ArrayLiteral):
-        return _array_to_sql(node, warnings)
+        return _array_to_sql(node, warnings, column_map)
     if isinstance(node, Transform):
-        return _transform_to_sql(node, warnings)
+        return _transform_to_sql(node, warnings, column_map)
     if isinstance(node, FilterExpression):
         subject_path = _identifier_path(node.subject)
         # addonsInfo.addons['addon-id'] — check addon ID membership in BQ array
@@ -212,17 +320,19 @@ def _node_to_sql(node, warnings: list[str]) -> Optional[str]:
     return None
 
 
-def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]:
+def _binary_to_sql(
+    node: BinaryExpression, warnings: list[str], column_map: dict[str, str]
+) -> Optional[str]:
     op = node.operator.symbol
 
     if _is_version_compare_node(node.left) and isinstance(node.right, Literal):
-        return _version_compare_binary_to_sql(node, warnings)
+        return _version_compare_binary_to_sql(node, warnings, column_map)
     if _is_version_compare_node(node.right) and isinstance(node.left, Literal):
-        return _version_compare_binary_to_sql_reversed(node, warnings)
+        return _version_compare_binary_to_sql_reversed(node, warnings, column_map)
 
     if op in ("&&", "||"):
-        left = _node_to_sql(node.left, warnings)
-        right = _node_to_sql(node.right, warnings)
+        left = _node_to_sql(node.left, warnings, column_map)
+        right = _node_to_sql(node.right, warnings, column_map)
         if left and right:
             sql_op = "AND" if op == "&&" else "OR"
             # BigQuery requires BOOL operands for AND/OR.
@@ -232,8 +342,8 @@ def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]
             return f"({left} {sql_op} {right})"
         return left or right
 
-    left = _node_to_sql(node.left, warnings)
-    right = _node_to_sql(node.right, warnings)
+    left = _node_to_sql(node.left, warnings, column_map)
+    right = _node_to_sql(node.right, warnings, column_map)
     if left is None or right is None:
         return None
 
@@ -310,9 +420,11 @@ def _binary_to_sql(node: BinaryExpression, warnings: list[str]) -> Optional[str]
     return None
 
 
-def _unary_to_sql(node: UnaryExpression, warnings: list[str]) -> Optional[str]:
+def _unary_to_sql(
+    node: UnaryExpression, warnings: list[str], column_map: dict[str, str]
+) -> Optional[str]:
     if node.operator.symbol == "!":
-        inner = _node_to_sql(node.right, warnings)
+        inner = _node_to_sql(node.right, warnings, column_map)
         if inner:
             if _is_boolean_sql(inner):
                 return f"NOT ({inner})"
@@ -321,15 +433,18 @@ def _unary_to_sql(node: UnaryExpression, warnings: list[str]) -> Optional[str]:
     return None  # pragma: no cover — pyjexl only produces UnaryExpression for "!"
 
 
-def _identifier_to_sql(node: Identifier, warnings: list[str]) -> Optional[str]:
+def _identifier_to_sql(
+    node: Identifier, warnings: list[str], column_map: dict[str, str]
+) -> Optional[str]:
     path = _identifier_path(node)
 
     if path == "null":
         return "NULL"
 
-    # Explicit mappings take priority over parent being in KNOWN_UNTRANSLATABLE
-    if path in JEXL_TO_BQ_COLUMN:
-        return JEXL_TO_BQ_COLUMN[path]
+    # column_map takes priority — covers both direct columns and JSON_VALUE expressions.
+    # KNOWN_UNTRANSLATABLE is a secondary hint for Desktop paths we know will never map.
+    if path in column_map:
+        return column_map[path]
 
     if _is_untranslatable(path):
         _add_warning(warnings, path)
@@ -349,26 +464,34 @@ def _literal_to_sql(node: Literal) -> str:
     return str(value)
 
 
-def _array_to_sql(node: ArrayLiteral, warnings: list[str]) -> Optional[str]:
-    items = [_node_to_sql(item, warnings) for item in node.value]
+def _array_to_sql(
+    node: ArrayLiteral, warnings: list[str], column_map: dict[str, str]
+) -> Optional[str]:
+    items = [_node_to_sql(item, warnings, column_map) for item in node.value]
     items = [i for i in items if i is not None]
     if not items:
         return None
     return f"({', '.join(items)})"
 
 
-def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
+def _transform_to_sql(
+    node: Transform, warnings: list[str], column_map: dict[str, str]
+) -> Optional[str]:
     subject_path = _identifier_path(node.subject)
 
     # If the subject itself is untranslatable, warn about it rather than the transform
-    if subject_path and _is_untranslatable(subject_path):
+    if (
+        subject_path
+        and subject_path not in column_map
+        and _is_untranslatable(subject_path)
+    ):
         _add_warning(warnings, subject_path)
         return None
 
     if node.name == "date":
         # profileAgeCreated is epoch ms — return column directly for arithmetic
-        if subject_path == "profileAgeCreated":
-            return JEXL_TO_BQ_COLUMN["profileAgeCreated"]
+        if subject_path == "profileAgeCreated" and "profileAgeCreated" in column_map:
+            return column_map["profileAgeCreated"]
         if subject_path == "currentDate":
             return "UNIX_MILLIS(CURRENT_TIMESTAMP())"
         _add_warning(warnings, "|date")
@@ -377,18 +500,19 @@ def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
     if node.name == "length":
         # BigQuery has no JSON_ARRAY_LENGTH for STRING columns — metrics.object.*
         # columns are JSON strings, so use ARRAY_LENGTH(JSON_QUERY_ARRAY(...)).
-        subject_sql = _node_to_sql(node.subject, warnings)
+        subject_sql = _node_to_sql(node.subject, warnings, column_map)
         if subject_sql:
             return f"ARRAY_LENGTH(JSON_QUERY_ARRAY({subject_sql}))"
         _add_warning(warnings, "|length")
         return None
 
     if node.name == "preferenceValue":
+        # Desktop-only: pref data lives in a Glean metrics column that does not exist
+        # in mobile BQ tables. Warn and bail when running against a mobile column map.
+        if "firefoxVersion" not in column_map:
+            _add_warning(warnings, "|preferenceValue")
+            return None
         # Pref names stored with dots replaced by __ in BigQuery.
-        # Returns the raw JSON string value — callers that need a boolean comparison
-        # (e.g. pref == 'value') get a STRING they can compare against.
-        # Boolean prefs used as bare truthy values in JEXL (e.g. pref|preferenceValue
-        # in an && chain) are handled by _is_boolean_sql recognizing this pattern.
         pref_name = _literal_value(node.subject)
         if pref_name:
             bq_key = pref_name.replace(".", "__")
@@ -397,6 +521,10 @@ def _transform_to_sql(node: Transform, warnings: list[str]) -> Optional[str]:
         return None
 
     if node.name == "preferenceIsUserSet":
+        # Desktop-only: same reasoning as preferenceValue above.
+        if "firefoxVersion" not in column_map:
+            _add_warning(warnings, "|preferenceIsUserSet")
+            return None
         # user_set_prefs is a JSON array of pref names (using original dot notation)
         pref_name = _literal_value(node.subject)
         if pref_name:
@@ -422,7 +550,7 @@ def _extract_major_version(version_str: str) -> Optional[int]:
 
 
 def _version_compare_binary_to_sql(
-    node: BinaryExpression, warnings: list[str]
+    node: BinaryExpression, warnings: list[str], column_map: dict[str, str]
 ) -> Optional[str]:
     """version|versionCompare('X.!') <op> 0 → firefox_version <op> X"""
     return _version_compare_binary_to_sql_with(
@@ -430,11 +558,12 @@ def _version_compare_binary_to_sql(
         op_symbol=node.operator.symbol,
         comparand_value=node.right.value,
         warnings=warnings,
+        column_map=column_map,
     )
 
 
 def _version_compare_binary_to_sql_reversed(
-    node: BinaryExpression, warnings: list[str]
+    node: BinaryExpression, warnings: list[str], column_map: dict[str, str]
 ) -> Optional[str]:
     # 0 <= version|versionCompare('X') → flip operands and operator, reuse same logic
     reverse_op = {
@@ -457,11 +586,16 @@ def _version_compare_binary_to_sql_reversed(
         op_symbol=flipped_op,
         comparand_value=node.left.value,
         warnings=warnings,
+        column_map=column_map,
     )
 
 
 def _version_compare_binary_to_sql_with(
-    transform, op_symbol: str, comparand_value, warnings: list[str]
+    transform,
+    op_symbol: str,
+    comparand_value,
+    warnings: list[str],
+    column_map: dict[str, str],
 ) -> Optional[str]:
     if comparand_value != 0:
         _add_warning(warnings, "|versionCompare")
@@ -470,6 +604,11 @@ def _version_compare_binary_to_sql_with(
     subject_path = _identifier_path(transform.subject)
     if subject_path != "version":
         _add_warning(warnings, subject_path or "|versionCompare")
+        return None
+
+    version_col = column_map.get("firefoxVersion")
+    if version_col is None:
+        _add_warning(warnings, "|versionCompare")
         return None
 
     if not transform.args:
@@ -490,7 +629,7 @@ def _version_compare_binary_to_sql_with(
         _add_warning(warnings, "|versionCompare")
         return None
 
-    return f"{JEXL_TO_BQ_COLUMN['firefoxVersion']} {sql_op} {major}"
+    return f"{version_col} {sql_op} {major}"
 
 
 def _identifier_path(node) -> str:

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -114,9 +114,9 @@ _USER_MONTHLY_ACTIVITY_COL = (
     "metrics.object.nimbus_targeting_context_user_monthly_activity"
 )
 
-# App slugs used to select the right mobile column map in jexl_to_sql().
-_FENIX_APP = "fenix"
-_IOS_APP = "ios"
+# App identifiers used to select the right mobile column map in jexl_to_sql().
+FENIX_APP = "fenix"
+IOS_APP = "ios"
 
 # Mobile BQ tables store all context as a JSON blob column. BOOL columns are wrapped in
 # CAST(col AS BOOL) so that _is_boolean_sql() detects them correctly and _coerce_to_bool()
@@ -260,8 +260,14 @@ KNOWN_UNTRANSLATABLE = {
 # Maps Experimenter application app_name to the jexl_to_sql app parameter.
 # "firefox_desktop" and all other app names map to None (desktop column map).
 APP_NAME_TO_JEXL_APP: dict[str, str] = {
-    "fenix": "fenix",
-    "firefox_ios": "ios",
+    "fenix": FENIX_APP,
+    "firefox_ios": IOS_APP,
+}
+
+# Maps jexl_to_sql app parameter to the corresponding column map.
+_APP_COLUMN_MAP: dict[str, dict] = {
+    FENIX_APP: JEXL_TO_BQ_COLUMN_FENIX,
+    IOS_APP: JEXL_TO_BQ_COLUMN_IOS,
 }
 
 _VERSION_PATTERN = re.compile(r"^(\d+)")
@@ -281,12 +287,7 @@ def jexl_to_sql(jexl_expression: str, app: Optional[str] = None) -> JEXLToSQLRes
     Returns sql=None with a warnings list when nothing can be translated.
     Returns partial sql with warnings when only some clauses translate.
     """
-    if app == _FENIX_APP:
-        column_map = JEXL_TO_BQ_COLUMN_FENIX
-    elif app == _IOS_APP:
-        column_map = JEXL_TO_BQ_COLUMN_IOS
-    else:
-        column_map = JEXL_TO_BQ_COLUMN
+    column_map = _APP_COLUMN_MAP.get(app, JEXL_TO_BQ_COLUMN)
 
     if not jexl_expression or jexl_expression == "true":
         return JEXLToSQLResult(sql=None, warnings=[])
@@ -516,7 +517,7 @@ def _transform_to_sql(
     if node.name == "preferenceValue":
         # Desktop-only: pref data lives in a Glean metrics column that does not exist
         # in mobile BQ tables. Warn and bail when running against a mobile column map.
-        if "firefoxVersion" not in column_map:
+        if column_map is not JEXL_TO_BQ_COLUMN:
             _add_warning(warnings, "|preferenceValue")
             return None
         # Pref names stored with dots replaced by __ in BigQuery.
@@ -529,7 +530,7 @@ def _transform_to_sql(
 
     if node.name == "preferenceIsUserSet":
         # Desktop-only: same reasoning as preferenceValue above.
-        if "firefoxVersion" not in column_map:
+        if column_map is not JEXL_TO_BQ_COLUMN:
             _add_warning(warnings, "|preferenceIsUserSet")
             return None
         # user_set_prefs is a JSON array of pref names (using original dot notation)

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -258,7 +258,7 @@ APP_NAME_TO_JEXL_APP: dict[str, str] = {
     "firefox_ios": IOS_APP,
 }
 
-_APP_COLUMN_MAP: dict[str, dict] = {
+_APP_COLUMN_MAP: dict[str, dict[str, str]] = {
     FENIX_APP: JEXL_TO_BQ_COLUMN_FENIX,
     IOS_APP: JEXL_TO_BQ_COLUMN_IOS,
 }

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -114,7 +114,6 @@ _USER_MONTHLY_ACTIVITY_COL = (
     "metrics.object.nimbus_targeting_context_user_monthly_activity"
 )
 
-# App identifiers used to select the right mobile column map in jexl_to_sql().
 FENIX_APP = "fenix"
 IOS_APP = "ios"
 
@@ -254,14 +253,11 @@ KNOWN_UNTRANSLATABLE = {
     "registered",
 }
 
-# Maps Experimenter application app_name to the jexl_to_sql app parameter.
-# "firefox_desktop" and all other app names map to None (desktop column map).
 APP_NAME_TO_JEXL_APP: dict[str, str] = {
     "fenix": FENIX_APP,
     "firefox_ios": IOS_APP,
 }
 
-# Maps jexl_to_sql app parameter to the corresponding column map.
 _APP_COLUMN_MAP: dict[str, dict] = {
     FENIX_APP: JEXL_TO_BQ_COLUMN_FENIX,
     IOS_APP: JEXL_TO_BQ_COLUMN_IOS,

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -121,7 +121,6 @@ IOS_APP = "ios"
 # Mobile BQ tables store all context as a JSON blob column. BOOL columns are wrapped in
 # CAST(col AS BOOL) so that _is_boolean_sql() detects them correctly and _coerce_to_bool()
 # does not try to compare a BOOL column against '' or 'false'.
-# Schema confirmed from live BQ queries against both tables.
 
 # Columns present as typed top-level fields in BOTH Fenix and iOS tables.
 _SHARED_MOBILE_COLUMNS = {
@@ -145,7 +144,6 @@ _SHARED_MOBILE_COLUMNS = {
 # Fenix (Android) — moz-fx-data-shared-prod.fenix.nimbus_recorded_targeting_context
 JEXL_TO_BQ_COLUMN_FENIX = {
     **_SHARED_MOBILE_COLUMNS,
-    # Fenix-specific typed columns
     "androidSdkVersion": "androidSdkVersion",
     "android_sdk_version": "androidSdkVersion",
     "deviceManufacturer": "deviceManufacturer",
@@ -190,7 +188,6 @@ JEXL_TO_BQ_COLUMN_FENIX = {
 # moz-fx-data-shared-prod.org_mozilla_ios_firefox.nimbus_recorded_targeting_context
 JEXL_TO_BQ_COLUMN_IOS = {
     **_SHARED_MOBILE_COLUMNS,
-    # iOS-specific typed columns
     "isDefaultBrowser": "CAST(isDefaultBrowser AS BOOL)",
     "is_default_browser": "CAST(isDefaultBrowser AS BOOL)",
     "isPhone": "CAST(isPhone AS BOOL)",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -257,6 +257,13 @@ KNOWN_UNTRANSLATABLE = {
     "registered",
 }
 
+# Maps Experimenter application app_name to the jexl_to_sql app parameter.
+# "firefox_desktop" and all other app names map to None (desktop column map).
+APP_NAME_TO_JEXL_APP: dict[str, str] = {
+    "fenix": "fenix",
+    "firefox_ios": "ios",
+}
+
 _VERSION_PATTERN = re.compile(r"^(\d+)")
 
 

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -47,7 +47,11 @@ from experimenter.experiments.constants import (
     NimbusConstants,
     TargetingMultipleKintoCollectionsError,
 )
-from experimenter.experiments.jexl_to_sql import ensure_bool_sql, jexl_to_sql
+from experimenter.experiments.jexl_to_sql import (
+    APP_NAME_TO_JEXL_APP,
+    ensure_bool_sql,
+    jexl_to_sql,
+)
 from experimenter.experiments.jexl_utils import format_jexl
 from experimenter.experiments.monitoring_utils import (
     check_srm_mismatch,
@@ -2500,7 +2504,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def sizing_sql_predicate(self):
-        sql = jexl_to_sql(self.targeting).sql
+        app = APP_NAME_TO_JEXL_APP.get(self.application_config.app_name)
+        sql = jexl_to_sql(self.targeting, app=app).sql
         if sql is None:
             return None
         return ensure_bool_sql(sql)

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2504,7 +2504,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
 
     @property
     def sizing_sql_predicate(self):
-        app = APP_NAME_TO_JEXL_APP.get(self.application_config.app_name)
+        config = self.application_config
+        app = APP_NAME_TO_JEXL_APP.get(config.app_name) if config else None
         sql = jexl_to_sql(self.targeting, app=app).sql
         if sql is None:
             return None

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -672,6 +672,8 @@ class TestNimbusExperimentSerializer(TestCase):
         data = serializer.data["targetingSql"]
         self.assertIsNotNone(data)
         # days_since_update < 7 && days_since_install >= 7
-        # → daysSinceUpdate < 7 AND daysSinceInstall >= 7 (iOS BQ columns)
-        self.assertEqual(data["sql"], "daysSinceUpdate < 7 AND daysSinceInstall >= 7")
+        # → (daysSinceUpdate < 7 AND daysSinceInstall >= 7) (iOS BQ columns)
+        self.assertEqual(
+            data["sql"], "(daysSinceUpdate < 7 AND daysSinceInstall >= 7)"
+        )
         self.assertEqual(data["warnings"], [])

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -673,7 +673,5 @@ class TestNimbusExperimentSerializer(TestCase):
         self.assertIsNotNone(data)
         # days_since_update < 7 && days_since_install >= 7
         # → (daysSinceUpdate < 7 AND daysSinceInstall >= 7) (iOS BQ columns)
-        self.assertEqual(
-            data["sql"], "(daysSinceUpdate < 7 AND daysSinceInstall >= 7)"
-        )
+        self.assertEqual(data["sql"], "(daysSinceUpdate < 7 AND daysSinceInstall >= 7)")
         self.assertEqual(data["warnings"], [])

--- a/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
+++ b/experimenter/experimenter/experiments/tests/api/v8/test_serializers.py
@@ -636,3 +636,42 @@ class TestNimbusExperimentSerializer(TestCase):
         )
         serializer = NimbusExperimentSerializer(experiment)
         self.assertIsNone(serializer.data["targetingSql"])
+
+    def test_targeting_sql_uses_fenix_column_map_for_fenix_experiment(self):
+        # days_since_install is KNOWN_UNTRANSLATABLE on Desktop but maps to
+        # daysSinceInstall in the Fenix column map. Verify the serializer routes
+        # Fenix experiments through jexl_to_sql(app="fenix").
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.FENIX,
+            targeting_config_slug="mobile_14_day_users",
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        data = serializer.data["targetingSql"]
+        self.assertIsNotNone(data)
+        # days_since_install < 15 → daysSinceInstall < 15 (Fenix BQ column)
+        self.assertEqual(data["sql"], "daysSinceInstall < 15")
+        self.assertEqual(data["warnings"], [])
+
+    def test_targeting_sql_uses_ios_column_map_for_ios_experiment(self):
+        # days_since_update is KNOWN_UNTRANSLATABLE on Desktop but maps to
+        # daysSinceUpdate in the iOS column map. Verify the serializer routes
+        # iOS experiments through jexl_to_sql(app="ios").
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.IOS,
+            targeting_config_slug="mobile_recently_updated_users",
+            channels=[],
+            firefox_min_version=NimbusExperiment.Version.NO_VERSION,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+        )
+        serializer = NimbusExperimentSerializer(experiment)
+        data = serializer.data["targetingSql"]
+        self.assertIsNotNone(data)
+        # days_since_update < 7 && days_since_install >= 7
+        # → daysSinceUpdate < 7 AND daysSinceInstall >= 7 (iOS BQ columns)
+        self.assertEqual(data["sql"], "daysSinceUpdate < 7 AND daysSinceInstall >= 7")
+        self.assertEqual(data["warnings"], [])

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -547,13 +547,23 @@ class TestJEXLToSQLMobile(TestCase):
             # Fenix-specific columns
             ("android_sdk", "androidSdkVersion", FENIX_APP, "androidSdkVersion"),
             ("android_sdk_snake", "android_sdk_version", FENIX_APP, "androidSdkVersion"),
-            ("device_manufacturer", "deviceManufacturer", FENIX_APP, "deviceManufacturer"),
+            (
+                "device_manufacturer",
+                "deviceManufacturer",
+                FENIX_APP,
+                "deviceManufacturer",
+            ),
             ("device_model", "deviceModel", FENIX_APP, "deviceModel"),
             ("utm_source", _UTM_SRC, FENIX_APP, _UTM_SRC),
             ("utm_source_snake", _UTM_SRC_SNAKE, FENIX_APP, _UTM_SRC),
             # Fenix JSON-only (not a typed column; uses JSON_VALUE)
             ("rc_fenix", "isReviewCheckerEnabled", FENIX_APP, _REVIEW_CHECKER_JSON),
-            ("rc_snake_fenix", "is_review_checker_enabled", FENIX_APP, _REVIEW_CHECKER_JSON),
+            (
+                "rc_snake_fenix",
+                "is_review_checker_enabled",
+                FENIX_APP,
+                _REVIEW_CHECKER_JSON,
+            ),
             # iOS-specific columns
             ("default_browser_ios", "isDefaultBrowser", IOS_APP, _CAST_DFLT),
             ("default_browser_snake", "is_default_browser", IOS_APP, _CAST_DFLT),
@@ -577,14 +587,24 @@ class TestJEXLToSQLMobile(TestCase):
                 FENIX_APP,
                 "(region IN ('US', 'CA'))",
             ),
-            ("days_lt_fenix", "days_since_install < 7", FENIX_APP, "daysSinceInstall < 7"),
+            (
+                "days_lt_fenix",
+                "days_since_install < 7",
+                FENIX_APP,
+                "daysSinceInstall < 7",
+            ),
             (
                 "sdk_gte_fenix",
                 "android_sdk_version >= 28",
                 FENIX_APP,
                 "androidSdkVersion >= 28",
             ),
-            ("is_phone_eq_ios", "isPhone == true", IOS_APP, "CAST(isPhone AS BOOL) = TRUE"),
+            (
+                "is_phone_eq_ios",
+                "isPhone == true",
+                IOS_APP,
+                "CAST(isPhone AS BOOL) = TRUE",
+            ),
         ]
     )
     def test_comparison_translates(self, _name, jexl, app, expected_sql):

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -32,7 +32,6 @@ _FF = "metrics.quantity.nimbus_targeting_context_firefox_version"
 
 
 class TestJEXLToSQL(TestCase):
-
     @parameterized.expand(
         [
             ("locale", "locale", "metrics.string.nimbus_targeting_context_locale"),
@@ -108,7 +107,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql(jexl)
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
-
 
     @parameterized.expand(
         [
@@ -190,7 +188,6 @@ class TestJEXLToSQL(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-
     _VC = "|versionCompare"
 
     @parameterized.expand(
@@ -218,7 +215,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql(jexl)
         self.assertIsNone(result.sql)
         self.assertIn(expected_warning, result.warnings)
-
 
     @parameterized.expand(
         [
@@ -250,7 +246,6 @@ class TestJEXLToSQL(TestCase):
     def test_transform_warns(self, _name, jexl, expected_warning):
         result = jexl_to_sql(jexl)
         self.assertIn(expected_warning, result.warnings)
-
 
     def test_empty_expression_returns_none(self):
         result = jexl_to_sql("")
@@ -298,7 +293,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql('locale == "it-IT"')
         self.assertIn("'it-IT'", result.sql)
 
-
     def test_not_boolean_column(self):
         result = jexl_to_sql("!isDefaultBrowser")
         self.assertEqual(
@@ -321,7 +315,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("NOT", result.sql)
         self.assertIn(_USER_PREFS, result.sql)
 
-
     def test_os_is_windows_derived_from_not_mac_not_linux(self):
         result = jexl_to_sql("os.isWindows")
         self.assertIsNotNone(result.sql)
@@ -329,7 +322,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("isLinux", result.sql)
         self.assertIn("NOT", result.sql)
         self.assertEqual(result.warnings, [])
-
 
     def test_bool_arithmetic_casts_to_int64(self):
         # JEXL pattern `(bool && 1 || 0) + (bool && 1 || 0)` sums booleans.
@@ -413,7 +405,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("UNIX_MILLIS", result.sql)
         self.assertEqual(result.warnings, [])
 
-
     def test_version_compare_gte(self):
         result = jexl_to_sql("version|versionCompare('120.!') >= 0")
         self.assertEqual(result.sql, f"{_FF} >= 120")
@@ -423,7 +414,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql("0 <= version|versionCompare('120.!')")
         self.assertEqual(result.sql, f"{_FF} >= 120")
         self.assertEqual(result.warnings, [])
-
 
     def test_addons_specific_addon_id_installed(self):
         # addon != null means installed → (id IN UNNEST(addons))
@@ -516,7 +506,6 @@ class TestJEXLToSQL(TestCase):
 
 
 class TestJEXLToSQLMobile(TestCase):
-
     _CAST_BOOL = "CAST(isFirstRun AS BOOL)"
     _CAST_DFLT = "CAST(isDefaultBrowser AS BOOL)"
     _CAST_PHONE = "CAST(isPhone AS BOOL)"
@@ -577,7 +566,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-
     @parameterized.expand(
         [
             ("locale_eq_fenix", "locale == 'en-US'", FENIX_APP, "locale = 'en-US'"),
@@ -612,7 +600,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-
     def test_bool_column_not_string_coerced_in_and_fenix(self):
         result = jexl_to_sql("isFirstRun && daysSinceInstall < 7", app=FENIX_APP)
         self.assertEqual(
@@ -624,7 +611,6 @@ class TestJEXLToSQLMobile(TestCase):
         result = jexl_to_sql("isDefaultBrowser && region == 'US'", app=IOS_APP)
         self.assertEqual(result.sql, "(CAST(isDefaultBrowser AS BOOL) AND region = 'US')")
         self.assertEqual(result.warnings, [])
-
 
     _PREF_JEXL = "'browser.urlbar.suggest.searches'|preferenceValue"
 
@@ -639,7 +625,6 @@ class TestJEXLToSQLMobile(TestCase):
         result = jexl_to_sql(jexl, app=app)
         self.assertIsNone(result.sql)
         self.assertIn(expected_warning, result.warnings)
-
 
     def test_no_app_uses_desktop_map(self):
         result = jexl_to_sql("firefoxVersion >= 120")
@@ -686,7 +671,6 @@ class TestJEXLToSQLMobile(TestCase):
         result = jexl_to_sql("version|versionCompare('120.!') >= 0", app=FENIX_APP)
         self.assertIsNone(result.sql)
         self.assertIn("|versionCompare", result.warnings)
-
 
     def test_real_config_mobile_new_user_fenix(self):
         result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=FENIX_APP)

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -32,7 +32,6 @@ _FF = "metrics.quantity.nimbus_targeting_context_firefox_version"
 
 
 class TestJEXLToSQL(TestCase):
-    # --- Column mappings: (jexl_expression, expected_sql) ---
 
     @parameterized.expand(
         [
@@ -110,7 +109,6 @@ class TestJEXLToSQL(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-    # --- Comparisons: (jexl, expected_sql) ---
 
     @parameterized.expand(
         [
@@ -192,7 +190,6 @@ class TestJEXLToSQL(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-    # --- Untranslatable: expressions that produce warnings, no sql ---
 
     _VC = "|versionCompare"
 
@@ -222,7 +219,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIsNone(result.sql)
         self.assertIn(expected_warning, result.warnings)
 
-    # --- Transforms that warn ---
 
     @parameterized.expand(
         [
@@ -255,7 +251,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql(jexl)
         self.assertIn(expected_warning, result.warnings)
 
-    # --- Edge cases ---
 
     def test_empty_expression_returns_none(self):
         result = jexl_to_sql("")
@@ -303,7 +298,6 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql('locale == "it-IT"')
         self.assertIn("'it-IT'", result.sql)
 
-    # --- NOT operator ---
 
     def test_not_boolean_column(self):
         result = jexl_to_sql("!isDefaultBrowser")
@@ -327,7 +321,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("NOT", result.sql)
         self.assertIn(_USER_PREFS, result.sql)
 
-    # --- os.isWindows derived ---
 
     def test_os_is_windows_derived_from_not_mac_not_linux(self):
         result = jexl_to_sql("os.isWindows")
@@ -337,7 +330,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("NOT", result.sql)
         self.assertEqual(result.warnings, [])
 
-    # --- Transforms ---
 
     def test_bool_arithmetic_casts_to_int64(self):
         # JEXL pattern `(bool && 1 || 0) + (bool && 1 || 0)` sums booleans.
@@ -421,7 +413,6 @@ class TestJEXLToSQL(TestCase):
         self.assertIn("UNIX_MILLIS", result.sql)
         self.assertEqual(result.warnings, [])
 
-    # --- versionCompare ---
 
     def test_version_compare_gte(self):
         result = jexl_to_sql("version|versionCompare('120.!') >= 0")
@@ -433,7 +424,6 @@ class TestJEXLToSQL(TestCase):
         self.assertEqual(result.sql, f"{_FF} >= 120")
         self.assertEqual(result.warnings, [])
 
-    # --- addonsInfo ---
 
     def test_addons_specific_addon_id_installed(self):
         # addon != null means installed → (id IN UNNEST(addons))
@@ -526,7 +516,6 @@ class TestJEXLToSQL(TestCase):
 
 
 class TestJEXLToSQLMobile(TestCase):
-    # --- Column mappings ---
 
     _CAST_BOOL = "CAST(isFirstRun AS BOOL)"
     _CAST_DFLT = "CAST(isDefaultBrowser AS BOOL)"
@@ -578,7 +567,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-    # --- Comparisons ---
 
     @parameterized.expand(
         [
@@ -604,7 +592,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, expected_sql)
         self.assertEqual(result.warnings, [])
 
-    # --- Boolean columns are not string-coerced in && / || ---
 
     def test_bool_column_not_string_coerced_in_and_fenix(self):
         result = jexl_to_sql("isFirstRun && daysSinceInstall < 7", app=FENIX_APP)
@@ -618,7 +605,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, "(CAST(isDefaultBrowser AS BOOL) AND region = 'US')")
         self.assertEqual(result.warnings, [])
 
-    # --- Desktop attributes warn on mobile ---
 
     _PREF_JEXL = "'browser.urlbar.suggest.searches'|preferenceValue"
 
@@ -634,7 +620,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertIsNone(result.sql)
         self.assertIn(expected_warning, result.warnings)
 
-    # --- No app falls back to Desktop map ---
 
     def test_no_app_uses_desktop_map(self):
         result = jexl_to_sql("firefoxVersion >= 120")
@@ -682,7 +667,6 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertIsNone(result.sql)
         self.assertIn("|versionCompare", result.warnings)
 
-    # --- Real targeting config strings ---
 
     def test_real_config_mobile_new_user_fenix(self):
         result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=FENIX_APP)

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -9,9 +9,16 @@ from experimenter.experiments.jexl_to_sql import (
 from experimenter.targeting.constants import (
     FIRST_RUN_WINDOWS_1903_NEWER,
     FX95_DESKTOP_USERS,
+    IOS_EXISTING_USERS,
+    MOBILE_NEW_USER,
+    MOBILE_RECENTLY_UPDATED,
     NO_ENTERPRISE_MAC_WINDOWS_ONLY,
     WIN11_ONLY,
 )
+
+_FENIX = "fenix"
+_IOS = "ios"
+_REVIEW_CHECKER_JSON = "CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS BOOL)"
 
 _OS = "metrics.object.nimbus_targeting_context_os"
 _BS = "metrics.object.nimbus_targeting_context_browser_settings"
@@ -516,3 +523,178 @@ class TestJEXLToSQL(TestCase):
         result = jexl_to_sql("(firefoxVersion + 1)|someTransform")
         self.assertIsNone(result.sql)
         self.assertIn("|someTransform", result.warnings)
+
+
+class TestJEXLToSQLMobile(TestCase):
+    # --- Column mappings ---
+
+    _CAST_BOOL = "CAST(isFirstRun AS BOOL)"
+    _CAST_DFLT = "CAST(isDefaultBrowser AS BOOL)"
+    _CAST_PHONE = "CAST(isPhone AS BOOL)"
+    _CAST_RC_IOS = "CAST(isReviewCheckerEnabled AS BOOL)"
+    _UTM_SRC = "installReferrerResponseUtmSource"
+    _UTM_SRC_SNAKE = "install_referrer_response_utm_source"
+    _EQ_DAYS = "eventQuery_daysOpenedInLast28"
+    _EQ_JEXL = "eventQueryValues.daysOpenedInLast28"
+    _EQ_SNAKE = "event_query_values.days_opened_in_last_28"
+
+    @parameterized.expand(
+        [
+            # Shared columns — same on Fenix and iOS
+            ("locale_fenix", "locale", _FENIX, "locale"),
+            ("locale_ios", "locale", _IOS, "locale"),
+            ("region_fenix", "region", _FENIX, "region"),
+            ("language_fenix", "language", _FENIX, "language"),
+            ("app_version_fenix", "appVersion", _FENIX, "appVersion"),
+            ("app_version_snake", "app_version", _FENIX, "appVersion"),
+            ("is_first_run_fenix", "isFirstRun", _FENIX, _CAST_BOOL),
+            ("is_first_run_snake", "is_first_run", _FENIX, _CAST_BOOL),
+            ("is_first_run_ios", "isFirstRun", _IOS, _CAST_BOOL),
+            ("days_install_fenix", "daysSinceInstall", _FENIX, "daysSinceInstall"),
+            ("days_install_snake", "days_since_install", _FENIX, "daysSinceInstall"),
+            ("days_update_fenix", "daysSinceUpdate", _FENIX, "daysSinceUpdate"),
+            ("event_query_fenix", _EQ_JEXL, _FENIX, _EQ_DAYS),
+            ("event_query_snake", _EQ_SNAKE, _FENIX, _EQ_DAYS),
+            # Fenix-specific columns
+            ("android_sdk", "androidSdkVersion", _FENIX, "androidSdkVersion"),
+            ("android_sdk_snake", "android_sdk_version", _FENIX, "androidSdkVersion"),
+            ("device_manufacturer", "deviceManufacturer", _FENIX, "deviceManufacturer"),
+            ("device_model", "deviceModel", _FENIX, "deviceModel"),
+            ("utm_source", _UTM_SRC, _FENIX, _UTM_SRC),
+            ("utm_source_snake", _UTM_SRC_SNAKE, _FENIX, _UTM_SRC),
+            # Fenix JSON-only (not a typed column; uses JSON_VALUE)
+            ("rc_fenix", "isReviewCheckerEnabled", _FENIX, _REVIEW_CHECKER_JSON),
+            ("rc_snake_fenix", "is_review_checker_enabled", _FENIX, _REVIEW_CHECKER_JSON),
+            # iOS-specific columns
+            ("default_browser_ios", "isDefaultBrowser", _IOS, _CAST_DFLT),
+            ("default_browser_snake", "is_default_browser", _IOS, _CAST_DFLT),
+            ("is_phone_ios", "isPhone", _IOS, _CAST_PHONE),
+            ("is_phone_snake", "is_phone", _IOS, _CAST_PHONE),
+            ("rc_ios", "isReviewCheckerEnabled", _IOS, _CAST_RC_IOS),
+        ]
+    )
+    def test_attribute_translates_to_column(self, _name, jexl, app, expected_sql):
+        result = jexl_to_sql(jexl, app=app)
+        self.assertEqual(result.sql, expected_sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- Comparisons ---
+
+    @parameterized.expand(
+        [
+            ("locale_eq_fenix", "locale == 'en-US'", _FENIX, "locale = 'en-US'"),
+            (
+                "region_in_fenix",
+                "region in ['US', 'CA']",
+                _FENIX,
+                "(region IN ('US', 'CA'))",
+            ),
+            ("days_lt_fenix", "days_since_install < 7", _FENIX, "daysSinceInstall < 7"),
+            (
+                "sdk_gte_fenix",
+                "android_sdk_version >= 28",
+                _FENIX,
+                "androidSdkVersion >= 28",
+            ),
+            ("is_phone_eq_ios", "isPhone == true", _IOS, "CAST(isPhone AS BOOL) = TRUE"),
+        ]
+    )
+    def test_comparison_translates(self, _name, jexl, app, expected_sql):
+        result = jexl_to_sql(jexl, app=app)
+        self.assertEqual(result.sql, expected_sql)
+        self.assertEqual(result.warnings, [])
+
+    # --- Boolean columns are not string-coerced in && / || ---
+
+    def test_bool_column_not_string_coerced_in_and_fenix(self):
+        result = jexl_to_sql("isFirstRun && daysSinceInstall < 7", app=_FENIX)
+        self.assertEqual(
+            result.sql, "(CAST(isFirstRun AS BOOL) AND daysSinceInstall < 7)"
+        )
+        self.assertEqual(result.warnings, [])
+
+    def test_bool_column_not_string_coerced_in_and_ios(self):
+        result = jexl_to_sql("isDefaultBrowser && region == 'US'", app=_IOS)
+        self.assertEqual(result.sql, "(CAST(isDefaultBrowser AS BOOL) AND region = 'US')")
+        self.assertEqual(result.warnings, [])
+
+    # --- Desktop attributes warn on mobile ---
+
+    _PREF_JEXL = "'browser.urlbar.suggest.searches'|preferenceValue"
+
+    @parameterized.expand(
+        [
+            ("ff_version_fenix", "firefoxVersion >= 120", _FENIX, "firefoxVersion"),
+            ("fxa_signed_in_ios", "isFxASignedIn", _IOS, "isFxASignedIn"),
+            ("pref_value_fenix", _PREF_JEXL, _FENIX, "|preferenceValue"),
+        ]
+    )
+    def test_desktop_attr_warns_on_mobile(self, _name, jexl, app, expected_warning):
+        result = jexl_to_sql(jexl, app=app)
+        self.assertIsNone(result.sql)
+        self.assertIn(expected_warning, result.warnings)
+
+    # --- No app falls back to Desktop map ---
+
+    def test_no_app_uses_desktop_map(self):
+        result = jexl_to_sql("firefoxVersion >= 120")
+        self.assertIsNotNone(result.sql)
+        self.assertEqual(result.warnings, [])
+
+    def test_addon_ids_in_fenix(self):
+        result = jexl_to_sql("'uBlock0@raymondhill.net' in addon_ids", app=_FENIX)
+        self.assertEqual(
+            result.sql,
+            "('uBlock0@raymondhill.net' IN UNNEST(JSON_VALUE_ARRAY(addonIds)))",
+        )
+        self.assertEqual(result.warnings, [])
+
+    def test_addon_ids_not_in_fenix(self):
+        result = jexl_to_sql(
+            "('uBlock0@raymondhill.net' in addon_ids) == false", app=_FENIX
+        )
+        self.assertEqual(
+            result.sql,
+            "('uBlock0@raymondhill.net' IN UNNEST(JSON_VALUE_ARRAY(addonIds))) = FALSE",
+        )
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_fenix_first_run_region(self):
+        result = jexl_to_sql("isFirstRun && region == 'US'", app=_FENIX)
+        self.assertEqual(result.sql, "(CAST(isFirstRun AS BOOL) AND region = 'US')")
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_ios_default_browser_phone(self):
+        result = jexl_to_sql("isDefaultBrowser && isPhone", app=_IOS)
+        self.assertEqual(
+            result.sql,
+            "(CAST(isDefaultBrowser AS BOOL) AND CAST(isPhone AS BOOL))",
+        )
+        self.assertEqual(result.warnings, [])
+
+    def test_preference_is_user_set_warns_on_mobile(self):
+        result = jexl_to_sql("'browser.search.region'|preferenceIsUserSet", app=_FENIX)
+        self.assertIsNone(result.sql)
+        self.assertIn("|preferenceIsUserSet", result.warnings)
+
+    def test_version_compare_warns_on_mobile(self):
+        result = jexl_to_sql("version|versionCompare('120.!') >= 0", app=_FENIX)
+        self.assertIsNone(result.sql)
+        self.assertIn("|versionCompare", result.warnings)
+
+    # --- Real targeting config strings ---
+
+    def test_real_config_mobile_new_user_fenix(self):
+        result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=_FENIX)
+        self.assertEqual(result.sql, "daysSinceInstall < 7")
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_mobile_recently_updated_fenix(self):
+        result = jexl_to_sql(MOBILE_RECENTLY_UPDATED.targeting, app=_FENIX)
+        self.assertEqual(result.sql, "(daysSinceUpdate < 7 AND daysSinceInstall >= 7)")
+        self.assertEqual(result.warnings, [])
+
+    def test_real_config_ios_existing_users(self):
+        result = jexl_to_sql(IOS_EXISTING_USERS.targeting, app=_IOS)
+        self.assertEqual(result.sql, "daysSinceInstall >= 28")
+        self.assertEqual(result.warnings, [])

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -2,6 +2,8 @@ from django.test import TestCase
 from parameterized import parameterized
 
 from experimenter.experiments.jexl_to_sql import (
+    FENIX_APP,
+    IOS_APP,
     KNOWN_UNTRANSLATABLE,
     ensure_bool_sql,
     jexl_to_sql,
@@ -16,8 +18,6 @@ from experimenter.targeting.constants import (
     WIN11_ONLY,
 )
 
-_FENIX = "fenix"
-_IOS = "ios"
 _REVIEW_CHECKER_JSON = "CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS BOOL)"
 
 _OS = "metrics.object.nimbus_targeting_context_os"
@@ -541,36 +541,36 @@ class TestJEXLToSQLMobile(TestCase):
     @parameterized.expand(
         [
             # Shared columns — same on Fenix and iOS
-            ("locale_fenix", "locale", _FENIX, "locale"),
-            ("locale_ios", "locale", _IOS, "locale"),
-            ("region_fenix", "region", _FENIX, "region"),
-            ("language_fenix", "language", _FENIX, "language"),
-            ("app_version_fenix", "appVersion", _FENIX, "appVersion"),
-            ("app_version_snake", "app_version", _FENIX, "appVersion"),
-            ("is_first_run_fenix", "isFirstRun", _FENIX, _CAST_BOOL),
-            ("is_first_run_snake", "is_first_run", _FENIX, _CAST_BOOL),
-            ("is_first_run_ios", "isFirstRun", _IOS, _CAST_BOOL),
-            ("days_install_fenix", "daysSinceInstall", _FENIX, "daysSinceInstall"),
-            ("days_install_snake", "days_since_install", _FENIX, "daysSinceInstall"),
-            ("days_update_fenix", "daysSinceUpdate", _FENIX, "daysSinceUpdate"),
-            ("event_query_fenix", _EQ_JEXL, _FENIX, _EQ_DAYS),
-            ("event_query_snake", _EQ_SNAKE, _FENIX, _EQ_DAYS),
+            ("locale_fenix", "locale", FENIX_APP, "locale"),
+            ("locale_ios", "locale", IOS_APP, "locale"),
+            ("region_fenix", "region", FENIX_APP, "region"),
+            ("language_fenix", "language", FENIX_APP, "language"),
+            ("app_version_fenix", "appVersion", FENIX_APP, "appVersion"),
+            ("app_version_snake", "app_version", FENIX_APP, "appVersion"),
+            ("is_first_run_fenix", "isFirstRun", FENIX_APP, _CAST_BOOL),
+            ("is_first_run_snake", "is_first_run", FENIX_APP, _CAST_BOOL),
+            ("is_first_run_ios", "isFirstRun", IOS_APP, _CAST_BOOL),
+            ("days_install_fenix", "daysSinceInstall", FENIX_APP, "daysSinceInstall"),
+            ("days_install_snake", "days_since_install", FENIX_APP, "daysSinceInstall"),
+            ("days_update_fenix", "daysSinceUpdate", FENIX_APP, "daysSinceUpdate"),
+            ("event_query_fenix", _EQ_JEXL, FENIX_APP, _EQ_DAYS),
+            ("event_query_snake", _EQ_SNAKE, FENIX_APP, _EQ_DAYS),
             # Fenix-specific columns
-            ("android_sdk", "androidSdkVersion", _FENIX, "androidSdkVersion"),
-            ("android_sdk_snake", "android_sdk_version", _FENIX, "androidSdkVersion"),
-            ("device_manufacturer", "deviceManufacturer", _FENIX, "deviceManufacturer"),
-            ("device_model", "deviceModel", _FENIX, "deviceModel"),
-            ("utm_source", _UTM_SRC, _FENIX, _UTM_SRC),
-            ("utm_source_snake", _UTM_SRC_SNAKE, _FENIX, _UTM_SRC),
+            ("android_sdk", "androidSdkVersion", FENIX_APP, "androidSdkVersion"),
+            ("android_sdk_snake", "android_sdk_version", FENIX_APP, "androidSdkVersion"),
+            ("device_manufacturer", "deviceManufacturer", FENIX_APP, "deviceManufacturer"),
+            ("device_model", "deviceModel", FENIX_APP, "deviceModel"),
+            ("utm_source", _UTM_SRC, FENIX_APP, _UTM_SRC),
+            ("utm_source_snake", _UTM_SRC_SNAKE, FENIX_APP, _UTM_SRC),
             # Fenix JSON-only (not a typed column; uses JSON_VALUE)
-            ("rc_fenix", "isReviewCheckerEnabled", _FENIX, _REVIEW_CHECKER_JSON),
-            ("rc_snake_fenix", "is_review_checker_enabled", _FENIX, _REVIEW_CHECKER_JSON),
+            ("rc_fenix", "isReviewCheckerEnabled", FENIX_APP, _REVIEW_CHECKER_JSON),
+            ("rc_snake_fenix", "is_review_checker_enabled", FENIX_APP, _REVIEW_CHECKER_JSON),
             # iOS-specific columns
-            ("default_browser_ios", "isDefaultBrowser", _IOS, _CAST_DFLT),
-            ("default_browser_snake", "is_default_browser", _IOS, _CAST_DFLT),
-            ("is_phone_ios", "isPhone", _IOS, _CAST_PHONE),
-            ("is_phone_snake", "is_phone", _IOS, _CAST_PHONE),
-            ("rc_ios", "isReviewCheckerEnabled", _IOS, _CAST_RC_IOS),
+            ("default_browser_ios", "isDefaultBrowser", IOS_APP, _CAST_DFLT),
+            ("default_browser_snake", "is_default_browser", IOS_APP, _CAST_DFLT),
+            ("is_phone_ios", "isPhone", IOS_APP, _CAST_PHONE),
+            ("is_phone_snake", "is_phone", IOS_APP, _CAST_PHONE),
+            ("rc_ios", "isReviewCheckerEnabled", IOS_APP, _CAST_RC_IOS),
         ]
     )
     def test_attribute_translates_to_column(self, _name, jexl, app, expected_sql):
@@ -582,21 +582,21 @@ class TestJEXLToSQLMobile(TestCase):
 
     @parameterized.expand(
         [
-            ("locale_eq_fenix", "locale == 'en-US'", _FENIX, "locale = 'en-US'"),
+            ("locale_eq_fenix", "locale == 'en-US'", FENIX_APP, "locale = 'en-US'"),
             (
                 "region_in_fenix",
                 "region in ['US', 'CA']",
-                _FENIX,
+                FENIX_APP,
                 "(region IN ('US', 'CA'))",
             ),
-            ("days_lt_fenix", "days_since_install < 7", _FENIX, "daysSinceInstall < 7"),
+            ("days_lt_fenix", "days_since_install < 7", FENIX_APP, "daysSinceInstall < 7"),
             (
                 "sdk_gte_fenix",
                 "android_sdk_version >= 28",
-                _FENIX,
+                FENIX_APP,
                 "androidSdkVersion >= 28",
             ),
-            ("is_phone_eq_ios", "isPhone == true", _IOS, "CAST(isPhone AS BOOL) = TRUE"),
+            ("is_phone_eq_ios", "isPhone == true", IOS_APP, "CAST(isPhone AS BOOL) = TRUE"),
         ]
     )
     def test_comparison_translates(self, _name, jexl, app, expected_sql):
@@ -607,14 +607,14 @@ class TestJEXLToSQLMobile(TestCase):
     # --- Boolean columns are not string-coerced in && / || ---
 
     def test_bool_column_not_string_coerced_in_and_fenix(self):
-        result = jexl_to_sql("isFirstRun && daysSinceInstall < 7", app=_FENIX)
+        result = jexl_to_sql("isFirstRun && daysSinceInstall < 7", app=FENIX_APP)
         self.assertEqual(
             result.sql, "(CAST(isFirstRun AS BOOL) AND daysSinceInstall < 7)"
         )
         self.assertEqual(result.warnings, [])
 
     def test_bool_column_not_string_coerced_in_and_ios(self):
-        result = jexl_to_sql("isDefaultBrowser && region == 'US'", app=_IOS)
+        result = jexl_to_sql("isDefaultBrowser && region == 'US'", app=IOS_APP)
         self.assertEqual(result.sql, "(CAST(isDefaultBrowser AS BOOL) AND region = 'US')")
         self.assertEqual(result.warnings, [])
 
@@ -624,9 +624,9 @@ class TestJEXLToSQLMobile(TestCase):
 
     @parameterized.expand(
         [
-            ("ff_version_fenix", "firefoxVersion >= 120", _FENIX, "firefoxVersion"),
-            ("fxa_signed_in_ios", "isFxASignedIn", _IOS, "isFxASignedIn"),
-            ("pref_value_fenix", _PREF_JEXL, _FENIX, "|preferenceValue"),
+            ("ff_version_fenix", "firefoxVersion >= 120", FENIX_APP, "firefoxVersion"),
+            ("fxa_signed_in_ios", "isFxASignedIn", IOS_APP, "isFxASignedIn"),
+            ("pref_value_fenix", _PREF_JEXL, FENIX_APP, "|preferenceValue"),
         ]
     )
     def test_desktop_attr_warns_on_mobile(self, _name, jexl, app, expected_warning):
@@ -642,7 +642,7 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.warnings, [])
 
     def test_addon_ids_in_fenix(self):
-        result = jexl_to_sql("'uBlock0@raymondhill.net' in addon_ids", app=_FENIX)
+        result = jexl_to_sql("'uBlock0@raymondhill.net' in addon_ids", app=FENIX_APP)
         self.assertEqual(
             result.sql,
             "('uBlock0@raymondhill.net' IN UNNEST(JSON_VALUE_ARRAY(addonIds)))",
@@ -651,7 +651,7 @@ class TestJEXLToSQLMobile(TestCase):
 
     def test_addon_ids_not_in_fenix(self):
         result = jexl_to_sql(
-            "('uBlock0@raymondhill.net' in addon_ids) == false", app=_FENIX
+            "('uBlock0@raymondhill.net' in addon_ids) == false", app=FENIX_APP
         )
         self.assertEqual(
             result.sql,
@@ -660,12 +660,12 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.warnings, [])
 
     def test_real_config_fenix_first_run_region(self):
-        result = jexl_to_sql("isFirstRun && region == 'US'", app=_FENIX)
+        result = jexl_to_sql("isFirstRun && region == 'US'", app=FENIX_APP)
         self.assertEqual(result.sql, "(CAST(isFirstRun AS BOOL) AND region = 'US')")
         self.assertEqual(result.warnings, [])
 
     def test_real_config_ios_default_browser_phone(self):
-        result = jexl_to_sql("isDefaultBrowser && isPhone", app=_IOS)
+        result = jexl_to_sql("isDefaultBrowser && isPhone", app=IOS_APP)
         self.assertEqual(
             result.sql,
             "(CAST(isDefaultBrowser AS BOOL) AND CAST(isPhone AS BOOL))",
@@ -673,28 +673,28 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.warnings, [])
 
     def test_preference_is_user_set_warns_on_mobile(self):
-        result = jexl_to_sql("'browser.search.region'|preferenceIsUserSet", app=_FENIX)
+        result = jexl_to_sql("'browser.search.region'|preferenceIsUserSet", app=FENIX_APP)
         self.assertIsNone(result.sql)
         self.assertIn("|preferenceIsUserSet", result.warnings)
 
     def test_version_compare_warns_on_mobile(self):
-        result = jexl_to_sql("version|versionCompare('120.!') >= 0", app=_FENIX)
+        result = jexl_to_sql("version|versionCompare('120.!') >= 0", app=FENIX_APP)
         self.assertIsNone(result.sql)
         self.assertIn("|versionCompare", result.warnings)
 
     # --- Real targeting config strings ---
 
     def test_real_config_mobile_new_user_fenix(self):
-        result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=_FENIX)
+        result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=FENIX_APP)
         self.assertEqual(result.sql, "daysSinceInstall < 7")
         self.assertEqual(result.warnings, [])
 
     def test_real_config_mobile_recently_updated_fenix(self):
-        result = jexl_to_sql(MOBILE_RECENTLY_UPDATED.targeting, app=_FENIX)
+        result = jexl_to_sql(MOBILE_RECENTLY_UPDATED.targeting, app=FENIX_APP)
         self.assertEqual(result.sql, "(daysSinceUpdate < 7 AND daysSinceInstall >= 7)")
         self.assertEqual(result.warnings, [])
 
     def test_real_config_ios_existing_users(self):
-        result = jexl_to_sql(IOS_EXISTING_USERS.targeting, app=_IOS)
+        result = jexl_to_sql(IOS_EXISTING_USERS.targeting, app=IOS_APP)
         self.assertEqual(result.sql, "daysSinceInstall >= 28")
         self.assertEqual(result.warnings, [])

--- a/experimenter/experimenter/targeting/tests/test_targeting_configs.py
+++ b/experimenter/experimenter/targeting/tests/test_targeting_configs.py
@@ -4,6 +4,8 @@ from parameterized import parameterized
 from experimenter.experiments.constants import Application
 from experimenter.experiments.jexl_to_sql import (
     JEXL_TO_BQ_COLUMN,
+    JEXL_TO_BQ_COLUMN_FENIX,
+    JEXL_TO_BQ_COLUMN_IOS,
     KNOWN_UNTRANSLATABLE,
     jexl_to_sql,
 )
@@ -90,6 +92,58 @@ class TestTargetingConfigs(TestCase):
                     f"Every transform must be supported by every application "
                     f"the config targets.",
                 )
+
+    @parameterized.expand(
+        [
+            (t,)
+            for t in TargetingConstants.TARGETING_CONFIGS.values()
+            if Application.FENIX.name in t.application_choice_names
+        ]
+    )
+    def test_fenix_targeting_config_jexl_attributes_are_known(self, targeting_config):
+        if not targeting_config.targeting or targeting_config.targeting == "true":
+            return
+        result = jexl_to_sql(targeting_config.targeting, app="fenix")
+        for warning in result.warnings:
+            if warning.startswith("|"):
+                continue
+            parts = warning.split(".")
+            self.assertTrue(
+                any(
+                    ".".join(parts[:i]) in KNOWN_UNTRANSLATABLE
+                    or warning in JEXL_TO_BQ_COLUMN_FENIX
+                    for i in range(1, len(parts) + 1)
+                ),
+                f"Unrecognized attribute '{warning}' in "
+                f"{targeting_config.name}. Add it to "
+                f"JEXL_TO_BQ_COLUMN_FENIX or KNOWN_UNTRANSLATABLE.",
+            )
+
+    @parameterized.expand(
+        [
+            (t,)
+            for t in TargetingConstants.TARGETING_CONFIGS.values()
+            if Application.IOS.name in t.application_choice_names
+        ]
+    )
+    def test_ios_targeting_config_jexl_attributes_are_known(self, targeting_config):
+        if not targeting_config.targeting or targeting_config.targeting == "true":
+            return
+        result = jexl_to_sql(targeting_config.targeting, app="ios")
+        for warning in result.warnings:
+            if warning.startswith("|"):
+                continue
+            parts = warning.split(".")
+            self.assertTrue(
+                any(
+                    ".".join(parts[:i]) in KNOWN_UNTRANSLATABLE
+                    or warning in JEXL_TO_BQ_COLUMN_IOS
+                    for i in range(1, len(parts) + 1)
+                ),
+                f"Unrecognized attribute '{warning}' in "
+                f"{targeting_config.name}. Add it to "
+                f"JEXL_TO_BQ_COLUMN_IOS or KNOWN_UNTRANSLATABLE.",
+            )
 
     def test_desktop_targeting_context_fields_are_mapped(self):
         """Every field in the Desktop targeting context must be in JEXL_TO_BQ_COLUMN


### PR DESCRIPTION
Because

- Mobile population sizing needs to translate JEXL targeting expressions into BigQuery SQL against Fenix and iOS BQ tables. The existing jexl_to_sql() only knew about Firefox Desktop columns, so any mobile targeting expression would produce warnings instead of SQL.

This commit

- Adds mobile-aware column maps (JEXL_TO_BQ_COLUMN_FENIX, JEXL_TO_BQ_COLUMN_IOS) and an app parameter to jexl_to_sql(), so sizing queries for Android and iOS experiments can be computed without touching the Desktop translation path.

Fixes #16944 