### PR TITLE
fix(nimbus): Stop Enter from saving a card while a field is focused

### DIFF
--- a/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
@@ -21,6 +21,15 @@ document.addEventListener("showToast", (event) => {
   showToast(event.detail?.id);
 });
 
+document.addEventListener("keydown", (event) => {
+  if (
+    event.key === "Enter" &&
+    event.target.closest?.(".card-edit-form input")
+  ) {
+    event.preventDefault();
+  }
+});
+
 document.addEventListener("click", (event) => {
   const trigger = event.target.closest?.("[data-toast-id]");
   if (trigger) {


### PR DESCRIPTION
Because

* The Project Tags and Subscribers search boxes are plain text inputs inside the edit form, so Enter triggered implicit submission and dropped the card back to read-only

This commit

* Ignores Enter on inputs inside a card edit form

Fixes #16973