### PR TITLE
feat(nimbus): add Learn more link to population sizing estimate UI

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -217,6 +217,7 @@ Optional - We expect this to <describe impact> on <core metric>.
         "targeting_criteria_request_url": "https://github.com/mozilla/experimenter/issues/new?template=targeting_request_template.yml&title=Targeting%20criteria%20request",
         "sticky_targeting_url": "https://experimenter.info/advanced/custom-audiences#sticky-targeting",
         "experimentation_office_hours_url": "https://mozilla-hub.atlassian.net/wiki/spaces/DATA/pages/6849684/Experimentation+Office+Hours",
+        "population_sizing_learn_more_url": "https://experimenter.info/advanced/population-sizing#automatic-population-sizing-in-experimenter",
     }
     OVERVIEW_PAGE_LINKS = {
         "risk_link": "https://mana.mozilla.org/wiki/display/FIREFOX/Pref-Flip+and+Add-On+Experiments#PrefFlipandAddOnExperiments-Doesthishavehighrisktothebrand?",

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/population_sizing/card.html
@@ -14,6 +14,10 @@
         <div class="d-flex align-items-baseline gap-2 mb-3">
           <span class="fs-4 fw-semibold text-body">~{{ experiment.sizing_eligible_count|short_number }}</span>
           <span class="small text-body">estimated eligible clients</span>
+          <a href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.population_sizing_learn_more_url }}"
+             target="_blank"
+             rel="noopener noreferrer"
+             class="small">Learn more</a>
         </div>
         {% if rollout_phase_population_estimates %}
           <table class="table table-borderless table-sm align-middle mb-0 w-auto">

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/detail_card_sizing.html
@@ -8,6 +8,10 @@
   <div class="d-flex align-items-center justify-content-between">
     <h4 class="mb-0">
       <a href="#sizing" class="text-decoration-none text-body">{{ NimbusUIConstants.POPULATION_SIZING_CARD_TITLE }}</a>
+      <a href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.population_sizing_learn_more_url }}"
+         target="_blank"
+         rel="noopener noreferrer"
+         class="ms-2 fs-6 fw-normal">Learn more</a>
     </h4>
     {% if experiment.sizing_data_updated_at %}
       <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>

--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/edit_audience.html
@@ -264,7 +264,13 @@
                  role="alert"
                  data-testid="sizing-callout">
               <div class="d-flex align-items-baseline justify-content-between mb-1">
-                <strong>Audience Size Estimate</strong>
+                <strong>
+                  Audience Size Estimate
+                  <a href="{{ NimbusUIConstants.AUDIENCE_PAGE_LINKS.population_sizing_learn_more_url }}"
+                     target="_blank"
+                     rel="noopener noreferrer"
+                     class="ms-1 small fw-normal">Learn more</a>
+                </strong>
                 {% if experiment.sizing_data_updated_at %}
                   <span class="text-muted small">Last updated: {{ experiment.sizing_data_updated_at|timesince }} ago</span>
                 {% endif %}


### PR DESCRIPTION
Because

- The automated population sizing estimate on the Audience page gave no indication of what targeting attributes are included in the count and what are excluded. Amber raised that owners need a way to understand what the estimate covers (channel, region/locale, version, standard targeting) and what it doesn't (Advanced Targeting event-based conditions, Required/Excluded Experiments), so they can interpret the number correctly.

This commit

- Adds a `population_sizing_learn_more_url` constant to `AUDIENCE_PAGE_LINKS` pointing to the population sizing docs section that explains inclusions/exclusions.
- Adds a "Learn more" link next to the "Audience Size Estimate" heading on the edit audience page.
- Adds a "Learn more" link next to the card title on the experiment detail sizing card.
- Adds a "Learn more" link beside the "estimated eligible clients" count on the rollout population sizing card.

Fixes #17098

