### PR TITLE
feat(nimbus): add reviewers, editors, jetstream error counts, and conclusion recommendations to reports

### DIFF
--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1237,6 +1237,35 @@
           "takeaways_summary": {
             "type": "string",
             "nullable": true
+          },
+          "conclusion_recommendations": {
+            "type": "string",
+            "readOnly": true
+          },
+          "project_impact": {
+            "enum": [
+              "HIGH",
+              "MODERATE",
+              "TARGETED"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "next_steps": {
+            "type": "string",
+            "nullable": true
+          },
+          "reviewer_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "editor_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "jetstream_errors_count": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [
@@ -1279,6 +1308,14 @@
             "type": "boolean"
           },
           "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "reviewer_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "editor_emails": {
             "type": "string",
             "readOnly": true
           },
@@ -1471,6 +1508,10 @@
             "readOnly": true
           },
           "results_data": {
+            "type": "string",
+            "readOnly": true
+          },
+          "jetstream_errors_by_key": {
             "type": "string",
             "readOnly": true
           }

--- a/docs/experimenter/openapi-schema.json
+++ b/docs/experimenter/openapi-schema.json
@@ -1263,7 +1263,7 @@
             "type": "string",
             "readOnly": true
           },
-          "jetstream_errors_count": {
+          "analysis_errors_count": {
             "type": "string",
             "readOnly": true
           }
@@ -1511,7 +1511,7 @@
             "type": "string",
             "readOnly": true
           },
-          "jetstream_errors_by_key": {
+          "analysis_errors_by_key": {
             "type": "string",
             "readOnly": true
           }

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1275,7 +1275,7 @@
             "type": "string",
             "readOnly": true
           },
-          "jetstream_errors_count": {
+          "analysis_errors_count": {
             "type": "string",
             "readOnly": true
           }
@@ -1523,7 +1523,7 @@
             "type": "string",
             "readOnly": true
           },
-          "jetstream_errors_by_key": {
+          "analysis_errors_by_key": {
             "type": "string",
             "readOnly": true
           }

--- a/docs/experimenter/swagger-ui.html
+++ b/docs/experimenter/swagger-ui.html
@@ -1249,6 +1249,35 @@
           "takeaways_summary": {
             "type": "string",
             "nullable": true
+          },
+          "conclusion_recommendations": {
+            "type": "string",
+            "readOnly": true
+          },
+          "project_impact": {
+            "enum": [
+              "HIGH",
+              "MODERATE",
+              "TARGETED"
+            ],
+            "type": "string",
+            "nullable": true
+          },
+          "next_steps": {
+            "type": "string",
+            "nullable": true
+          },
+          "reviewer_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "editor_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "jetstream_errors_count": {
+            "type": "string",
+            "readOnly": true
           }
         },
         "required": [
@@ -1291,6 +1320,14 @@
             "type": "boolean"
           },
           "owner": {
+            "type": "string",
+            "readOnly": true
+          },
+          "reviewer_emails": {
+            "type": "string",
+            "readOnly": true
+          },
+          "editor_emails": {
             "type": "string",
             "readOnly": true
           },
@@ -1483,6 +1520,10 @@
             "readOnly": true
           },
           "results_data": {
+            "type": "string",
+            "readOnly": true
+          },
+          "jetstream_errors_by_key": {
             "type": "string",
             "readOnly": true
           }

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -257,7 +257,7 @@ class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
             "next_steps",
             "reviewer_emails",
             "editor_emails",
-            "jetstream_errors_count",
+            "analysis_errors_count",
         ]
 
     def get_feature_configs(self, obj):
@@ -358,7 +358,7 @@ class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
             "excluded_experiments",
             "parent_experiment",
             "results_data",
-            "jetstream_errors_by_key",
+            "analysis_errors_by_key",
         ]
 
     def get_hypothesis(self, obj):

--- a/experimenter/experimenter/experiments/api/v5/serializers.py
+++ b/experimenter/experimenter/experiments/api/v5/serializers.py
@@ -229,6 +229,9 @@ class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
     feature_configs = serializers.SerializerMethodField()
     experiment_summary = serializers.CharField(source="experiment_url")
     results_url = serializers.SerializerMethodField()
+    conclusion_recommendations = serializers.SerializerMethodField()
+    reviewer_emails = serializers.SerializerMethodField()
+    editor_emails = serializers.SerializerMethodField()
 
     class Meta:
         model = NimbusExperiment
