### PR TITLE
fix(nimbus): Keep audience dropdowns stable while scrolling

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -397,4 +397,9 @@
     font-family: var(--bs-font-monospace);
     font-size: 0.875rem;
   }
+
+  .bootstrap-select .dropdown-menu,
+  .bootstrap-select .dropdown-menu .inner {
+    overscroll-behavior: contain;
+  }
 }


### PR DESCRIPTION
Because

* Audience dropdowns cause scrolling in the page behind

This commit

* Keeps scrolling inside the dropdown so the page behind it does not move

Fixes #17009
