### PR TITLE
feat(nimbus): Add targeting for launch-at-login-infobar-existing-user

### DIFF
--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -1344,6 +1344,42 @@ WINDOWS_LAUNCH_ON_LOGIN_ELIGIBLE_IMPROVED = NimbusTargetingConfig(
     application_choice_names=(Application.DESKTOP.name,),
 )
 
+WINDOWS_LAUNCH_AT_LOGIN_FINAL = NimbusTargetingConfig(
+    name="Windows users eligible for launch at login - final",
+    slug="windows_launch_at_login_eligible_final",
+    description="Users eligible for the launch-at-login-infobar-existing-user treatment.",
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && !launchOnLoginEnabled && "
+        "launchOnLoginAllowedByPolicy && "
+        "'browser.startup.windowsLaunchOnLogin.enabled'|preferenceValue && "
+        "(!isMSIX || os.windowsBuildNumber >= 22000) && "
+        "profileAgeCreated < '2026-06-16'|date && "
+        "profileGroupProfileCount < 2 && "
+        "!hasActiveEnterprisePolicies && "
+        "userMonthlyActivity|length < 25 && "
+        "'browser.contentblocking.category'|preferenceValue == 'standard' && "
+        "!'privacy.globalprivacycontrol.enabled'|preferenceValue && "
+        "!'dom.security.https_only_mode'|preferenceValue && "
+        "!'dom.security.https_only_mode_pbm'|preferenceValue && "
+        "'browser.newtabpage.activity-stream.feeds.topsites'|preferenceValue && "
+        "'browser.newtabpage.activity-stream.showSponsoredTopSites'|preferenceValue && "
+        "'browser.newtabpage.activity-stream.feeds.section.topstories'|preferenceValue"
+        " && 'browser.newtabpage.activity-stream.showSponsored'|preferenceValue && "
+        "'browser.urlbar.suggest.quicksuggest.all'|preferenceValue && "
+        "'browser.urlbar.suggest.quicksuggest.sponsored'|preferenceValue && "
+        "!addonsInfo.addons['{d10d0bf8-f5b5-c8b4-a8b2-2b9879e08c5d}'] && "
+        "!addonsInfo.addons['uBlock0@raymondhill.net'] && "
+        "!addonsInfo.addons['adguardadblocker@adguard.com'] && "
+        "!addonsInfo.addons['jid1-NIfFY2CA8fy1tg@jetpack'] && "
+        "!addonsInfo.addons['adblockultimate@adblockultimate.net'] && "
+        "!addonsInfo.addons['firefox@ghostery.com']"
+    ),
+    desktop_telemetry="",
+    sticky_required=False,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
 EXISTING_USERS_PDF_PROMO_ELIGIBLE = NimbusTargetingConfig(
     name="Windows 10+ users eligible for Split PDF promo",
     slug="win10_pdf_split_promo",


### PR DESCRIPTION
Because:

- We have a huge list of new targeting conditions for future LAL messaging

This commit:

- Adds a targeting config including those conditions

Fixes #17146