### PR TITLE
fix(nimbus): Show all options when scrolling the dropdowns

### DIFF
--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -69,6 +69,7 @@ class MultiSelectWidget(SelectedFirstMixin, forms.SelectMultiple):
                 "class": self.class_attrs,
                 "data-live-search": "true",
                 "data-live-search-placeholder": "Search",
+                "data-virtual-scroll": "false",
             }
         )
 


### PR DESCRIPTION
Because

* The include/exclude lists went blank part way down

This commit

* Disables virtual scroll on the multi-select widget so every option renders

Fixes #17008