@@ -249,6 +252,12 @@ class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
             "takeaways_gain_amount",
             "takeaways_qbr_learning",
             "takeaways_summary",
+            "conclusion_recommendations",
+            "project_impact",
+            "next_steps",
+            "reviewer_emails",
+            "editor_emails",
+            "jetstream_errors_count",
         ]
 
     def get_feature_configs(self, obj):
@@ -259,6 +268,15 @@ class NimbusExperimentCsvSerializer(serializers.ModelSerializer):
 
     def get_results_url(self, obj):
         return f"{obj.experiment_url}results" if obj.results_ready else ""
+
+    def get_conclusion_recommendations(self, obj):
+        return ",".join(obj.conclusion_recommendation_labels)
+
+    def get_reviewer_emails(self, obj):
+        return ",".join(obj.reviewer_emails)
+
+    def get_editor_emails(self, obj):
+        return ",".join(obj.editor_emails)
 
 
 class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
@@ -294,6 +312,8 @@ class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
             "hypothesis",
             "is_rollout",
             "owner",
+            "reviewer_emails",
+            "editor_emails",
             "application_display",
             "channels",
             "feature_configs",
@@ -338,6 +358,7 @@ class NimbusExperimentYamlSerializer(serializers.ModelSerializer):
             "excluded_experiments",
             "parent_experiment",
             "results_data",
+            "jetstream_errors_by_key",
         ]
 
     def get_hypothesis(self, obj):

--- a/experimenter/experimenter/experiments/api/v5/views.py
+++ b/experimenter/experimenter/experiments/api/v5/views.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 
 import yaml
 from dateutil.relativedelta import relativedelta
-from django.db.models import F
+from django.db.models import F, Prefetch
 from django.http import HttpResponse
 from rest_framework.generics import ListAPIView, UpdateAPIView
 from rest_framework.pagination import PageNumberPagination
@@ -32,7 +32,15 @@ class NimbusExperimentCsvListView(CachedListMixin, ListAPIView):
     cache_content_type = "text/csv; charset=utf-8"
     queryset = (
         NimbusExperiment.objects.select_related("owner")
-        .prefetch_related("feature_configs")
+        .prefetch_related(
+            "feature_configs",
+            Prefetch(
+                "changes",
+                queryset=NimbusChangeLog.objects.select_related("changed_by").defer(
+                    "experiment_data"
+                ),
+            ),
+        )
         .filter(is_archived=False)
     )
     serializer_class = NimbusExperimentCsvSerializer
@@ -195,6 +203,12 @@ class NimbusExperimentYamlListView(CachedListMixin, ListAPIView):
             "tags",
             "required_experiments",
             "excluded_experiments",
+            Prefetch(
+                "changes",
+                queryset=NimbusChangeLog.objects.select_related("changed_by").defer(
+                    "experiment_data"
+                ),
+            ),
         )
         .filter(is_archived=False, status=NimbusExperiment.Status.COMPLETE)
         .order_by(F("_start_date").desc(nulls_last=True), "-id")

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2759,6 +2759,41 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
                     return True
         return False
 
+    @property
+    def jetstream_errors_by_key(self):
+        counts = {}
+        if self.results_data:
+            errors = self.results_data.get("v3", {}).get("errors", {})
+            for key, key_errors in errors.items():
+                if key_errors:
+                    counts[key] = len(key_errors)
+        return counts
+
+    @property
+    def jetstream_errors_count(self):
+        return sum(self.jetstream_errors_by_key.values())
+
+    @property
+    def reviewer_emails(self):
+        return sorted(
+            {
+                change.changed_by.email
+                for change in self.changes.all()
+                if change.old_publish_status == self.PublishStatus.REVIEW
+                and change.new_publish_status == self.PublishStatus.APPROVED
+            }
+        )
+
+    @property
+    def editor_emails(self):
+        return sorted(
+            {
+                change.changed_by.email
+                for change in self.changes.all()
+                if change.changed_by.email != settings.KINTO_DEFAULT_CHANGELOG_USER
+            }
+        )
+
     def get_invalid_fields_errors(self, serializer_class=None):
         if serializer_class is None:
             serializer = self._review_serializer

--- a/experimenter/experimenter/experiments/models.py
+++ b/experimenter/experimenter/experiments/models.py
@@ -2760,7 +2760,7 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return False
 
     @property
-    def jetstream_errors_by_key(self):
+    def analysis_errors_by_key(self):
         counts = {}
         if self.results_data:
             errors = self.results_data.get("v3", {}).get("errors", {})
