### PR TITLE
fix(nimbus): look up pref flip test feature config by slug

### DIFF
--- a/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_client_integrations.py
@@ -120,11 +120,15 @@ def test_check_telemetry_pref_flip(
     application,
 ):
     about_config = AboutConfig(selenium)
+    feature_id = helpers.get_feature_id_as_string(
+        "nimbus-qa-1", BaseExperimentApplications.FIREFOX_DESKTOP.value
+    )
+    assert feature_id
     helpers.create_experiment(
         experiment_slug,
         BaseExperimentApplications.FIREFOX_DESKTOP.value,
         {
-            "feature_config_ids": [9],
+            "feature_config_ids": [int(feature_id)],
             "reference_branch": {
                 "name": "Branch 1",
                 "description": "reference branch",


### PR DESCRIPTION
Because

* test_check_telemetry_pref_flip hardcodes a feature config primary key, which shifts whenever a desktop feature is added above nimbus-qa-1 in the manifest
* When it shifts the test builds its experiment on the wrong feature, the branch value fails schema validation, and the launch controls never render

This commit

* Resolves the feature config by slug with helpers.get_feature_id_as_string

Fixes #17085