### PR TITLE
refactor(nimbus): render review serializer warnings in one shared warning ui

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -679,6 +679,29 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
             dict[NimbusFeatureConfig, NimbusVersionedSchema]
         ] = None
 
+    @staticmethod
+    def flatten_messages(messages):
+        if isinstance(messages, dict):
+            return [
+                m
+                for value in messages.values()
+                for m in NimbusReviewSerializer.flatten_messages(value)
+            ]
+        if isinstance(messages, (list, tuple)):
+            return [
+                m
+                for value in messages
+                for m in NimbusReviewSerializer.flatten_messages(value)
+            ]
+        return [str(messages)]
+
+    @property
+    def flat_warnings(self):
+        return {
+            field: list(dict.fromkeys(self.flatten_messages(messages)))
+            for field, messages in self.warnings.items()
+        }
+
     def to_representation(self, instance):
         data = super().to_representation(instance)
         data["feature_config"] = None
@@ -1459,25 +1482,6 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
 
         return data
 
-    def _validate_bucket_duplicates(self, data):
-        is_rollout = self.instance.is_rollout
-        if not self.instance or not is_rollout:
-            return data
-
-        count = NimbusExperiment.objects.filter(
-            status=NimbusExperiment.Status.LIVE,
-            channel=self.instance.channel,
-            application=self.instance.application,
-            targeting_config_slug=self.instance.targeting_config_slug,
-            feature_configs__in=self.instance.feature_configs.all(),
-            is_rollout=is_rollout,
-        ).count()
-
-        if count > 0:
-            self.warnings["bucketing"] = [NimbusConstants.ERROR_BUCKET_EXISTS]
-
-        return data
-
     def _validate_localizations(self, data):
         is_localized = data.get("is_localized")
         if not is_localized:
@@ -1680,6 +1684,15 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
                     )
                 }
             )
+
+        return data
+
+    def _validate_desktop_multichannel(self, data):
+        if data.get("is_rollout"):
+            return data
+
+        if len(data.get("channels", [])) > 1:
+            self.warnings["channels"] = [NimbusConstants.EXPERIMENT_MULTICHANNEL_WARNING]
 
         return data
 
@@ -1991,7 +2004,6 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         data = self._validate_targeting_parses(data)
         data = self._validate_newtab_trainhop_targeting(data)
         data = self._validate_sticky_enrollment(data)
-        data = self._validate_bucket_duplicates(data)
         data = self._validate_proposed_release_date(data)
         data = self._validate_feature_value_variables(data)
         data = self._validate_primary_secondary_outcomes(data)
@@ -2000,6 +2012,7 @@ class NimbusReviewSerializer(serializers.ModelSerializer):
         if application == NimbusExperiment.Application.DESKTOP:
             data = self._validate_desktop_pref_rollouts(data)
             data = self._validate_desktop_pref_flips(data)
+            data = self._validate_desktop_multichannel(data)
         return data
 
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -766,12 +766,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
     ERROR_BRANCH_SWAP = "You are trying to swap branch names. \
         Please choose another name for the branches."
 
-    ERROR_BUCKET_EXISTS = "WARNING: A rollout already exists for this combination \
-        of application, feature, channel, and advanced targeting! \
-        If this rollout is launched, a client meeting the advanced targeting criteria \
-        will be enrolled in one and not the other and \
-        you will not be able to adjust the sizing for this rollout."
-
     ERROR_ROLLOUT_VERSION = (
         "WARNING: Adjusting the population size while the "
         "rollout is live is not supported for {application} versions under {version}."
@@ -869,6 +863,11 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "rollout will re-enroll in this rollout, which will result in overriding their "
         "changes."
     )
