### PR TITLE
fix(nimbus): cast appVersion STRING to INT64 for mobile versionCompare

### DIFF
--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -653,7 +653,13 @@ def _version_compare_binary_to_sql_with(
         _add_warning(warnings, "|versionCompare")
         return None
 
-    return f"{version_col} {sql_op} {major}"
+    # appVersion is a STRING column (e.g. "155.0.1") on mobile; extract major
+    # version as INT64 so the comparison is type-safe in BigQuery.
+    if version_col == "appVersion":
+        lhs = f"SAFE_CAST(SPLIT({version_col}, '.')[SAFE_OFFSET(0)] AS INT64)"
+    else:
+        lhs = version_col
+    return f"{lhs} {sql_op} {major}"
 
 
 def _identifier_path(node) -> str:

--- a/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/tests/test_jexl_to_sql.py
@@ -706,6 +706,22 @@ class TestJEXLToSQLMobile(TestCase):
         self.assertEqual(result.sql, "androidSdkVersion >= 29")
         self.assertEqual(result.warnings, [])
 
+    def test_app_version_compare_fenix(self):
+        result = jexl_to_sql("app_version|versionCompare('155.!') >= 0", app=FENIX_APP)
+        self.assertEqual(
+            result.sql,
+            "SAFE_CAST(SPLIT(appVersion, '.')[SAFE_OFFSET(0)] AS INT64) >= 155",
+        )
+        self.assertEqual(result.warnings, [])
+
+    def test_app_version_compare_ios(self):
+        result = jexl_to_sql("app_version|versionCompare('156.1.0') >= 0", app=IOS_APP)
+        self.assertEqual(
+            result.sql,
+            "SAFE_CAST(SPLIT(appVersion, '.')[SAFE_OFFSET(0)] AS INT64) >= 156",
+        )
+        self.assertEqual(result.warnings, [])
+
     def test_real_config_mobile_new_user_fenix(self):
         result = jexl_to_sql(MOBILE_NEW_USER.targeting, app=FENIX_APP)
         self.assertEqual(result.sql, "daysSinceInstall < 7")


### PR DESCRIPTION
Because:

- `app_version|versionCompare('155.!') >= 0\` was generating `appVersion >= 155\` (integer literal), which fails BigQuery type checking — `appVersion` is a STRING column in the Fenix/iOS nimbus sizing tables
- this caused the population estimates ETL (\`monitoring__experiment_population_estimates__v1`) to silently skip every mobile experiment via the `_dry_run_sql` validation, so no Fenix or iOS rows appeared in `experiment_population_estimates_v1`

This commit:

- extracts the major version as INT64 via \`SAFE_CAST(SPLIT(appVersion, '.')[SAFE_OFFSET(0)] AS INT64)\` so the comparison is type-safe in BigQuery
- leaves `androidSdkVersion` (INTEGER column) unchanged
- adds `test_app_version_compare_fenix` and `test_app_version_compare_ios` to cover the new code path