### PR TITLE
feat(nimbus): add results page button to export raw results_data json

### DIFF
--- a/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
+++ b/experimenter/experimenter/nimbus_ui/templates/nimbus_experiments/results-inner.html
@@ -15,11 +15,18 @@
   <div class="px-5 pt-4 pb-5 shadow-sm rounded-4 bg-body border border-1">
     <div class="d-flex mt-2 align-items-center justify-content-between">
       <h4 class="m-0">Overview</h4>
-      <div>
-        Results last calculated:
-        <span class="fw-bold">{{ experiment.results_data.v3.metadata.analysis_start_time|parse_date|date:"N j, Y g:i A"|default:"N/A" }}
-          {% if experiment.results_data.v3.metadata.analysis_start_time %}UTC{% endif %}
-        </span>
+      <div class="d-flex align-items-center gap-3">
+        <div>
+          Results last calculated:
+          <span class="fw-bold">{{ experiment.results_data.v3.metadata.analysis_start_time|parse_date|date:"N j, Y g:i A"|default:"N/A" }}
+            {% if experiment.results_data.v3.metadata.analysis_start_time %}UTC{% endif %}
+          </span>
+        </div>
+        <a class="btn btn-primary"
+           id="export-results-json-{{ experiment.slug }}"
+           href="{% url 'nimbus-ui-results-export' slug=experiment.slug %}">
+          <i class="fa-solid fa-download me-2"></i>Export JSON
+        </a>
       </div>
     </div>
     <div id="{{ experiment.slug }}-results-overview">

--- a/experimenter/experimenter/nimbus_ui/tests/test_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_views.py
@@ -4534,6 +4534,39 @@ class TestResultsView(AuthTestCase):
         self.assertEqual(response.context["displayed_window"], expected_window)
 
 
+class TestResultsExportView(AuthTestCase):
+    def test_exports_results_data(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            results_data={"v3": {"weekly": {"enrollments": {"all": {}}}}},
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-results-export", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "application/json")
+        self.assertEqual(
+            response["Content-Disposition"],
+            f'attachment; filename="{experiment.slug}-results.json"',
+        )
+        self.assertEqual(json.loads(response.content), experiment.results_data)
+
+    def test_exports_empty_object_when_no_results(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.ENDING_APPROVE_APPROVE,
+            results_data=None,
+        )
+
+        response = self.client.get(
+            reverse("nimbus-ui-results-export", kwargs={"slug": experiment.slug}),
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(json.loads(response.content), {})
+
+
 class TestBranchScreenshotCreateView(AuthTestCase):
     def test_post_creates_screenshot(self):
         experiment = NimbusExperimentFactory.create_with_lifecycle(

--- a/experimenter/experimenter/nimbus_ui/urls.py
+++ b/experimenter/experimenter/nimbus_ui/urls.py
@@ -87,6 +87,7 @@ from experimenter.nimbus_ui.views import (
     PreviewToDraftView,
     PreviewToReviewView,
     QAStatusUpdateView,
+    ResultsExportView,
     ResultsView,
     ReviewToApproveView,
     ReviewToDraftView,
@@ -427,6 +428,11 @@ urlpatterns = [
         r"^(?P<slug>[\w-]+)/results/$",
         ResultsView.as_view(),
         name="nimbus-ui-results",
+    ),
+    re_path(
+        r"^(?P<slug>[\w-]+)/results/export/$",
+        ResultsExportView.as_view(),
+        name="nimbus-ui-results-export",
     ),
     re_path(
         r"^(?P<slug>[\w-]+)/create_branch_screenshot/$",

--- a/experimenter/experimenter/nimbus_ui/views.py
+++ b/experimenter/experimenter/nimbus_ui/views.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.core.paginator import Paginator
 from django.db.models import Q
-from django.http import HttpResponse, HttpResponseRedirect
+from django.http import HttpResponse, HttpResponseRedirect, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.urls import reverse
 from django.views import View
@@ -923,6 +923,18 @@ class ResultsView(PrefetchExperimentQuerysetMixin, NimbusExperimentViewMixin, De
         )
 
         return context
+
+
+class ResultsExportView(View):
+    def get(self, request, slug):
+        experiment = get_object_or_404(NimbusExperiment, slug=slug)
+        response = JsonResponse(
+            experiment.results_data or {}, json_dumps_params={"indent": 2}
+        )
+        response["Content-Disposition"] = (
+            f'attachment; filename="{experiment.slug}-results.json"'
+        )
+        return response
 
 
 class NimbusFeaturesView(TemplateView):


### PR DESCRIPTION
Because

* The results page renders a curated view of results_data with no way to get the underlying payload out of the UI.
* Retrieving the raw analysis JSON currently requires Django admin or database access.

This commit

* Adds a ResultsExportView serving an experiment's results_data as a JSON file download.
* Adds an Export JSON button to the results page Overview header.

Fixes #17252