+
+    EXPERIMENT_MULTICHANNEL_WARNING = """WARNING: This experiment is targeting multiple
+    channels.  Each channel has significantly different population sizes and user
+    behaviour.  Running an experiment on multiple channels can create misleading or
+    inaccurate results.  It is recommended to run experiments only on a single channel."""
 
     # There is a maximum size for prefs that Desktop can write. It will warn at
     # 4KiB and hard error at 1MiB.

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2655,31 +2655,6 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return self.publish_status == self.PublishStatus.WAITING and review_expired
 
     @property
-    def rollout_version_warning(self):
-        if not self.is_rollout or not self.firefox_min_version:
-            return None
-
-        min_required_version = (
-            NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION.get(
-                self.application
-            )
-        )
-
-        parsed_required_version = NimbusExperiment.Version.parse(min_required_version)
-        parsed_current_version = NimbusExperiment.Version.parse(self.firefox_min_version)
-
-        if parsed_current_version < parsed_required_version:
-            return {
-                "text": NimbusConstants.ERROR_ROLLOUT_VERSION.format(
-                    application=NimbusExperiment.Application(self.application).label,
-                    version=parsed_required_version,
-                ),
-                "variant": "warning",
-                "slugs": [],
-                "learn_more_link": None,
-            }
-
-    @property
     def supports_rollout_reenable(self):
         if not self.is_rollout:
             return True
@@ -2705,6 +2680,38 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             NimbusConstants.Status.LIVE,
         )
 
+    @cached_property
+    def _review_serializer(self):
+        from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
+
+        serializer = NimbusReviewSerializer(self, data=NimbusReviewSerializer(self).data)
+        serializer.is_valid()
+        return serializer
+
+    @property
+    def review_warnings(self):
+        if self.status not in [
+            NimbusConstants.Status.DRAFT,
+            NimbusConstants.Status.PREVIEW,
+        ]:
+            return []
+
+        issues = []
+        for field, messages in self._review_serializer.flat_warnings.items():
+            label = NimbusUIConstants.REVIEW_WARNING_LABELS.get(
+                field, field.replace("_", " ").title()
+            )
+            learn_more_url = NimbusUIConstants.REVIEW_WARNING_LEARN_MORE.get(field)
+            issues.extend(
+                {
+                    "label": label,
+                    "detail": message,
+                    "learn_more_url": learn_more_url,
+                }
+                for message in messages
+            )
+        return issues
+
     @property
     def audience_overlap_warnings(self):
         if self.status not in [
@@ -2718,28 +2725,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
             {"slug": d["slug"], "reasons": d["reasons"]} for d in collisions["deliveries"]
         ]
 
-        self_issues = []
-
-        if version_warning := self.rollout_version_warning:
-            self_issues.append(
-                {
-                    "label": (
-                        NimbusUIConstants.COLLISION_SELF_ISSUE_VERSION_BELOW_MINIMUM
-                    ),
-                    "detail": version_warning["text"],
-                    "learn_more_url": (
-                        NimbusUIConstants.COLLISION_LEARN_MORE_VERSION_BELOW_MINIMUM
-                    ),
-                }
-            )
-
-        if self.is_desktop and not self.is_rollout and len(self.channels) > 1:
-            self_issues.append(
-                {
-                    "label": NimbusUIConstants.COLLISION_SELF_ISSUE_MULTICHANNEL,
-                    "detail": NimbusUIConstants.EXPERIMENT_MULTICHANNEL_WARNING,
-                }
-            )
+        self_issues = self.review_warnings
 
         if not entries and not self_issues:
             return []
@@ -2775,27 +2761,19 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return False
 
     def get_invalid_fields_errors(self, serializer_class=None):
-        from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
-
         if serializer_class is None:
-            serializer_class = NimbusReviewSerializer
+            serializer = self._review_serializer
+        else:
+            serializer = serializer_class(self, data=serializer_class(self).data)
+            serializer.is_valid()
 
-        serializer_data = serializer_class(self).data
-        serializer = serializer_class(self, data=serializer_data)
+        errors = dict(serializer.errors)
 
