### PR TITLE
fix(project): reduce CI flakiness from Docker Hub registry errors

### DIFF
--- a/.github/actions/run-integration-test/action.yml
+++ b/.github/actions/run-integration-test/action.yml
@@ -8,6 +8,9 @@ inputs:
   retries:
     description: "Number of retry attempts after the first failure"
     default: "1"
+  backoff-seconds:
+    description: "Seconds to sleep before each retry, multiplied by the attempt number"
+    default: "30"
   artifact-name:
     description: "Name for the uploaded test report artifact"
     required: true
@@ -20,6 +23,7 @@ runs:
       env:
         BUILDKIT_PROGRESS: plain
         COMPOSE_ANSI: never
+        RETRY_BACKOFF: ${{ inputs.backoff-seconds }}
       run: |
         cp .env.integration-tests .env
         attempts=$(( ${{ inputs.retries }} + 1 ))
@@ -35,6 +39,7 @@ runs:
             exit 1
           fi
           echo "::warning::Attempt $attempt failed, retrying..."
+          sleep $((attempt * RETRY_BACKOFF))
         done
 
     - name: Upload test report

--- a/.github/workflows/fenix-integration-test.yml
+++ b/.github/workflows/fenix-integration-test.yml
@@ -76,11 +76,13 @@ jobs:
         if: steps.check-paths.outputs.should-run == 'true'
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      - name: Bring up Experimenter stack
+      - uses: ./.github/actions/retry
         if: steps.check-paths.outputs.should-run == 'true'
-        run: |
-          cp .env.integration-tests .env
-          make refresh SKIP_DUMMY=1 up_prod_detached
+        with:
+          label: Bring up Experimenter stack
+          run: |
+            cp .env.integration-tests .env
+            make refresh SKIP_DUMMY=1 up_prod_detached
 
       - name: Wait for Experimenter backend to be ready
         if: steps.check-paths.outputs.should-run == 'true'

--- a/.github/workflows/ios-integration-test.yml
+++ b/.github/workflows/ios-integration-test.yml
@@ -46,11 +46,13 @@ jobs:
         if: steps.check-paths.outputs.should-run == 'true'
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      - name: Bring up Experimenter stack
+      - uses: ./.github/actions/retry
         if: steps.check-paths.outputs.should-run == 'true'
-        run: |
-          cp .env.integration-tests .env
-          make refresh SKIP_DUMMY=1 up_prod_detached
+        with:
+          label: Bring up Experimenter stack
+          run: |
+            cp .env.integration-tests .env
+            make refresh SKIP_DUMMY=1 up_prod_detached
 
       - name: Wait for Experimenter backend to be ready
         if: steps.check-paths.outputs.should-run == 'true'

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:1.19.8
+FROM nginx:1.30.4
 
 RUN rm /etc/nginx/nginx.conf
 COPY nginx.conf /etc/nginx/


### PR DESCRIPTION
Because

* Docker Hub intermittently returns 500 from its auth endpoint, and a
  sweep of the last week's failed runs found every occurrence was a
  pull of nginx:1.19.8, an image last pushed in March 2021.
* The two steps where those failures land have inadequate retry: one
  is a bare run with none at all, and the other retries twice with no
  sleep, so its attempts ran two seconds apart and could not outlast
  the blip.
* The same window shows no such failures in setup-cached-build, which
  retries three times with backoff.

This commit

* Bumps the nginx base image to 1.30.4, the current stable.
* Retries bringing up the Experimenter stack in the mobile
  integration workflows.
* Sleeps between integration test attempts.

Fixes #17188