### PR TITLE
fix(nimbus): Correct the sticky enrollment description

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -168,6 +168,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     targeting list - file a new targeting request with this link, and share the created
     request with either your feature engineering team or in #ask-experimenter
     so the new targeting can be added."""
+    STICKY_ENROLLMENT_DESCRIPTION = (
+        "Clients remain enrolled even if they no longer meet the targeting."
+    )
     TIMELINE_TOOLTIPS = {
         "Draft": (
             "The duration from the initial draft of the experiment to its entry "

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -136,7 +136,7 @@
       <label for="id_is_sticky" class="small text-body mb-2">
         Apply sticky enrollment?
         <span class="d-block text-secondary fw-normal">
-          If applied, users continue to get the experience even after the experiment is done.
+          {{ NimbusUIConstants.STICKY_ENROLLMENT_DESCRIPTION }}
           <a target="_blank"
              href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.sticky_targeting_url }}">Learn more</a>
         </span>


### PR DESCRIPTION
Because

* The rollout audience form described sticky as users keeping the experience after the experiment ends which is not what it does

This commit

* Adds the old UI's wording and puts it in place of the inaccurate text

Fixes #17049