-        errors = {}
-        if not serializer.is_valid():
-            errors = serializer.errors
+        if "excluded_experiments" in errors:
+            errors["excluded_experiments_branches"] = errors.pop("excluded_experiments")
 
-            if "excluded_experiments" in errors:
-                errors["excluded_experiments_branches"] = errors.pop(
-                    "excluded_experiments"
-                )
-
-            if "required_experiments" in errors:
-                errors["required_experiments_branches"] = errors.pop(
-                    "required_experiments"
-                )
+        if "required_experiments" in errors:
+            errors["required_experiments_branches"] = errors.pop("required_experiments")
 
         return errors
 

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -957,6 +957,7 @@ class TestNimbusReviewSerializerSingleFeature(
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             warn_feature_schema=True,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
@@ -1057,6 +1058,7 @@ class TestNimbusReviewSerializerSingleFeature(
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             warn_feature_schema=True,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
@@ -1110,6 +1112,7 @@ class TestNimbusReviewSerializerSingleFeature(
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             warn_feature_schema=True,
             feature_configs=[
                 NimbusFeatureConfigFactory.create(
@@ -1626,160 +1629,53 @@ class TestNimbusReviewSerializerSingleFeature(
             },
         )
 
-    def test_bucket_namespace_warning_for_dupe_rollouts(self):
-        desktop = NimbusExperiment.Application.DESKTOP
-        channel = NimbusExperiment.Channel.NIGHTLY
-        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
-        feature_configs = [NimbusFeatureConfigFactory(application=desktop)]
-
-        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
-            application=desktop,
-            channel=NimbusExperiment.Channel.NO_CHANNEL,
-            channels=[channel],
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=feature_configs,
-            is_sticky=False,
-            is_rollout=True,
-            targeting_config_slug=targeting_config_slug,
-        )
-        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
+    @parameterized.expand(
+        [
+            (True, [NimbusExperiment.Channel.RELEASE], False),
+            (False, [NimbusExperiment.Channel.RELEASE], False),
+            (
+                True,
+                [NimbusExperiment.Channel.RELEASE, NimbusExperiment.Channel.BETA],
+                False,
+            ),
+            (
+                False,
+                [NimbusExperiment.Channel.RELEASE, NimbusExperiment.Channel.BETA],
+                True,
+            ),
+        ]
+    )
+    def test_desktop_multichannel_warning(self, is_rollout, channels, expected):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
-            application=desktop,
+            application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
-            channels=[channel],
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=feature_configs,
-            is_sticky=False,
-            is_rollout=True,
-            targeting_config_slug=targeting_config_slug,
+            channels=channels,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            is_rollout=is_rollout,
         )
 
-        for branch in chain(
-            experiment1.treatment_branches, experiment2.treatment_branches
-        ):
-            branch.delete()
-
-        experiment1.save()
-        experiment2.save()
+        if is_rollout:
+            for branch in experiment.treatment_branches:
+                branch.delete()
 
         serializer = NimbusReviewSerializer(
-            experiment2,
+            experiment,
             data=NimbusReviewSerializer(
-                experiment2,
+                experiment,
                 context={"user": self.user},
             ).data,
-            partial=True,
             context={"user": self.user},
         )
 
-        self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(serializer.is_valid())
-        self.assertEqual(
-            serializer.warnings["bucketing"],
-            [NimbusExperiment.ERROR_BUCKET_EXISTS],
-        )
-
-    def test_bucket_namespace_warning_for_non_dupe_rollouts(self):
-        lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
-        channel = NimbusExperiment.Channel.NIGHTLY
-        feature_configs_fenix = [
-            NimbusFeatureConfigFactory(application=NimbusExperiment.Application.FENIX)
-        ]
-        feature_configs_ios = [
-            NimbusFeatureConfigFactory(application=NimbusExperiment.Application.IOS)
-        ]
-        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
-
-        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle,
-            application=NimbusExperiment.Application.FENIX,
-            channel=channel,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_116,
-            feature_configs=feature_configs_fenix,
-            is_sticky=False,
-            is_rollout=True,
-            targeting_config_slug=targeting_config_slug,
-        )
-        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle,
-            application=NimbusExperiment.Application.IOS,
-            channel=channel,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_116,
-            feature_configs=feature_configs_ios,
-            is_sticky=False,
-            is_rollout=True,
-            targeting_config_slug=targeting_config_slug,
-        )
-
-        for branch in chain(
-            experiment1.treatment_branches, experiment2.treatment_branches
-        ):
-            branch.delete()
-
-        experiment1.save()
-        experiment2.save()
-
-        serializer = NimbusReviewSerializer(
-            experiment2,
-            data=NimbusReviewSerializer(
-                experiment2,
-                context={"user": self.user},
-            ).data,
-            partial=True,
-            context={"user": self.user},
-        )
-
-        self.assertTrue(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(serializer.is_valid())
-        self.assertEqual(serializer.warnings, {})
-
-    def test_bucket_namespace_warning_for_experiments(self):
-        lifecycle = NimbusExperimentFactory.Lifecycles.CREATED
-        desktop = NimbusExperiment.Application.DESKTOP
-        channel = NimbusExperiment.Channel.NIGHTLY
-        feature_configs = [NimbusFeatureConfigFactory(application=desktop)]
-        targeting_config_slug = NimbusExperiment.TargetingConfig.MAC_ONLY
-
-        experiment1 = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle,
-            application=desktop,
-            channel=NimbusExperiment.Channel.NO_CHANNEL,
-            channels=[channel],
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=feature_configs,
-            is_sticky=False,
-            is_rollout=False,
-            targeting_config_slug=targeting_config_slug,
-        )
-        experiment2 = NimbusExperimentFactory.create_with_lifecycle(
-            lifecycle,
-            application=desktop,
-            channel=NimbusExperiment.Channel.NO_CHANNEL,
-            channels=[channel],
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_108,
-            feature_configs=feature_configs,
-            is_sticky=False,
-            is_rollout=False,
-            targeting_config_slug=targeting_config_slug,
-        )
-
-        experiment1.save()
-        experiment2.save()
-
-        serializer = NimbusReviewSerializer(
-            experiment2,
-            data=NimbusReviewSerializer(
-                experiment2,
-                context={"user": self.user},
-            ).data,
-            partial=True,
-            context={"user": self.user},
-        )
-
-        self.assertFalse(experiment1.is_rollout and experiment2.is_rollout)
-        self.assertTrue(serializer.is_valid())
-        self.assertEqual(serializer.warnings, {})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        if expected:
+            self.assertEqual(
+                serializer.warnings["channels"],
+                [NimbusConstants.EXPERIMENT_MULTICHANNEL_WARNING],
+            )
+        else:
+            self.assertNotIn("channels", serializer.warnings)
 
     def test_substitute_localizations(self):
         value = {
@@ -4016,6 +3912,8 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=min_version,
             firefox_max_version=max_version,
             feature_configs=[feature],
@@ -4977,6 +4875,8 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=min_version,
             firefox_max_version=max_version,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
@@ -5009,6 +4909,8 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             firefox_min_version=NimbusExperiment.Version.FIREFOX_119,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_119,
             targeting_config_slug=NimbusExperiment.TargetingConfig.ATTRIBUTION_MEDIUM_EMAIL,
@@ -5066,6 +4968,11 @@ class VersionedFeatureValidationTests(MockFmlErrorMixin, TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=app,
+            channels=(
+                [NimbusExperiment.Channel.RELEASE]
+                if app == NimbusExperiment.Application.DESKTOP
+                else []
+            ),
             firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             firefox_max_version=NimbusExperiment.Version.FIREFOX_121,
             targeting_config_slug=targeting_config,
@@ -5421,6 +5328,7 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             warn_feature_schema=True,
             feature_configs=[
                 self.feature_without_schema,
@@ -5474,6 +5382,7 @@ class TestNimbusReviewSerializerMultiFeature(MockFmlErrorMixin, TestCase):
             status=NimbusExperiment.Status.DRAFT,
             application=NimbusExperiment.Application.DESKTOP,
             channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
             warn_feature_schema=True,
             feature_configs=[
                 self.feature_without_schema,

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -3297,7 +3297,9 @@ class TestNimbusExperiment(TestCase):
             slug="combo-draft",
             is_rollout=False,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
             channels=[NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             feature_configs=[feature],
         )
 
@@ -3368,7 +3370,9 @@ class TestNimbusExperiment(TestCase):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.CREATED,
             application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
             channels=[NimbusExperiment.Channel.NIGHTLY, NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
             is_rollout=False,
         )
 
@@ -3404,61 +3408,14 @@ class TestNimbusExperiment(TestCase):
             )
         ]
     )
-    def test_rollout_version_warning_below_min_supported(self, application, min_version):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            application=application,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_10503,
-        )
-
-        warning = experiment.rollout_version_warning
-        self.assertIsNotNone(warning)
-        self.assertEqual(warning["variant"], "warning")
-        self.assertIn(str(min_version), warning["text"])
-        self.assertIn(NimbusExperiment.Application(application).label, warning["text"])
-
-    @parameterized.expand(
-        [
-            (
-                application,
-                min_version,
-            )
-            for application, min_version in (
-                NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION.items()
-            )
-        ]
-    )
-    def test_rollout_version_warning_meets_min_supported(self, application, min_version):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
-            application=application,
-            firefox_min_version=min_version,
-        )
-
-        warning = experiment.rollout_version_warning
-        self.assertIsNone(warning)
-
-    @parameterized.expand(
-        [
-            (
-                application,
-                min_version,
-            )
-            for application, min_version in (
-                NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION.items()
-            )
-        ]
-    )
-    def test_audience_overlap_warnings_includes_rollout_version(
+    def test_audience_overlap_warnings_rollout_version_below_min_supported(
         self, application, min_version
     ):
-        experiment = NimbusExperimentFactory.create(
-            status=NimbusExperiment.Status.DRAFT,
-            is_rollout=True,
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
             application=application,
-            firefox_min_version=NimbusExperiment.Version.FIREFOX_12,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_10503,
+            is_rollout=True,
         )
 
         warnings = experiment.audience_overlap_warnings
@@ -3467,9 +3424,220 @@ class TestNimbusExperiment(TestCase):
         version_issues = [
             issue
             for issue in warnings[0]["self_issues"]
-            if NimbusExperiment.Application(application).label in issue["detail"]
+            if issue["label"]
+            == NimbusUIConstants.REVIEW_WARNING_LABELS["firefox_min_version"]
         ]
         self.assertEqual(len(version_issues), 1)
+        self.assertIn(str(min_version), version_issues[0]["detail"])
+        self.assertIn(
+            NimbusExperiment.Application(application).label,
+            version_issues[0]["detail"],
+        )
+        self.assertEqual(
+            version_issues[0]["learn_more_url"],
+            NimbusUIConstants.REVIEW_WARNING_LEARN_MORE["firefox_min_version"],
+        )
+
+    @parameterized.expand(
+        [
+            (
+                application,
+                min_version,
+            )
+            for application, min_version in (
+                NimbusConstants.ROLLOUT_LIVE_RESIZE_MIN_SUPPORTED_VERSION.items()
+            )
+        ]
+    )
+    def test_audience_overlap_warnings_rollout_version_meets_min_supported(
+        self, application, min_version
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=application,
+            firefox_min_version=min_version,
+            is_rollout=True,
+        )
+
+        labels = [
+            issue["label"]
+            for warning in experiment.audience_overlap_warnings
+            for issue in warning["self_issues"]
+        ]
+        self.assertNotIn(
+            NimbusUIConstants.REVIEW_WARNING_LABELS["firefox_min_version"], labels
+        )
+
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Status.LIVE,),
+            (NimbusExperiment.Status.COMPLETE,),
+        ]
+    )
+    def test_review_warnings_empty_for_non_draft_status(self, status):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[
+                NimbusExperiment.Channel.NIGHTLY,
+                NimbusExperiment.Channel.RELEASE,
+            ],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            is_rollout=False,
+        )
+        self.assertNotEqual(experiment.review_warnings, [])
+
+        experiment.status = status
+
+        self.assertEqual(experiment.review_warnings, [])
+
+    def test_review_warnings_pref_rollout_reenroll(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            is_rollout=True,
+            prevent_pref_conflicts=False,
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    application=NimbusExperiment.Application.DESKTOP,
+                    schemas=[
+                        NimbusVersionedSchemaFactory.build(
+                            version=None,
+                            schema=None,
+                            set_pref_vars={"baz": "foo.bar.baz"},
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        self.assertIn(
+            {
+                "label": NimbusUIConstants.REVIEW_WARNING_LABELS["pref_rollout_reenroll"],
+                "detail": NimbusConstants.WARNING_ROLLOUT_PREF_REENROLL,
+                "learn_more_url": (
+                    NimbusUIConstants.COLLISION_LEARN_MORE_SETS_SAME_PREFERENCE
+                ),
+            },
+            experiment.review_warnings,
+        )
+
+    def test_review_warnings_proposed_release_date(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            is_first_run=False,
+            proposed_release_date=datetime.date(2026, 1, 1),
+        )
+
+        self.assertIn(
+            {
+                "label": NimbusUIConstants.REVIEW_WARNING_LABELS["proposed_release_date"],
+                "detail": NimbusConstants.ERROR_FIRST_RUN_RELEASE_DATE,
+                "learn_more_url": None,
+            },
+            experiment.review_warnings,
+        )
+
+    def test_review_warnings_flattens_nested_branch_warnings(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
+        )
+        experiment._review_serializer.warnings["treatment_branches"] = [
+            {"feature_values": [{"value": ["shared message"]}, {}]},
+            {"feature_values": [{"value": ["shared message", "other message"]}]},
+        ]
+
+        branch_issues = [
+            issue
+            for issue in experiment.review_warnings
+            if issue["label"]
+            == NimbusUIConstants.REVIEW_WARNING_LABELS["treatment_branches"]
+        ]
+        self.assertEqual(
+            [issue["detail"] for issue in branch_issues],
+            ["shared message", "other message"],
+        )
+
+    def test_review_warnings_humanizes_unmapped_warning_key(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.RELEASE],
+        )
+        experiment._review_serializer.warnings["some_new_field"] = ["A new warning."]
+
+        self.assertIn(
+            {
+                "label": "Some New Field",
+                "detail": "A new warning.",
+                "learn_more_url": None,
+            },
+            experiment.review_warnings,
+        )
+
+    def test_audience_overlap_warnings_renders_each_warning_once(self):
+        feature = NimbusFeatureConfigFactory.create(
+            slug="duplicate-rollout-feature",
+            application=NimbusExperiment.Application.DESKTOP,
+        )
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_APPROVE,
+            slug="live-duplicate",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.BETA],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_10503,
+        )
+        draft = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="draft-duplicate",
+            is_rollout=True,
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.BETA],
+            targeting_config_slug=NimbusExperiment.TargetingConfig.FIRST_RUN,
+            feature_configs=[feature],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_10503,
+        )
+
+        warnings = draft.audience_overlap_warnings
+        self.assertEqual(len(warnings), 1)
+
+        self_labels = [issue["label"] for issue in warnings[0]["self_issues"]]
+        self.assertEqual(
+            self_labels.count(
+                NimbusUIConstants.REVIEW_WARNING_LABELS["firefox_min_version"]
+            ),
+            1,
+        )
+
+        reason_labels = [
+            reason.get("label")
+            for entry in warnings[0]["entries"]
+            for reason in entry["reasons"]
+        ]
+        self.assertEqual(
+            reason_labels.count(NimbusUIConstants.COLLISION_LABEL_MATCHING_CONFIGURATION),
+            1,
+        )
+        self.assertNotIn(
+            NimbusUIConstants.COLLISION_LABEL_MATCHING_CONFIGURATION, self_labels
+        )
 
     # Firefox Desktop 156 is the first version that supports re-enabling a rollout
     # under the same slug, so anything below it cannot be re-enabled once disabled.

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -94,11 +94,6 @@ Optional - We expect this to <describe impact> on <core metric>.
         "within a healthy range — below the alert threshold."
     )
 
