### PR TITLE
fix(nimbus): Warn before leaving an open edit form

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -412,6 +412,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ROLLOUT_PREVIEW_BLOCKED_TOOLTIP = (
         "Resolve the detected setup issues before previewing or launching"
     )
+    ROLLOUT_UNSAVED_CHANGES_CONFIRM = (
+        "A section is still open for editing. Click OK to continue and discard "
+        "those changes, or Cancel to go back and save them first."
+    )
     ROLLOUT_LIVE_MESSAGE = (
         "This rollout is live. You can advance to the next phase to adjust its "
         "population sizing, or disable it."

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -433,6 +433,7 @@ class NewCardUpdateView(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["hx_swap_oob"] = self.request.method not in ("GET", "HEAD")
+        context["editing_card"] = True
         return context
 
     def can_edit(self):
@@ -444,6 +445,7 @@ class NewCardUpdateView(
 
     def render_valid_response(self):
         context = self.get_context_data()
+        context["editing_card"] = False
         return trigger_toast(
             self.response_class(
                 request=self.request,

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/card_cancel_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/card_cancel_button.html
@@ -4,6 +4,7 @@
         data-toast-id="{{ NimbusUIConstants.TOAST_EDIT_CANCELLED }}"
         hx-get="{% url 'new-nimbus-ui-rollout-detail' experiment.slug %}"
         hx-select="#rollout-card-{{ card_id }}"
+        hx-select-oob="#sidebar-preview-button"
         hx-target="#rollout-card-{{ card_id }}"
         hx-swap="outerHTML">
   {% if icon_only %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -6,7 +6,8 @@
               class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
               hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-              hx-disabled-elt="this">
+              hx-disabled-elt="this"
+              {% if editing_card %}hx-confirm="{{ NimbusUIConstants.ROLLOUT_UNSAVED_CHANGES_CONFIRM }}"{% endif %}>
         {% include "new/common/sidebar_transition_spinner.html" %}
 
         <i class="fa-regular fa-eye"></i>
@@ -17,7 +18,8 @@
               class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-transition-button"
               hx-post="{% url 'nimbus-ui-new-draft-to-review-rollout' experiment.slug %}"
               hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-              hx-disabled-elt="this">
+              hx-disabled-elt="this"
+              {% if editing_card %}hx-confirm="{{ NimbusUIConstants.ROLLOUT_UNSAVED_CHANGES_CONFIRM }}"{% endif %}>
         {% include "new/common/sidebar_transition_spinner.html" %}
 
         <i class="fa-regular fa-paper-plane"></i>

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_setup_refresh.html
@@ -4,4 +4,7 @@
   {% include "new/common/setup_issues_modal.html" with oob=True %}
   {% include "new/common/sidebar_preview_button.html" with oob=True %}
 
+{% elif editing_card %}
+  {% include "new/common/sidebar_preview_button.html" with oob=True %}
+
 {% endif %}


### PR DESCRIPTION
Because

* Previewing or requesting enrollment can replace the page and discard unsaved card changes

This commit

* Tracks when a card is being edited
* Shows a confirmation before Preview or Request Enrollment if there are unsaved edits

Fixes #17057