@@ -2770,8 +2770,8 @@ class NimbusExperiment(NimbusConstants, TargetingConstants, FilterMixin, models.
         return counts
 
     @property
-    def jetstream_errors_count(self):
-        return sum(self.jetstream_errors_by_key.values())
+    def analysis_errors_count(self):
+        return sum(self.analysis_errors_by_key.values())
 
     @property
     def reviewer_emails(self):

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -52,7 +52,7 @@ class TestNimbusExperimentCsvSerializer(TestCase):
                 "next_steps": None,
                 "reviewer_emails": experiment.owner.email,
                 "editor_emails": experiment.owner.email,
-                "jetstream_errors_count": 0,
+                "analysis_errors_count": 0,
             },
         )
 
@@ -105,7 +105,7 @@ class TestNimbusExperimentCsvSerializer(TestCase):
             data["editor_emails"],
             "editor@example.com,owner@example.com,reviewer@example.com",
         )
-        self.assertEqual(data["jetstream_errors_count"], 3)
+        self.assertEqual(data["analysis_errors_count"], 3)
         self.assertEqual(data["conclusion_recommendations"], "Rerun,Graduate")
         self.assertEqual(data["project_impact"], NimbusExperiment.ProjectImpact.HIGH)
         self.assertEqual(data["next_steps"], "Ship it.")

--- a/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_serializers/test_nimbus_experiment_csv_serializer.py
@@ -5,9 +5,11 @@ from django.test import TestCase
 from experimenter.experiments.api.v5.serializers import NimbusExperimentCsvSerializer
 from experimenter.experiments.models import NimbusExperiment
 from experimenter.experiments.tests.factories import (
+    NimbusChangeLogFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
 )
+from experimenter.openidc.tests.factories import UserFactory
 
 
 class TestNimbusExperimentCsvSerializer(TestCase):
@@ -45,5 +47,65 @@ class TestNimbusExperimentCsvSerializer(TestCase):
                 "takeaways_gain_amount": experiment.takeaways_gain_amount,
                 "takeaways_qbr_learning": experiment.takeaways_qbr_learning,
                 "takeaways_summary": experiment.takeaways_summary,
+                "conclusion_recommendations": "",
+                "project_impact": None,
+                "next_steps": None,
+                "reviewer_emails": experiment.owner.email,
+                "editor_emails": experiment.owner.email,
+                "jetstream_errors_count": 0,
             },
         )
