### PR TITLE
fix(nimbus): Give rollouts their own hypothesis template

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -15,6 +15,17 @@ Optional - We believe this outcome will <describe impact> on <core metric>
 
     """.strip()  # noqa: E501
 
+    ROLLOUT_HYPOTHESIS_PLACEHOLDER = """
+Observations: We have observed <this> for <these users> via <data source, UR, survey>.
+
+Context: <describe the problem, opportunity, or change in direction behind this rollout>.
+
+We are rolling out <this change> to <these users>.
+
+Optional - We expect this to <describe impact> on <core metric>.
+
+    """.strip()
+
     ERROR_NAME_INVALID = "This is not a valid name."
     ERROR_SLUG_DUPLICATE = "An experiment with this slug already exists."
     ERROR_SLUG_DUPLICATE_BRANCH = "A branch with this slug already exists."

--- a/experimenter/experimenter/nimbus_ui/new/forms.py
+++ b/experimenter/experimenter/nimbus_ui/new/forms.py
@@ -220,6 +220,8 @@ class FeatureConfigModelChoiceField(forms.ModelMultipleChoiceField):
 
 
 class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
+    hypothesis_placeholder = NimbusUIConstants.HYPOTHESIS_PLACEHOLDER
+
     owner = forms.ModelChoiceField(
         User.objects.all(),
         widget=forms.widgets.HiddenInput(),
@@ -239,7 +241,6 @@ class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
     hypothesis = forms.CharField(
         label="",
         widget=forms.widgets.Textarea(),
-        initial=NimbusUIConstants.HYPOTHESIS_PLACEHOLDER,
     )
     application = forms.ChoiceField(
         label="",
@@ -261,6 +262,10 @@ class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
             "application",
         ]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["hypothesis"].initial = self.hypothesis_placeholder
+
     def get_changelog_message(self):
         return f"{self.request.user} created {self.cleaned_data['name']}"
 
@@ -275,7 +280,7 @@ class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
     def clean_hypothesis(self):
         hypothesis = self.cleaned_data["hypothesis"]
-        if hypothesis.strip() == NimbusUIConstants.HYPOTHESIS_PLACEHOLDER.strip():
+        if hypothesis.strip() == self.hypothesis_placeholder.strip():
             raise forms.ValidationError(NimbusUIConstants.ERROR_HYPOTHESIS_PLACEHOLDER)
         return hypothesis
 
@@ -302,6 +307,8 @@ class NimbusExperimentCreateForm(NimbusChangeLogFormMixin, forms.ModelForm):
 
 
 class NimbusRolloutCreateForm(NimbusExperimentCreateForm):
+    hypothesis_placeholder = NimbusUIConstants.ROLLOUT_HYPOTHESIS_PLACEHOLDER
+
     def save(self, *args, **kwargs):
         self.instance.is_rollout = True
         return super().save(*args, **kwargs)

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -107,6 +107,7 @@ class NimbusExperimentViewMixin:
         )
         context["all_tags"] = Tag.objects.all().order_by("name")
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_rollout_form"] = NimbusRolloutCreateForm()
         context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         if experiment and experiment.slug:

--- a/experimenter/experimenter/nimbus_ui/templates/common/header.html
+++ b/experimenter/experimenter/nimbus_ui/templates/common/header.html
@@ -311,7 +311,7 @@
           <form id="createRolloutForm"
                 hx-post="{% url 'nimbus-ui-new-create-rollout' %}"
                 hx-target="#createRolloutForm">
-            {% include "nimbus_experiments/create.html" with form=create_form %}
+            {% include "nimbus_experiments/create.html" with form=create_rollout_form %}
 
           </form>
         </div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_forms.py
@@ -148,6 +148,14 @@ class TestNimbusExperimentCreateForm(RequestFormTestCase):
         self.assertFalse(form.is_valid())
         self.assertEqual(form.errors["name"], [NimbusUIConstants.ERROR_SLUG_DUPLICATE])
 
+    def test_form_prefills_the_experiment_hypothesis_placeholder(self):
+        form = NimbusExperimentCreateForm(request=self.request)
+
+        self.assertEqual(
+            form.fields["hypothesis"].initial,
+            NimbusUIConstants.HYPOTHESIS_PLACEHOLDER,
+        )
+
     def test_invalid_with_placeholder_hypothesis(self):
         data = {
             "owner": self.user,
@@ -199,6 +207,32 @@ class TestNimbusRolloutCreateForm(RequestFormTestCase):
         self.assertEqual(rollout.branches.count(), 1)
         self.assertEqual(rollout.reference_branch.name, "Control")
 
+    def test_form_prefills_the_rollout_hypothesis_placeholder(self):
+        form = NimbusRolloutCreateForm(request=self.request)
+
+        self.assertEqual(
+            form.fields["hypothesis"].initial,
+            NimbusUIConstants.ROLLOUT_HYPOTHESIS_PLACEHOLDER,
+        )
+        self.assertNotEqual(
+            NimbusUIConstants.ROLLOUT_HYPOTHESIS_PLACEHOLDER,
+            NimbusUIConstants.HYPOTHESIS_PLACEHOLDER,
+        )
+
+    def test_invalid_with_placeholder_hypothesis(self):
+        data = {
+            "owner": self.user,
+            "name": "Test Rollout",
+            "hypothesis": NimbusUIConstants.ROLLOUT_HYPOTHESIS_PLACEHOLDER,
+            "application": NimbusExperiment.Application.DESKTOP,
+        }
+        form = NimbusRolloutCreateForm(data, request=self.request)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["hypothesis"], [NimbusUIConstants.ERROR_HYPOTHESIS_PLACEHOLDER]
+        )
+
 
 class TestNimbusFirefoxLabsCreateForm(RequestFormTestCase):
     def test_form_creates_labs_rollout(self):
@@ -217,6 +251,14 @@ class TestNimbusFirefoxLabsCreateForm(RequestFormTestCase):
         self.assertTrue(labs.is_rollout)
         self.assertEqual(labs.branches.count(), 1)
         self.assertEqual(labs.reference_branch.name, "Control")
+
+    def test_form_prefills_the_rollout_hypothesis_placeholder(self):
+        form = NimbusFirefoxLabsCreateForm(request=self.request)
+
+        self.assertEqual(
+            form.fields["hypothesis"].initial,
+            NimbusUIConstants.ROLLOUT_HYPOTHESIS_PLACEHOLDER,
+        )
 
     def test_form_only_offers_applications_supporting_labs(self):
         form = NimbusFirefoxLabsCreateForm(request=self.request)

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -80,7 +80,10 @@ from experimenter.nimbus_ui.forms import (
     ToggleReviewSlackNotificationsForm,
     UnsubscribeForm,
 )
-from experimenter.nimbus_ui.new.forms import NimbusFirefoxLabsCreateForm
+from experimenter.nimbus_ui.new.forms import (
+    NimbusFirefoxLabsCreateForm,
+    NimbusRolloutCreateForm,
+)
 
 
 class IntegrationTestBranchDataMixin:
@@ -208,6 +211,7 @@ class NimbusExperimentViewMixin:
             {tag.id for tag in experiment.tags.all()} if experiment else set()
         )
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_rollout_form"] = NimbusRolloutCreateForm()
         context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         return context
@@ -294,6 +298,7 @@ class NimbusExperimentsListView(NimbusExperimentViewMixin, FilterView):
             status_counts=status_counts,
             sort_choices=SortChoices,
             create_form=NimbusExperimentCreateForm(),
+            create_rollout_form=NimbusRolloutCreateForm(),
             create_labs_form=NimbusFirefoxLabsCreateForm(),
             **kwargs,
         )
@@ -1137,6 +1142,7 @@ class NimbusFeaturesView(TemplateView):
         }
 
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_rollout_form"] = NimbusRolloutCreateForm()
         context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
 
         # Add subscribers form if a feature is selected
@@ -1253,6 +1259,7 @@ class NimbusExperimentsHomeView(FilterView):
 
         context["sortable_headers"] = HomeSortChoices.sortable_headers()
         context["create_form"] = NimbusExperimentCreateForm()
+        context["create_rollout_form"] = NimbusRolloutCreateForm()
         context["create_labs_form"] = NimbusFirefoxLabsCreateForm()
         return context
 


### PR DESCRIPTION
Because

* Create Rollout modal used the experiment hypothesis template which doesn’t make sense for rollouts

This commit

* Adds a new placeholder for the create new rollout and labs forms

Fixes #17054
