### PR TITLE
fix(nimbus): Refresh the targeting expression when rollout features change

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/common/full_targeting_expression.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/full_targeting_expression.html
@@ -1,0 +1,10 @@
+{% load static %}
+
+<div id="rollout-full-targeting-expression"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
+  {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
+  {% include "new/common/validation_errors.html" with errors=validation_errors.targeting %}
+  {% include "new/common/validation_errors.html" with errors=validation_errors.non_field_errors %}
+
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -148,13 +148,8 @@
 
       </div>
       {# Full targeting expression #}
-      <div>
-        <div class="text-secondary mb-1" style="font-size: 12px;">Full targeting expression</div>
-        {% include "nimbus_experiments/readonly_targeting.html" with json_content=experiment.targeting_formatted %}
-        {% include "new/common/validation_errors.html" with errors=validation_errors.targeting %}
-        {% include "new/common/validation_errors.html" with errors=validation_errors.non_field_errors %}
+      {% include "new/common/full_targeting_expression.html" %}
 
-      </div>
       {# Required experiments #}
       <div>
         <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing experiments</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -90,6 +90,7 @@
   </div>
   {% if hx_swap_oob %}
     {% include "new/common/audience_overlap_warnings.html" with oob=True %}
+    {% include "new/common/full_targeting_expression.html" with oob=True %}
 
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
Because:

- saving the features card never re-rendered the audience card, so the targeting expression was stale until a page reload

This commit:

- swaps the full targeting expression out of band when features are saved

Fixes #17032
