### PR TITLE
fix(project): move Docker base images off end-of-life Debian 11

### DIFF
--- a/application-services/Dockerfile
+++ b/application-services/Dockerfile
@@ -1,8 +1,7 @@
-FROM debian:bullseye-20240130
+FROM debian:trixie-slim
 WORKDIR /application-services
 
 RUN apt-get update && \
-    apt-get upgrade -y && \
     apt-get install -y curl jq zip
 
 COPY . .

--- a/cirrus/server/Dockerfile
+++ b/cirrus/server/Dockerfile
@@ -1,7 +1,7 @@
 # python-builder
 # --------------
 # This image gathers all the required Python dependencies.
-FROM python:3.11-slim-bullseye AS python-builder
+FROM python:3.11-slim-trixie AS python-builder
 
 # Set working directory for the container
 WORKDIR /cirrus
@@ -61,7 +61,7 @@ COPY . .
 # ------
 # This image contains a lightweight container intended for deployment.
 
-FROM python:3.11-slim-bullseye AS deploy
+FROM python:3.11-slim-trixie AS deploy
 
 # Create a non-root user
 ARG USERNAME=cirrus

--- a/experimenter/Dockerfile
+++ b/experimenter/Dockerfile
@@ -1,9 +1,10 @@
 #-------------------------
 # System packages
-FROM python:3.13-bullseye AS system-builder
+FROM python:3.13-trixie AS system-builder
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+RUN install -d /etc/apt/keyrings && \
+    curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg -o /etc/apt/keyrings/yarn.asc
+RUN echo "deb [signed-by=/etc/apt/keyrings/yarn.asc] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 RUN apt-get update
 RUN apt-get --no-install-recommends install -y apt-utils ca-certificates postgresql-client yarn parallel
 

--- a/experimenter/tests/integration/Dockerfile
+++ b/experimenter/tests/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-bullseye
+FROM python:3.11-trixie
 
 COPY --from=experimenter:megazords \
     /application-services/megazords/nimbus-experimenter /application-services/nimbus_megazord


### PR DESCRIPTION
Because

* Debian 11 (bullseye) reached LTS end-of-life on 2026-08-31, and the
  bullseye-security Release file expired on 2026-09-07, so apt-get
  update now fails for every image still based on it.
* That takes down the megazord, cirrus and experimenter image builds,
  and with them every CI job that goes through setup-cached-build.
* apt-get upgrade is not needed in an ephemeral build container that
  only runs curl, jq and zip, and it adds a per-build dependency on
  the security pool being internally consistent.
* apt-key is not present on trixie, so the yarn repository key has to
  be installed as a signed-by keyring instead.

This commit

* Moves the megazord, cirrus, experimenter and integration-test images
  to Debian 13 (trixie), supported until 2028-08-09 and then 2030-06-30.
* Drops apt-get upgrade from the megazord build.
* Installs the yarn repository key as a signed-by keyring.

Fixes #17179