### PR TITLE
fix(nimbus): Show the feature schema toggle on the rollout features form

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/edit_form.html
@@ -78,6 +78,24 @@
                 {% with fv_errors=validation_errors.reference_branch.feature_values|get_item:forloop.counter0 %}
                   {% for error in fv_errors.value %}<div class="form-text text-danger">{{ error }}</div>{% endfor %}
                 {% endwith %}
+                {% if branch_feature_values_form.instance.unversioned_schema %}
+                  <div class="mt-2">
+                    <button type="button"
+                            class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2 toggle-schema-btn show-schema-btn"
+                            data-target="rollout-schema-{{ forloop.counter0 }}">
+                      <i class="fa-solid fa-chevron-down"></i> Show Schema
+                    </button>
+                    <button type="button"
+                            class="btn btn-outline-secondary btn-sm d-inline-flex align-items-center gap-2 toggle-schema-btn hide-schema-btn d-none"
+                            data-target="rollout-schema-{{ forloop.counter0 }}">
+                      <i class="fa-solid fa-chevron-up"></i> Hide feature schema
+                    </button>
+                    <div id="rollout-schema-{{ forloop.counter0 }}"
+                         class="schema-display d-none mt-2 mw-100 overflow-auto">
+                      <textarea class="readonly-json">{{ branch_feature_values_form.instance.unversioned_schema }}</textarea>
+                    </div>
+                  </div>
+                {% endif %}
               </div>
             </div>
           {% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1809,6 +1809,32 @@ class TestNewRolloutFeaturesUpdateView(AuthTestCase):
         self.assertEqual(experiment.takeaways_summary, "Original rollout experience")
         self.assertEqual(experiment.feature_configs.count(), 0)
 
+    def test_post_selected_feature_renders_schema_toggle(self):
+        feature_config = NimbusFeatureConfigFactory.create(
+            application=NimbusExperiment.Application.DESKTOP,
+            slug="rollout-feature-schema",
+        )
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[feature_config],
+        )
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=feature_config
+        )
+
+        response = self.client.post(
+            reverse(self.url_name, kwargs={"slug": experiment.slug}),
+            self.features_data(feature_value, feature_configs=[feature_config.id]),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, "new/rollouts/rollout_features/edit_form.html")
+        self.assertContains(response, "toggle-schema-btn show-schema-btn")
+        self.assertContains(response, "toggle-schema-btn hide-schema-btn")
+        self.assertContains(response, 'id="rollout-schema-0"')
+        self.assertContains(response, "Show Schema")
+
     def test_post_deselecting_feature_hides_editor_without_saving(self):
         feature_config = NimbusFeatureConfigFactory.create(
             application=NimbusExperiment.Application.DESKTOP,


### PR DESCRIPTION
Because

* The "Show Schema" button for features is missing on the new UI

This commit

* Renders the Show/Hide Schema buttons and the readonly schema display for each selected feature config

Fixes #17026