### PR TITLE
fix(nimbus): Reject rollout phases scheduled out of order

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2047,6 +2047,7 @@ class NimbusRolloutReviewSerializer(NimbusReviewSerializer):
             raise serializers.ValidationError(
                 NimbusConstants.ERROR_ROLLOUT_FIRST_PHASE_ZERO
             )
+        previous_phase = None
         for phase in phases:
             if not (0 <= phase.population_percent <= 100):
                 raise serializers.ValidationError(
@@ -2056,6 +2057,13 @@ class NimbusRolloutReviewSerializer(NimbusReviewSerializer):
                 raise serializers.ValidationError(
                     NimbusConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER
                 )
+            if previous_phase is not None:
+                boundary = previous_phase.end_date or previous_phase.start_date
+                if boundary and phase.start_date and phase.start_date < boundary:
+                    raise serializers.ValidationError(
+                        NimbusConstants.ERROR_ROLLOUT_PHASE_SEQUENCE
+                    )
+            previous_phase = phase
         return value
 
 

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -747,6 +747,9 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "The first rollout phase must have a population percent greater than 0."
     )
     ERROR_ROLLOUT_PHASE_DATE_ORDER = "The end date must be on or after the start date."
+    ERROR_ROLLOUT_PHASE_SEQUENCE = (
+        "Each phase must start after or when the previous phase ends."
+    )
     ERROR_ROLLOUT_PHASE_POPULATION_RANGE = (
         "Each rollout phase population percent must be between 0 and 100."
     )

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -594,6 +594,44 @@ class TestNimbusReviewSerializerSingleFeature(
             [NimbusConstants.ERROR_ROLLOUT_PHASE_DATE_ORDER],
         )
 
+    def test_rollout_serializer_rejects_phases_out_of_sequence(self):
+        experiment = self.create_rollout()
+        NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=10,
+            start_date=datetime.date(2026, 2, 1),
+            end_date=datetime.date(2026, 3, 1),
+        )
+        NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=20,
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 1, 15),
+        )
+        serializer = self.get_rollout_review_serializer(experiment)
+        self.assertFalse(serializer.is_valid())
+        self.assertEqual(
+            serializer.errors["rollout_phases"],
+            [NimbusConstants.ERROR_ROLLOUT_PHASE_SEQUENCE],
+        )
+
+    def test_rollout_serializer_accepts_contiguous_phases(self):
+        experiment = self.create_rollout()
+        NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=10,
+            start_date=datetime.date(2026, 1, 1),
+            end_date=datetime.date(2026, 2, 1),
+        )
+        NimbusRolloutPhaseFactory.create(
+            experiment=experiment,
+            population_percent=20,
+            start_date=datetime.date(2026, 2, 1),
+            end_date=datetime.date(2026, 3, 1),
+        )
+        serializer = self.get_rollout_review_serializer(experiment)
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
     def test_rollout_serializer_rejects_phase_population_out_of_range(self):
         experiment = self.create_rollout()
         NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=150)


### PR DESCRIPTION
Because:

- a phase could be given dates that start before the previous phase ends

This commit:

- adds a review validation error when phases are not in sequence

Fixes #17007