### PR TITLE
fix(nimbus): Update readonly editor colors when the theme is toggled

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/index.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/index.js
@@ -11,6 +11,7 @@ import {
   setupReadonlyJsonEditors,
   setupReadonlySqlEditors,
 } from "./codemirror_utils.js";
+import { updateAllViewThemes, observeThemeChanges } from "./theme_utils.js";
 import { setupDevtoolsBanner } from "./nimbus_devtools.js";
 
 window.bootstrap = bootstrap;
@@ -158,6 +159,7 @@ $(() => {
   setupSlugCopyToast();
   setupHTMXLoadingOverlay();
   setupReadonlyJsonEditors();
+  observeThemeChanges(updateAllViewThemes);
   document.addEventListener("shown.bs.modal", (event) => {
     setupReadonlySqlEditors(event.target);
   });


### PR DESCRIPTION
Because

* The app bundle builds the readonly CodeMirror editors but never observed theme changes, so recipe JSON, feature value, and targeting fields kept their old colors until a refresh

This commit

* Registers the theme observer in index.js so every view reconfigures its theme on toggle

Fixes #16965