### PR TITLE
fix(nimbus): Display screenshot descriptions on the rollout features card

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -65,18 +65,25 @@
       <div class="text-secondary mb-1" style="font-size: 12px;">Rollout screenshots</div>
       {% with screenshots=experiment.reference_branch.screenshots.all %}
         {% if screenshots %}
-          <div class="d-flex flex-wrap gap-2">
+          <div class="d-flex flex-wrap gap-4">
             {% for screenshot in screenshots %}
               {% if screenshot.image %}
-                <div class="border border-secondary-subtle rounded overflow-hidden">
+                <figure class="mb-0 border border-secondary-subtle rounded overflow-hidden"
+                        style="width: min-content">
                   <img src="{{ screenshot.image.url }}"
                        alt="{{ screenshot.description }}"
                        title="{{ screenshot.description }}"
-                       class="rounded"
-                       style="height: 125px;
+                       style="display: block;
+                              height: 125px;
                               width: auto;
                               object-fit: cover">
-                </div>
+                  {% if screenshot.description %}
+                    <figcaption id="rollout-features-screenshot-description-{{ forloop.counter0 }}"
+                                class="small text-body border-top border-secondary-subtle px-2 py-1"
+                                style="overflow-wrap: anywhere;
+                                       white-space: pre-wrap">{{ screenshot.description }}</figcaption>
+                  {% endif %}
+                </figure>
               {% endif %}
             {% endfor %}
           </div>


### PR DESCRIPTION
Because:

- descriptions never appeared on the page

This commit:

- renders each screenshot's description under its image

Fixes #17028
