### PR TITLE
fix(nimbus): Disable Preview when a rollout cannot be previewed

### DIFF
--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -2036,6 +2036,18 @@ class NimbusRolloutReviewSerializer(NimbusReviewSerializer):
         # this skips the parent's non-empty check
         return value
 
+    def _validate_desktop_pref_flips_value(self, value, min_version, max_version):
+        # The schema check has already rejected a malformed prefs value, so skip
+        # the scan rather than raise while rendering the rollout page
+        try:
+            return super()._validate_desktop_pref_flips_value(
+                value, min_version, max_version
+            )
+        except (AttributeError, TypeError):
+            if isinstance(value, dict) and isinstance(value.get("prefs"), dict):
+                raise
+            return self.ValidateFeatureResult()
+
     def validate_rollout_phases(self, value):
         if self.instance and not self.instance.is_rollout:
             return value

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_ready_for_review_serializer.py
@@ -2749,6 +2749,105 @@ class TestNimbusReviewSerializerSingleFeature(
 
     @parameterized.expand(
         (
+            json.dumps({"prefs": True}),
+            json.dumps({"prefs": "enabled"}),
+            json.dumps({"prefs": []}),
+            json.dumps(True),
+        )
+    )
+    def test_rollout_prefflips_non_object_prefs_reports_errors(self, value):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            feature_configs=[prefflips_feature],
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
+            is_rollout=True,
+            is_sticky=True,
+        )
+        for branch in experiment.treatment_branches:
+            branch.delete()
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=100)
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = value
+        feature_value.save()
+
+        serializer = self.get_rollout_review_serializer(experiment)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("reference_branch", serializer.errors)
+
+    def test_rollout_prefflips_object_prefs_is_validated(self):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            feature_configs=[prefflips_feature],
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
+            is_rollout=True,
+            is_sticky=True,
+        )
+        for branch in experiment.treatment_branches:
+            branch.delete()
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=100)
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps(
+            {"prefs": {"browser.test.pref": {"branch": "user", "value": True}}}
+        )
+        feature_value.save()
+
+        serializer = self.get_rollout_review_serializer(experiment)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_rollout_prefflips_unexpected_type_error_is_reraised(self):
+        prefflips_feature = NimbusFeatureConfigFactory.create_desktop_prefflips_feature()
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.CREATED,
+            application=NimbusExperiment.Application.DESKTOP,
+            firefox_min_version=NimbusExperiment.Version.FIREFOX_129,
+            firefox_max_version=NimbusExperiment.Version.NO_VERSION,
+            feature_configs=[prefflips_feature],
+            channel=NimbusExperiment.Channel.NO_CHANNEL,
+            channels=[NimbusExperiment.Channel.NIGHTLY],
+            is_rollout=True,
+            is_sticky=True,
+        )
+        for branch in experiment.treatment_branches:
+            branch.delete()
+        NimbusRolloutPhaseFactory.create(experiment=experiment, population_percent=100)
+
+        feature_value = experiment.reference_branch.feature_values.get(
+            feature_config=prefflips_feature
+        )
+        feature_value.value = json.dumps(
+            {"prefs": {"browser.test.pref": {"branch": "user", "value": True}}}
+        )
+        feature_value.save()
+
+        with patch.object(
+            NimbusReviewSerializer,
+            "_validate_desktop_pref_flips_value",
+            side_effect=TypeError("unrelated failure"),
+        ):
+            serializer = self.get_rollout_review_serializer(experiment)
+            with self.assertRaises(TypeError):
+                serializer.is_valid()
+
+    @parameterized.expand(
+        (
             NimbusExperiment.Channel.UNBRANDED,
             NimbusExperiment.Channel.NIGHTLY,
             NimbusExperiment.Channel.BETA,

--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -435,6 +435,10 @@ Optional - We expect this to <describe impact> on <core metric>.
     ROLLOUT_ARCHIVED_TOOLTIP = (
         "This rollout is archived. Unarchive it before previewing or launching."
     )
+    ROLLOUT_PREVIEW_UNSUPPORTED_TOOLTIP = (
+        "This rollout uses features that prevent it from being launched to preview. "
+        "We highly recommend QAing this rollout on stage first."
+    )
     ROLLOUT_UNSAVED_CHANGES_CONFIRM = (
         "A section is still open for editing. Click OK to continue and discard "
         "those changes, or Cancel to go back and save them first."

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/card_base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/card_base.html
@@ -1,3 +1,8 @@
 {% block card %}{% endblock %}
 {% include "new/common/sidebar_setup_refresh.html" %}
 {% include "new/rollouts/card_subtitles_refresh.html" %}
+
+{% block cross_card_validation_refresh %}
+  {% include "new/rollouts/rollout_features/validation_errors_refresh.html" %}
+
+{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/sidebar_preview_button.html
@@ -2,18 +2,33 @@
   {% if experiment.active_rollout_stage == 'setup' %}
     {% if experiment.is_draft and not setup_issues_count and not experiment.is_archived %}
       <div class="d-flex flex-column gap-2 mt-2">
-        <button type="button"
-                id="rollout-preview-btn"
-                class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-action-button"
-                hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
-                hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
-                hx-disabled-elt=".sidebar-action-button"
-                {% if editing_card %}hx-confirm="{{ NimbusUIConstants.ROLLOUT_UNSAVED_CHANGES_CONFIRM }}"{% endif %}>
-          {% include "new/common/sidebar_transition_spinner.html" %}
+        {% if experiment.can_publish_to_preview %}
+          <button type="button"
+                  id="rollout-preview-btn"
+                  class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-action-button"
+                  hx-post="{% url 'nimbus-ui-new-draft-to-preview-rollout' experiment.slug %}"
+                  hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'
+                  hx-disabled-elt=".sidebar-action-button"
+                  {% if editing_card %}hx-confirm="{{ NimbusUIConstants.ROLLOUT_UNSAVED_CHANGES_CONFIRM }}"{% endif %}>
+            {% include "new/common/sidebar_transition_spinner.html" %}
 
-          <i class="fa-regular fa-eye"></i>
-          Preview
-        </button>
+            <i class="fa-regular fa-eye"></i>
+            Preview
+          </button>
+        {% else %}
+          <span class="d-inline-block w-100"
+                data-bs-toggle="tooltip"
+                data-bs-title="{{ NimbusUIConstants.ROLLOUT_PREVIEW_UNSUPPORTED_TOOLTIP }}">
+            <button type="button"
+                    id="rollout-preview-btn"
+                    class="btn btn-secondary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 opacity-50"
+                    disabled
+                    aria-disabled="true">
+              <i class="fa-regular fa-eye"></i>
+              Preview
+            </button>
+          </span>
+        {% endif %}
         <button type="button"
                 id="rollout-launch-btn"
                 class="btn btn-primary btn-sm w-100 d-flex align-items-center justify-content-center gap-2 sidebar-action-button"

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/card.html
@@ -26,8 +26,7 @@
       {% empty %}
         <div class="small text-body">—</div>
       {% endfor %}
-      {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
-      {% include "new/common/validation_errors.html" with errors=feature_value_errors %}
+      {% include "new/rollouts/rollout_features/feature_validation_errors.html" %}
 
     </div>
     {# Warn only on feature schema validation failure #}
@@ -94,3 +93,4 @@
 
   {% endif %}
 {% endblock %}
+{% block cross_card_validation_refresh %}{% endblock %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/feature_validation_errors.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/feature_validation_errors.html
@@ -1,0 +1,6 @@
+<div id="rollout-features-feature-errors"
+     {% if oob %}hx-swap-oob="true"{% endif %}>
+  {% include "new/common/validation_errors.html" with errors=validation_errors.feature_configs %}
+  {% include "new/common/validation_errors.html" with errors=feature_value_errors %}
+
+</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/validation_errors_refresh.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/rollout_features/validation_errors_refresh.html
@@ -1,0 +1,4 @@
+{% if hx_swap_oob %}
+  {% include "new/rollouts/rollout_features/feature_validation_errors.html" with oob=True %}
+
+{% endif %}

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -703,6 +703,45 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         )
         self.assertContains(response, "Not launched")
 
+    @mock.patch.object(NimbusExperiment, "get_invalid_fields_errors", return_value={})
+    def test_pref_flips_rollout_disables_only_the_preview_button(self, _mock_errors):
+        experiment = NimbusExperimentFactory.create(
+            is_rollout=True,
+            status=NimbusExperiment.Status.DRAFT,
+            status_next=None,
+            publish_status=NimbusExperiment.PublishStatus.IDLE,
+            application=NimbusExperiment.Application.DESKTOP,
+            feature_configs=[
+                NimbusFeatureConfigFactory.create(
+                    slug=NimbusConstants.DESKTOP_PREFFLIPS_SLUG,
+                    application=NimbusExperiment.Application.DESKTOP,
+                )
+            ],
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertFalse(experiment.can_publish_to_preview)
+        self.assertContains(
+            response, NimbusUIConstants.ROLLOUT_PREVIEW_UNSUPPORTED_TOOLTIP
+        )
+        self.assertNotContains(
+            response,
+            reverse(
+                "nimbus-ui-new-draft-to-preview-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+        self.assertContains(
+            response,
+            reverse(
+                "nimbus-ui-new-draft-to-review-rollout",
+                kwargs={"slug": experiment.slug},
+            ),
+        )
+
     @parameterized.expand(
         [
             (NimbusExperiment.Status.LIVE,),


### PR DESCRIPTION
Because:

- preview does not apply to pref flip rollouts but the preview button stayed active in the new UI
- the rollout page runs review validation on every load and that iterated the prefs value even after the schema check rejected it so a non-object value returned a 500

This commit:

- greys out Preview when can_publish_to_preview is false, reusing the explanation the old UI already shows for this case
- skips the pref conflict scan for a value the schema rejected but re-raises when a well formed one fails so real bugs still surface

Fixes #16962