### PR TITLE
fix(nimbus): Use "delivery" wording in subscription toasts

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -466,8 +466,8 @@ Optional - We expect this to <describe impact> on <core metric>.
 
     TOASTS = {
         TOAST_SAVED: "Changes saved",
-        TOAST_SUBSCRIBED: "Subscribed to this experiment",
-        TOAST_UNSUBSCRIBED: "Unsubscribed from this experiment",
+        TOAST_SUBSCRIBED: "Subscribed to this delivery",
+        TOAST_UNSUBSCRIBED: "Unsubscribed from this delivery",
         TOAST_SLACK_ENABLED: "Review Slack notifications enabled",
         TOAST_SLACK_DISABLED: "Review Slack notifications disabled",
         TOAST_EDIT_CANCELLED: "Edit cancelled",


### PR DESCRIPTION
Because:

- the subscribe bell on a new rollout page showed "Subscribed to this experiment"

This commit:

- renames the subscribe/unsubscribe toast messages to refer to a delivery

Fixes #17075