+
+    def test_serializer_outputs_reviewers_editors_errors_and_takeaways(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            feature_configs=[feature_config],
+            owner=UserFactory.create(email="owner@example.com"),
+            conclusion_recommendations=[
+                NimbusExperiment.ConclusionRecommendation.RERUN,
+                NimbusExperiment.ConclusionRecommendation.GRADUATE,
+            ],
+            project_impact=NimbusExperiment.ProjectImpact.HIGH,
+            next_steps="Ship it.",
+            results_data={
+                "v3": {
+                    "errors": {
+                        "ad_clicks": [
+                            {"analysis_basis": "enrollments", "segment": "all"},
+                            {"analysis_basis": "exposures", "segment": "all"},
+                        ],
+                        "experiment": [{"analysis_basis": "enrollments"}],
+                    },
+                }
+            },
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            changed_by=UserFactory.create(email="reviewer@example.com"),
+            old_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            new_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            changed_by=UserFactory.create(email="editor@example.com"),
+            old_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        data = NimbusExperimentCsvSerializer(experiment).data
+
+        self.assertEqual(
+            data["reviewer_emails"], "owner@example.com,reviewer@example.com"
+        )
+        self.assertEqual(
+            data["editor_emails"],
+            "editor@example.com,owner@example.com,reviewer@example.com",
+        )
+        self.assertEqual(data["jetstream_errors_count"], 3)
+        self.assertEqual(data["conclusion_recommendations"], "Rerun,Graduate")
+        self.assertEqual(data["project_impact"], NimbusExperiment.ProjectImpact.HIGH)
+        self.assertEqual(data["next_steps"], "Ship it.")

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -15,10 +15,12 @@ from experimenter.experiments.tests.api.v5.test_serializers.mixins import (
     MockFmlErrorMixin,
 )
 from experimenter.experiments.tests.factories import (
+    NimbusChangeLogFactory,
     NimbusExperimentFactory,
     NimbusFeatureConfigFactory,
     NimbusFmlErrorDataClass,
 )
+from experimenter.openidc.tests.factories import UserFactory
 
 
 @override_settings(
@@ -356,6 +358,68 @@ class TestNimbusExperimentYamlListView(TestCase):
             "search_metrics"
         ]["search_count"]
         self.assertEqual(search["significance"]["treatment"]["overall"]["1"], "positive")
+
+    def test_yaml_contains_reviewers_editors_and_jetstream_errors(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            name="Reviewed Experiment",
+            slug="reviewed-experiment",
+            application=application,
+            feature_configs=[feature_config],
+            owner=UserFactory.create(email="owner@example.com"),
+            results_data={
+                "v3": {
+                    "errors": {
+                        "ad_clicks": [
+                            {"analysis_basis": "enrollments", "segment": "all"},
+                            {"analysis_basis": "exposures", "segment": "all"},
+                        ],
+                        "retained": [],
+                        "experiment": [{"analysis_basis": "enrollments"}],
+                    },
+                }
+            },
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            changed_by=UserFactory.create(email="reviewer@example.com"),
+            old_publish_status=NimbusExperiment.PublishStatus.REVIEW,
+            new_publish_status=NimbusExperiment.PublishStatus.APPROVED,
+        )
+        NimbusChangeLogFactory.create(
+            experiment=experiment,
+            changed_by=UserFactory.create(email=settings.KINTO_DEFAULT_CHANGELOG_USER),
+            old_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+        )
+
+        data = self._get_yaml()
+        exp = next(e for e in data if e["slug"] == "reviewed-experiment")
+
+        self.assertEqual(
+            exp["reviewer_emails"], ["owner@example.com", "reviewer@example.com"]
+        )
+        self.assertEqual(
+            exp["editor_emails"], ["owner@example.com", "reviewer@example.com"]
+        )
+        self.assertEqual(
+            exp["jetstream_errors_by_key"], {"ad_clicks": 2, "experiment": 1}
+        )
+
+    def test_yaml_omits_empty_jetstream_errors(self):
+        application = NimbusExperiment.Application.DESKTOP
+        feature_config = NimbusFeatureConfigFactory.create(application=application)
+        NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            application=application,
+            feature_configs=[feature_config],
+            results_data={"v3": {"errors": {"experiment": []}}},
+        )
+
+        data = self._get_yaml()
+        self.assertNotIn("jetstream_errors_by_key", data[0])
 
     def test_default_hypothesis_excluded(self):
         application = NimbusExperiment.Application.DESKTOP

--- a/experimenter/experimenter/experiments/tests/api/v5/test_views.py
+++ b/experimenter/experimenter/experiments/tests/api/v5/test_views.py
@@ -359,7 +359,7 @@ class TestNimbusExperimentYamlListView(TestCase):
         ]["search_count"]
         self.assertEqual(search["significance"]["treatment"]["overall"]["1"], "positive")
 
-    def test_yaml_contains_reviewers_editors_and_jetstream_errors(self):
+    def test_yaml_contains_reviewers_editors_and_analysis_errors(self):
         application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         experiment = NimbusExperimentFactory.create_with_lifecycle(
@@ -404,11 +404,9 @@ class TestNimbusExperimentYamlListView(TestCase):
         self.assertEqual(
             exp["editor_emails"], ["owner@example.com", "reviewer@example.com"]
         )
-        self.assertEqual(
-            exp["jetstream_errors_by_key"], {"ad_clicks": 2, "experiment": 1}
-        )
+        self.assertEqual(exp["analysis_errors_by_key"], {"ad_clicks": 2, "experiment": 1})
 
-    def test_yaml_omits_empty_jetstream_errors(self):
+    def test_yaml_omits_empty_analysis_errors(self):
         application = NimbusExperiment.Application.DESKTOP
         feature_config = NimbusFeatureConfigFactory.create(application=application)
         NimbusExperimentFactory.create_with_lifecycle(
@@ -419,7 +417,7 @@ class TestNimbusExperimentYamlListView(TestCase):
         )
 
         data = self._get_yaml()
-        self.assertNotIn("jetstream_errors_by_key", data[0])
+        self.assertNotIn("analysis_errors_by_key", data[0])
 
     def test_default_hypothesis_excluded(self):
         application = NimbusExperiment.Application.DESKTOP

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -6115,11 +6115,11 @@ class TestNimbusExperiment(TestCase):
             ),
         ]
     )
-    def test_jetstream_errors(self, results_data, expected_by_key, expected_count):
+    def test_analysis_errors(self, results_data, expected_by_key, expected_count):
         experiment = NimbusExperimentFactory.create(results_data=results_data)
 
