### PR TITLE
chore(project): scope integration test path gates to each job

### DIFF
--- a/.github/actions/check-changed-paths/action.yml
+++ b/.github/actions/check-changed-paths/action.yml
@@ -5,6 +5,10 @@ inputs:
   paths:
     description: "Space-separated list of path patterns to check (e.g. 'experimenter/ application-services/')"
     required: true
+  integration:
+    description: "Also match the shared integration test harness and the paths that rebuild the prod image"
+    required: false
+    default: "false"
 
 outputs:
   should-run:
@@ -50,7 +54,13 @@ runs:
           exit 0
         fi
 
-        for pattern in ${{ inputs.paths }}; do
+        PATTERNS="${{ inputs.paths }}"
+
+        if [[ "${{ inputs.integration }}" == "true" ]]; then
+          PATTERNS="$PATTERNS experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock"
+        fi
+
+        for pattern in $PATTERNS; do
           if echo "$CHANGED" | grep -q "^${pattern}"; then
             echo "should_run=true" >> "$GITHUB_OUTPUT"
             exit 0

--- a/.github/actions/check-changed-paths/action.yml
+++ b/.github/actions/check-changed-paths/action.yml
@@ -21,6 +21,9 @@ runs:
     - name: Check changed paths
       id: check
       shell: bash
+      env:
+        INPUT_PATHS: ${{ inputs.paths }}
+        INPUT_INTEGRATION: ${{ inputs.integration }}
       run: |
         if [[ "${{ github.event_name }}" == "merge_group" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           echo "should_run=true" >> "$GITHUB_OUTPUT"
@@ -54,9 +57,9 @@ runs:
           exit 0
         fi
 
-        PATTERNS="${{ inputs.paths }}"
+        PATTERNS="$INPUT_PATHS"
 
-        if [[ "${{ inputs.integration }}" == "true" ]]; then
+        if [[ "$INPUT_INTEGRATION" == "true" ]]; then
           PATTERNS="$PATTERNS experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock"
         fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/ ${{ matrix.extra_paths }}"
+          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/tests/integration/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock ${{ matrix.extra_paths }}"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/ application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -199,7 +199,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/tests/integration/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock ${{ matrix.extra_paths }}"
+          paths: "experimenter/experimenter/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/ ${{ matrix.extra_paths }}"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -227,7 +227,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/ application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -264,7 +264,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/ application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -291,7 +291,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/ application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,7 +160,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -199,7 +200,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/tests/integration/ experimenter/tests/nimbus_integration_tests.sh experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock ${{ matrix.extra_paths }}"
+          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/tests/nimbus_integration_tests.sh ${{ matrix.extra_paths }}"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -227,7 +229,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -264,7 +267,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -291,7 +295,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_desktop_release_build.env experimenter/tests/nimbus_integration_tests.sh application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'
@@ -318,7 +323,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/integration/ cirrus/ application-services/"
+          paths: "experimenter/experimenter/ cirrus/ application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -41,7 +41,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/ experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/ experimenter/tests/integration/ experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env"
+          paths: "experimenter/experimenter/ experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/tests/firefox_fenix_beta_build.env experimenter/tests/firefox_fenix_release_build.env"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/tests/integration/nimbus/ios/ experimenter/tests/firefox_ios_main_build.env"
+          paths: "experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/tests/firefox_ios_main_build.env"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/experimenter/features/ experimenter/tests/firefox_ios_main_build.env experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
+          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/experimenter/features/ experimenter/tests/firefox_ios_main_build.env application-services/"
+          integration: true
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: ./.github/actions/check-changed-paths
         id: check-paths
         with:
-          paths: "experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/tests/firefox_ios_main_build.env"
+          paths: "experimenter/experimenter/experiments/ experimenter/experimenter/targeting/ experimenter/experimenter/features/ experimenter/tests/firefox_ios_main_build.env experimenter/tests/integration/ experimenter/tests/pytest.ini experimenter/tests/pyproject.toml experimenter/tests/uv.lock experimenter/Dockerfile experimenter/pyproject.toml experimenter/uv.lock experimenter/package.json experimenter/yarn.lock application-services/"
 
       - uses: ./.github/actions/setup-cached-build
         if: steps.check-paths.outputs.should-run == 'true'


### PR DESCRIPTION
Because

* The move off CircleCI dropped its universal integration-tests clause and widened four desktop gates to the whole experimenter directory
* Those four jobs run on every mobile version bump, the iOS jobs skip when the shared test harness changes, and no gate covers the inputs that rebuild the image the tests run in

This commit

* Adds an opt-in integration input to the changed paths action that appends the shared harness and prod image build paths
* Reduces each integration gate to the code that job exercises

Fixes #17086