### PR TITLE
fix(nimbus): Remove the duplicate expand arrow from rollout card headers

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/css/style.scss
+++ b/experimenter/experimenter/nimbus_ui/static/css/style.scss
@@ -345,6 +345,10 @@
   grid-column: 1 / -1;
 }
 
+.accordion-no-icon::after {
+  display: none;
+}
+
 // Rollout card collapse/expand chevron rotation
 .rollout-card-toggle .chevron-icon {
   transition: transform 0.2s ease;

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_review_controls.html
@@ -8,10 +8,8 @@
                 --bs-accordion-active-color: var(--bs-body-color)">
       <div class="accordion-item border-0 bg-transparent rounded-3">
         <h2 class="accordion-header">
-          <div class="accordion-button bg-transparent shadow-none fw-semibold text-body small pb-1"
-               style="cursor: default;
-                      --bs-accordion-btn-icon: none;
-                      --bs-accordion-btn-active-icon: none">
+          <div class="accordion-button accordion-no-icon bg-transparent shadow-none fw-semibold text-body small pb-1"
+               style="cursor: default">
             {% if controls %}
               <i class="fa-regular fa-hourglass-half text-secondary me-2"></i>
               Review requested

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/detail_card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/detail_card.html
@@ -6,11 +6,7 @@
     <div class="accordion-item border-0 bg-transparent">
       <h2 class="accordion-header">
         <div class="d-flex align-items-start justify-content-between pe-4">
-          <button class="accordion-button bg-transparent shadow-none fw-semibold small text-body collapsed px-4 py-4 rollout-card-toggle"
-                  style="--bs-accordion-btn-icon: none;
-                         --bs-accordion-btn-active-icon: none;
-                         --bs-accordion-btn-active-color: var(--bs-body-color);
-                         --bs-accordion-btn-active-bg: transparent"
+          <button class="accordion-button accordion-no-icon bg-transparent shadow-none fw-semibold small text-body collapsed px-4 py-4 rollout-card-toggle"
                   type="button"
                   data-bs-toggle="collapse"
                   data-bs-target="#collapse-{{ card_id }}"


### PR DESCRIPTION
Because

* The cards suppress Bootstrap's built-in chevron so they can draw their own on the left, but Bootstrap re-declares that variable in dark mode

This commit

* Hides it with an accordion-no-icon class instead of blanking its background image, so no theme can restore it

Fixes #16959