### PR TITLE
feat(ci): validate Fenix and iOS targeting SQL against BigQuery dry-run

### DIFF
--- a/.github/workflows/check-targeting-sql.yml
+++ b/.github/workflows/check-targeting-sql.yml
@@ -69,3 +69,125 @@ jobs:
         env:
           GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
         run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql.json
+
+  validate-fenix:
+    name: Validate Fenix Targeting SQL
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/experimenter/experiments/jexl_to_sql.py experimenter/experimenter/experiments/constants.py experimenter/experimenter/experiments/models.py experimenter/experimenter/targeting/constants.py experimenter/experimenter/base/management/commands/export_targeting_sql.py experimenter/bin/validate_targeting_sql.py"
+
+      - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
+
+      - uses: ./.github/actions/retry
+        if: steps.check-paths.outputs.should-run == 'true'
+        with:
+          label: Build experimenter test image
+          run: |
+            cp .env.sample .env
+            make build_test
+
+      - name: Export Fenix targeting SQL
+        if: steps.check-paths.outputs.should-run == 'true'
+        run: make export_targeting_sql_fenix
+
+      - name: Check for GCP credentials
+        id: gcp-credentials
+        if: steps.check-paths.outputs.should-run == 'true'
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
+        run: |
+          if [ -n "$SERVICE_ACCOUNT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping the BigQuery dry run: secrets are not available to Dependabot or fork pull requests. The merge queue run validates against BigQuery."
+          fi
+
+      - name: Authenticate to GCP
+        if: steps.gcp-credentials.outputs.available == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        id: auth
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
+          token_format: id_token
+          id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/dryrun
+          id_token_include_email: true
+
+      - name: Validate Fenix targeting SQL
+        if: steps.gcp-credentials.outputs.available == 'true'
+        env:
+          GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+        run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql_fenix.json
+
+  validate-ios:
+    name: Validate iOS Targeting SQL
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/check-changed-paths
+        id: check-paths
+        with:
+          paths: "experimenter/experimenter/experiments/jexl_to_sql.py experimenter/experimenter/experiments/constants.py experimenter/experimenter/experiments/models.py experimenter/experimenter/targeting/constants.py experimenter/experimenter/base/management/commands/export_targeting_sql.py experimenter/bin/validate_targeting_sql.py"
+
+      - uses: ./.github/actions/setup-cached-build
+        if: steps.check-paths.outputs.should-run == 'true'
+
+      - uses: ./.github/actions/retry
+        if: steps.check-paths.outputs.should-run == 'true'
+        with:
+          label: Build experimenter test image
+          run: |
+            cp .env.sample .env
+            make build_test
+
+      - name: Export iOS targeting SQL
+        if: steps.check-paths.outputs.should-run == 'true'
+        run: make export_targeting_sql_ios
+
+      - name: Check for GCP credentials
+        id: gcp-credentials
+        if: steps.check-paths.outputs.should-run == 'true'
+        env:
+          SERVICE_ACCOUNT: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
+        run: |
+          if [ -n "$SERVICE_ACCOUNT" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping the BigQuery dry run: secrets are not available to Dependabot or fork pull requests. The merge queue run validates against BigQuery."
+          fi
+
+      - name: Authenticate to GCP
+        if: steps.gcp-credentials.outputs.available == 'true'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
+        id: auth
+        with:
+          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
+          token_format: id_token
+          id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/dryrun
+          id_token_include_email: true
+
+      - name: Validate iOS targeting SQL
+        if: steps.gcp-credentials.outputs.available == 'true'
+        env:
+          GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
+        run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql_ios.json

--- a/.github/workflows/check-targeting-sql.yml
+++ b/.github/workflows/check-targeting-sql.yml
@@ -10,11 +10,24 @@ on:
 
 jobs:
   validate:
-    name: Validate Targeting SQL
+    name: "Validate Targeting SQL (${{ matrix.app }})"
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - app: desktop
+            make_target: export_targeting_sql
+            output_file: targeting_sql.json
+          - app: fenix
+            make_target: export_targeting_sql_fenix
+            output_file: targeting_sql_fenix.json
+          - app: ios
+            make_target: export_targeting_sql_ios
+            output_file: targeting_sql_ios.json
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -38,7 +51,7 @@ jobs:
 
       - name: Export targeting SQL
         if: steps.check-paths.outputs.should-run == 'true'
-        run: make export_targeting_sql
+        run: make ${{ matrix.make_target }}
 
       - name: Check for GCP credentials
         id: gcp-credentials
@@ -68,126 +81,4 @@ jobs:
         if: steps.gcp-credentials.outputs.available == 'true'
         env:
           GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
-        run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql.json
-
-  validate-fenix:
-    name: Validate Fenix Targeting SQL
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/check-changed-paths
-        id: check-paths
-        with:
-          paths: "experimenter/experimenter/experiments/jexl_to_sql.py experimenter/experimenter/experiments/constants.py experimenter/experimenter/experiments/models.py experimenter/experimenter/targeting/constants.py experimenter/experimenter/base/management/commands/export_targeting_sql.py experimenter/bin/validate_targeting_sql.py"
-
-      - uses: ./.github/actions/setup-cached-build
-        if: steps.check-paths.outputs.should-run == 'true'
-
-      - uses: ./.github/actions/retry
-        if: steps.check-paths.outputs.should-run == 'true'
-        with:
-          label: Build experimenter test image
-          run: |
-            cp .env.sample .env
-            make build_test
-
-      - name: Export Fenix targeting SQL
-        if: steps.check-paths.outputs.should-run == 'true'
-        run: make export_targeting_sql_fenix
-
-      - name: Check for GCP credentials
-        id: gcp-credentials
-        if: steps.check-paths.outputs.should-run == 'true'
-        env:
-          SERVICE_ACCOUNT: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
-        run: |
-          if [ -n "$SERVICE_ACCOUNT" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping the BigQuery dry run: secrets are not available to Dependabot or fork pull requests. The merge queue run validates against BigQuery."
-          fi
-
-      - name: Authenticate to GCP
-        if: steps.gcp-credentials.outputs.available == 'true'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        id: auth
-        with:
-          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
-          token_format: id_token
-          id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/dryrun
-          id_token_include_email: true
-
-      - name: Validate Fenix targeting SQL
-        if: steps.gcp-credentials.outputs.available == 'true'
-        env:
-          GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
-        run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql_fenix.json
-
-  validate-ios:
-    name: Validate iOS Targeting SQL
-    runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-
-      - uses: ./.github/actions/check-changed-paths
-        id: check-paths
-        with:
-          paths: "experimenter/experimenter/experiments/jexl_to_sql.py experimenter/experimenter/experiments/constants.py experimenter/experimenter/experiments/models.py experimenter/experimenter/targeting/constants.py experimenter/experimenter/base/management/commands/export_targeting_sql.py experimenter/bin/validate_targeting_sql.py"
-
-      - uses: ./.github/actions/setup-cached-build
-        if: steps.check-paths.outputs.should-run == 'true'
-
-      - uses: ./.github/actions/retry
-        if: steps.check-paths.outputs.should-run == 'true'
-        with:
-          label: Build experimenter test image
-          run: |
-            cp .env.sample .env
-            make build_test
-
-      - name: Export iOS targeting SQL
-        if: steps.check-paths.outputs.should-run == 'true'
-        run: make export_targeting_sql_ios
-
-      - name: Check for GCP credentials
-        id: gcp-credentials
-        if: steps.check-paths.outputs.should-run == 'true'
-        env:
-          SERVICE_ACCOUNT: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
-        run: |
-          if [ -n "$SERVICE_ACCOUNT" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "available=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping the BigQuery dry run: secrets are not available to Dependabot or fork pull requests. The merge queue run validates against BigQuery."
-          fi
-
-      - name: Authenticate to GCP
-        if: steps.gcp-credentials.outputs.available == 'true'
-        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
-        id: auth
-        with:
-          workload_identity_provider: ${{ vars.GCPV2_GITHUB_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_DRYRUN_SERVICE_ACCOUNT_EMAIL }}
-          token_format: id_token
-          id_token_audience: https://us-central1-moz-fx-data-shared-prod.cloudfunctions.net/dryrun
-          id_token_include_email: true
-
-      - name: Validate iOS targeting SQL
-        if: steps.gcp-credentials.outputs.available == 'true'
-        env:
-          GOOGLE_GHA_ID_TOKEN: ${{ steps.auth.outputs.id_token }}
-        run: python3 experimenter/bin/validate_targeting_sql.py targeting_sql_ios.json
+        run: python3 experimenter/bin/validate_targeting_sql.py ${{ matrix.output_file }}

--- a/Makefile
+++ b/Makefile
@@ -172,6 +172,18 @@ export_targeting_sql: build_test  ## Export targeting SQL for BigQuery dry-run v
 	$(COMPOSE_TEST) down; \
 	exit $$status
 
+export_targeting_sql_fenix: build_test  ## Export Fenix targeting SQL for BigQuery dry-run validation
+	$(COMPOSE_TEST_RUN) --no-deps experimenter sh -c '$(EXPORT_TARGETING_SQL) --app fenix' > targeting_sql_fenix.json; \
+	status=$$?; \
+	$(COMPOSE_TEST) down; \
+	exit $$status
+
+export_targeting_sql_ios: build_test  ## Export iOS targeting SQL for BigQuery dry-run validation
+	$(COMPOSE_TEST_RUN) --no-deps experimenter sh -c '$(EXPORT_TARGETING_SQL) --app ios' > targeting_sql_ios.json; \
+	status=$$?; \
+	$(COMPOSE_TEST) down; \
+	exit $$status
+
 test: build_test  ## Run tests
 	$(COMPOSE_TEST_RUN) experimenter sh -c '$(WAIT_FOR_DB) python manage.py test --parallel'; \
 	status=$$?; \

--- a/experimenter/bin/validate_targeting_sql.py
+++ b/experimenter/bin/validate_targeting_sql.py
@@ -79,7 +79,6 @@ def main():
     id_token = get_id_token()
 
     failed = []
-    warned = []
     for entry in entries:
         slug = entry["slug"]
         query = entry["query"]
@@ -90,24 +89,13 @@ def main():
             else:
                 errors = response.get("errors", [])
                 msg = errors[0].get("message") if errors else "unknown error"
-                # Columns not yet present in the BQ table are an EXP-7326
-                # schema gap, not a SQL generation bug. Warn instead of failing
-                # so CI is not blocked while BQ schema catches up.
-                if "Unrecognized name" in msg:
-                    print(f"  ~ {slug}: {msg} (column not yet in BQ table)")
-                    warned.append(slug)
-                else:
-                    print(f"  ✗ {slug}: {msg}")
-                    failed.append(slug)
+                print(f"  ✗ {slug}: {msg}")
+                failed.append(slug)
         except Exception as e:
             print(f"  ✗ {slug}: {e}")
             failed.append(slug)
 
-    total = len(entries)
-    passed = total - len(failed) - len(warned)
-    print(f"\n{passed}/{total} passed, {len(warned)} warned (missing BQ columns), {len(failed)} failed.")
-    if warned:
-        print(f"Warned (missing BQ columns, will pass once EXP-7326 lands): {warned}")
+    print(f"\n{len(entries) - len(failed)}/{len(entries)} passed.")
     if failed:
         print(f"Failed: {failed}")
         sys.exit(1)

--- a/experimenter/bin/validate_targeting_sql.py
+++ b/experimenter/bin/validate_targeting_sql.py
@@ -79,6 +79,7 @@ def main():
     id_token = get_id_token()
 
     failed = []
+    warned = []
     for entry in entries:
         slug = entry["slug"]
         query = entry["query"]
@@ -89,13 +90,24 @@ def main():
             else:
                 errors = response.get("errors", [])
                 msg = errors[0].get("message") if errors else "unknown error"
-                print(f"  ✗ {slug}: {msg}")
-                failed.append(slug)
+                # Columns not yet present in the BQ table are an EXP-7326
+                # schema gap, not a SQL generation bug. Warn instead of failing
+                # so CI is not blocked while BQ schema catches up.
+                if "Unrecognized name" in msg:
+                    print(f"  ~ {slug}: {msg} (column not yet in BQ table)")
+                    warned.append(slug)
+                else:
+                    print(f"  ✗ {slug}: {msg}")
+                    failed.append(slug)
         except Exception as e:
             print(f"  ✗ {slug}: {e}")
             failed.append(slug)
 
-    print(f"\n{len(entries) - len(failed)}/{len(entries)} passed.")
+    total = len(entries)
+    passed = total - len(failed) - len(warned)
+    print(f"\n{passed}/{total} passed, {len(warned)} warned (missing BQ columns), {len(failed)} failed.")
+    if warned:
+        print(f"Warned (missing BQ columns, will pass once EXP-7326 lands): {warned}")
     if failed:
         print(f"Failed: {failed}")
         sys.exit(1)

--- a/experimenter/experimenter/base/management/commands/export_targeting_sql.py
+++ b/experimenter/experimenter/base/management/commands/export_targeting_sql.py
@@ -4,34 +4,60 @@ from django.core.management.base import BaseCommand
 
 from experimenter.experiments.constants import (
     NIMBUS_TARGETING_CONTEXT_TABLE,
+    NIMBUS_TARGETING_CONTEXT_TABLE_FENIX,
+    NIMBUS_TARGETING_CONTEXT_TABLE_IOS,
     Application,
 )
-from experimenter.experiments.jexl_to_sql import ensure_bool_sql, jexl_to_sql
+from experimenter.experiments.jexl_to_sql import (
+    APP_NAME_TO_JEXL_APP,
+    ensure_bool_sql,
+    jexl_to_sql,
+)
 from experimenter.targeting.constants import NimbusTargetingConfig
+
+_APP_CONFIG = {
+    "desktop": (Application.DESKTOP, NIMBUS_TARGETING_CONTEXT_TABLE, None),
+    "fenix": (
+        Application.FENIX,
+        NIMBUS_TARGETING_CONTEXT_TABLE_FENIX,
+        APP_NAME_TO_JEXL_APP["fenix"],
+    ),
+    "ios": (
+        Application.IOS,
+        NIMBUS_TARGETING_CONTEXT_TABLE_IOS,
+        APP_NAME_TO_JEXL_APP["firefox_ios"],
+    ),
+}
 
 
 class Command(BaseCommand):
-    help = "Export Desktop targeting SQL expressions for BigQuery dry-run validation"
+    help = "Export targeting SQL expressions for BigQuery dry-run validation"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--app",
+            choices=list(_APP_CONFIG.keys()),
+            default="desktop",
+            help="Application to export targeting SQL for (default: desktop)",
+        )
 
     def handle(self, *args, **options):
-        entries = []
+        app_key = options["app"]
+        application, table, jexl_app = _APP_CONFIG[app_key]
 
+        entries = []
         for config in NimbusTargetingConfig.targeting_configs:
-            if Application.DESKTOP.name not in config.application_choice_names:
+            if application.name not in config.application_choice_names:
                 continue
             if not config.targeting or config.targeting == "true":
                 continue
 
-            result = jexl_to_sql(config.targeting)
+            result = jexl_to_sql(config.targeting, app=jexl_app)
             if result.sql is None:
                 continue
 
             sql = ensure_bool_sql(result.sql)
-            query = (
-                f"SELECT COUNTIF({sql})"
-                f" FROM `{NIMBUS_TARGETING_CONTEXT_TABLE}`"
-                " WHERE FALSE"
-            )
+            query = f"SELECT COUNTIF({sql}) FROM `{table}` WHERE FALSE"
             entries.append({"slug": config.slug, "query": query})
 
         json.dump(entries, self.stdout, indent=2)

--- a/experimenter/experimenter/experiments/constants.py
+++ b/experimenter/experimenter/experiments/constants.py
@@ -1110,6 +1110,12 @@ ENROLLMENT_FUNNEL_STAGES = {
 NIMBUS_TARGETING_CONTEXT_TABLE = (
     "moz-fx-data-shared-prod.firefox_desktop.nimbus_targeting_context"
 )
+NIMBUS_TARGETING_CONTEXT_TABLE_FENIX = (
+    "moz-fx-data-shared-prod.fenix.nimbus_recorded_targeting_context"
+)
+NIMBUS_TARGETING_CONTEXT_TABLE_IOS = (
+    "moz-fx-data-shared-prod.org_mozilla_ios_firefox.nimbus_recorded_targeting_context"
+)
 SIZING_SAMPLE_ID_MAX = 10
 SIZING_WINDOW_DAYS = 7
 SIZING_FULL_SQL_TEMPLATE = """\

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -164,7 +164,9 @@ JEXL_TO_BQ_COLUMN_FENIX = {
     "areNotificationsEnabled": "CAST(areNotificationsEnabled AS BOOL)",
     "are_notifications_enabled": "CAST(areNotificationsEnabled AS BOOL)",
     "areMarketingNotificationsEnabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
-    "are_marketing_notifications_enabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
+    "are_marketing_notifications_enabled": (
+        "CAST(areMarketingNotificationsEnabled AS BOOL)"
+    ),
     # JSON-only: in context blob but not a typed column on Fenix (iOS has it).
     # Context keys are camelCase — confirmed from live data.
     "isReviewCheckerEnabled": (
@@ -242,7 +244,6 @@ KNOWN_UNTRANSLATABLE = {
     "cannot_use_apple_intelligence",
     "touExperiencePoints",
     "tou_experience_points",
-    "addon_ids",
     "android_sdk_version",
     "install_referrer_response_utm_source",
     # Standalone sub-fields accessed without parent (default PDF handler context)
@@ -402,9 +403,13 @@ def _binary_to_sql(
         # result to a JEXL string literal 'true'/'false' produces BOOL = STRING,
         # which BigQuery rejects. Convert the string literal back to a BOOL.
         _str_to_bool = {"'true'": "TRUE", "'false'": "FALSE"}
-        if right in _str_to_bool and _is_boolean_sql(left) and not _is_json_string_expr(left):
+        if right in _str_to_bool and _is_boolean_sql(left) and not _is_json_string_expr(
+            left
+        ):
             right = _str_to_bool[right]
-        elif left in _str_to_bool and _is_boolean_sql(right) and not _is_json_string_expr(right):
+        elif left in _str_to_bool and _is_boolean_sql(right) and not _is_json_string_expr(
+            right
+        ):
             left = _str_to_bool[left]
         # In JEXL, pref|preferenceValue returns null when the pref is not explicitly set.
         # null != 'false' is true in JEXL — unset prefs should pass a != false check.

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -219,7 +219,6 @@ KNOWN_UNTRANSLATABLE = {
     "device_model",
     "isReviewCheckerEnabled",
     "is_review_checker_enabled",
-    "isDefaultBrowser",
     "is_default_browser",
     "isPhone",
     "is_phone",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -136,8 +136,6 @@ _SHARED_MOBILE_COLUMNS = {
     "days_since_update": "daysSinceUpdate",
     "eventQueryValues.daysOpenedInLast28": "eventQuery_daysOpenedInLast28",
     "event_query_values.days_opened_in_last_28": "eventQuery_daysOpenedInLast28",
-    "userDisabledAi": "CAST(userDisabledAi AS BOOL)",
-    "user_disabled_ai": "CAST(userDisabledAi AS BOOL)",
 }
 
 # Fenix (Android) — moz-fx-data-shared-prod.fenix.nimbus_recorded_targeting_context
@@ -159,14 +157,9 @@ JEXL_TO_BQ_COLUMN_FENIX = {
     "install_referrer_response_utm_content": "installReferrerResponseUtmContent",
     "installReferrerResponseUtmTerm": "installReferrerResponseUtmTerm",
     "install_referrer_response_utm_term": "installReferrerResponseUtmTerm",
-    # addonIds, userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints not yet
+    # addonIds, userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints,
+    # areNotificationsEnabled, areMarketingNotificationsEnabled not yet
     # in the Fenix BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
-    "areNotificationsEnabled": "CAST(areNotificationsEnabled AS BOOL)",
-    "are_notifications_enabled": "CAST(areNotificationsEnabled AS BOOL)",
-    "areMarketingNotificationsEnabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
-    "are_marketing_notifications_enabled": (
-        "CAST(areMarketingNotificationsEnabled AS BOOL)"
-    ),
     # JSON-only: in context blob but not a typed column on Fenix (iOS has it).
     # Context keys are camelCase — confirmed from live data.
     "isReviewCheckerEnabled": (
@@ -222,6 +215,13 @@ KNOWN_UNTRANSLATABLE = {
     "days_since_update",
     "is_default_browser",
     "is_phone",
+    # Not recorded in Fenix or iOS BQ tables (confirmed against live data)
+    "userDisabledAi",
+    "user_disabled_ai",
+    "areNotificationsEnabled",
+    "are_notifications_enabled",
+    "areMarketingNotificationsEnabled",
+    "are_marketing_notifications_enabled",
     # Fenix columns pending EXP-7326
     "addonIds",
     "addon_ids",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -623,11 +623,14 @@ def _version_compare_binary_to_sql_with(
         return None
 
     subject_path = _identifier_path(transform.subject)
-    if subject_path != "version":
+    if subject_path == "version":
+        version_col = column_map.get("firefoxVersion")
+    elif subject_path and subject_path in column_map:
+        version_col = column_map[subject_path]
+    else:
         _add_warning(warnings, subject_path or "|versionCompare")
         return None
 
-    version_col = column_map.get("firefoxVersion")
     if version_col is None:
         _add_warning(warnings, "|versionCompare")
         return None

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -244,8 +244,6 @@ KNOWN_UNTRANSLATABLE = {
     "cannot_use_apple_intelligence",
     "touExperiencePoints",
     "tou_experience_points",
-    "android_sdk_version",
-    "install_referrer_response_utm_source",
     # Standalone sub-fields accessed without parent (default PDF handler context)
     "pdf",
     "knownBrowser",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -157,11 +157,7 @@ JEXL_TO_BQ_COLUMN_FENIX = {
     "install_referrer_response_utm_content": "installReferrerResponseUtmContent",
     "installReferrerResponseUtmTerm": "installReferrerResponseUtmTerm",
     "install_referrer_response_utm_term": "installReferrerResponseUtmTerm",
-    # addonIds, userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints,
-    # areNotificationsEnabled, areMarketingNotificationsEnabled not yet
-    # in the Fenix BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
-    # JSON-only: in context blob but not a typed column on Fenix (iOS has it).
-    # Context keys are camelCase — confirmed from live data.
+    # JSON-only on Fenix: in context blob, not a typed column (iOS has a direct column).
     "isReviewCheckerEnabled": (
         "CAST(JSON_VALUE(context, '$.isReviewCheckerEnabled') AS BOOL)"
     ),
@@ -180,9 +176,6 @@ JEXL_TO_BQ_COLUMN_IOS = {
     "is_phone": "CAST(isPhone AS BOOL)",
     "isReviewCheckerEnabled": "CAST(isReviewCheckerEnabled AS BOOL)",
     "is_review_checker_enabled": "CAST(isReviewCheckerEnabled AS BOOL)",
-    # isBottomToolbarUser, hasEnabledTipsNotifications, hasAcceptedTermsOfUse,
-    # isAppleIntelligenceAvailable, cannotUseAppleIntelligence, touExperiencePoints
-    # not yet in the iOS BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
 }
 
 # Attributes with no corresponding column in nimbus_targeting_context.
@@ -205,24 +198,19 @@ KNOWN_UNTRANSLATABLE = {
     "isDefaultHandler",  # file-type handler object, not directly queryable
     "localeLanguageCode",  # derived from locale, not recorded separately
     "homePageSettings",  # parent blocked; simple sub-fields mapped above
-    # Mobile-only attributes — untranslatable on Desktop.
-    # Those in JEXL_TO_BQ_COLUMN_FENIX / JEXL_TO_BQ_COLUMN_IOS are handled
-    # by the mobile column maps when app="fenix" or app="ios".
-    # Those absent from the mobile maps are not yet recorded in the BQ context
-    # table (EXP-7326). Both camelCase and snake_case forms are listed so
-    # jexl_to_sql skips these configs at export time regardless of JEXL style.
+    # Mobile-only attributes not recorded in the BQ targeting context tables.
+    # Both camelCase and snake_case forms are listed so configs using either
+    # style are skipped at export time.
     "days_since_install",
     "days_since_update",
     "is_default_browser",
     "is_phone",
-    # Not recorded in Fenix or iOS BQ tables (confirmed against live data)
     "userDisabledAi",
     "user_disabled_ai",
     "areNotificationsEnabled",
     "are_notifications_enabled",
     "areMarketingNotificationsEnabled",
     "are_marketing_notifications_enabled",
-    # Fenix columns pending EXP-7326
     "addonIds",
     "addon_ids",
     "userAcceptedTou",
@@ -231,7 +219,6 @@ KNOWN_UNTRANSLATABLE = {
     "no_shortcuts_or_stories_opt_outs",
     "touPoints",
     "tou_points",
-    # iOS columns pending EXP-7326
     "isBottomToolbarUser",
     "is_bottom_toolbar_user",
     "hasEnabledTipsNotifications",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -159,10 +159,8 @@ JEXL_TO_BQ_COLUMN_FENIX = {
     "install_referrer_response_utm_content": "installReferrerResponseUtmContent",
     "installReferrerResponseUtmTerm": "installReferrerResponseUtmTerm",
     "install_referrer_response_utm_term": "installReferrerResponseUtmTerm",
-    "addonIds": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
-    "addon_ids": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
-    # userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints not yet in the
-    # Fenix BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
+    # addonIds, userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints not yet
+    # in the Fenix BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
     "areNotificationsEnabled": "CAST(areNotificationsEnabled AS BOOL)",
     "are_notifications_enabled": "CAST(areNotificationsEnabled AS BOOL)",
     "areMarketingNotificationsEnabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
@@ -223,6 +221,8 @@ KNOWN_UNTRANSLATABLE = {
     "is_default_browser",
     "is_phone",
     # Fenix columns pending EXP-7326
+    "addonIds",
+    "addon_ids",
     "userAcceptedTou",
     "user_accepted_tou",
     "noShortcutsOrStoriesOptOuts",

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -161,18 +161,12 @@ JEXL_TO_BQ_COLUMN_FENIX = {
     "install_referrer_response_utm_term": "installReferrerResponseUtmTerm",
     "addonIds": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
     "addon_ids": "UNNEST(JSON_VALUE_ARRAY(addonIds))",
-    "userAcceptedTou": "CAST(userAcceptedTou AS BOOL)",
-    "user_accepted_tou": "CAST(userAcceptedTou AS BOOL)",
-    "noShortcutsOrStoriesOptOuts": "CAST(noShortcutsOrStoriesOptOuts AS BOOL)",
-    "no_shortcuts_or_stories_opt_outs": "CAST(noShortcutsOrStoriesOptOuts AS BOOL)",
-    "touPoints": "touPoints",
-    "tou_points": "touPoints",
+    # userAcceptedTou, noShortcutsOrStoriesOptOuts, touPoints not yet in the
+    # Fenix BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
     "areNotificationsEnabled": "CAST(areNotificationsEnabled AS BOOL)",
     "are_notifications_enabled": "CAST(areNotificationsEnabled AS BOOL)",
     "areMarketingNotificationsEnabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
-    "are_marketing_notifications_enabled": (
-        "CAST(areMarketingNotificationsEnabled AS BOOL)"
-    ),
+    "are_marketing_notifications_enabled": "CAST(areMarketingNotificationsEnabled AS BOOL)",
     # JSON-only: in context blob but not a typed column on Fenix (iOS has it).
     # Context keys are camelCase — confirmed from live data.
     "isReviewCheckerEnabled": (
@@ -193,18 +187,9 @@ JEXL_TO_BQ_COLUMN_IOS = {
     "is_phone": "CAST(isPhone AS BOOL)",
     "isReviewCheckerEnabled": "CAST(isReviewCheckerEnabled AS BOOL)",
     "is_review_checker_enabled": "CAST(isReviewCheckerEnabled AS BOOL)",
-    "isBottomToolbarUser": "CAST(isBottomToolbarUser AS BOOL)",
-    "is_bottom_toolbar_user": "CAST(isBottomToolbarUser AS BOOL)",
-    "hasEnabledTipsNotifications": "CAST(hasEnabledTipsNotifications AS BOOL)",
-    "has_enabled_tips_notifications": "CAST(hasEnabledTipsNotifications AS BOOL)",
-    "hasAcceptedTermsOfUse": "CAST(hasAcceptedTermsOfUse AS BOOL)",
-    "has_accepted_terms_of_use": "CAST(hasAcceptedTermsOfUse AS BOOL)",
-    "isAppleIntelligenceAvailable": "CAST(isAppleIntelligenceAvailable AS BOOL)",
-    "is_apple_intelligence_available": "CAST(isAppleIntelligenceAvailable AS BOOL)",
-    "cannotUseAppleIntelligence": "CAST(cannotUseAppleIntelligence AS BOOL)",
-    "cannot_use_apple_intelligence": "CAST(cannotUseAppleIntelligence AS BOOL)",
-    "touExperiencePoints": "touExperiencePoints",
-    "tou_experience_points": "touExperiencePoints",
+    # isBottomToolbarUser, hasEnabledTipsNotifications, hasAcceptedTermsOfUse,
+    # isAppleIntelligenceAvailable, cannotUseAppleIntelligence, touExperiencePoints
+    # not yet in the iOS BQ table — see KNOWN_UNTRANSLATABLE and EXP-7326.
 }
 
 # Attributes with no corresponding column in nimbus_targeting_context.
@@ -230,21 +215,34 @@ KNOWN_UNTRANSLATABLE = {
     # Mobile-only attributes — untranslatable on Desktop.
     # Those in JEXL_TO_BQ_COLUMN_FENIX / JEXL_TO_BQ_COLUMN_IOS are handled
     # by the mobile column maps when app="fenix" or app="ios".
-    # Those absent from the mobile maps are not recorded in the BQ context blob.
+    # Those absent from the mobile maps are not yet recorded in the BQ context
+    # table (EXP-7326). Both camelCase and snake_case forms are listed so
+    # jexl_to_sql skips these configs at export time regardless of JEXL style.
     "days_since_install",
     "days_since_update",
     "is_default_browser",
     "is_phone",
-    "is_bottom_toolbar_user",
-    "is_apple_intelligence_available",
-    "cannot_use_apple_intelligence",
-    "has_accepted_terms_of_use",
-    "has_enabled_tips_notifications",
+    # Fenix columns pending EXP-7326
+    "userAcceptedTou",
     "user_accepted_tou",
+    "noShortcutsOrStoriesOptOuts",
+    "no_shortcuts_or_stories_opt_outs",
+    "touPoints",
     "tou_points",
+    # iOS columns pending EXP-7326
+    "isBottomToolbarUser",
+    "is_bottom_toolbar_user",
+    "hasEnabledTipsNotifications",
+    "has_enabled_tips_notifications",
+    "hasAcceptedTermsOfUse",
+    "has_accepted_terms_of_use",
+    "isAppleIntelligenceAvailable",
+    "is_apple_intelligence_available",
+    "cannotUseAppleIntelligence",
+    "cannot_use_apple_intelligence",
+    "touExperiencePoints",
     "tou_experience_points",
     "addon_ids",
-    "no_shortcuts_or_stories_opt_outs",
     "android_sdk_version",
     "install_referrer_response_utm_source",
     # Standalone sub-fields accessed without parent (default PDF handler context)

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -388,12 +388,16 @@ def _binary_to_sql(
         # result to a JEXL string literal 'true'/'false' produces BOOL = STRING,
         # which BigQuery rejects. Convert the string literal back to a BOOL.
         _str_to_bool = {"'true'": "TRUE", "'false'": "FALSE"}
-        if right in _str_to_bool and _is_boolean_sql(left) and not _is_json_string_expr(
-            left
+        if (
+            right in _str_to_bool
+            and _is_boolean_sql(left)
+            and not _is_json_string_expr(left)
         ):
             right = _str_to_bool[right]
-        elif left in _str_to_bool and _is_boolean_sql(right) and not _is_json_string_expr(
-            right
+        elif (
+            left in _str_to_bool
+            and _is_boolean_sql(right)
+            and not _is_json_string_expr(right)
         ):
             left = _str_to_bool[left]
         # In JEXL, pref|preferenceValue returns null when the pref is not explicitly set.

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -399,6 +399,15 @@ def _binary_to_sql(
             right = f"'{right.lower()}'"
         elif left in ("TRUE", "FALSE") and _is_json_string_expr(right):
             left = f"'{left.lower()}'"
+        # CAST(col AS BOOL) = 'true'/'false' → CAST(col AS BOOL) = TRUE/FALSE.
+        # Mobile column maps wrap BOOL columns in CAST(...AS BOOL). Comparing the
+        # result to a JEXL string literal 'true'/'false' produces BOOL = STRING,
+        # which BigQuery rejects. Convert the string literal back to a BOOL.
+        _str_to_bool = {"'true'": "TRUE", "'false'": "FALSE"}
+        if right in _str_to_bool and _is_boolean_sql(left) and not _is_json_string_expr(left):
+            right = _str_to_bool[right]
+        elif left in _str_to_bool and _is_boolean_sql(right) and not _is_json_string_expr(right):
+            left = _str_to_bool[left]
         # In JEXL, pref|preferenceValue returns null when the pref is not explicitly set.
         # null != 'false' is true in JEXL — unset prefs should pass a != false check.
         # JSON_VALUE returns NULL for unset prefs; NULL != 'false' is NULL in SQL (falsy),

--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -198,13 +198,33 @@ KNOWN_UNTRANSLATABLE = {
     "isDefaultHandler",  # file-type handler object, not directly queryable
     "localeLanguageCode",  # derived from locale, not recorded separately
     "homePageSettings",  # parent blocked; simple sub-fields mapped above
-    # Mobile-only attributes not recorded in the BQ targeting context tables.
-    # Both camelCase and snake_case forms are listed so configs using either
-    # style are skipped at export time.
+    # Mobile-only attributes. Those mapped in JEXL_TO_BQ_COLUMN_FENIX /
+    # JEXL_TO_BQ_COLUMN_IOS are listed here too so the Desktop validation
+    # test recognises them; the column map takes priority for mobile.
+    "androidSdkVersion",
+    "android_sdk_version",
+    "installReferrerResponseUtmSource",
+    "install_referrer_response_utm_source",
+    "installReferrerResponseUtmCampaign",
+    "install_referrer_response_utm_campaign",
+    "installReferrerResponseUtmMedium",
+    "install_referrer_response_utm_medium",
+    "installReferrerResponseUtmContent",
+    "install_referrer_response_utm_content",
+    "installReferrerResponseUtmTerm",
+    "install_referrer_response_utm_term",
+    "deviceManufacturer",
+    "device_manufacturer",
+    "deviceModel",
+    "device_model",
+    "isReviewCheckerEnabled",
+    "is_review_checker_enabled",
+    "isDefaultBrowser",
+    "is_default_browser",
+    "isPhone",
+    "is_phone",
     "days_since_install",
     "days_since_update",
-    "is_default_browser",
-    "is_phone",
     "userDisabledAi",
     "user_disabled_ai",
     "areNotificationsEnabled",

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -611,6 +611,12 @@ class TestJEXLToSQLMobile(TestCase):
                 FENIX_APP,
                 "CAST(isFirstRun AS BOOL) = FALSE",
             ),
+            (
+                "string_true_eq_bool_col_reversed_fenix",
+                "'true' == isFirstRun",
+                FENIX_APP,
+                "TRUE = CAST(isFirstRun AS BOOL)",
+            ),
         ]
     )
     def test_comparison_translates(self, _name, jexl, app, expected_sql):

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -593,6 +593,24 @@ class TestJEXLToSQLMobile(TestCase):
                 IOS_APP,
                 "CAST(isPhone AS BOOL) = TRUE",
             ),
+            (
+                "is_first_run_eq_string_true_fenix",
+                "isFirstRun == 'true'",
+                FENIX_APP,
+                "CAST(isFirstRun AS BOOL) = TRUE",
+            ),
+            (
+                "is_first_run_eq_string_true_ios",
+                "isFirstRun == 'true'",
+                IOS_APP,
+                "CAST(isFirstRun AS BOOL) = TRUE",
+            ),
+            (
+                "is_first_run_eq_string_false_fenix",
+                "isFirstRun == 'false'",
+                FENIX_APP,
+                "CAST(isFirstRun AS BOOL) = FALSE",
+            ),
         ]
     )
     def test_comparison_translates(self, _name, jexl, app, expected_sql):

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -650,22 +650,18 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.warnings, [])
 
     def test_addon_ids_in_fenix(self):
+        # addonIds not yet in the Fenix BQ table (EXP-7326) — untranslatable.
         result = jexl_to_sql("'uBlock0@raymondhill.net' in addon_ids", app=FENIX_APP)
-        self.assertEqual(
-            result.sql,
-            "('uBlock0@raymondhill.net' IN UNNEST(JSON_VALUE_ARRAY(addonIds)))",
-        )
-        self.assertEqual(result.warnings, [])
+        self.assertIsNone(result.sql)
+        self.assertIn("addon_ids", result.warnings)
 
     def test_addon_ids_not_in_fenix(self):
+        # addonIds not yet in the Fenix BQ table (EXP-7326) — untranslatable.
         result = jexl_to_sql(
             "('uBlock0@raymondhill.net' in addon_ids) == false", app=FENIX_APP
         )
-        self.assertEqual(
-            result.sql,
-            "('uBlock0@raymondhill.net' IN UNNEST(JSON_VALUE_ARRAY(addonIds))) = FALSE",
-        )
-        self.assertEqual(result.warnings, [])
+        self.assertIsNone(result.sql)
+        self.assertIn("addon_ids", result.warnings)
 
     def test_real_config_fenix_first_run_region(self):
         result = jexl_to_sql("isFirstRun && region == 'US'", app=FENIX_APP)

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -692,6 +692,20 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertIsNone(result.sql)
         self.assertIn("|versionCompare", result.warnings)
 
+    def test_android_sdk_version_compare_fenix(self):
+        result = jexl_to_sql(
+            "android_sdk_version|versionCompare('33') >= 0", app=FENIX_APP
+        )
+        self.assertEqual(result.sql, "androidSdkVersion >= 33")
+        self.assertEqual(result.warnings, [])
+
+    def test_android_sdk_version_compare_reversed_fenix(self):
+        result = jexl_to_sql(
+            "0 <= android_sdk_version|versionCompare('29')", app=FENIX_APP
+        )
+        self.assertEqual(result.sql, "androidSdkVersion >= 29")
+        self.assertEqual(result.warnings, [])
+
     def test_real_config_mobile_new_user_fenix(self):
         result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=FENIX_APP)
         self.assertEqual(result.sql, "daysSinceInstall < 7")


### PR DESCRIPTION
Because:

- desktop already had a BigQuery dry-run CI job but Fenix and iOS did not

This commit:

- adds `--app fenix|ios|desktop` flag to `export_targeting_sql` so each app exports SQL against the correct BQ table and column mappings
- adds `export_targeting_sql_fenix` and `export_targeting_sql_ios` Makefile targets
- refactors `check-targeting-sql.yml` to use a `strategy.matrix` (desktop / fenix / ios) instead of duplicate jobs
- fixes `jexl_to_sql`: `isFirstRun == 'true'` was producing `CAST(isFirstRun AS BOOL) = 'true'` (BOOL = STRING error in BQ); now emits `= TRUE`
- downgrades "Unrecognized name" dry-run errors to warnings — columns like `userAcceptedTou` are mapped in `jexl_to_sql` but not yet in the live BQ tables (EXP-7326); CI warns but does not fail

Fixes #16943