### PR TITLE
feat(nimbus): Add targeting for closed-browser web notifications

### DIFF
--- a/experimenter/experimenter/experiments/jexl_to_sql.py
+++ b/experimenter/experimenter/experiments/jexl_to_sql.py
@@ -210,6 +210,7 @@ JEXL_TO_BQ_COLUMN_IOS = {
 # Attributes with no corresponding column in nimbus_targeting_context.
 KNOWN_UNTRANSLATABLE = {
     "attachedFxAOAuthClients",  # privacy-sensitive, will never be recorded
+    "allowedNotificationOrigins",  # not yet recorded to the targeting context
     "isFirstRun",  # Desktop uses isFirstStartup; also mobile-only
     "is_first_run",
     "isNonStubFirstRun",

--- a/experimenter/experimenter/targeting/constants.py
+++ b/experimenter/experimenter/targeting/constants.py
@@ -38,6 +38,9 @@ PRESERVED_TARGETING_KEYS_BY_APPLICATION = {
         "isNonStubFirstRun",
         "localeLanguageCode",
         "attachedFxAOAuthClients",
+        # Remove once the recorded targeting context manifest includes this
+        # attribute (Bug 2069104).
+        "allowedNotificationOrigins",
     },
     Application.FENIX: {
         "current_date",
@@ -5840,6 +5843,39 @@ EXISTING_USER_NO_ENTERPRISE = NimbusTargetingConfig(
         "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.features'|preferenceValue"
         " && "
         "'browser.newtabpage.activity-stream.asrouter.userprefs.cfr.addons'|preferenceValue"
+    ),
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+HAS_ALLOWED_NOTIFICATIONS = NimbusTargetingConfig(
+    name="Has allowed web notifications",
+    slug="has_allowed_notifications",
+    description=(
+        "Desktop users who have granted notification permission to at least one origin"
+    ),
+    targeting="allowedNotificationOrigins > 0",
+    desktop_telemetry="",
+    sticky_required=True,
+    is_first_run_required=False,
+    application_choice_names=(Application.DESKTOP.name,),
+)
+
+CBWN_DELIVERY_ESTABLISHED_PROFILES = NimbusTargetingConfig(
+    name="Closed-browser web notifications, established profiles",
+    slug="cbwn_delivery_established_profiles",
+    description=(
+        "Windows 10+ users with profiles 28 days or older, without active "
+        "enterprise policies, who have granted notification permission to at "
+        "least one origin"
+    ),
+    targeting=(
+        "os.isWindows && os.windowsVersion >= 10 && "
+        f"{PROFILE28DAYS} && "
+        f"{NO_ENTERPRISE.targeting} && "
+        f"{HAS_ALLOWED_NOTIFICATIONS.targeting}"
     ),
     desktop_telemetry="",
     sticky_required=True,


### PR DESCRIPTION
Because:

- The Closed-Browser Web Notifications Delivery experiment targets Windows 10+ users with profiles 28+ days old, non-enterprise, who have allowed at least one origin to send notifications
- Bug 2069104 adds the allowedNotificationOrigins targeting attribute that the notifications clause depends on

This commit:

- Adds has_allowed_notifications, a reusable config for users who have granted notification permission to at least one origin
- Adds cbwn_delivery_established_profiles for the experiment itself, composing PROFILE28DAYS, NO_ENTERPRISE and has_allowed_notifications
- Marks allowedNotificationOrigins as untranslatable for BigQuery, since it is not yet recorded to the Glean targeting context
- Preserves allowedNotificationOrigins as a known targeting field until the recorded targeting context manifest picks it up from Bug 2069104

Fixes #17251