-    EXPERIMENT_MULTICHANNEL_WARNING = """WARNING: This experiment is targeting multiple
-    channels.  Each channel has significantly different population sizes and user
-    behaviour.  Running an experiment on multiple channels can create misleading or
-    inaccurate results.  It is recommended to run experiments only on a single channel."""
-
     POPULATION_SIZING_CARD_TITLE = "Audience Size Estimate"
     AUDIENCE_OVERLAP_WARNING = (
         "https://experimenter.info/advanced/warnings#audience-overlap"
@@ -150,12 +145,6 @@ Optional - We expect this to <describe impact> on <core metric>.
         "proportion accounts for this."
     )
 
-    # --- collision_warnings self-issue labels ---
-    COLLISION_SELF_ISSUE_VERSION_BELOW_MINIMUM = (
-        "Firefox version below the rollout minimum"
-    )
-    COLLISION_SELF_ISSUE_MULTICHANNEL = "Targeting multiple channels"
-
     # --- collision_warnings per-reason learn-more URLs ---
     # Only set where the doc page directly addresses the warning. Reasons
     # without a tight-fit doc page (Shares feature, Shares an audience,
@@ -171,10 +160,26 @@ Optional - We expect this to <describe impact> on <core metric>.
         "https://experimenter.info/advanced/warnings"
         "#rollouts-and-setpref-interaction-(desktop)"
     )
