### PR TITLE
fix(nimbus): Move application out of overview and into the page header

### DIFF
--- a/experimenter/experimenter/nimbus_ui/constants.py
+++ b/experimenter/experimenter/nimbus_ui/constants.py
@@ -387,6 +387,10 @@ Optional - We believe this outcome will <describe impact> on <core metric>
         "Resolve the highlighted errors above before saving this plan."
     )
     ERROR_ROLLOUT_PHASE_LOCKED = "This rollout phase is locked and cannot be changed."
+    ROLLOUT_APPLICATION_TOOLTIP = (
+        "Rollouts can only target one Application at a time. Application can "
+        "not be changed after a rollout is created."
+    )
     ROLLOUT_REVIEW_PENDING_TOOLTIP = "A review is currently pending."
     ROLLOUT_NO_NEXT_PHASE_TOOLTIP = "There is no further phase to start."
     ROLLOUT_HAS_ISSUES_TOOLTIP = "All rollout issues must be resolved first."
@@ -457,7 +461,6 @@ Optional - We believe this outcome will <describe impact> on <core metric>
                 ("Name", ("name",)),
                 ("Observations & Problem Space", ("hypothesis",)),
                 ("Public Description", ("public_description",)),
-                ("Application", ("application",)),
                 ("Important Links", ("documentation_links",)),
                 ("Project Tags", ()),
                 ("Subscribers", ()),

--- a/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/common/base.html
@@ -53,6 +53,13 @@
                 <span>{{ experiment.slug }}</span>
                 <i class="fa-regular fa-copy"></i>
               </button>
+              <div class="d-flex align-items-center gap-1 small text-secondary">
+                <span id="experiment-application">{{ experiment.get_application_display }}</span>
+                <i class="fa-regular fa-circle-question"
+                   data-bs-toggle="tooltip"
+                   data-bs-placement="right"
+                   title="{{ NimbusUIConstants.ROLLOUT_APPLICATION_TOOLTIP }}"></i>
+              </div>
               {% if experiment.parent %}
                 <p class="text-secondary small mb-0">
                   Cloned from

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/card.html
@@ -27,13 +27,6 @@
       {% include "new/common/validation_errors.html" with errors=validation_errors.public_description %}
 
     </div>
-    {# Application #}
-    <div>
-      <div class="text-secondary mb-1" style="font-size: 12px;">Application</div>
-      <div class="small text-body">{{ experiment.get_application_display }}</div>
-      {% include "new/common/validation_errors.html" with errors=validation_errors.application %}
-
-    </div>
     {# Important Links #}
     <div>
       <div class="text-secondary mb-1" style="font-size: 12px;">Important Links</div>

--- a/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
+++ b/experimenter/experimenter/nimbus_ui/templates/new/rollouts/overview/edit_form.html
@@ -40,21 +40,6 @@
 
         <p class="form-text mb-0">{{ NimbusUIConstants.PUBLIC_DESCRIPTION_TEXT }}</p>
       </div>
-      {# Application #}
-      <div>
-        <label for="id_application" class="small text-body mb-1">Application</label>
-        {{ form.application }}
-        {% if form.application.errors %}
-          <div class="text-danger small mt-1">{{ form.application.errors|join:", " }}</div>
-        {% endif %}
-        {% include "new/common/validation_errors.html" with errors=validation_errors.application %}
-
-        <p class="form-text mb-0">
-          Rollouts can only target one Application at a time.
-          <br>
-          Application can not be changed after a rollout is created.
-        </p>
-      </div>
       {# Important Links #}
       <div>
         <label class="small text-body mb-1">Important Links</label>


### PR DESCRIPTION
Because

* Application is set at creation and can never be edited so a read-only row could be confusing

This commit

* Moves application under the slug in the page header, with the form's wording kept as a tooltip

Fixes #17048
