### PR TITLE
fix(nimbus): Hide the rollout preview card for non-desktop applications

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_detail.html
@@ -18,7 +18,7 @@
       {% include "new/rollouts/detail_card.html" with card_id="population_sizing" title=NimbusUIConstants.POPULATION_SIZING_CARD_TITLE subtitle="Estimated eligible and enrolled clients" show_edit_btn=False body_template="new/rollouts/population_sizing/card.html" %}
 
     {% endif %}
-    {% if experiment.is_preview %}
+    {% if experiment.is_preview and experiment.is_desktop %}
       <div class="d-flex flex-column gap-2" id="rollout-preview-section">
         {% include "new/rollouts/detail_card.html" with card_id="preview" title="Preview links & testing details" subtitle="Rollout experience" show_edit_btn=False body_template="new/rollouts/preview/card.html" %}
 

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1310,6 +1310,29 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertContains(response, "Rollout experience")
         self.assertContains(response, EXTERNAL_URLS["PREVIEW_LAUNCH_DOC"])
 
+    @parameterized.expand(
+        [
+            (NimbusExperiment.Application.FENIX,),
+            (NimbusExperiment.Application.IOS,),
+            (NimbusExperiment.Application.MONITOR,),
+        ]
+    )
+    def test_preview_card_hidden_for_non_desktop_application(self, application):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
+            application=application,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(experiment.is_preview)
+        self.assertFalse(experiment.is_desktop)
+        self.assertNotContains(response, "Preview links & testing details")
+
     def test_preview_card_lists_all_screenshots(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.PREVIEW,

--- a/experimenter/tests/integration/nimbus/pages/rollouts/base.py
+++ b/experimenter/tests/integration/nimbus/pages/rollouts/base.py
@@ -21,6 +21,7 @@ class RolloutBase(Base):
     _live_badge_locator = (By.ID, "rollout-live-badge")
     _preview_button_locator = (By.ID, "rollout-preview-btn")
     _preview_section_locator = (By.ID, "rollout-preview-section")
+    _back_to_setup_button_locator = (By.ID, "rollout-back-to-setup-btn")
     _request_enrollment_button_locator = (
         By.ID,
         "rollout-request-enrollment-btn",
@@ -95,6 +96,11 @@ class RolloutBase(Base):
 
     @property
     def is_in_preview(self):
+        self.wait_for_htmx()
+        return bool(self.selenium.find_elements(*self._back_to_setup_button_locator))
+
+    @property
+    def has_preview_card(self):
         self.wait_for_htmx()
         return bool(self.selenium.find_elements(*self._preview_section_locator))
 

--- a/experimenter/tests/integration/nimbus/test_rollouts_ui.py
+++ b/experimenter/tests/integration/nimbus/test_rollouts_ui.py
@@ -2,9 +2,12 @@ import pytest
 
 
 @pytest.mark.nimbus_ui
-def test_rollout_can_be_launched(configured_rollout, kinto_client):
+def test_rollout_can_be_launched(
+    configured_rollout, kinto_client, mobile_apps, application
+):
     configured_rollout.transition_to_preview()
     assert configured_rollout.is_in_preview
+    assert configured_rollout.has_preview_card == (application not in mobile_apps)
 
     configured_rollout.request_enrollment()
     configured_rollout.approve_review()


### PR DESCRIPTION
Because:

- mobile rollouts in Preview showed the "Preview links & testing details" section with desktop-only testing instructions

This commit:

- gates the rollout preview section on experiment.is_desktop

Fixes #17079