### PR TITLE
fix(nimbus): Show whether rollout audience fields are included/excluded

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -64,8 +64,18 @@
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">
           {% if experiment.is_desktop %}
+            {% if experiment.exclude_locales %}
+              Excluded
+            {% else %}
+              Included
+            {% endif %}
             Locales
           {% else %}
+            {% if experiment.exclude_languages %}
+              Excluded
+            {% else %}
+              Included
+            {% endif %}
             Languages
           {% endif %}
         </div>
@@ -106,7 +116,14 @@
       </div>
       {# Countries #}
       <div>
-        <div class="text-secondary mb-1" style="font-size: 12px;">Countries</div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">
+          {% if experiment.exclude_countries %}
+            Excluded
+          {% else %}
+            Included
+          {% endif %}
+          Countries
+        </div>
         <div id="rollout-audience-countries" class="small text-body">
           {% with experiment.countries.all as countries %}
             {% if countries %}


### PR DESCRIPTION
Because

* The new Audience card labelled these fields "Countries" and "Locales"/"Languages" regardless of the exclude flags, so an exclusion list was the same as an inclusion list on the read-only card

This commit

* Prefixes the labels with "Included" or "Excluded" based on `exclude_countries`, `exclude_locales`, and `exclude_languages`, matching the old UI's Summary page

Fixes #17011
