### PR TITLE
fix(nimbus): Advance rollout phase when population percent is unchanged

### DIFF
--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -3691,9 +3691,13 @@ class NimbusChangeLogManager(models.Manager["NimbusChangeLog"]):
 
     def latest_rejection(self):
         change = self.latest_change()
-        if change and change.has_filter(
-            NimbusChangeLog.Filters.IS_REJECTION
-            | NimbusChangeLog.Filters.IS_UPDATE_REJECTION
+        if (
+            change
+            and change.message != NimbusChangeLog.Messages.UPDATED_IN_KINTO
+            and change.has_filter(
+                NimbusChangeLog.Filters.IS_REJECTION
+                | NimbusChangeLog.Filters.IS_UPDATE_REJECTION
+            )
         ):
             return change
 

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -39,6 +39,7 @@ from experimenter.experiments.models import (
     NimbusBranch,
     NimbusBranchScreenshot,
     NimbusBucketRange,
+    NimbusChangeLog,
     NimbusExperiment,
     NimbusExperimentBranchThroughExcluded,
     NimbusExperimentBranchThroughRequired,
@@ -6712,6 +6713,25 @@ class TestNimbusChangeLogManager(TestCase):
         generate_nimbus_changelog(experiment, experiment.owner, "test message")
 
         self.assertIsNone(experiment.changes.latest_rejection())
+
+    def test_unchanged_published_dto_update_is_not_considered_latest_rejection(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
+            is_rollout=True,
+            published_dto={"id": "cool-cat", "test": False},
+        )
+
+        experiment.status = NimbusExperiment.Status.LIVE
+        experiment.publish_status = NimbusExperiment.PublishStatus.IDLE
+        experiment.save()
+        generate_nimbus_changelog(
+            experiment,
+            experiment.owner,
+            NimbusChangeLog.Messages.UPDATED_IN_KINTO,
+        )
+
+        self.assertIsNone(experiment.changes.latest_rejection())
+        self.assertIsNone(experiment.rejection_block)
 
     def test_stale_timeout_not_returned(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/kinto/tasks.py
+++ b/experimenter/experimenter/kinto/tasks.py
@@ -263,12 +263,13 @@ def handle_updating_experiments(applications, records, collection):
         stored_record = experiment.published_dto.copy()
         stored_record.pop("last_modified", None)
 
-        if published_record != stored_record:
+        is_advancing_rollout_phase = (
+            experiment.is_rollout_with_phases
+            and experiment.rollout_phase_next_id is not None
+        )
+
+        if published_record != stored_record or is_advancing_rollout_phase:
             logger.info(f"{experiment} is updated in Kinto".format(experiment=experiment))
-            is_advancing_rollout_phase = (
-                experiment.is_rollout_with_phases
-                and experiment.rollout_phase_next_id is not None
-            )
             with transaction.atomic():
                 next_status = experiment.status_next
                 if experiment.is_rollout_with_phases and experiment.rollout_phase_next_id:

--- a/experimenter/experimenter/kinto/tests/test_tasks.py
+++ b/experimenter/experimenter/kinto/tests/test_tasks.py
@@ -1284,6 +1284,60 @@ class TestNimbusCheckKintoPushQueueByCollection(
             ),
         )
 
+    def test_remote_settings_update_approval_commits_phase_with_unchanged_population(
+        self,
+    ):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,
+            application=NimbusExperiment.Application.FENIX,
+            is_rollout=True,
+        )
+        experiment.published_dto = {"id": experiment.slug}
+        current_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=50
+        )
+        next_phase = NimbusRolloutPhaseFactory.create(
+            experiment=experiment, population_percent=50
+        )
+        experiment.rollout_phase = current_phase
+        experiment.population_percent = current_phase.population_percent
+        experiment.save()
+        experiment.stage_rollout_phase_advance()
+
+        self.assertEqual(experiment.rollout_phase, current_phase)
+        self.assertEqual(experiment.rollout_phase_next, next_phase)
+
+        tasks.handle_updating_experiments(
+            [NimbusExperiment.Application.FENIX],
+            {
+                experiment.slug: {
+                    "id": experiment.slug,
+                    "last_modified": 1,
+                }
+            },
+            experiment.kinto_collection,
+        )
+
+        experiment.refresh_from_db()
+        current_phase.refresh_from_db()
+        next_phase.refresh_from_db()
+        self.assertEqual(experiment.rollout_phase, next_phase)
+        self.assertIsNone(experiment.rollout_phase_next)
+        self.assertEqual(current_phase.end_date, timezone.now().date())
+        self.assertEqual(next_phase.actual_start_date, timezone.now().date())
+        self.assertEqual(experiment.publish_status, NimbusExperiment.PublishStatus.IDLE)
+        self.assertIsNone(experiment.status_next)
+        self.assertTrue(
+            experiment.changes.filter(
+                message=NimbusChangeLog.Messages.UPDATED_IN_KINTO
+            ).exists()
+        )
+        self.assertFalse(
+            experiment.changes.filter(
+                message=NimbusChangeLog.Messages.REJECTED_FROM_KINTO
+            ).exists()
+        )
+
     def test_remote_settings_rejection_reverts_staged_rollout_phase(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(
             NimbusExperimentFactory.Lifecycles.LIVE_APPROVE_WAITING,


### PR DESCRIPTION
Because:

- a phase advance to a phase with the same population percent serializes to an identical Remote Settings record, so handle_updating_experiments never saw a change and skipped committing the advance
- the rollout was then swept by handle_waiting_experiments and reported as "Rejected from Remote Settings" despite being approved

This commit:

- commits the advance when a phase transition is staged regardless of whether the published record changed

Fixes #17108