### PR TITLE
perf(project): share one browser per module in the targeting suite and stop freeing disk

### DIFF
--- a/.github/actions/setup-cached-build/action.yml
+++ b/.github/actions/setup-cached-build/action.yml
@@ -1,18 +1,9 @@
 name: "Setup Docker Build"
-description: "Free disk space, set up Buildx, and build megazords/schemas/cirrus images with retry"
+description: "Set up Buildx and build megazords/schemas/cirrus images with retry"
 
 runs:
   using: composite
   steps:
-    - name: Free disk space
-      shell: bash
-      run: |
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /opt/ghc
-        docker system prune -af
-        df -h /
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
       with:

--- a/experimenter/tests/integration/nimbus/conftest.py
+++ b/experimenter/tests/integration/nimbus/conftest.py
@@ -140,13 +140,22 @@ def sensitive_url():
     pass
 
 
-@pytest.fixture
-def firefox_options(firefox_options):
-    """Set Firefox Options."""
+def configure_firefox_options(firefox_options):
     firefox_options.log.level = "trace"
     firefox_options.set_preference("remote.system-access-check.enabled", False)
     firefox_options.add_argument("-remote-allow-system-access")
     return firefox_options
+
+
+def start_firefox(firefox_options):
+    firefox_service = Service("/usr/bin/geckodriver")
+    return webdriver.Firefox(service=firefox_service, options=firefox_options)
+
+
+@pytest.fixture
+def firefox_options(firefox_options):
+    """Set Firefox Options."""
+    return configure_firefox_options(firefox_options)
 
 
 @pytest.fixture
@@ -179,8 +188,7 @@ def selenium(selenium, experiment_slug, kinto_client):
 
 @pytest.fixture
 def driver(firefox_options):
-    firefox_service = Service("/usr/bin/geckodriver")
-    driver = webdriver.Firefox(service=firefox_service, options=firefox_options)
+    driver = start_firefox(firefox_options)
     yield driver
     driver.quit()
 

--- a/experimenter/tests/integration/nimbus/test_desktop_targeting.py
+++ b/experimenter/tests/integration/nimbus/test_desktop_targeting.py
@@ -4,10 +4,20 @@ from functools import cache
 from pathlib import Path
 
 import pytest
+from selenium.webdriver.firefox.options import Options
 
+from nimbus.conftest import configure_firefox_options, start_firefox
 from nimbus.models.base_dataclass import BaseExperimentApplications
 from nimbus.pages.browser import Browser
 from nimbus.utils import helpers
+
+
+@pytest.fixture(scope="module")
+def driver():
+    """Share one browser per module: these tests only read, never mutate state."""
+    driver = start_firefox(configure_firefox_options(Options()))
+    yield driver
+    driver.quit()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
Because

* The targeting suite gave every test its own Firefox purely to evaluate one
  JEXL expression in the chrome context, at 645 browser launches per CI run and
  62.8% of all pytest wall time.
* Those tests never navigate, set a pref, or leave any state behind, so a fresh
  profile per test buys nothing.
* The free-disk-space step ran in all twenty jobs at a 41s median, reclaimed
  1.88GB, and left 105G of 145G available, so nothing in the build set is near
  the disk limit.

This commit

* Overrides the driver fixture at module scope in the desktop targeting suite,
  leaving every other suite on a fresh profile per test.
* Extracts the Firefox option and launch helpers so both fixtures share one
  definition.
* Removes the free-disk-space step from setup-cached-build.

Fixes #17235