### PR TITLE
fix(nimbus): Preserve line breaks in rollout text fields

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -5,7 +5,9 @@
     {# Brand impact #}
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">Rollout experience</div>
-      <div id="rollout-features-experience" class="small text-body">{{ experiment.takeaways_summary|default:"—" }}</div>
+      <div id="rollout-features-experience"
+           class="small text-body"
+           style="white-space: pre-wrap">{{ experiment.takeaways_summary|default:"—" }}</div>
       {% include "new/common/validation_errors.html" with errors=validation_errors.takeaways_summary %}
 
     </div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/schedule/card.html
@@ -152,9 +152,9 @@
         <div class="text-secondary mb-1" style="font-size: 12px;">
           {{ NimbusUIConstants.ROLLOUT_ADVANCE_OBSERVATIONS_LABEL }}
         </div>
-        <div id="rollout-schedule-advance-observations" class="small text-body">
-          {{ experiment.rollout_advance_observations|default:"—" }}
-        </div>
+        <div id="rollout-schedule-advance-observations"
+             class="small text-body"
+             style="white-space: pre-wrap">{{ experiment.rollout_advance_observations|default:"—" }}</div>
         {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_advance_observations %}
 
       </div>
@@ -163,9 +163,9 @@
         <div class="text-secondary mb-1" style="font-size: 12px;">
           {{ NimbusUIConstants.ROLLOUT_PAUSE_OBSERVATIONS_LABEL }}
         </div>
-        <div id="rollout-schedule-pause-observations" class="small text-body">
-          {{ experiment.rollout_pause_observations|default:"—" }}
-        </div>
+        <div id="rollout-schedule-pause-observations"
+             class="small text-body"
+             style="white-space: pre-wrap">{{ experiment.rollout_pause_observations|default:"—" }}</div>
         {% include "new/common/validation_errors.html" with errors=validation_errors.rollout_pause_observations %}
 
       </div>


### PR DESCRIPTION
Because

* The card templates render textarea values without newlines

This commit

* Adds white-space: pre-wrap for the rollout experience, advance observations, and pause observations fields

Fixes #17029