### PR TITLE
fix(nimbus): Use "deliveries" in rollout audience include/exclude labels

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/card.html
@@ -157,7 +157,7 @@
       </div>
       {# Required experiments #}
       <div>
-        <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing experiments</div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Include users from existing deliveries</div>
         {% with experiment.required_experiments_branches.all as required_branches %}
           {% if required_branches %}
             {% for branch in required_branches %}
@@ -179,7 +179,7 @@
       </div>
       {# Excluded experiments #}
       <div>
-        <div class="text-secondary mb-1" style="font-size: 12px;">Exclude users from other experiments/rollouts</div>
+        <div class="text-secondary mb-1" style="font-size: 12px;">Exclude users from other deliveries</div>
         {% with experiment.excluded_experiments_branches.all as excluded_branches %}
           {% if excluded_branches %}
             {% for branch in excluded_branches %}

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/audience/edit_form.html
@@ -113,7 +113,7 @@
 
     </div>
     <div>
-      <label for="id_name" class="small text-body mb-2">Include users from existing experiments</label>
+      <label for="id_name" class="small text-body mb-2">Include users from existing deliveries</label>
       {{ form.required_experiments_branches }}
       {% if form.required_experiments_branches.errors %}
         <div class="text-danger small mt-1">{{ form.required_experiments_branches.errors|join:", " }}</div>
@@ -123,7 +123,7 @@
       {% endfor %}
     </div>
     <div>
-      <label for="id_name" class="small text-body mb-2">Exclude users from other experiments/rollouts</label>
+      <label for="id_name" class="small text-body mb-2">Exclude users from other deliveries</label>
       {{ form.excluded_experiments_branches }}
       {% if form.excluded_experiments_branches.errors %}
         <div class="text-danger small mt-1">{{ form.excluded_experiments_branches.errors|join:", " }}</div>


### PR DESCRIPTION
Because:

- the rollout Audience section described the include/exclude fields as "experiments" which excludes rollouts

This commit:

- relabels the fields to use the word “deliveries” in both the audience card and its edit form

Fixes #17172