### PR TITLE
fix(project): route slack tasks to the remote_settings celery queue

### DIFF
--- a/experimenter/experimenter/settings.py
+++ b/experimenter/experimenter/settings.py
@@ -437,6 +437,7 @@ CELERY_BEAT_SCHEDULE = {
 }
 CELERY_TASK_ROUTES = {
     "experimenter.kinto.tasks.*": {"queue": "remote_settings"},
+    "experimenter.slack.tasks.*": {"queue": "remote_settings"},
 }
 
 # Recipe Configuration


### PR DESCRIPTION
Because

* Slack tasks share the default celery queue with the jetstream fetches and hourly cache warming, and that worker runs at concurrency 1.
* A long data-fetch run therefore serializes ahead of every queued Slack task, delaying review emoji updates.

This commit

* Routes experimenter.slack.tasks.* to the remote_settings queue, which is served by a separate worker.

Fixes #17082
