### PR TITLE
chore(project): enable auto-merge on bot update prs at creation

### DIFF
--- a/.github/workflows/update-configs.yml
+++ b/.github/workflows/update-configs.yml
@@ -56,6 +56,8 @@ jobs:
               gh pr close external-config --repo mozilla/experimenter 2>/dev/null || true
               git push origin external-config -f
               gh pr create -t "chore(nimbus): Update External Configs" -F /tmp/pr-body.txt --base main --head external-config --repo mozilla/experimenter
+              gh pr merge external-config --auto --squash --repo mozilla/experimenter \
+                || echo "::warning::Could not enable auto-merge on external-config; approve and merge it manually."
             fi
           else
             echo "No config changes, skipping"
@@ -109,6 +111,8 @@ jobs:
               gh pr close update-application-services --repo mozilla/experimenter 2>/dev/null || true
               git push origin update-application-services -f
               gh pr create -t "chore(nimbus): Update Application Services" -b "" --base main --head update-application-services --repo mozilla/experimenter
+              gh pr merge update-application-services --auto --squash --repo mozilla/experimenter \
+                || echo "::warning::Could not enable auto-merge on update-application-services; approve and merge it manually."
             fi
           else
             echo "No config changes, skipping"

--- a/scripts/external_integration_updater_script.sh
+++ b/scripts/external_integration_updater_script.sh
@@ -135,6 +135,8 @@ if (($(git status --porcelain | wc -c) > 0)); then
         gh pr close "${BRANCH_NAME}" --repo mozilla/experimenter 2>/dev/null || true
         git push origin -f "${BRANCH_NAME}"
         gh pr create -t "${PR_TITLE}" -b "${PR_BODY}" --base main --head "${BRANCH_NAME}" --repo mozilla/experimenter
+        gh pr merge "${BRANCH_NAME}" --auto --squash --repo mozilla/experimenter \
+            || echo "::warning::Could not enable auto-merge on ${BRANCH_NAME}; approve and merge it manually."
     fi
 else
     echo "No config changes, skipping"


### PR DESCRIPTION
Because

* The update workflows only opened PRs, leaving the merge to be done by hand later
* The bot rotates these PRs several times a day, so the merge step recurs constantly

This commit

* Arms auto-merge on each PR as it is created, using the existing app token
* Warns instead of failing the job when auto-merge cannot be enabled

Fixes #17223