### PR TITLE
fix(nimbus): Use "delivery" instead of "experiment" in subscribe bell tooltip

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/subscribe_bell.html
@@ -7,9 +7,9 @@
     {% csrf_token %}
     <button type="submit"
             class="btn p-0 border-0 text-secondary"
-            aria-label="Unsubscribe from this experiment"
+            aria-label="Unsubscribe from this delivery"
             data-bs-toggle="tooltip"
-            title="Unsubscribe from this experiment">
+            title="Unsubscribe from this delivery">
       <i class="fa-solid fa-bell"></i>
     </button>
   </form>
@@ -22,9 +22,9 @@
     {% csrf_token %}
     <button type="submit"
             class="btn p-0 border-0 text-secondary"
-            aria-label="Subscribe to this experiment"
+            aria-label="Subscribe to this delivery"
             data-bs-toggle="tooltip"
-            title="Subscribe to this experiment">
+            title="Subscribe to this delivery">
       <i class="fa-regular fa-bell"></i>
     </button>
   </form>


### PR DESCRIPTION
Because

* The notification bell read "Subscribe to this experiment" / "Unsubscribe from this experiment", which is wrong for rollouts

This commit

* Renames the bell's tooltip to "Subscribe to this delivery" / "Unsubscribe from this delivery"

Fixes #16961