-    COLLISION_LEARN_MORE_VERSION_BELOW_MINIMUM = (
-        "https://experimenter.info/advanced/rollouts"
-        "#supported-platforms-and-minimum-versions"
-    )
+
+    # --- review serializer warning labels and learn-more URLs ---
+    REVIEW_WARNING_LABELS = {
+        "firefox_min_version": "Firefox version below the rollout minimum",
+        "channels": "Targeting multiple channels",
+        "pref_rollout_reenroll": "Rollout may re-enroll and override user pref changes",
+        "reference_branch": "Feature value warning",
+        "treatment_branches": "Feature value warning",
+        "targeting_config_slug": "Targeting field unsupported in some versions",
+        "proposed_release_date": "Release date set on a non-first-run experiment",
+    }
+
+    REVIEW_WARNING_LEARN_MORE = {
+        "firefox_min_version": (
+            "https://experimenter.info/advanced/rollouts"
+            "#supported-platforms-and-minimum-versions"
+        ),
+        "pref_rollout_reenroll": COLLISION_LEARN_MORE_SETS_SAME_PREFERENCE,
+    }
+
     TARGETING_CRITERIA_REQUEST_INFO = """If the option you need is not in the advanced
     targeting list - file a new targeting request with this link, and share the created
     request with either your feature engineering team or in #ask-experimenter

--- a/experimenter/experimenter/nimbus_ui/new/views.py
+++ b/experimenter/experimenter/nimbus_ui/new/views.py
@@ -257,13 +257,6 @@ class UpdateRedirectViewMixin:
 
 
 class RolloutSetupProgressMixin:
-    def flatten_errors(self, messages):
-        if isinstance(messages, dict):
-            return [m for value in messages.values() for m in self.flatten_errors(value)]
-        if isinstance(messages, (list, tuple)):
-            return [m for value in messages for m in self.flatten_errors(value)]
-        return [str(messages)]
-
     def drop_documentation_link_title_errors(self, field_errors):
         # The title select has no blank option so a just-added link always errors
         # until the next save picks up its default
@@ -327,7 +320,9 @@ class RolloutSetupProgressMixin:
             group = groups.setdefault(
                 card_id, {"card_id": card_id, "section": section, "fields": {}}
             )
-            group["fields"].setdefault(label, []).extend(self.flatten_errors(messages))
+            group["fields"].setdefault(label, []).extend(
+                NimbusRolloutReviewSerializer.flatten_messages(messages)
+            )
         for group in groups.values():
             group["fields"] = [
                 {"label": label, "messages": messages}
@@ -344,7 +339,9 @@ class RolloutSetupProgressMixin:
         )
         context["validation_errors"] = {
             field: (
-                messages if field in raw_error_fields else self.flatten_errors(messages)
+                messages
+                if field in raw_error_fields
+                else NimbusRolloutReviewSerializer.flatten_messages(messages)
             )
             for field, messages in field_errors.items()
         }
@@ -370,13 +367,13 @@ class RolloutSetupProgressMixin:
 
     def readonly_card_errors(self, field_errors):
         return {
-            "feature_value_errors": self.flatten_errors(
+            "feature_value_errors": NimbusRolloutReviewSerializer.flatten_messages(
                 field_errors.get("reference_branch") or []
             ),
-            "screenshot_errors": self.flatten_errors(
+            "screenshot_errors": NimbusRolloutReviewSerializer.flatten_messages(
                 field_errors.get("reference_branch_screenshots") or []
             ),
-            "documentation_link_errors": self.flatten_errors(
+            "documentation_link_errors": NimbusRolloutReviewSerializer.flatten_messages(
                 field_errors.get("documentation_links") or []
             ),
         }

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -18,6 +18,7 @@ from experimenter.base.tests.factories import (
     LanguageFactory,
     LocaleFactory,
 )
+from experimenter.experiments.api.v5.serializers import NimbusReviewSerializer
 from experimenter.experiments.constants import EXTERNAL_URLS, NimbusConstants
 from experimenter.experiments.models import (
     NimbusBranchFeatureValue,
@@ -1617,6 +1618,39 @@ class NimbusExperimentDetailViewTest(AuthTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertTrue(response.context["uses_secure_collection"])
+
+    def test_renders_review_warnings_in_a_single_validation_pass(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            slug="multichannel-experiment",
+            application=NimbusExperiment.Application.DESKTOP,
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[
+                NimbusExperiment.Channel.NIGHTLY,
+                NimbusExperiment.Channel.RELEASE,
+            ],
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_120,
+            is_rollout=False,
+        )
+
+        original_is_valid = NimbusReviewSerializer.is_valid
+        validated = []
+
+        def counting_is_valid(serializer, **kwargs):
+            validated.append(serializer)
+            return original_is_valid(serializer, **kwargs)
+
+        with patch.object(NimbusReviewSerializer, "is_valid", counting_is_valid):
+            response = self.client.get(
+                reverse("nimbus-ui-detail", kwargs={"slug": experiment.slug}),
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(validated), 1)
+        self.assertContains(
+            response,
+            NimbusUIConstants.REVIEW_WARNING_LABELS["channels"],
+        )
 
 
 class TestNimbusExperimentsCreateView(AuthTestCase):


### PR DESCRIPTION
Because

* The review serializer computes warnings that no template reads, so four warning channels render nowhere.
* Two warning rules are implemented twice, once in the serializer and once hand-copied into the model.

This commit

* Renders every review serializer warning generically as a self issue on the existing warning card.
* Removes the duplicated rollout version and bucket duplicate checks.
* Moves the desktop multichannel warning into the review serializer.
* Caches the validated review serializer so the summary page keeps a single validation pass.

Fixes #17087