-        self.assertEqual(experiment.jetstream_errors_by_key, expected_by_key)
-        self.assertEqual(experiment.jetstream_errors_count, expected_count)
+        self.assertEqual(experiment.analysis_errors_by_key, expected_by_key)
+        self.assertEqual(experiment.analysis_errors_count, expected_count)
 
     def test_reviewer_emails_returns_sorted_distinct_approvers(self):
         experiment = NimbusExperimentFactory.create()

--- a/experimenter/experimenter/experiments/tests/test_models.py
+++ b/experimenter/experimenter/experiments/tests/test_models.py
@@ -6092,6 +6092,96 @@ class TestNimbusExperiment(TestCase):
 
         self.assertEqual(experiment.has_results_errors, expected_results)
 
+    @parameterized.expand(
+        [
+            (None, {}, 0),
+            ({"other_key": {}}, {}, 0),
+            ({"v3": {"errors": {"experiment": []}}}, {}, 0),
+            (
+                {
+                    "v3": {
+                        "errors": {
+                            "ad_clicks": [
+                                {"analysis_basis": "enrollments", "segment": "all"},
+                                {"analysis_basis": "exposures", "segment": "all"},
+                            ],
+                            "retained": [],
+                            "experiment": [{"analysis_basis": "enrollments"}],
+                        },
+                    }
+                },
+                {"ad_clicks": 2, "experiment": 1},
+                3,
+            ),
+        ]
+    )
+    def test_jetstream_errors(self, results_data, expected_by_key, expected_count):
+        experiment = NimbusExperimentFactory.create(results_data=results_data)
+
+        self.assertEqual(experiment.jetstream_errors_by_key, expected_by_key)
+        self.assertEqual(experiment.jetstream_errors_count, expected_count)
+
+    def test_reviewer_emails_returns_sorted_distinct_approvers(self):
+        experiment = NimbusExperimentFactory.create()
+        approver = UserFactory.create(email="zoe@example.com")
+
+        for changed_by, old_publish_status, new_publish_status in [
+            (
+                approver,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.PublishStatus.APPROVED,
+            ),
+            (
+                approver,
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.PublishStatus.APPROVED,
+            ),
+            (
+                UserFactory.create(email="amy@example.com"),
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.PublishStatus.APPROVED,
+            ),
+            (
+                UserFactory.create(email="requester@example.com"),
+                NimbusExperiment.PublishStatus.IDLE,
+                NimbusExperiment.PublishStatus.REVIEW,
+            ),
+            (
+                UserFactory.create(email="rejecter@example.com"),
+                NimbusExperiment.PublishStatus.REVIEW,
+                NimbusExperiment.PublishStatus.IDLE,
+            ),
+        ]:
+            NimbusChangeLogFactory.create(
+                experiment=experiment,
+                changed_by=changed_by,
+                old_publish_status=old_publish_status,
+                new_publish_status=new_publish_status,
+            )
+
+        self.assertEqual(
+            experiment.reviewer_emails, ["amy@example.com", "zoe@example.com"]
+        )
+
+    def test_editor_emails_excludes_automated_changelog_user(self):
+        experiment = NimbusExperimentFactory.create()
+        editor = UserFactory.create(email="zoe@example.com")
+
+        for changed_by in [
+            editor,
+            editor,
+            UserFactory.create(email="amy@example.com"),
+            UserFactory.create(email=settings.KINTO_DEFAULT_CHANGELOG_USER),
+        ]:
+            NimbusChangeLogFactory.create(
+                experiment=experiment,
+                changed_by=changed_by,
+                old_publish_status=NimbusExperiment.PublishStatus.IDLE,
+                new_publish_status=NimbusExperiment.PublishStatus.IDLE,
+            )
+
+        self.assertEqual(experiment.editor_emails, ["amy@example.com", "zoe@example.com"])
+
     def test_monitoring_summary_returns_none_when_no_monitoring_data(self):
         experiment = NimbusExperimentFactory.create(monitoring_data=None)
         self.assertIsNone(experiment.monitoring_summary)


### PR DESCRIPTION
Because

* The CSV and YAML report consumers need to know who reviewed and who edited each experiment
* Jetstream analysis error counts and the full takeaways set were only visible in the UI

This commit

* Adds NimbusExperiment convenience properties for reviewer emails, editor emails, and jetstream error counts
* Adds those fields plus the remaining takeaways fields to the CSV and YAML report serializers
* Prefetches changelogs with experiment_data deferred on both report querysets

Fixes #17249