### PR TITLE
fix(nimbus): Always show the rollout preview link and toast on copy

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -471,6 +471,7 @@ Optional - We expect this to <describe impact> on <core metric>.
     TOAST_SLACK_ENABLED = "toast-slack-enabled"
     TOAST_SLACK_DISABLED = "toast-slack-disabled"
     TOAST_EDIT_CANCELLED = "toast-edit-cancelled"
+    TOAST_PREVIEW_LINK_COPIED = "toast-preview-link-copied"
 
     TOASTS = {
         TOAST_SAVED: "Changes saved",
@@ -479,6 +480,7 @@ Optional - We expect this to <describe impact> on <core metric>.
         TOAST_SLACK_ENABLED: "Review Slack notifications enabled",
         TOAST_SLACK_DISABLED: "Review Slack notifications disabled",
         TOAST_EDIT_CANCELLED: "Edit cancelled",
+        TOAST_PREVIEW_LINK_COPIED: "Preview link copied to clipboard",
     }
 
     ROLLOUT_CARD_FIELDS = {

--- a/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
+++ b/experimenter/experimenter/nimbus_ui/static/js/new/rollout_cards.js
@@ -37,6 +37,13 @@ document.addEventListener("click", (event) => {
   }
 });
 
+document.addEventListener("click", (event) => {
+  const trigger = event.target.closest?.("[data-copy-text]");
+  if (trigger) {
+    navigator.clipboard?.writeText(trigger.dataset.copyText);
+  }
+});
+
 const expandCard = (card) => {
   const collapse = card.querySelector(".accordion-collapse");
   if (collapse && !collapse.classList.contains("show")) {

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
@@ -20,8 +20,12 @@
       <i class="fa-regular fa-copy me-2" aria-hidden="true"></i>Copy preview link
     </button>
   </div>
-  {% include "nimbus_devtools/opt_in_pane.html" %}
+  <div class="row g-3">
+    <div class="col-12 col-md-6">
+      {% include "nimbus_devtools/opt_in_pane.html" %}
 
+    </div>
+  </div>
   {# Rollout experience card #}
   <div class="row g-3">
     <div class="col-12 col-md-6">

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/preview/card.html
@@ -3,6 +3,25 @@
     <strong>Note:</strong> Before generating links, go to <code>about:config</code>
     and enable the <code>nimbus.debug</code> configuration first.
   </p>
+  {# about:studies opt-in URL for the rollout branch, always shown under the note #}
+  <div class="d-flex flex-column align-items-start gap-2">
+    <code id="rollout-preview-url"
+          class="user-select-all text-break rounded-3 border border-secondary-subtle bg-body-tertiary px-3 py-2 small text-danger"
+          role="button"
+          tabindex="0"
+          title="Copy preview link"
+          data-copy-text="about:studies?optin_slug={{ experiment.slug }}&amp;optin_branch={{ experiment.reference_branch.slug }}&amp;optin_collection=nimbus-preview"
+          data-toast-id="{{ NimbusUIConstants.TOAST_PREVIEW_LINK_COPIED }}">about:studies?optin_slug={{ experiment.slug }}&amp;optin_branch={{ experiment.reference_branch.slug }}&amp;optin_collection=nimbus-preview</code>
+    <button type="button"
+            id="rollout-preview-link-btn"
+            class="btn btn-primary d-inline-flex align-items-center justify-content-center"
+            data-copy-text="about:studies?optin_slug={{ experiment.slug }}&amp;optin_branch={{ experiment.reference_branch.slug }}&amp;optin_collection=nimbus-preview"
+            data-toast-id="{{ NimbusUIConstants.TOAST_PREVIEW_LINK_COPIED }}">
+      <i class="fa-regular fa-copy me-2" aria-hidden="true"></i>Copy preview link
+    </button>
+  </div>
+  {% include "nimbus_devtools/opt_in_pane.html" %}
+
   {# Rollout experience card #}
   <div class="row g-3">
     <div class="col-12 col-md-6">
@@ -81,16 +100,6 @@
             </div>
           {% endif %}
         {% endwith %}
-        {% if experiment.is_desktop %}
-          {# about:studies opt-in URL for the rollout branch #}
-          <button type="button"
-                  class="btn btn-primary d-inline-flex align-items-center justify-content-center"
-                  onclick="navigator.clipboard.writeText('about:studies?optin_slug={{ experiment.slug }}&optin_branch={{ experiment.reference_branch.slug }}&optin_collection=nimbus-preview');this.innerText='Copied';">
-            <i class="fa-regular fa-eye me-2" aria-hidden="true"></i>Preview link
-          </button>
-          {% include "nimbus_devtools/opt_in_pane.html" %}
-
-        {% endif %}
       </div>
     </div>
   </div>

--- a/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
+++ b/experimenter/experimenter/nimbus_ui/tests/test_new_views.py
@@ -1444,6 +1444,51 @@ class TestNimbusRolloutDetailView(AuthTestCase):
         self.assertContains(response, screenshot_1.image.url)
         self.assertContains(response, screenshot_2.image.url)
 
+    @parameterized.expand([(True,), (False,)])
+    def test_preview_card_always_shows_preview_link(self, with_screenshot):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
+        )
+        if with_screenshot:
+            NimbusBranchScreenshotFactory.create(branch=experiment.reference_branch)
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="rollout-preview-url"')
+        self.assertContains(response, 'id="rollout-preview-link-btn"')
+        self.assertContains(
+            response,
+            (
+                f"about:studies?optin_slug={experiment.slug}"
+                f"&amp;optin_branch={experiment.reference_branch.slug}"
+                "&amp;optin_collection=nimbus-preview"
+            ),
+        )
+
+    def test_preview_link_triggers_toast_instead_of_relabeling_the_button(self):
+        experiment = NimbusExperimentFactory.create_with_lifecycle(
+            NimbusExperimentFactory.Lifecycles.PREVIEW,
+            is_rollout=True,
+        )
+
+        response = self.client.get(
+            reverse("new-nimbus-ui-rollout-detail", kwargs={"slug": experiment.slug})
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response,
+            f'data-toast-id="{NimbusUIConstants.TOAST_PREVIEW_LINK_COPIED}"',
+        )
+        self.assertContains(
+            response, f'<div id="{NimbusUIConstants.TOAST_PREVIEW_LINK_COPIED}"'
+        )
+        self.assertNotContains(response, "this.innerText='Copied'")
+
     @override_settings(SKIP_REVIEW_ACCESS_CONTROL_FOR_DEV_USER=True)
     @mock.patch.object(NimbusExperiment, "get_invalid_fields_errors", return_value={})
     def test_sidebar_shows_approve_control_for_dev_reviewer(self, _mock_errors):


### PR DESCRIPTION
## Because

The preview link was buried at the bottom of the card, below the screenshot.

Clicking it relabeled the button to "Copied" instead of using a toast.

## This commit

Shows the `about:studies` URL and a copy button directly under the note.

Swaps the "Copied" relabel for the `TOAST_PREVIEW_LINK_COPIED` toast.

## Screenshot

Fixes #17051